### PR TITLE
fix: avoid TabDPT install crashing benchmark install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ extras_require = {
     ],
     "tabdpt": [
         # TODO: pypi package is not available yet
-        "tabdpt @ git+https://github.com/layer6ai-labs/TabDPT.git",
+        # FIXME: newest version (1.1) has (unnecessary) strict version requirements
+        #  that are not compatible with autogluon, so we stick to the old hash
+        "tabdpt @ git+https://github.com/layer6ai-labs/TabDPT.git@9699d9592b61c5f70fc88f5531cdb87b40cbedf5",
         # used hash: 9699d9592b61c5f70fc88f5531cdb87b40cbedf5
     ],
     "tabm": [


### PR DESCRIPTION
See changes in toml file for cause of issues: https://github.com/layer6ai-labs/TabDPT/commits/main/

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
