### PR TITLE
New RealMLP search space

### DIFF
--- a/tabrepo/models/realmlp/generate_alt.py
+++ b/tabrepo/models/realmlp/generate_alt.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+from tabrepo.benchmark.models.ag.realmlp.realmlp_model import RealMLPModel
+from tabrepo.models.utils import convert_numpy_dtypes
+from tabrepo.benchmark.experiment import YamlExperimentSerializer
+from tabrepo.utils.config_utils import generate_bag_experiments
+from tabrepo.utils.config_utils import CustomAGConfigGenerator
+
+
+def generate_single_config_realmlp_alt(rng):
+    # common search space
+    params = {
+        'n_hidden_layers': rng.integers(1, 4, endpoint=True),
+        'hidden_sizes': 'rectangular',
+        'hidden_width': rng.choice([256, 384, 512]),
+        'p_drop': rng.uniform(0.0, 0.5),
+        'act': 'mish',
+        'plr_sigma': np.exp(rng.uniform(np.log(1e-2), np.log(50))),
+        'sq_mom': 1.0 - np.exp(rng.uniform(np.log(5e-3), np.log(5e-2))),
+        'plr_lr_factor': np.exp(rng.uniform(np.log(5e-2), np.log(3e-1))),
+        'scale_lr_factor': np.exp(rng.uniform(np.log(2.0), np.log(10.0))),
+        'first_layer_lr_factor': np.exp(rng.uniform(np.log(0.3), np.log(1.5))),
+        'ls_eps_sched': 'coslog4',
+        'ls_eps': np.exp(rng.uniform(np.log(5e-3), np.log(2e-1))),
+        'p_drop_sched': 'flat_cos',
+        'lr': np.exp(rng.uniform(np.log(2e-2), np.log(3e-1))),
+        'wd': np.exp(rng.uniform(np.log(1e-3), np.log(5e-2))),
+    }
+
+    if rng.uniform(0.0, 1.0) > 0.5:
+        # large configs
+        params['plr_hidden_1'] = rng.choice([8, 16, 32, 64])
+        params['plr_hidden_2'] = rng.choice([8, 16, 32, 64])
+        params['n_epochs'] = rng.choice([256, 512])
+        params['use_early_stopping'] = True
+    else:
+        # default values, used here to always set the same set of parameters
+        params['plr_hidden_1'] = 16
+        params['plr_hidden_2'] = 4
+        params['n_epochs'] = 256
+        params['use_early_stopping'] = False
+
+    params = convert_numpy_dtypes(params)
+    return params
+
+
+def generate_configs_realmlp_alt(num_random_configs=200, seed=1234):
+    # note: this doesn't set val_metric_name, which should be set outside
+    rng = np.random.default_rng(seed)
+    return [generate_single_config_realmlp_alt(rng) for _ in range(num_random_configs)]
+
+
+gen_realmlp_alt = CustomAGConfigGenerator(model_cls=RealMLPModel, search_space_func=generate_configs_realmlp_alt,
+                                          manual_configs=[{}])
+
+if __name__ == '__main__':
+    configs_yaml = []
+    config_defaults = [{}]
+    configs = generate_configs_realmlp_alt(100, seed=1234)
+
+    experiments_realmlp_streamlined = gen_realmlp_alt.generate_all_bag_experiments(100)
+
+    experiments_default = generate_bag_experiments(model_cls=RealMLPModel, configs=config_defaults, time_limit=3600,
+                                                   name_id_prefix="c")
+    experiments_random = generate_bag_experiments(model_cls=RealMLPModel, configs=configs, time_limit=3600)
+    experiments = experiments_default + experiments_random
+    YamlExperimentSerializer.to_yaml(experiments=experiments, path="configs_realmlp.yaml")

--- a/tabrepo/models/realmlp/generate_alt.py
+++ b/tabrepo/models/realmlp/generate_alt.py
@@ -25,6 +25,7 @@ def generate_single_config_realmlp_alt(rng):
         'p_drop_sched': 'flat_cos',
         'lr': np.exp(rng.uniform(np.log(2e-2), np.log(3e-1))),
         'wd': np.exp(rng.uniform(np.log(1e-3), np.log(5e-2))),
+        'use_ls': True,  # use label smoothing (will be ignored for regression)
     }
 
     if rng.uniform(0.0, 1.0) > 0.5:


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Unified the classification and regression versions of the RealMLP search space. Still, half of the configs currently use a more expensive setup while the other ones use the standard parameters in terms of n_epochs, embedding sizes, etc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
