### PR TITLE
fix: support new numpy version

### DIFF
--- a/tabrepo/metrics/_fast_roc_auc.py
+++ b/tabrepo/metrics/_fast_roc_auc.py
@@ -17,7 +17,7 @@ fast_roc_auc_cpp = make_scorer('roc_auc',
 
 
 def _preprocess_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    return y_true.astype(np.bool8), y_pred_bulk.astype(np.float32)
+    return y_true.astype(np.bool_), y_pred_bulk.astype(np.float32)
 
 
 fast_roc_auc_cpp.preprocess_bulk = _preprocess_bulk


### PR DESCRIPTION
np.bool8 was deprecated in `1.24`. But the dependencies of TabRepo (e.g. AutoGluon) support `"numpy": ">=1.25.0,<2.1.4"`.
Thus, I replace it with its (supposedly) alias np.bool_. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
