### PR TITLE
Faster experiment setup and simple fix for low budget setups

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -5,9 +5,36 @@ from autogluon_zeroshot.repository.evaluation_repository import load, Evaluation
 
 output_path = Path(__file__).parent
 
-def load_context(version: str = "BAG_D244_F3_C1416") -> EvaluationRepository:
+def load_context(version: str = "BAG_D244_F3_C1416", filter_very_large_dataset: bool = True) -> EvaluationRepository:
     def _load_fun():
         repo = load(version=version)
         repo = repo.subset(models=[m for m in repo.list_models() if not "NeuralNetFastAI" in m])
         return repo
-    return cache_function(_load_fun, cache_name=f"repo_{version}")
+    repo = cache_function(_load_fun, cache_name=f"repo_{version}")
+
+    if filter_very_large_dataset:
+        # For some reason, only 184 datasets are found from this list
+        # from autogluon_zeroshot.contexts.context_2023_08_21 import datasets
+        # filtered_datasets = datasets[-200:]
+        # tids = [repo.dataset_to_tid(d) for d in filtered_datasets if d in repo.dataset_names()]
+        # return repo.subset(tids=[tid for tid in repo.tids() if tid in tids])
+
+        # Therefore we set the list manually
+        very_large_datasets = [
+            "nyc-taxi-green-dec-2016",
+            "volkert",
+            # "CIFAR_10",  # This dataset is not present
+            "Fashion-MNIST",
+            "Kuzushiji-MNIST",
+            "mnist_784",
+            "fars",
+            "tamilnadu-electricity",
+            "albert",
+            "airlines",
+            "ldpa",
+            "porto-seguro",
+        ]
+        very_large_datasets_tids = [repo.dataset_to_tid(d) for d in very_large_datasets if d in repo.dataset_names()]
+        return repo.subset(tids=[tid for tid in repo.tids() if tid not in very_large_datasets_tids])
+    else:
+        return repo

--- a/scripts/baseline_comparison/evaluate_baselines.py
+++ b/scripts/baseline_comparison/evaluate_baselines.py
@@ -118,8 +118,7 @@ if __name__ == "__main__":
     parser.add_argument("--engine", type=str, required=False, default="ray", choices=["sequential", "ray", "joblib"],
                         help="Engine used for embarrassingly parallel loop.")
     parser.add_argument("--ray_process_ratio", type=float,
-                        help="The ratio of ray processes to logical cpu cores. Use lower values to reduce memory usage. Only used if engine == 'ray'",
-                        default=0.25)
+                        help="The ratio of ray processes to logical cpu cores. Use lower values to reduce memory usage. Only used if engine == 'ray'",)
     args = parser.parse_args()
     print(args.__dict__)
 
@@ -132,7 +131,7 @@ if __name__ == "__main__":
     if n_datasets:
         expname += f"-{n_datasets}"
 
-    if engine == "ray":
+    if engine == "ray" and args.ray_process_ratio is not None:
         assert (ray_process_ratio <= 1) and (ray_process_ratio > 0)
         num_cpus = os.cpu_count()
         num_ray_processes = math.ceil(num_cpus*ray_process_ratio)


### PR DESCRIPTION
* Add filtering of 200 datasets by default in experiments
* make optional reducing of cores for ray (not needed with 200 datasets)
* compute zeroshot on configurations in budget 95% of the time and remove filter (both bring significant improvement on low budget settings