### PR TITLE
Sparse

### DIFF
--- a/scripts/baseline_comparison/baselines.py
+++ b/scripts/baseline_comparison/baselines.py
@@ -99,6 +99,7 @@ def evaluate_configs(
             fold=fold,
             config_names=config_sampled,
             runtime_col='time_train_s',
+            fail_if_missing=False,
         )
         latencies = get_runtime(
             repo=repo,
@@ -106,6 +107,7 @@ def evaluate_configs(
             fold=fold,
             config_names=config_selected_ensemble,
             runtime_col='time_infer_s',
+            fail_if_missing=False,
         )
         rows.append(ResultRow(
             dataset=dataset,

--- a/scripts/baseline_comparison/evaluate_baselines.py
+++ b/scripts/baseline_comparison/evaluate_baselines.py
@@ -279,6 +279,8 @@ if __name__ == "__main__":
         expname += "_ALL"
 
     repo: EvaluationRepository = load_context(version=repo_version, ignore_cache=ignore_cache, as_paper=as_paper)
+    # use predictions from this method in case of model failures
+    repo.set_config_fallback("ExtraTrees_c1_BAG_L1")
     repo.print_info()
 
     if n_eval_folds == -1:

--- a/tabrepo/predictions/tabular_predictions.py
+++ b/tabrepo/predictions/tabular_predictions.py
@@ -304,7 +304,7 @@ class TabularPredictionsMemmap(TabularModelPredictions):
 
     @classmethod
     def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str = None, datasets: Optional[List[str]] = None, dtype: str = "float32"):
-        cls._keep_only_models_in_both_validation_and_test(pred_dict)
+        # cls._keep_only_models_in_both_validation_and_test(pred_dict)
         cls._cache_data(pred_dict=pred_dict, data_dir=output_dir, dtype=dtype)
         return cls(data_dir=output_dir, datasets=datasets)
 

--- a/tabrepo/predictions/tabular_predictions.py
+++ b/tabrepo/predictions/tabular_predictions.py
@@ -222,7 +222,8 @@ class TabularPredictionsInMemory(TabularModelPredictions):
     @classmethod
     def from_dict(cls, pred_dict: TabularPredictionsDict, datasets: Optional[List[str]] = None, output_dir: str = None):
         # Optional, avoids changing passed object
-        cls._keep_only_models_in_both_validation_and_test(copy.deepcopy(pred_dict))
+        pred_dict = copy.deepcopy(pred_dict)
+        cls._keep_only_models_in_both_validation_and_test(pred_dict)
         return cls(pred_dict=pred_dict, datasets=datasets)
 
     def to_dict(self) -> TabularPredictionsDict:
@@ -304,7 +305,7 @@ class TabularPredictionsMemmap(TabularModelPredictions):
 
     @classmethod
     def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str = None, datasets: Optional[List[str]] = None, dtype: str = "float32"):
-        # cls._keep_only_models_in_both_validation_and_test(pred_dict)
+        cls._keep_only_models_in_both_validation_and_test(pred_dict)
         cls._cache_data(pred_dict=pred_dict, data_dir=output_dir, dtype=dtype)
         return cls(data_dir=output_dir, datasets=datasets)
 

--- a/tabrepo/predictions/tabular_predictions.py
+++ b/tabrepo/predictions/tabular_predictions.py
@@ -115,17 +115,19 @@ class TabularModelPredictions:
                 fp[:] = pred_test[:]
                 fp.flush()
 
-    def predict_val(self, dataset: str, fold: int, models: List[str] = None) -> np.array:
+    def predict_val(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
         """
         Obtains validation predictions on a given dataset and fold for a list of models
+        :param: model_fallback to use for fallback if one model of `models` is not found
         :return: predictions with shape (num_models, num_rows, num_classes) for classification and
         (num_models, num_rows, ) for regression
         """
         raise NotImplementedError()
 
-    def predict_test(self, dataset: str, fold: int, models: List[str] = None) -> np.array:
+    def predict_test(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
         """
         Obtains test predictions on a given dataset and fold for a list of models
+        :param: model_fallback to use for fallback if one model of `models` is not found
         :return: predictions with shape (num_models, num_rows, num_classes) for classification and
         (num_models, num_rows, ) for regression
         """
@@ -231,10 +233,12 @@ class TabularPredictionsInMemory(TabularModelPredictions):
         memmap = TabularPredictionsMemmap.from_data_dir(data_dir=data_dir, datasets=datasets)
         return cls.from_dict(pred_dict=memmap.to_dict(), datasets=datasets)
 
-    def predict_val(self, dataset: str, fold: int, models: List[str] = None) -> np.array:
+    def predict_val(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
+        assert model_fallback is None, "model_fallback not supported for in memory data-structure"
         return self._load_pred(dataset=dataset, fold=fold, models=models, split="val")
 
-    def predict_test(self, dataset: str, fold: int, models: List[str] = None) -> np.array:
+    def predict_test(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
+        assert model_fallback is None, "model_fallback not supported for in memory data-structure"
         return self._load_pred(dataset=dataset, fold=fold, models=models, split="test")
 
     def _load_pred(self, dataset: str, split: str, fold: int, models: List[str] = None):

--- a/tst/test_impute.py
+++ b/tst/test_impute.py
@@ -1,21 +1,9 @@
-"""
-TODO:
-* add test for repository
-* add behavior for time
-DONE:
-* create artificial example with tabular prediction
-* add one sparse model
-* test behavior
-* implement impute logic
-"""
 import numpy as np
-import pandas as pd
 
 from tabrepo import EvaluationRepository
-from tabrepo.contexts.context_artificial import load_repo_artificial, load_context_artificial
+from tabrepo.contexts.context_artificial import load_context_artificial
 from tabrepo.predictions import TabularPredictionsMemmap
-from tabrepo.predictions.tabular_predictions import TabularPredictionsDict, TabularModelPredictions, \
-    TabularPredictionsInMemory
+from tabrepo.predictions.tabular_predictions import TabularModelPredictions
 from tabrepo.utils.test_utils import generate_artificial_dict
 
 num_models = 13

--- a/tst/test_impute.py
+++ b/tst/test_impute.py
@@ -1,0 +1,70 @@
+"""
+TODO:
+* add test for repository
+* add behavior for time
+DONE:
+* create artificial example with tabular prediction
+* add one sparse model
+* test behavior
+* implement impute logic
+"""
+import numpy as np
+import pandas as pd
+
+from tabrepo import EvaluationRepository
+from tabrepo.contexts.context_artificial import load_repo_artificial, load_context_artificial
+from tabrepo.predictions import TabularPredictionsMemmap
+from tabrepo.predictions.tabular_predictions import TabularPredictionsDict, TabularModelPredictions, \
+    TabularPredictionsInMemory
+from tabrepo.utils.test_utils import generate_artificial_dict
+
+num_models = 13
+num_folds = 3
+dataset_shapes = {
+    "d1": ((20,), (50,)),
+    "d2": ((10,), (5,)),
+    "d3": ((4, 3), (8, 3)),
+}
+models = [f"{i}" for i in range(num_models)]
+
+def test_keep_only_models_in_both_validation_and_test():
+    pred_dict = generate_artificial_dict(num_folds, models, dataset_shapes)
+    pred_dict["d2"][1]['pred_proba_dict_val'].pop("2")
+    TabularModelPredictions._keep_only_models_in_both_validation_and_test(pred_dict)
+
+    # check that the intersection works as expected, model "2" should not be present in the test split as it was
+    # absent from the validation split
+    assert "2" not in pred_dict["d2"][1]['pred_proba_dict_test']
+
+
+def test_tabular_predictions():
+    pred_dict = generate_artificial_dict(num_folds, models, dataset_shapes)
+
+    # remove the second model from the second dataset and the second fold
+    pred_dict["d2"][1]['pred_proba_dict_val'].pop("2")
+    # pred_dict["d2"][1]['pred_proba_dict_test'].pop("2")
+
+    # TODO proper tmpdir
+    preds = TabularPredictionsMemmap.from_dict(pred_dict, output_dir='/tmp/foo')
+    pred_expected = preds.predict_val(dataset="d2", fold=1, models=["3"], model_fallback="3")
+    pred_obtained = preds.predict_val(dataset="d2", fold=1, models=["2"], model_fallback="3")
+    assert np.allclose(pred_expected, pred_obtained)
+
+
+def test_repository():
+    zsc, configs_full, pred_proba, zeroshot_gt = load_context_artificial()
+
+    # remove NeuralNetFastAI_r1 from fold 1 of abalone...
+    pred_dict = pred_proba.pred_dict
+    pred_dict["abalone"][1]['pred_proba_dict_val'].pop("NeuralNetFastAI_r1")
+    repo = EvaluationRepository(
+        zeroshot_context=zsc,
+        tabular_predictions=TabularPredictionsMemmap.from_dict(pred_dict, "/tmp/foo2"),
+        ground_truth=zeroshot_gt,
+    )
+
+    # ... and make sure we retrieve the result of the fallback when querying results from missing NeuralNetFastAI_r1
+    repo.set_config_fallback("NeuralNetFastAI_r2")
+    pred_expected = repo.predict_val(dataset="abalone", fold=1, config="NeuralNetFastAI_r2")
+    pred_obtained = repo.predict_val(dataset="abalone", fold=1, config="NeuralNetFastAI_r1")
+    assert np.allclose(pred_expected, pred_obtained)


### PR DESCRIPTION
This adds logic to fallback to extra-trees in case of missing predictions. I have added test that make sure that the expected behavior happens for tabular predictions and the repository. For runtimes, the current logic will impute the mean of model runtime if it is not found.

The logic `_keep_only_models_in_both_validation_and_test` only keeps model which are present in both val and test split (this was just assumed and asserted in previous version) now the filter happens automatically.