### PR TITLE
Implement recursive ELO computation in cases where one model is always better than another

### DIFF
--- a/tst/test_elo_utils.py
+++ b/tst/test_elo_utils.py
@@ -1,0 +1,36 @@
+import pytest
+from tabrepo.tabarena.elo_utils import EloHelper
+import pandas as pd
+
+
+class TestEloHelper:
+    @pytest.mark.parametrize('battles,outcome', [
+        (pd.DataFrame({
+            "method_1": ["Winner", "Winner"],
+            "method_2": ["Loser", "Loser"],
+            "winner": ["1", "1"],
+            "dataset": ["dataset1", "dataset2"],
+        }), -1),
+        (pd.DataFrame({
+            "method_1": ["Model1", "Model1"],
+            "method_2": ["Model2", "Model2"],
+            "winner": ["tie", "tie"],
+            "dataset": ["dataset1", "dataset2"],
+        }), 0),
+        (pd.DataFrame({
+            "method_1": ["Loser", "Loser"],
+            "method_2": ["Winner", "Winner"],
+            "winner": ["2", "2"],
+            "dataset": ["dataset1", "dataset2"],
+        }), 1),
+    ])
+    def test_compute_recursive_elo_scores(self, battles, outcome):
+        elo_helper = EloHelper()
+
+        elo_scores = elo_helper.compute_recursive_elo_scores(battles)
+        if outcome == -1:
+            assert elo_scores[0] > elo_scores[1]
+        elif outcome == 1:
+            assert elo_scores[0] < elo_scores[1]
+        else:
+            assert elo_scores[0] == elo_scores[1]


### PR DESCRIPTION
Currently, the logistic regression-based ELO computation crashes if the sampled "battle" between AutoML frameworks only contains wins from a single framework. This is because Scikit-Learn's logistic regression cannot be fit with just one class (classes corresponding to win/loss outcomes).

This PR fixes this by implementing a backup approach to computing ELO using the original recursive formula ([info](https://mattmazzola.medium.com/implementing-the-elo-rating-system-a085f178e065)). This ELO calculation methods works for both cases where one framework dominates the other and when frameworks win and loses on different datasets. In the latter case, the resulting ELO scores are slightly different than the logistic regression calculation method. I tuned the `K-factor` hyperparameter on the current Tabrepo's leaderboard such that the results are roughly similar to that computed by logistic regression (currently set to 128).

This recursive formula only triggers in edge cases where the sampled battles only contains wins from a single framework, so it should not change existing behavior and make the repo more robust in general.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
