### PR TITLE
Adding test scripts

### DIFF
--- a/examples/temp_script.py
+++ b/examples/temp_script.py
@@ -35,6 +35,7 @@ if __name__ == '__main__':
     task_metadata = load_task_metadata('task_metadata.csv')
 
     tids = [359955, 146818]
+    # tids = [146818]
     folds = [0, 1, 2]
 
     methods_dict = {
@@ -68,23 +69,25 @@ if __name__ == '__main__':
         val_error="metric_error_val",
     ))
 
+    results_df = convert_leaderboard_to_configs(results_df)
+
     with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 1000):
         print(results_df)
 
     evaluator = Evaluator(
-        # frameworks=frameworks_run,
+        # frameworks=frameworks_run,    #why do we not pass frameworks_run here?
         task_metadata=task_metadata,
         # treat_folds_as_datasets=treat_folds_as_datasets,
     )
     evaluator_output = evaluator.transform(data=results_df)
 
-    results_ranked_df = evaluator_output.results_ranked
+    # results_ranked_df = evaluator_output.results_ranked
 
     context_name = "D244_F3_C1530_30"
     context = get_context(name=context_name)
     config_hyperparameters = context.load_configs_hyperparameters()
     repo: EvaluationRepository = load_repository(context_name, cache=True)
-    metrics = repo.compare_metrics(results_df, datasets=["blood-transfusion-service-center", "Australian"], configs=["CatBoost_r1_BAG_L1", "LightGBM_r41_BAG_L1"])
+    metrics = repo.compare_metrics(results_df, datasets=["blood-transfusion-service-center", "Australian"], configs=["CatBoost_r1_BAG_L1", "LightGBM_r41_BAG_L1"], folds=[0,1])
     with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
         print(f"Config Metrics Example:\n{metrics}")
 

--- a/examples/temp_script.py
+++ b/examples/temp_script.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from autogluon_benchmark.metadata.metadata_loader import load_task_metadata
+from autogluon_benchmark.tasks.experiment_utils import run_experiments
+from autogluon_benchmark.evaluation.evaluator import Evaluator
+from tabrepo import load_repository, get_context, EvaluationRepository
+
+
+def convert_leaderboard_to_configs(leaderboard: pd.DataFrame, minimal: bool = True) -> pd.DataFrame:
+    df_configs = leaderboard.rename(columns=dict(
+        model="framework",
+        fit_time="time_train_s",
+        pred_time_test="time_infer_s"
+    ))
+    if minimal:
+        df_configs = df_configs[[
+            "dataset",
+            "fold",
+            "framework",
+            "metric_error",
+            "metric_error_val",
+            "metric",
+            "problem_type",
+            "time_train_s",
+            "time_infer_s",
+            "tid",
+        ]]
+    return df_configs
+
+if __name__ == '__main__':
+    expname = "./test_results"  # folder location of all experiment artifacts
+    ignore_cache = True  # set to True to overwrite existing caches and re-run experiments from scratch
+    task_metadata = load_task_metadata('task_metadata.csv')
+
+    tids = [359955, 146818]
+    folds = [0, 1, 2]
+
+    methods_dict = {
+        "TABPFN": {
+            "hyperparameters": {"TABPFN": {}},
+            "fit_weighted_ensemble": False,
+        },
+        "RF": {
+            "hyperparameters": {"RF": {}},
+            "fit_weighted_ensemble": False,
+        }
+    }
+    methods = list(methods_dict.keys())
+
+    results_lst = run_experiments(
+        expname=expname,
+        tids=tids,
+        folds=folds,
+        methods=methods,
+        methods_dict=methods_dict,
+        task_metadata=task_metadata,
+        ignore_cache=ignore_cache,
+    )
+    results_df = pd.concat(results_lst, ignore_index=True)
+
+    results_df = results_df.rename(columns=dict(
+        time_fit="time_train_s",
+        time_predict="time_infer_s",
+        test_error="metric_error",
+        eval_metric="metric",
+        val_error="metric_error_val",
+    ))
+
+    with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 1000):
+        print(results_df)
+
+    evaluator = Evaluator(
+        # frameworks=frameworks_run,
+        task_metadata=task_metadata,
+        # treat_folds_as_datasets=treat_folds_as_datasets,
+    )
+    evaluator_output = evaluator.transform(data=results_df)
+
+    results_ranked_df = evaluator_output.results_ranked
+
+    context_name = "D244_F3_C1530_30"
+    context = get_context(name=context_name)
+    config_hyperparameters = context.load_configs_hyperparameters()
+    repo: EvaluationRepository = load_repository(context_name, cache=True)
+    metrics = repo.compare_metrics(results_df, datasets=["blood-transfusion-service-center", "Australian"], configs=["CatBoost_r1_BAG_L1", "LightGBM_r41_BAG_L1"])
+    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+        print(f"Config Metrics Example:\n{metrics}")
+
+

--- a/tabrepo/repository/evaluation_repository.py
+++ b/tabrepo/repository/evaluation_repository.py
@@ -240,6 +240,23 @@ class EvaluationRepository(SaveLoadMixin):
         df = df[mask]
 
         return df
+    
+    def compare_metrics(self, results_df: pd.DataFrame, datasets: List[str] = None, folds: List[int] = None, configs: List[str] = None) -> pd.DataFrame:
+        df_exp = results_df.reset_index().set_index(["dataset", "fold", "framework"])[
+            ["metric_error", "metric_error_val", "time_train_s", "time_infer_s"]
+        ]
+
+        #TO DO: use self._zeroshot_context.df_configs to match fit df and tab repo df
+        # Will yield incorrect result - still in progress
+        df_tr = self.metrics(datasets=datasets, folds=folds, configs=configs)
+        #Future Question - Dropping rank as it is not in the results_df
+        df_tr.drop(columns=['rank'], inplace=True)
+        df_tr = df_tr.reset_index().set_index(["dataset", "fold","framework"])
+        df = pd.concat([df_exp, df_tr], axis=0)
+        df = df.sort_index()
+
+        # Future question - for plotting how do match the 15 cols in results_df with the tabrepo columns?
+        return df
 
     def predict_test(self, dataset: str, fold: int, config: str, binary_as_multiclass: bool = False) -> np.ndarray:
         """

--- a/tabrepo/repository/evaluation_repository.py
+++ b/tabrepo/repository/evaluation_repository.py
@@ -243,19 +243,23 @@ class EvaluationRepository(SaveLoadMixin):
     
     def compare_metrics(self, results_df: pd.DataFrame, datasets: List[str] = None, folds: List[int] = None, configs: List[str] = None) -> pd.DataFrame:
         df_exp = results_df.reset_index().set_index(["dataset", "fold", "framework"])[
-            ["metric_error", "metric_error_val", "time_train_s", "time_infer_s"]
+            ["metric_error", "metric_error_val", "time_train_s", "time_infer_s", "metric", "problem_type", "tid"]
         ]
 
-        #TO DO: use self._zeroshot_context.df_configs to match fit df and tab repo df
-        # Will yield incorrect result - still in progress
-        df_tr = self.metrics(datasets=datasets, folds=folds, configs=configs)
-        #Future Question - Dropping rank as it is not in the results_df
-        df_tr.drop(columns=['rank'], inplace=True)
-        df_tr = df_tr.reset_index().set_index(["dataset", "fold","framework"])
+       # Dropping task column in df_tr
+        df_tr = self._zeroshot_context.df_configs.set_index(["dataset", "fold", "framework"])[
+            ["metric_error", "metric_error_val", "time_train_s", "time_infer_s", "metric", "problem_type", "tid"]
+        ]
+
+        mask = df_tr.index.get_level_values("dataset").isin(datasets)
+        if folds is not None:
+            mask = mask & df_tr.index.get_level_values("fold").isin(folds)
+        if configs is not None:
+            mask = mask & df_tr.index.get_level_values("framework").isin(configs)
+        df_tr = df_tr[mask]
         df = pd.concat([df_exp, df_tr], axis=0)
         df = df.sort_index()
 
-        # Future question - for plotting how do match the 15 cols in results_df with the tabrepo columns?
         return df
 
     def predict_test(self, dataset: str, fold: int, config: str, binary_as_multiclass: bool = False) -> np.ndarray:


### PR DESCRIPTION
*Description of changes:*
`temp_script.py` fits `TABPFN` and `RF` models on two datasets - namely `Australian` and `blood-transfusion-service-center` over `3 folds.` 
this is then passed over to be compared to models in tabrepo, namely `Catboost` and `LightGBM`, note that we only retrieve `2 folds` when fetching metrics from tabrepo.
This fold mismatch is done on purpose to see if the final dataframe after `compare_metrics()` is correct or not.

Below is the attached screenshot of the final df, which groups and compares the fitted AG models with TabRepo configs
![image](https://github.com/user-attachments/assets/ea06c5aa-40e0-43ee-bbbe-6c9ad87420c7)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
