### PR TITLE
Update yaml experiment serialization to support same-name classes

### DIFF
--- a/tabflow/tabflow/cli/evaluate.py
+++ b/tabflow/tabflow/cli/evaluate.py
@@ -8,7 +8,7 @@ from tabflow.utils.utils import find_method_by_name
 from tabflow.utils.s3_utils import download_from_s3
 from tabflow.utils.logging_utils import setup_logging
 from tabrepo import EvaluationRepository
-from tabrepo.benchmark.experiment import ExperimentBatchRunner, AGModelBagExperiment, Experiment, YamlExperimentSerializer, AGExperiment
+from tabrepo.benchmark.experiment import ExperimentBatchRunner, AGModelBagExperiment, Experiment, YamlExperimentSerializer, YamlSingleExperimentSerializer, AGExperiment
 from tabrepo.benchmark.models.simple import SimpleLightGBM
 from autogluon.tabular.models import *
 from tabrepo.benchmark.models.ag import *
@@ -35,7 +35,7 @@ def load_tasks(
         fold = task["fold"]
         method_name = task["method_name"]
         method_kwargs = find_method_by_name(methods_config, method_name)
-        method: Experiment = YamlExperimentSerializer.parse_method(method_kwargs, globals())
+        method: Experiment = YamlSingleExperimentSerializer.parse_method(method_kwargs, globals())
 
         task_dict = dict(
             method=method,

--- a/tabrepo/benchmark/experiment/__init__.py
+++ b/tabrepo/benchmark/experiment/__init__.py
@@ -6,6 +6,7 @@ from tabrepo.benchmark.experiment.experiment_constructor import (
     AGModelExperiment,
     Experiment,
     YamlExperimentSerializer,
+    YamlSingleExperimentSerializer,
 )
 from tabrepo.benchmark.experiment.experiment_runner import (
     ExperimentRunner,

--- a/tst/benchmark/test_yaml_experiment_serialization.py
+++ b/tst/benchmark/test_yaml_experiment_serialization.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import io
+import os
+
+from tabrepo.benchmark.experiment.experiment_constructor import (
+    AGModelExperiment,
+    YamlExperimentSerializer,
+    YamlSingleExperimentSerializer,
+)
+from tabrepo.models.realmlp.generate import gen_realmlp
+from tabrepo.benchmark.models.ag.realmlp.realmlp_model import RealMLPModel
+
+
+def _as_str_path(p: str | os.PathLike) -> str:
+    return os.fspath(p)
+
+
+def _init_memory_fs(monkeypatch):
+    # --- Tiny in-memory filesystem just for this test ---
+    fs: dict[str, str] = {}
+
+    def mem_exists(path):
+        path = _as_str_path(path)
+        return path in fs
+
+    def mem_open(path, mode="r", *args, **kwargs):
+        path = _as_str_path(path)
+        # Text-mode only (YAML). If your serializers use 'b', handle BytesIO similarly.
+        if "w" in mode:
+            buf = io.StringIO()
+            _orig_close = buf.close
+
+            def _close_and_persist():
+                fs[path] = buf.getvalue()
+                _orig_close()
+
+            buf.close = _close_and_persist  # type: ignore[assignment]
+            return buf
+        elif "r" in mode:
+            if path not in fs:
+                raise FileNotFoundError(path)
+            return io.StringIO(fs[path])
+        else:
+            raise ValueError(f"Unsupported mode: {mode}")
+
+    # Patch builtins.open and os.path.exists so the serializers think the file is there.
+    monkeypatch.setattr("builtins.open", mem_open, raising=True)
+    monkeypatch.setattr("os.path.exists", mem_exists, raising=True)
+
+
+def test_yaml_experiment_serialization(monkeypatch):
+    """
+    Verify that saving and loading experiments to/from yaml results in no changes to the object.
+    """
+    # patch so no file is created on disk
+    _init_memory_fs(monkeypatch=monkeypatch)
+
+    num_random_configs = 3
+    experiments_realmlp = gen_realmlp.generate_all_bag_experiments(num_random_configs=num_random_configs)
+    assert len(experiments_realmlp) == num_random_configs + 1
+    experiment_default: AGModelExperiment = experiments_realmlp[0]
+    assert experiment_default.method_kwargs["model_cls"] == RealMLPModel
+
+    yaml_path = "tmp.yaml"
+    experiment_default.to_yaml(path=yaml_path)
+
+    experiment_loaded = YamlSingleExperimentSerializer.from_yaml(path=yaml_path)
+
+    assert experiment_default.__class__ == experiment_loaded.__class__
+    assert experiment_default.__dict__ == experiment_loaded.__dict__
+
+    YamlExperimentSerializer.to_yaml(experiments=[experiment_default], path=yaml_path)
+    experiments_loaded = YamlExperimentSerializer.from_yaml(path=yaml_path)
+
+    for cur_exp, cur_exp_loaded in zip(experiments_realmlp, experiments_loaded):
+        assert cur_exp.__class__ == cur_exp_loaded.__class__
+        assert cur_exp.__dict__ == cur_exp_loaded.__dict__


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Update yaml experiment serialization to support same-name classes
- Now saves the `ag_key` variable value in the yaml instead of the class name. The `ag_key` value will uniquely identify the model class.
- Resolves the issue in #194 without needing to touch the model code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
