### PR TITLE
Add max_models and max_models_per_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Below is a list of the available contexts in TabRepo.
 
 ## Reproducing paper experiments
 
+To ensure reproducibility, you can use the `AutoML2024` [branch](https://github.com/autogluon/tabrepo/tree/AutoML2024) which provides a snapshot of the code that is able to reproduce the results.
+
 To reproduce the experiments from the paper, run:
 
 ```bash

--- a/scripts/baseline_comparison/baselines.py
+++ b/scripts/baseline_comparison/baselines.py
@@ -396,8 +396,8 @@ def zeroshot_results(
     :param n_training_datasets: number of dataset to use when fitting zeroshot
     :param n_training_folds: number of folds to use when fitting zeroshot
     :param n_training_configs: number of configurations available when fitting zeroshot TODO per framework
-    :param n_max_models: `max_models` kwarg value during ensemble fit.
-    :param n_max_models_per_type: `max_models_per_type` kwarg value during ensemble fit.
+    :param n_max_models: maximum number of models considered when fitting ensemble
+    :param n_max_models_per_type: maximum number of models for each framework considered when fitting ensemble
     :param max_runtimes: max runtime available when evaluating zeroshot configuration at test time
     :param engine: engine to use, must be "sequential", "joblib" or "ray"
     :param seeds: the seeds for the random number generator used for shuffling the configs

--- a/scripts/baseline_comparison/baselines.py
+++ b/scripts/baseline_comparison/baselines.py
@@ -46,6 +46,7 @@ def evaluate_configs(
         method: str,
         config_selected: List[str],
         ensemble_size: int = default_ensemble_size,
+        ensemble_kwargs=None,
         config_sampled: List[str] = None,
         folds: List[int] = range(10),
         seed: int = 0,
@@ -67,6 +68,8 @@ def evaluate_configs(
         config_sampled = config_selected
     if ensemble_size is None:
         ensemble_size = default_ensemble_size
+    if ensemble_kwargs is None:
+        ensemble_kwargs = {}
 
     # Makes results invariant to config order (otherwise tie breaking logic in Caruana selection can make the
     # result depend on configuration order)
@@ -77,6 +80,7 @@ def evaluate_configs(
         datasets=[dataset],
         configs=config_selected,
         ensemble_size=ensemble_size,
+        ensemble_kwargs=ensemble_kwargs,
         backend='native',
         folds=folds,
         rank=False,
@@ -320,19 +324,22 @@ def time_suffix(max_runtime: float) -> str:
 def zeroshot_name(
         n_portfolio: int = n_portfolios_default, n_ensemble: int = None, n_training_dataset: int = None,
         n_training_fold: int = None, n_training_config: int = None,
-        max_runtime: float = default_runtime, prefix: str = None, n_ensemble_in_name: bool = False
+        max_runtime: float = default_runtime, prefix: str = None, n_ensemble_in_name: bool = False,
+        max_models: int = None, max_models_per_type: int = None,
 ):
     """
     :return: name of the zeroshot method such as Zeroshot-N20-C40 if n_training_dataset or n_training_folds are not
     None, suffixes "-D{n_training_dataset}" and "-S{n_training_folds}" are added, for instance "Zeroshot-N20-C40-D30-S5"
     would be the name if n_training_dataset=30 and n_training_fold=5
     """
+    if max_models_per_type is not None and isinstance(max_models_per_type, str) and max_models_per_type == "auto":
+        max_models_per_type = 0  # FIXME: HACK, using 0 because otherwise regex parsing fails if "auto". Switch to not rely on name parsing in experiments.
     if prefix is None:
         prefix = ""
     suffix = [
         f"-{letter}{x}" if x is not None else ""
         for letter, x in
-        [("N", n_portfolio), ("D", n_training_dataset), ("S", n_training_fold), ("M", n_training_config)]
+        [("N", n_portfolio), ("D", n_training_dataset), ("S", n_training_fold), ("M", n_training_config), ("X", max_models), ("Z", max_models_per_type)]
     ]
     # if n_ensemble:
     #     suffix += f"-C{n_ensemble}"
@@ -373,6 +380,8 @@ def zeroshot_results(
         n_training_datasets: List[int] = [None],
         n_training_folds: List[int] = [None],
         n_training_configs: List[int] = [None],
+        n_max_models: List[int] = [None],
+        n_max_models_per_type: List[int] = [None],
         max_runtimes: List[float] = [default_runtime],
         engine: str = "ray",
         seeds: list = [0],
@@ -387,6 +396,8 @@ def zeroshot_results(
     :param n_training_datasets: number of dataset to use when fitting zeroshot
     :param n_training_folds: number of folds to use when fitting zeroshot
     :param n_training_configs: number of configurations available when fitting zeroshot TODO per framework
+    :param n_max_models: `max_models` kwarg value during ensemble fit.
+    :param n_max_models_per_type: `max_models_per_type` kwarg value during ensemble fit.
     :param max_runtimes: max runtime available when evaluating zeroshot configuration at test time
     :param engine: engine to use, must be "sequential", "joblib" or "ray"
     :param seeds: the seeds for the random number generator used for shuffling the configs
@@ -394,7 +405,7 @@ def zeroshot_results(
     """
 
     def evaluate_dataset(test_dataset, n_portfolio, n_ensemble, n_training_dataset, n_training_fold, n_training_config,
-                         max_runtime, seed: int, repo: EvaluationRepository, df_rank, rank_scorer, normalized_scorer,
+                         max_runtime, max_models, max_models_per_type, seed: int, repo: EvaluationRepository, df_rank, rank_scorer, normalized_scorer,
                          model_frameworks):
         method_name = zeroshot_name(
             n_portfolio=n_portfolio,
@@ -405,6 +416,8 @@ def zeroshot_results(
             n_training_config=n_training_config,
             prefix=method_prefix,
             n_ensemble_in_name=n_ensemble_in_name,
+            max_models=max_models,
+            max_models_per_type=max_models_per_type
         )
 
         rng = np.random.default_rng(seed=seed)
@@ -466,12 +479,18 @@ def zeroshot_results(
             # configuration that takes <1s to be evaluated
             portfolio_configs = [backup_fast_config]
 
+        ensemble_kwargs = {
+            "max_models": max_models,
+            "max_models_per_type": max_models_per_type,
+        }
+
         return evaluate_configs(
             repo=repo,
             rank_scorer=rank_scorer,
             normalized_scorer=normalized_scorer,
             config_selected=portfolio_configs,
             ensemble_size=n_ensemble,
+            ensemble_kwargs=ensemble_kwargs,
             tid=test_tid,
             method=method_name,
             folds=range(n_eval_folds),
@@ -493,7 +512,7 @@ def zeroshot_results(
     list_rows = parallel_for(
         evaluate_dataset,
         inputs=list(itertools.product(dataset_names, n_portfolios, n_ensembles, n_training_datasets, n_training_folds,
-                                      n_training_configs, max_runtimes, seeds)),
+                                      n_training_configs, max_runtimes, n_max_models, n_max_models_per_type, seeds)),
         context=dict(repo=repo, df_rank=df_rank, rank_scorer=rank_scorer, normalized_scorer=normalized_scorer,
                      model_frameworks=model_frameworks),
         engine=engine,

--- a/tabrepo/repository/evaluation_repository.py
+++ b/tabrepo/repository/evaluation_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import copy
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Type
 
 import numpy as np
 import pandas as pd
@@ -8,7 +8,7 @@ import pandas as pd
 from .. import repository
 from ..predictions.tabular_predictions import TabularModelPredictions
 from ..simulation.configuration_list_scorer import ConfigurationListScorer
-from ..simulation.ensemble_selection_config_scorer import EnsembleSelectionConfigScorer
+from ..simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels, EnsembleSelectionConfigScorer
 from ..simulation.ground_truth import GroundTruth
 from ..simulation.simulation_context import ZeroshotSimulatorContext
 from ..simulation.single_best_config_scorer import SingleBestConfigScorer
@@ -408,6 +408,8 @@ class EvaluationRepository(SaveLoadMixin):
         datasets: List[str],
         configs: List[str] = None,
         *,
+        ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
+        ensemble_kwargs: dict = None,
         ensemble_size: int = 100,
         rank: bool = True,
         folds: Optional[List[int]] = None,
@@ -417,6 +419,8 @@ class EvaluationRepository(SaveLoadMixin):
         :param datasets: list of datasets to compute errors on.
         :param configs: list of config to consider for ensembling. Uses all configs if None.
         :param ensemble_size: number of members to select with Caruana.
+        :param ensemble_cls: class used for the ensemble model.
+        :param ensemble_kwargs: kwargs to pass to the init of the ensemble class.
         :param rank: whether to return ranks or raw scores (e.g. RMSE). Ranks are computed over all base models and
         automl framework.
         :param folds: list of folds that need to be evaluated, use all folds if not provided.
@@ -437,6 +441,8 @@ class EvaluationRepository(SaveLoadMixin):
         scorer = self._construct_ensemble_selection_config_scorer(
             tasks=tasks,
             ensemble_size=ensemble_size,
+            ensemble_cls=ensemble_cls,
+            ensemble_kwargs=ensemble_kwargs,
             backend=backend,
         )
 

--- a/tabrepo/simulation/ensemble_selection_config_scorer.py
+++ b/tabrepo/simulation/ensemble_selection_config_scorer.py
@@ -161,10 +161,10 @@ class EnsembleScorer:
         """
         models_filtered_set = set(models_filtered)
 
-        # Preserve `models` order without duplicates
-        seen = set()
-        seen_add = seen.add
-        models_filtered = [m for m in models if (m in models_filtered_set) and not (m in seen or seen_add(m))]
+        # Preserve `models` order without duplicates (optimized)
+        models_seen = set()
+        # not (m in models_seen or models_seen.add(m) only adds `m` to models_seen if `m` was not already in models_seen.
+        models_filtered = [m for m in models if (m in models_filtered_set) and not (m in models_seen or models_seen.add(m))]
 
         if len(models_filtered_set) < len(models_filtered):
             # Duplicate names in `models`, have special handling

--- a/tabrepo/simulation/ensemble_selection_config_scorer.py
+++ b/tabrepo/simulation/ensemble_selection_config_scorer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -31,6 +31,7 @@ class EnsembleScorer:
                  zeroshot_pp: TabularModelPredictions,
                  zeroshot_gt: GroundTruth,
                  task_metrics_metadata,
+                 zeroshot_context: ZeroshotSimulatorContext = None,
                  ensemble_method: callable = EnsembleSelection,
                  ensemble_method_kwargs: dict = None,
                  proxy_fit_metric_map: dict = None,
@@ -47,6 +48,7 @@ class EnsembleScorer:
         self.ensemble_method_kwargs = ensemble_method_kwargs
         self.zeroshot_pp: TabularModelPredictions = zeroshot_pp
         self.zeroshot_gt = zeroshot_gt
+        self.zeroshot_context = zeroshot_context
         self.task_metrics_metadata = task_metrics_metadata
         self.proxy_fit_metric_map = proxy_fit_metric_map
         self.use_fast_metrics = use_fast_metrics
@@ -79,13 +81,24 @@ class EnsembleScorer:
         pred_test = self.zeroshot_pp.predict_test(dataset=dataset, fold=fold, models=models)
         return pred_val, pred_test
 
+    def filter_models(self, dataset: str, fold: int, models: List[str]) -> List[str]:
+        """
+        Filters models by user-defined logic. Used in class extensions.
+        """
+        return models
+
     def evaluate_task(self, dataset: str, fold: int, models: List[str]) -> Tuple[float, np.array]:
+        n_models = len(models)
         task_metadata = self.task_metrics_metadata[dataset]
         metric_name = task_metadata["metric"]
         problem_type = task_metadata["problem_type"]
 
         y_val = self.zeroshot_gt.labels_val(dataset=dataset, fold=fold)
         y_test = self.zeroshot_gt.labels_test(dataset=dataset, fold=fold)
+
+        # If filtering models, need to keep track of original model order to return ensemble weights list
+        models_filtered = self.filter_models(dataset=dataset, fold=fold, models=models)
+        models, models_filtered_idx = self._get_models_filtered_idx(models=models, models_filtered=models_filtered)
 
         pred_val, pred_test = self.get_preds_from_models(dataset=dataset, fold=fold, models=models)
 
@@ -135,7 +148,68 @@ class EnsembleScorer:
 
         ensemble_weights: np.array = weighted_ensemble.weights_
 
+        # ensemble_weights has to be updated, need to be in the original models order
+        ensemble_weights_fixed = np.zeros(n_models, dtype=np.float64)
+        ensemble_weights_fixed[models_filtered_idx] = ensemble_weights
+        ensemble_weights = ensemble_weights_fixed
+
         return err, ensemble_weights
+
+    def _get_models_filtered_idx(self, models: list[str], models_filtered: list[str]) -> Tuple[list[str], list[int]]:
+        """
+        Returns the filtered list of models and the index mapping of the filtered models to the original `models` list.
+        """
+        models_filtered_set = set(models_filtered)
+
+        # Preserve `models` order without duplicates
+        seen = set()
+        seen_add = seen.add
+        models_filtered = [m for m in models if (m in models_filtered_set) and not (m in seen or seen_add(m))]
+
+        if len(models_filtered_set) < len(models_filtered):
+            # Duplicate names in `models`, have special handling
+            models_idx = {}
+            for i, m in enumerate(models):
+                if m not in models_idx:
+                    models_idx[m] = []
+                models_idx[m].append(i)
+            models_filtered_idx = [models_idx[m].pop(0) for m in models_filtered]
+        else:
+            models_filtered_idx = [models.index(m) for m in models_filtered]
+        return models_filtered, models_filtered_idx
+
+
+class EnsembleScorerMaxModels(EnsembleScorer):
+    """
+    Identical to EnsembleScorer, with the addition of `max_models` and `max_models_per_type`.
+
+    Parameters
+    ----------
+    max_models: int, default = None
+        If specified, will limit ensemble candidates to the top `max_models` highest validation score models.
+        This logic is applied after the filtering from `max_models_per_type`.
+    max_models_per_type: int, default = None
+        If specified, will limit ensemble candidates of a given model type to the top `max_models_per_type` highest validation score models.
+    """
+    def __init__(self, zeroshot_context: ZeroshotSimulatorContext, max_models: int = None, max_models_per_type: int = None, **kwargs):
+        super().__init__(zeroshot_context=zeroshot_context, **kwargs)
+        assert self.zeroshot_context is not None
+        self.max_models = max_models
+        self.max_models_per_type = max_models_per_type
+
+    def filter_models(self, dataset: str, fold: int, models: List[str]) -> List[str]:
+        """
+        Filters models by user-defined logic. Used in class extensions.
+        """
+        if self.max_models is not None or self.max_models_per_type is not None:
+            models = self.zeroshot_context.get_top_configs(
+                dataset=dataset,
+                fold=fold,
+                configs=models,
+                max_models=self.max_models,
+                max_models_per_type=self.max_models_per_type,
+            )
+        return models
 
 
 # FIXME: Add temperature scaling!!
@@ -145,6 +219,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
                  zeroshot_gt: GroundTruth,
                  zeroshot_pred_proba: TabularModelPredictions,
                  ranker: RankScorer,
+                 zeroshot_simulator_context: ZeroshotSimulatorContext,
                  tid_to_dataset_name_dict: Dict[int, str],
                  task_metrics_metadata: Dict[int, Dict[str, str]],
                  ensemble_size=100,
@@ -152,6 +227,8 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
                  backend: str = 'native',
                  use_fast_metrics: bool = True,
                  proxy_fit_metric_map: Optional[Union[dict, str]] = None,  # TODO: Add unit test
+                 ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
+                 ensemble_kwargs: dict = None,
                  ):
         """
         A scorer object to evaluate configs via simulating ensemble selection.
@@ -160,6 +237,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         :param zeroshot_gt: The ground truth information and task metadata for all tasks.
         :param zeroshot_pred_proba: The TabularModelPredictions object that contains the predictions of all configs on all tasks.
         :param ranker: The ranking object used to compute scores on each task.
+        :param zeroshot_simulator_context: The ZSC used to obtain metadata for advanced `ensemble_cls`.
         :param dataset_name_to_tid_dict: Mapping of dataset names to corresponding TIDs. TODO: Remove?
         :param dataset_name_to_fold_dict: Mapping of dataset names to available folds. TODO: Remove?
         :param task_metrics_metadata: dictionary containing metric information and problem type for all tasks
@@ -174,12 +252,16 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             For example, the proxy metric could be faster to compute while producing a similar end result.
             If None: Do not use proxy metrics, equivalent to {}.
             If 'roc_auc_to_log_loss': set to {'roc_auc': 'log_loss'}, making 'log_loss' a proxy to 'roc_auc'
+        :param: ensemble_cls: The ensemble class to use for fitting and scoring.
+        :param: ensemble_kwargs: The kwargs to pass to the init call of `ensemble_cls`.
         """
-        super(EnsembleSelectionConfigScorer, self).__init__(tasks=tasks)
+        super().__init__(tasks=tasks)
         if zeroshot_gt is None:
             raise ValueError(f'zeroshot_gt cannot be None!')
         if zeroshot_pred_proba is None:
             raise ValueError(f'zeroshot_pred_proba cannot be None!')
+        if ensemble_kwargs is None:
+            ensemble_kwargs = {}
         self.zeroshot_gt = zeroshot_gt
         self.zeroshot_pred_proba = zeroshot_pred_proba
         self.ranker = ranker
@@ -201,13 +283,15 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         ensemble_selection_kwargs = copy.deepcopy(ensemble_selection_kwargs)
         ensemble_selection_kwargs["ensemble_size"] = ensemble_size
 
-        self.ensemble_scorer = EnsembleScorer(
+        self.ensemble_scorer = ensemble_cls(
             zeroshot_pp=zeroshot_pred_proba,
             zeroshot_gt=zeroshot_gt,
             task_metrics_metadata=task_metrics_metadata,
             ensemble_method_kwargs=ensemble_selection_kwargs,
             proxy_fit_metric_map=proxy_fit_metric_map,
             use_fast_metrics=use_fast_metrics,
+            zeroshot_context=zeroshot_simulator_context,
+            **ensemble_kwargs,
         )
 
     @classmethod
@@ -226,6 +310,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             ranker=zeroshot_simulator_context.rank_scorer,
             tid_to_dataset_name_dict=zeroshot_simulator_context.tid_to_dataset_dict,
             task_metrics_metadata=task_metrics_metadata,
+            zeroshot_simulator_context=zeroshot_simulator_context,
             **kwargs,
         )
 

--- a/tabrepo/simulation/simulation_context.py
+++ b/tabrepo/simulation/simulation_context.py
@@ -564,43 +564,9 @@ class ZeroshotSimulatorContext:
         df_configs_task_sorted["type"] = df_configs_task_sorted["framework"].map(self.configs_type).fillna("nan")
 
         if max_models_per_type is not None:
-            if isinstance(max_models_per_type, str):
-                assert max_models_per_type == "auto"
-                max_models_per_type = self._get_max_models_per_type_auto(dataset=dataset)
             df_configs_task_sorted["rank_by_type"] = df_configs_task_sorted.groupby(["type", "task"])["metric_error_val"].rank("first").astype(int)
             df_configs_task_sorted = df_configs_task_sorted[df_configs_task_sorted["rank_by_type"] <= max_models_per_type]
         if max_models is not None:
             df_configs_task_sorted["rank"] = df_configs_task_sorted.groupby("task")["metric_error_val"].rank("first").astype(int)
             df_configs_task_sorted = df_configs_task_sorted[df_configs_task_sorted["rank"] <= max_models]
         return list(df_configs_task_sorted["framework"])
-
-    def _get_max_models_per_type_auto(self, dataset: str) -> int:
-        """
-        Logic to mimic AutoGluon's default setting for `max_models_per_type`.
-        """
-        num_rows = int(self.df_metadata[self.df_metadata["dataset"] == dataset].iloc[0]["NumberOfInstances"] * 9 / 10)
-        if num_rows < 1000:
-            max_models_per_type = 1
-        elif num_rows < 5000:
-            max_models_per_type = 2
-        elif num_rows < 10000:
-            max_models_per_type = 3
-        elif num_rows < 15000:
-            max_models_per_type = 4
-        elif num_rows < 20000:
-            max_models_per_type = 5
-        elif num_rows < 25000:
-            max_models_per_type = 6
-        elif num_rows < 30000:
-            max_models_per_type = 7
-        elif num_rows < 35000:
-            max_models_per_type = 8
-        elif num_rows < 40000:
-            max_models_per_type = 9
-        elif num_rows < 45000:
-            max_models_per_type = 10
-        elif num_rows < 50000:
-            max_models_per_type = 11
-        else:
-            max_models_per_type = 12
-        return max_models_per_type

--- a/tst/test_repository.py
+++ b/tst/test_repository.py
@@ -59,6 +59,14 @@ def test_repository():
     task_0 = repo.task_name(dataset=dataset, fold=0)
     assert np.allclose(result_ensemble_weights.loc[(dataset, 0)], [1.0, 0.0])
 
+    # Test `max_models_per_type`
+    result_errors_w_max_models, result_ensemble_weights_w_max_models = repo.evaluate_ensemble(
+        datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native", ensemble_kwargs={"max_models_per_type": 1}
+    )
+    assert result_errors_w_max_models.shape == (3,)
+    assert len(result_ensemble_weights_w_max_models) == 3
+    assert np.allclose(result_ensemble_weights_w_max_models.loc[(dataset, 0)], [1.0, 0.0])
+
     assert repo.evaluate_ensemble(datasets=[dataset], configs=[config, config],
                                   ensemble_size=5, folds=[2], backend="native")[0].shape == (1,)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add max_models and max_models_per_type options for ensembling.
- `max_models_per_type` limits the number of models considered for a given model family during ensembling.
- Added logic for user to be able to customize the ensemble method by specifying the class and kwargs.
- The best setting (Z0 aka "auto") adapts the `max_models_per_type` value depending on the dataset size.
- This logic both makes inference time faster and has superior normalized error.
- Numbers below obtained by specifying `run_max_models_simulation=True` in `evaluate_baselines.py` (with all_configs=True):

| method                                   |   normalized-error |   rank |   time fit (s) |   time infer (s) |
|:-----------------------------------------|-------------------:|-------:|---------------:|-----------------:|
| Portfolio-N200-Z0 (ensemble) (4h)        |              0.347 |  184.2 |         6335.7 |            0.021 |
| Portfolio-N200-Z2 (ensemble) (4h)        |              0.348 |  186.3 |         6335.7 |            0.03  |
| Portfolio-N200-Z3 (ensemble) (4h)        |              0.348 |  189.5 |         6335.7 |            0.037 |
| Portfolio-N200-Z7 (ensemble) (4h)        |              0.35  |  192.8 |         6335.7 |            0.036 |
| Portfolio-N200-Z1 (ensemble) (4h)        |              0.35  |  180.8 |         6335.7 |            0.018 |
| Portfolio-N200-Z4 (ensemble) (4h)        |              0.35  |  194.7 |         6335.7 |            0.036 |
| Portfolio-N200-Z5 (ensemble) (4h)        |              0.351 |  194.5 |         6335.7 |            0.036 |
| Portfolio-N200-Z8 (ensemble) (4h)        |              0.351 |  193.9 |         6335.7 |            0.037 |
| Portfolio-N200-Z6 (ensemble) (4h)        |              0.352 |  195.5 |         6335.7 |            0.035 |
| Portfolio-N200-Z10 (ensemble) (4h)       |              0.352 |  196.8 |         6335.7 |            0.034 |
| Portfolio-N200-Z9 (ensemble) (4h)        |              0.353 |  197   |         6335.7 |            0.035 |
| Portfolio-N200 (ensemble) (4h)           |              0.355 |  195.5 |         6335.7 |            0.036 |


|   Rank | Model                                   |   Elo | 95% CI   |   Winrate |   Rescaled Acc |   Champ Delta % |
|-------:|:----------------------------------------|------:|:---------|----------:|---------------:|----------------:|
|      1 | Portfolio-N200-Z0 (ensemble) (4h)       |  1213 | +5/-5    |      0.73 |           0.95 |            13.9 |
|      2 | Portfolio-N200-Z7 (ensemble) (4h)       |  1201 | +6/-5    |      0.72 |           0.94 |            14.1 |
|      2 | Portfolio-N200-Z10 (ensemble) (4h)      |  1198 | +5/-6    |      0.71 |           0.94 |            14.2 |
|      2 | Portfolio-N200-Z8 (ensemble) (4h)       |  1196 | +4/-5    |      0.71 |           0.94 |            14.2 |
|      2 | Portfolio-N200-Z4 (ensemble) (4h)       |  1194 | +5/-5    |      0.71 |           0.94 |            14.2 |
|      2 | Portfolio-N200-Z3 (ensemble) (4h)       |  1194 | +5/-5    |      0.71 |           0.94 |            14   |
|      2 | Portfolio-N200-E100 (ensemble) (4h)     |  1193 | +5/-6    |      0.71 |           0.94 |            14.4 |
|      2 | Portfolio-N200-Z6 (ensemble) (4h)       |  1192 | +7/-6    |      0.71 |           0.94 |            14.1 |
|      2 | Portfolio-N200-Z9 (ensemble) (4h)       |  1192 | +5/-5    |      0.71 |           0.94 |            14.3 |
|      2 | Portfolio-N200-Z2 (ensemble) (4h)       |  1192 | +6/-5    |      0.71 |           0.95 |            13.9 |
|     11 | Portfolio-N200 (ensemble) (4h)          |  1192 | +4/-4    |      0.71 |           0.94 |            14.4 |
|     11 | Portfolio-N200-E50 (ensemble) (4h)      |  1191 | +5/-6    |      0.71 |           0.94 |            14.4 |
|     11 | Portfolio-N200-E75 (ensemble) (4h)      |  1189 | +5/-6    |      0.7  |           0.94 |            14.3 |
|     11 | Portfolio-N200-Z1 (ensemble) (4h)       |  1189 | +5/-6    |      0.71 |           0.95 |            13.8 |
|     11 | Portfolio-N200-E175 (ensemble) (4h)     |  1188 | +5/-4    |      0.7  |           0.94 |            14.4 |
|     11 | Portfolio-N200-E150 (ensemble) (4h)     |  1188 | +5/-6    |      0.7  |           0.94 |            14.4 |
|     11 | Portfolio-N200-E200 (ensemble) (4h)     |  1188 | +4/-5    |      0.7  |           0.94 |            14.4 |
|     11 | Portfolio-N200-Z5 (ensemble) (4h)       |  1188 | +6/-5    |      0.7  |           0.94 |            14.2 |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
