### PR TITLE
Fix minor docker build issues, clean up arguments and error handling

### DIFF
--- a/tabflow/docker/Dockerfile_SM
+++ b/tabflow/docker/Dockerfile_SM
@@ -10,11 +10,11 @@ RUN cd autogluon && ./full_install.sh
 RUN cd ..
 
 # COPY ../../../autogluon-bench /autogluon-bench - bench is not required at the moment
-COPY ../../../autogluon-benchmark /autogluon-benchmark
-COPY ../../tabflow /tabflow
+COPY autogluon-benchmark /autogluon-benchmark
+COPY tabrepo/tabflow /tabflow
 # Delete the below line if you clone the tabrepo repo and source install it in the Dockerfile
-COPY ../../../tabrepo /tabrepo
-COPY ./tabflow/src/tabflow/evaluate.py .
+COPY tabrepo /tabrepo
+COPY ./tabrepo/tabflow/tabflow/cli/evaluate.py .
 
 WORKDIR /
 

--- a/tabflow/tabflow/cli/evaluate.py
+++ b/tabflow/tabflow/cli/evaluate.py
@@ -26,6 +26,7 @@ if __name__ == '__main__':
     parser.add_argument('--s3_bucket', type=str, required=True, help="S3 bucket for the experiment")
     parser.add_argument('--methods_s3_path', type=str, required=True, help="S3 path to methods config")
     parser.add_argument('--load_predictions', action='store_true', help="Load predictions from S3")
+    parser.add_argument('--run_mode', type=str, default='aws', choices=['aws', 'local'], help="Run mode: aws or local")
 
     args = parser.parse_args()
 
@@ -62,12 +63,11 @@ if __name__ == '__main__':
         logger.info(f"Method Dict: {method}")
         methods = parse_method(method, globals())
         logger.info(f"Methods: {methods}")
-        # Repo -> results list
         repo: EvaluationRepository = ExperimentBatchRunner(expname=expname, task_metadata=repo_og.task_metadata).run(
         datasets=[dataset], 
         folds=[fold],
         methods=[methods], 
         ignore_cache=ignore_cache,
-        mode="aws",
+        mode=args.run_mode, # We use AWS for TabFlow
         s3_bucket=args.s3_bucket,
         )

--- a/tabflow/tabflow/cli/launch_jobs.py
+++ b/tabflow/tabflow/cli/launch_jobs.py
@@ -18,36 +18,37 @@ from tabflow.utils.constants import DOCKER_IMAGE_ALIASES
 logger = setup_logging(level=logging.ERROR)
 
 def launch_jobs(
-        experiment_name: str = "tabflow-test-cache",
+        experiment_name: str,
+        methods_file: str,
+        s3_bucket: str,
+        docker_image_uri: str,
+        sagemaker_role: str,
         context_name: str = "D244_F3_C1530_30", # 30 datasets. To run larger, set to "D244_F3_C1530_200"
         entry_point: str = "evaluate.py",
         source_dir: str = str(Path(__file__).parent),
         instance_type: str = "ml.m6i.4xlarge",
-        docker_image_uri: str = "mlflow-image",
-        sagemaker_role: str = "IAM_ROLE_ARN",  # Replace with your actual IAM role ARN
-        aws_profile: str | None = None,
-        hyperparameters: dict = None,
         keep_alive_period_in_seconds: int = 3600,
         limit_runtime: int = 24 * 60 * 60,
-        datasets: list = None,
-        folds: list = None,
-        methods_file: str = "methods.yaml",
         max_concurrent_jobs: int = 30,
         max_retry_attempts: int = 20,
-        s3_bucket: str = "test-bucket",
+        batch_size: int = 16,
+        aws_profile: str | None = None,
+        hyperparameters: dict = None,
+        datasets: list = None,
+        folds: list = None,
         add_timestamp: bool = False,
-        wait: bool = False,
-        batch_size: int = 2,
+        wait: bool = True,
 ) -> None:
     """
     Launch multiple SageMaker training jobs.
 
     Args:
         experiment_name: Name of the experiment
-        entry_point: The Python script to run
-        source_dir: Directory containing the training code
+        context_name: Name of the TabRepo context
+        entry_point: The Python script to run in sagemaker training job
+        source_dir: Directory containing the training code (here the entry point)
         instance_type: SageMaker instance type
-        docker_image_uri: Docker image to use
+        docker_image_uri: Docker image to use URI or alias in constants.py
         sagemaker_role: AWS IAM role for SageMaker
         aws_profile: AWS profile name
         hyperparameters: Dictionary of hyperparameters to pass to the training script
@@ -59,7 +60,7 @@ def launch_jobs(
         max_concurrent_jobs: Maximum number of concurrent jobs, based on account limit
         S3 bucket: S3 bucket to store the results
         add_timestamp: Whether to add a timestamp to the experiment name
-        wait: Whether to wait for all jobs to complete
+        wait: Whether to wait for all jobs to complete (no-wait from CLI)
         batch_size: Number of models to batch for each task
     """
     
@@ -193,20 +194,21 @@ def launch_jobs(
 def main():
     """Entrypoint for Launching sagemaker jobs using CLI"""
     parser = argparse.ArgumentParser()
-    parser.add_argument('--experiment_name', type=str, default="tabflow-test-cache", help="Name of the experiment")
+    parser.add_argument('--experiment_name', type=str, required=True, help="Name of the experiment")
     parser.add_argument('--context_name', type=str, default="D244_F3_C1530_30", help="Name of the context")
     parser.add_argument('--datasets', nargs='+', type=str, required=True, help="List of datasets to evaluate")
     parser.add_argument('--folds', nargs='+', type=int, required=True, help="List of folds to evaluate")
     parser.add_argument('--methods_file', type=str, required=True, help="Path to the YAML file containing methods")
     parser.add_argument('--max_concurrent_jobs', type=int, default=50,
                         help="Maximum number of concurrent jobs, based on account limit")
-    parser.add_argument('--docker_image_uri', type=str, default="mlflow-image", help="Docker image URI or alias")
+    parser.add_argument('--docker_image_uri', type=str, required=True, help="Docker image URI or alias in constants.py")
     parser.add_argument('--instance_type', type=str, default="ml.m6i.4xlarge", help="SageMaker instance type")
-    parser.add_argument('--sagemaker_role', type=str, default="IAM_ROLE_ARN", help="AWS IAM role ARN for SageMaker")
-    parser.add_argument('--s3_bucket', type=str, default="test-bucket", help="S3 bucket for the experiment")
+    parser.add_argument('--sagemaker_role', type=str, required=True, help="AWS IAM role ARN for SageMaker")
+    parser.add_argument('--s3_bucket', type=str, required=True, help="S3 bucket for the experiment")
     parser.add_argument('--add_timestamp', action='store_true', help="Add timestamp to the experiment name")
-    parser.add_argument('--wait', action='store_true', help="Wait for all jobs to complete")
-    parser.add_argument('--batch_size', type=int, default=2, help="Batch size for tasks")
+    parser.add_argument('--no-wait', dest='wait', action='store_false', help="Skip waiting for jobs to complete")
+    parser.set_defaults(wait=True)
+    parser.add_argument('--batch_size', type=int, default=16, help="Batch size for tasks")
     parser.add_argument('--verbose', action='store_true', help="Enable verbose logging")
 
     args = parser.parse_args()

--- a/tabflow/tabflow/cli/launch_jobs.py
+++ b/tabflow/tabflow/cli/launch_jobs.py
@@ -31,7 +31,7 @@ def launch_jobs(
         limit_runtime: int = 24 * 60 * 60,
         max_concurrent_jobs: int = 30,
         max_retry_attempts: int = 20,
-        batch_size: int = 16,
+        batch_size: int = 1,
         aws_profile: str | None = None,
         hyperparameters: dict = None,
         datasets: list = None,

--- a/tabrepo/benchmark/experiment/experiment_utils.py
+++ b/tabrepo/benchmark/experiment/experiment_utils.py
@@ -55,7 +55,7 @@ class ExperimentBatchRunner:
         folds: list[int],
         ignore_cache: bool = False,
         mode: str = "local",
-        s3_bucket: str = "test-bucket",
+        s3_bucket: str | None = None,
     ) -> list[dict[str, Any]]:
         """
 
@@ -67,6 +67,10 @@ class ExperimentBatchRunner:
         ignore_cache: bool, default False
             If True, will run the experiments regardless if the cache exists already, and will overwrite the cache file upon completion.
             If False, will load the cache result if it exists for a given experiment, rather than running the experiment again.
+        mode: str, default "local"
+        Either "local" or "aws". In "aws" mode, s3_bucket must be provided.
+        s3_bucket: str, default None
+            Required when mode="aws". The S3 bucket where artifacts will be stored.
 
         Returns
         -------
@@ -155,7 +159,7 @@ class ExperimentBatchRunner:
         ignore_cache: bool,
         convert_time_infer_s_from_batch_to_sample: bool = True,
         mode="local",
-        s3_bucket: str = "test-bucket",
+        s3_bucket: str | None = None,
     ) -> EvaluationRepository:
         """
 
@@ -166,6 +170,10 @@ class ExperimentBatchRunner:
         methods
         ignore_cache
         convert_time_infer_s_from_batch_to_sample
+        mode: str, default "local"
+            Either "local" or "aws". In "aws" mode, s3_bucket must be provided.
+        s3_bucket: str, default None
+            Required when mode="aws". The S3 bucket where artifacts will be stored.
 
         Returns
         -------
@@ -303,7 +311,7 @@ def run_experiments(
     cache_cls_kwargs: dict = None,
     cache_path_format: Literal["name_first", "task_first"] = "name_first",
     mode: str = "local",
-    s3_bucket: str = "test-bucket",
+    s3_bucket: str | None = None,
 ) -> list[dict]:
     """
 
@@ -319,12 +327,16 @@ def run_experiments(
     cache_cls_kwargs: WIP
     cache_path_format: {"name_first", "task_first"}, default "name_first"
     mode: {"local", "aws"}, default "local"
-    S3_bucket: str, default "test-bucket" works only for aws mode, stores artifacts in the given bucket
+    s3_bucket: str, default None
+        Required when mode="aws". The S3 bucket where artifacts will be stored.
 
     Returns
     -------
     result_lst: list[dict], containing all metrics from fit() and predict() of all the given OpenML tasks
     """
+    if mode == "aws" and (s3_bucket is None or s3_bucket == ""):
+        raise ValueError(f"s3_bucket parameter is required when mode is 'aws', got {s3_bucket}")
+
     if cache_cls is None:
         cache_cls = CacheFunctionDummy
     if cache_cls_kwargs is None:


### PR DESCRIPTION
*Description of changes:*
Make `wait` the default when benchmarking, the user can now add `--no-wait` to skip waiting instead.
Addressing minor docker build issues and cleaning up arguments.

Command to build docker, from any location run:` bash ./build_docker.sh ECR_REPO_NAME DOCKER_IMAGE_TAG SOURCE_ACCOUNT DESTINATION_ACCOUNT AWS_REGION`

Where `SOURCE_ACCOUNT` is the account where the base image is pulled from and `DESTINATION_ACCOUNT` is the account where your repository is present.

New run command: `tabflow --datasets Australian blood-transfusion-service-center --folds 0 1 --methods_file ~/method_configs.yaml --s3_bucket test-bucket --experiment_name test-experiment  --max_concurrent_jobs 400 --batch_size 2 --docker_image_uri ECR_DOCKER_IMAGE_URI --sagemaker_role SAGEMAKER_ROLE_ARN`

`docker_image_uri` and `sagemaker_role` must have the same AWS account, and image URI must be from the ECR repo in that AWS account

To download experiment results run the following:
`tabflow-download --s3_path {S3_URI} --destination_path {your_local_path}`


**To Do:**
1. Region Support []
2. JobLib Parallelization []
3. TS integration []
4. Add linter []
5. src file discovery bug []

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
