### PR TITLE
Add TaskMetadata and EnsembleScorer

### DIFF
--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -166,6 +166,8 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
                  proxy_fit_metric_map: Optional[Union[dict, str]] = None,  # TODO: Add unit test
                  ):
         """
+        A scorer object to evaluate configs via simulating ensemble selection.
+
         :param datasets: The list of datasets to consider for scoring.
         :param zeroshot_gt: The ground truth information and task metadata for all tasks.
         :param zeroshot_pred_proba: The TabularModelPredictions object that contains the predictions of all configs on all tasks.


### PR DESCRIPTION
Add TaskMetadata and EnsembleScorer to cleanup and streamline the logic in `ensemble_selection_config_scorer.py`.

The overall logic remains the same, but with a more clean structure. I've confirmed that simulation results remain identical.

Note: GitHub makes this look like a much bigger change than it is. What changed is that the logic in `run_task` was moved to a dedicated class called `EnsembleScorer`, which is constructed during init of `EnsembleSelectionConfigScorer`. `TaskMetadata` is a convenience wrapper around `zeroshot_gt` to simplify the code.