### PR TITLE
Switch to `~/.cache` for storing repo artifacts

### DIFF
--- a/tabrepo/contexts/context.py
+++ b/tabrepo/contexts/context.py
@@ -573,12 +573,12 @@ def construct_context(
     BenchmarkContext object that is able to load the data.
     """
     if local_prefix_is_relative:
-        path_context = str(Paths.results_root / local_prefix) + os.sep
+        path_context = str(Paths.results_root_cache / local_prefix) + os.sep
     else:
         path_context = str(Path(local_prefix)) + os.sep
 
     if local_prefix_is_relative:
-        data_root = Paths.data_root
+        data_root = Paths.data_root_cache
     else:
         data_root = Path(path_context).parent
 

--- a/tabrepo/loaders/__init__.py
+++ b/tabrepo/loaders/__init__.py
@@ -10,13 +10,8 @@ from ._download import download_zs_metadata
 class Paths:
     project_root: Path = Path(__file__).parent.parent.parent
     data_root: Path = project_root / 'data'
-    results_root: Path = data_root / 'results'
-    all_v3_results_root: Path = results_root / "all_v3"
-    bagged_results_root: Path = results_root / "bagged"
-    bagged_208_results_root: Path = results_root / "bagged_208"
-    bagged_289_results_root: Path = results_root / "bagged_289"
-    bagged_2023_07_25_results_root: Path = results_root / "2023_07_25"
-    automl_289_results_root: Path = results_root / "automl_289"
+    data_root_cache: Path = Path.home() / ".cache" / "tabrepo" / "data"
+    results_root_cache: Path = data_root_cache / "results"
 
     @staticmethod
     def abs_to_rel(path: str, relative_to: Path = project_root) -> str:

--- a/tabrepo/repository/evaluation_repository.py
+++ b/tabrepo/repository/evaluation_repository.py
@@ -186,8 +186,8 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             raise ValueError(f'Invalid config_scorer_type: {config_scorer_type}')
 
     @classmethod
-    def from_context(cls, version: str = None, cache: bool = False, prediction_format: str = "memmap") -> Self:
-        return load_repository(version=version, cache=cache, prediction_format=prediction_format)
+    def from_context(cls, version: str = None, cache: bool = False, load_predictions: bool = True, prediction_format: str = "memmap", use_s3: bool = True) -> Self:
+        return load_repository(version=version, cache=cache, load_predictions=load_predictions, prediction_format=prediction_format, use_s3=use_s3)
 
     # TODO: 1. Cleanup results_lst_simulation_artifacts, 2. Make context work with tasks instead of datasets x folds
     # TODO: Get raw data from repo method (X, y)

--- a/tabrepo/utils/result_utils.py
+++ b/tabrepo/utils/result_utils.py
@@ -1,10 +1,11 @@
 from pathlib import Path
-import tabrepo
 from autogluon.common.loaders import load_pd
 from autogluon.common.savers import save_pd
+from tabrepo.loaders import Paths
 
-def results_path():
-    res = Path(tabrepo.__path__[0]).parent / "data/results/"
+
+def results_path() -> Path:
+    res = Paths.results_root_cache
     if not res.exists():
         res.mkdir(parents=True, exist_ok=True)
     return res


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Switch to `~/.cache` for storing repo artifacts
- Previously, the repo artifacts were saved to `tabrepo/data/results/`
- Now they are saved to `~/.cache/tabrepo/data/results/`

This helps to de-couple the artifacts with the codebase, and adopts a similar logic as used by huggingface and openml.
This also improves usability for TabRepo if installed in non-editable mode (and opens the door for `pip install tabrepo` in future)

I've verified correctness with both s3 and huggingface download options.

NOTE: For users with existing caches, this will redownload caches in the new location. You will have to manually delete the old cache location to avoid having an extra unused data source.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
