### PR TITLE
Increase cpp compile timeout

### DIFF
--- a/tabrepo/metrics/_roc_auc_cpp/__init__.py
+++ b/tabrepo/metrics/_roc_auc_cpp/__init__.py
@@ -51,14 +51,14 @@ class CppAuc:
             proc = subprocess.Popen(compile_command.split(" "), shell=False, stdout=stdout, cwd=Path(__file__).parent)
 
         # wait command completion
-        for max_trials in range(50):
+        for max_trials in range(600):
             if proc.poll() is not None:
                 break
             time.sleep(0.1)
 
         # handle potential failure: timeout or error while compiling
         if proc.poll() is None:
-            raise ValueError("Could not compile after 5 secs.")
+            raise ValueError("Could not compile after 60 secs.")
         elif proc.poll() != 0:
             raise ValueError(f"Got an error while compiling, you can try to run manually {self.compile_script_path()}")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase cpp compile timeout to avoid failures if machine is slower than normal during install

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
