### PR TITLE
Simulation with incomplete results

### DIFF
--- a/tabrepo/repository/evaluation_repository_collection.py
+++ b/tabrepo/repository/evaluation_repository_collection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 from collections import defaultdict
 from typing import Literal
+from functools import reduce
 
 import numpy as np
 import pandas as pd
@@ -280,7 +281,17 @@ def merge_zeroshot(zeroshot_contexts: list[ZeroshotSimulatorContext], require_ma
     df_metadata_lst = [z.df_metadata for z in zeroshot_contexts]
     df_metadata_lst = [df_metadata for df_metadata in df_metadata_lst if df_metadata is not None and len(df_metadata) > 0]
     if df_metadata_lst:
-        df_metadata = pd.concat([z.df_metadata for z in zeroshot_contexts], ignore_index=True)
+        # The merge operation combines all available information in the metadata from different contexts, without loss of information.
+        df_metadata = reduce(
+            lambda left, right: pd.merge(
+                left,
+                right,
+                on=[col for col in left.columns if col in right.columns],
+                how='outer'
+            ),
+            df_metadata_lst
+        )
+        
         df_metadata = df_metadata.drop_duplicates(ignore_index=True)
     else:
         df_metadata = None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The metadata objects from the random forest context and new results was not matching. This led to issues when running the simulation with incomplete results and random forest imputation. This is fixed by correctly combining the metadata artifacts of the imputation and the new result contexts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
