### PR TITLE
Enhance EndToEnd Logic

### DIFF
--- a/examples/tabarena/run_beta_tabpfn_end_to_end.py
+++ b/examples/tabarena/run_beta_tabpfn_end_to_end.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tabrepo.nips2025_utils.artifacts.download_utils import download_and_extract_zip
-from tabrepo.nips2025_utils.end_to_end import EndToEndSingle, EndToEndResultsSingle
+from tabrepo.nips2025_utils.end_to_end_single import EndToEndSingle, EndToEndResultsSingle
 
 
 if __name__ == '__main__':
@@ -18,7 +18,6 @@ if __name__ == '__main__':
     Run logic end-to-end and cache all results:
     1. load raw artifacts
         path_raw should be a directory containing `results.pkl` files for each run.
-        In the current code, we require `path_raw` to contain the results of only 1 type of method.
     2. infer method_metadata
     3. cache method_metadata
     4. cache raw artifacts
@@ -36,8 +35,7 @@ if __name__ == '__main__':
     """
     Load cached results and compare on TabArena
     1. Generates figures and leaderboard using the TabArena methods and the user's method
-    2. Currently compares on all datasets, does not compare on subsets.
-    3. Missing values are imputed to default RandomForest.
+    2. Missing values are imputed to default RandomForest.
     """
     end_to_end_results = EndToEndResultsSingle.from_cache(method=method)
     leaderboard = end_to_end_results.compare_on_tabarena(output_dir=fig_output_dir)

--- a/examples/tabarena/run_beta_tabpfn_end_to_end.py
+++ b/examples/tabarena/run_beta_tabpfn_end_to_end.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tabrepo.nips2025_utils.artifacts.download_utils import download_and_extract_zip
-from tabrepo.nips2025_utils.end_to_end import EndToEnd, EndToEndResults
+from tabrepo.nips2025_utils.end_to_end import EndToEndSingle, EndToEndResultsSingle
 
 
 if __name__ == '__main__':
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     Once this is executed once, it does not need to be ran again.
     """
     if cache:
-        end_to_end = EndToEnd.from_path_raw(path_raw=path_raw)
+        end_to_end = EndToEndSingle.from_path_raw(path_raw=path_raw)
 
     """
     Load cached results and compare on TabArena
@@ -39,6 +39,6 @@ if __name__ == '__main__':
     2. Currently compares on all datasets, does not compare on subsets.
     3. Missing values are imputed to default RandomForest.
     """
-    end_to_end_results = EndToEndResults.from_cache(method=method)
+    end_to_end_results = EndToEndResultsSingle.from_cache(method=method)
     leaderboard = end_to_end_results.compare_on_tabarena(output_dir=fig_output_dir)
     print(leaderboard)

--- a/examples/tabarena/run_extra_methods_end_to_end.py
+++ b/examples/tabarena/run_extra_methods_end_to_end.py
@@ -57,7 +57,6 @@ def end_to_end_new_results(
 
 
 if __name__ == '__main__':
-    method = "BetaTabPFN"
     url_prefix = "https://data.lennart-purucker.com/tabarena/"
     local_path_prefix = Path("local_data")
     cache = True

--- a/examples/tabarena/run_extra_methods_end_to_end.py
+++ b/examples/tabarena/run_extra_methods_end_to_end.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tabrepo.nips2025_utils.artifacts.download_utils import download_and_extract_zip
+from tabrepo.nips2025_utils.end_to_end import EndToEnd, EndToEndResults
+from tabrepo.tabarena.website_format import format_leaderboard
+
+
+def download_results(
+    url_prefix,
+    local_path_prefix,
+    filename,
+):
+    url = f"{url_prefix}{filename}"
+    local_dir_suffix = Path(filename).with_suffix("").as_posix()
+    path_raw = local_path_prefix / local_dir_suffix
+    download_and_extract_zip(url=url, path_local=path_raw)
+
+
+def end_to_end_new_results(
+    path_raw,
+    methods: list[str | tuple[str, str]] | None = None,
+    cache: bool = True,
+):
+    fig_output_dir = Path("tabarena_figs") / "new_results"
+    """
+    Run logic end-to-end and cache all results:
+    1. load raw artifacts
+        path_raw should be a directory containing `results.pkl` files for each run.
+    2. infer method_metadata
+    3. cache method_metadata
+    4. cache raw artifacts
+    5. infer task_metadata
+    5. generate processsed
+    6. cache processed
+    7. generate results
+    8. cache results
+
+    Once this is executed once, it does not need to be ran again.
+    """
+    if cache:
+        end_to_end = EndToEnd.from_path_raw(path_raw=path_raw)
+        end_to_end_results = end_to_end.to_results()
+    else:
+        assert methods is not None
+        end_to_end_results = EndToEndResults.from_cache(methods=methods)
+
+    """
+    Load cached results and compare on TabArena
+    1. Generates figures and leaderboard using the TabArena methods and the user's method
+    2. Missing values are imputed to default RandomForest.
+    """
+    leaderboard = end_to_end_results.compare_on_tabarena(output_dir=fig_output_dir)
+    leaderboard_website = format_leaderboard(df_leaderboard=leaderboard)
+    print(leaderboard_website.to_markdown(index=False))
+
+
+if __name__ == '__main__':
+    method = "BetaTabPFN"
+    url_prefix = "https://data.lennart-purucker.com/tabarena/"
+    local_path_prefix = Path("local_data")
+    cache = True
+
+    filenames = [
+        "data_BetaTabPFN.zip",
+        "data_TabFlex.zip",
+        "leaderboard_submissions/data_Mitra_14082025.zip",
+    ]
+    for filename in filenames:
+        download_results(
+            url_prefix=url_prefix,
+            local_path_prefix=local_path_prefix,
+            filename=filename,
+        )
+
+    methods = [
+        "BetaTabPFN",
+        "Mitra",
+        "TabFlex",
+        # "AutoGluon_ExperimentalV140_4h",
+        # "LightGBM_aio_0808",
+    ]
+
+    end_to_end_new_results(
+        path_raw=local_path_prefix,
+        cache=cache,
+        # methods=methods,
+    )

--- a/examples/tabarena/run_quickstart_tabarena.py
+++ b/examples/tabarena/run_quickstart_tabarena.py
@@ -6,7 +6,7 @@ from typing import Any
 import pandas as pd
 
 from tabrepo.benchmark.experiment import AGModelBagExperiment, ExperimentBatchRunner
-from tabrepo.nips2025_utils.end_to_end import EndToEndMulti
+from tabrepo.nips2025_utils.end_to_end import EndToEnd
 from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
 from tabrepo.tabarena.website_format import format_leaderboard
 
@@ -32,19 +32,6 @@ if __name__ == '__main__':
         # This will be a `config` in EvaluationRepository, because it computes out-of-fold predictions and thus can be used for post-hoc ensemble.
         AGModelBagExperiment(  # Wrapper for fitting a single bagged model via AutoGluon
             # The name you want the config to have
-            name="RealMLP_c1_BAG_L1_Reproduced",
-
-            # The class of the model. Can also be a string if AutoGluon recognizes it, such as `"GBM"`
-            # Supports any model that inherits from `autogluon.core.models.AbstractModel`
-            model_cls=RealMLPModel,
-            model_hyperparameters={
-                # "ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"},  # uncomment to fit folds sequentially, allowing for use of a debugger
-            },  # The non-default model hyperparameters.
-            num_bag_folds=8,  # num_bag_folds=8 was used in the TabArena 2025 paper
-            time_limit=3600,  # time_limit=3600 was used in the TabArena 2025 paper
-        ),        # This will be a `config` in EvaluationRepository, because it computes out-of-fold predictions and thus can be used for post-hoc ensemble.
-        AGModelBagExperiment(  # Wrapper for fitting a single bagged model via AutoGluon
-            # The name you want the config to have
             name="LightGBM_c1_BAG_L1_Reproduced",
 
             # The class of the model. Can also be a string if AutoGluon recognizes it, such as `"GBM"`
@@ -55,6 +42,13 @@ if __name__ == '__main__':
             },  # The non-default model hyperparameters.
             num_bag_folds=8,  # num_bag_folds=8 was used in the TabArena 2025 paper
             time_limit=3600,  # time_limit=3600 was used in the TabArena 2025 paper
+        ),
+        AGModelBagExperiment(
+            name="RealMLP_c1_BAG_L1_Reproduced",
+            model_cls=RealMLPModel,
+            model_hyperparameters={},
+            num_bag_folds=8,
+            time_limit=3600,
         ),
     ]
 
@@ -69,9 +63,8 @@ if __name__ == '__main__':
         ignore_cache=ignore_cache,
     )
 
-    # FIXME: Support multiple different methods in EndToEnd
     # compute results
-    end_to_end = EndToEndMulti(results_lst=results_lst, task_metadata=task_metadata, cache=False)
+    end_to_end = EndToEnd(results_lst=results_lst, task_metadata=task_metadata, cache=False)
     end_to_end_results = end_to_end.to_results()
 
     # print(f"New Configs Hyperparameters: {end_to_end.repo.configs_hyperparameters()}")

--- a/examples/tabarena/run_quickstart_tabarena.py
+++ b/examples/tabarena/run_quickstart_tabarena.py
@@ -64,12 +64,12 @@ if __name__ == '__main__':
     )
 
     # compute results
-    end_to_end = EndToEnd.from_raw(results_lst=results_lst, task_metadata=task_metadata, cache=False)
+    end_to_end = EndToEnd.from_raw(results_lst=results_lst, task_metadata=task_metadata, cache=False, cache_raw=False)
     end_to_end_results = end_to_end.to_results()
 
-    # print(f"New Configs Hyperparameters: {end_to_end.repo.configs_hyperparameters()}")
-    # with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
-    #     print(f"Results:\n{end_to_end_results.model_results.head(100)}")
+    print(f"New Configs Hyperparameters: {end_to_end.configs_hyperparameters()}")
+    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+        print(f"Results:\n{end_to_end_results.model_results.head(100)}")
 
     leaderboard: pd.DataFrame = end_to_end_results.compare_on_tabarena(
         output_dir=eval_dir,

--- a/examples/tabarena/run_quickstart_tabarena.py
+++ b/examples/tabarena/run_quickstart_tabarena.py
@@ -5,19 +5,19 @@ from typing import Any
 
 import pandas as pd
 
-from tabrepo import EvaluationRepository, Evaluator
 from tabrepo.benchmark.experiment import AGModelBagExperiment, ExperimentBatchRunner
-from tabrepo.benchmark.result import ExperimentResults
-from tabrepo.nips2025_utils.fetch_metadata import load_task_metadata
+from tabrepo.nips2025_utils.end_to_end import EndToEnd
 from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
+from tabrepo.tabarena.website_format import format_leaderboard
 
 
 if __name__ == '__main__':
     expname = str(Path(__file__).parent / "experiments" / "quickstart")  # folder location to save all experiment artifacts
-    repo_dir = str(Path(__file__).parent / "repos" / "quickstart")  # Load the repo later via `EvaluationRepository.from_dir(repo_dir)`
+    eval_dir = Path(__file__).parent / "eval" / "quickstart"
     ignore_cache = False  # set to True to overwrite existing caches and re-run experiments from scratch
 
-    task_metadata = load_task_metadata()
+    tabarena_context = TabArenaContext()
+    task_metadata = tabarena_context.task_metadata
 
     # Sample for a quick demo
     datasets = ["anneal", "credit-g", "diabetes"]  # datasets = list(task_metadata["name"])
@@ -55,67 +55,19 @@ if __name__ == '__main__':
         ignore_cache=ignore_cache,
     )
 
-    experiment_results = ExperimentResults(task_metadata=task_metadata)
+    # FIXME: Support multiple different methods in EndToEnd
+    # compute results
+    end_to_end = EndToEnd(results_lst=results_lst, task_metadata=task_metadata, cache=False)
+    end_to_end_results = end_to_end.to_results()
 
-    # Convert the run artifacts into an EvaluationRepository
-    repo: EvaluationRepository = experiment_results.repo_from_results(results_lst=results_lst)
-    repo.print_info()
-
-    repo.to_dir(path=repo_dir)  # Load the repo later via `EvaluationRepository.from_dir(repo_dir)`
-
-    print(f"New Configs Hyperparameters: {repo.configs_hyperparameters()}")
-
-    # get the local results
-    evaluator = Evaluator(repo=repo)
-    metrics: pd.DataFrame = evaluator.compare_metrics().reset_index().rename(columns={"framework": "method"})
-
-    # load the TabArena paper results
-    tabarena_context = TabArenaContext()
-    tabarena_results = tabarena_context.load_results_paper(download_results="auto")
-    tabarena_results = tabarena_results[[c for c in tabarena_results.columns if c in metrics.columns]]
-
-    dataset_fold_map = metrics.groupby("dataset")["fold"].apply(set)
-
-    def is_in(dataset: str, fold: int) -> bool:
-        return (dataset in dataset_fold_map.index) and (fold in dataset_fold_map.loc[dataset])
-
-    # filter tabarena_results to only the dataset, fold pairs that are present in `metrics`
-    is_in_lst = [is_in(dataset, fold) for dataset, fold in zip(tabarena_results["dataset"], tabarena_results["fold"])]
-    tabarena_results = tabarena_results[is_in_lst]
-
-    metrics = pd.concat([
-        metrics,
-        tabarena_results,
-    ], ignore_index=True)
-
+    print(f"New Configs Hyperparameters: {end_to_end.repo.configs_hyperparameters()}")
     with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
-        print(f"Results:\n{metrics.head(100)}")
+        print(f"Results:\n{end_to_end_results.model_results.head(100)}")
 
-    calibration_framework = "RF (default)"
-
-    from tabrepo.tabarena.tabarena import TabArena
-    tabarena = TabArena(
-        method_col="method",
-        task_col="dataset",
-        seed_column="fold",
-        error_col="metric_error",
-        columns_to_agg_extra=[
-            "time_train_s",
-            "time_infer_s",
-        ],
-        groupby_columns=[
-            "metric",
-            "problem_type",
-        ]
+    leaderboard: pd.DataFrame = end_to_end_results.compare_on_tabarena(
+        output_dir=eval_dir,
+        filter_dataset_fold=True,  # True: only compare on tasks ran in `results_lst`
+        use_model_results=True,  # If False: Will instead use the ensemble/HPO results
     )
-
-    leaderboard = tabarena.leaderboard(
-        data=metrics,
-        include_elo=True,
-        elo_kwargs={
-            "calibration_framework": calibration_framework,
-        },
-    )
-
-    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
-        print(leaderboard)
+    leaderboard_website = format_leaderboard(df_leaderboard=leaderboard)
+    print(leaderboard_website.to_markdown(index=False))

--- a/examples/tabarena/run_quickstart_tabarena.py
+++ b/examples/tabarena/run_quickstart_tabarena.py
@@ -6,7 +6,7 @@ from typing import Any
 import pandas as pd
 
 from tabrepo.benchmark.experiment import AGModelBagExperiment, ExperimentBatchRunner
-from tabrepo.nips2025_utils.end_to_end import EndToEnd
+from tabrepo.nips2025_utils.end_to_end import EndToEndMulti
 from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
 from tabrepo.tabarena.website_format import format_leaderboard
 
@@ -25,6 +25,7 @@ if __name__ == '__main__':
 
     # import your model classes
     from tabrepo.benchmark.models.ag import RealMLPModel
+    from autogluon.tabular.models import LGBModel
 
     # This list of methods will be fit sequentially on each task (dataset x fold)
     methods = [
@@ -36,6 +37,19 @@ if __name__ == '__main__':
             # The class of the model. Can also be a string if AutoGluon recognizes it, such as `"GBM"`
             # Supports any model that inherits from `autogluon.core.models.AbstractModel`
             model_cls=RealMLPModel,
+            model_hyperparameters={
+                # "ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"},  # uncomment to fit folds sequentially, allowing for use of a debugger
+            },  # The non-default model hyperparameters.
+            num_bag_folds=8,  # num_bag_folds=8 was used in the TabArena 2025 paper
+            time_limit=3600,  # time_limit=3600 was used in the TabArena 2025 paper
+        ),        # This will be a `config` in EvaluationRepository, because it computes out-of-fold predictions and thus can be used for post-hoc ensemble.
+        AGModelBagExperiment(  # Wrapper for fitting a single bagged model via AutoGluon
+            # The name you want the config to have
+            name="LightGBM_c1_BAG_L1_Reproduced",
+
+            # The class of the model. Can also be a string if AutoGluon recognizes it, such as `"GBM"`
+            # Supports any model that inherits from `autogluon.core.models.AbstractModel`
+            model_cls=LGBModel,
             model_hyperparameters={
                 # "ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"},  # uncomment to fit folds sequentially, allowing for use of a debugger
             },  # The non-default model hyperparameters.
@@ -57,17 +71,18 @@ if __name__ == '__main__':
 
     # FIXME: Support multiple different methods in EndToEnd
     # compute results
-    end_to_end = EndToEnd(results_lst=results_lst, task_metadata=task_metadata, cache=False)
+    end_to_end = EndToEndMulti(results_lst=results_lst, task_metadata=task_metadata, cache=False)
     end_to_end_results = end_to_end.to_results()
 
-    print(f"New Configs Hyperparameters: {end_to_end.repo.configs_hyperparameters()}")
-    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
-        print(f"Results:\n{end_to_end_results.model_results.head(100)}")
+    # print(f"New Configs Hyperparameters: {end_to_end.repo.configs_hyperparameters()}")
+    # with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+    #     print(f"Results:\n{end_to_end_results.model_results.head(100)}")
 
     leaderboard: pd.DataFrame = end_to_end_results.compare_on_tabarena(
         output_dir=eval_dir,
         filter_dataset_fold=True,  # True: only compare on tasks ran in `results_lst`
         use_model_results=True,  # If False: Will instead use the ensemble/HPO results
+        new_result_prefix="Demo_",
     )
     leaderboard_website = format_leaderboard(df_leaderboard=leaderboard)
     print(leaderboard_website.to_markdown(index=False))

--- a/examples/tabarena/run_quickstart_tabarena.py
+++ b/examples/tabarena/run_quickstart_tabarena.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     )
 
     # compute results
-    end_to_end = EndToEnd(results_lst=results_lst, task_metadata=task_metadata, cache=False)
+    end_to_end = EndToEnd.from_raw(results_lst=results_lst, task_metadata=task_metadata, cache=False)
     end_to_end_results = end_to_end.to_results()
 
     # print(f"New Configs Hyperparameters: {end_to_end.repo.configs_hyperparameters()}")
@@ -73,7 +73,7 @@ if __name__ == '__main__':
 
     leaderboard: pd.DataFrame = end_to_end_results.compare_on_tabarena(
         output_dir=eval_dir,
-        filter_dataset_fold=True,  # True: only compare on tasks ran in `results_lst`
+        only_valid_tasks=True,  # True: only compare on tasks ran in `results_lst`
         use_model_results=True,  # If False: Will instead use the ensemble/HPO results
         new_result_prefix="Demo_",
     )

--- a/tabflow/scripts/run_evaluate_lightgbm_demo.py
+++ b/tabflow/scripts/run_evaluate_lightgbm_demo.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from tabrepo.nips2025_utils.end_to_end import EndToEnd, EndToEndResults
+from tabrepo.nips2025_utils.end_to_end import EndToEndSingle, EndToEndResultsSingle
 
 
 """
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     Once this is executed once, it does not need to be ran again.
     """
     if cache:
-        end_to_end = EndToEnd.from_path_raw(path_raw=path_raw, name_suffix=name_suffix)
+        end_to_end = EndToEndSingle.from_path_raw(path_raw=path_raw, name_suffix=name_suffix)
 
     """
     Load cached results and compare on TabArena
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     2. Compares on all datasets if `filter_dataset_fold=False`, else only tasks from the user's method if `filter_dataset_fold=True`.
     3. Missing values are imputed to default RandomForest.
     """
-    end_to_end_results = EndToEndResults.from_cache(method=method)
+    end_to_end_results = EndToEndResultsSingle.from_cache(method=method)
 
     leaderboard: pd.DataFrame = end_to_end_results.compare_on_tabarena(
         output_dir=fig_output_dir,

--- a/tabflow/scripts/run_evaluate_lightgbm_demo.py
+++ b/tabflow/scripts/run_evaluate_lightgbm_demo.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from tabrepo.nips2025_utils.end_to_end import EndToEndSingle, EndToEndResultsSingle
+from tabrepo.nips2025_utils.end_to_end_single import EndToEndSingle, EndToEndResultsSingle
 
 
 """
@@ -49,7 +49,7 @@ if __name__ == '__main__':
 
     leaderboard: pd.DataFrame = end_to_end_results.compare_on_tabarena(
         output_dir=fig_output_dir,
-        filter_dataset_fold=True,
+        only_valid_tasks=True,
     )
 
     print(leaderboard.to_markdown())

--- a/tabrepo/contexts/context.py
+++ b/tabrepo/contexts/context.py
@@ -415,8 +415,6 @@ class BenchmarkContext:
                       f'\tfolds: {folds}')
             if download_files and exists == 'ignore':
                 if self.benchmark_paths.exists_all(check_zs=load_predictions):
-                    if verbose:
-                        print(f'All required files are present...')
                     download_files = False
             if download_files:
                 if verbose:
@@ -433,8 +431,6 @@ class BenchmarkContext:
 
             configs_hyperparameters = self.load_configs_hyperparameters()
             zsc = self._load_zsc(folds=folds, configs_hyperparameters=configs_hyperparameters, verbose=verbose)
-            if verbose:
-                print(f'Loading config hyperparameter definitions... Note: Hyperparameter definitions are only accurate for the latest version.')
 
             if load_predictions:
                 zeroshot_pred_proba, zeroshot_gt, zsc = self._load_predictions(zsc=zsc, prediction_format=prediction_format, verbose=verbose)

--- a/tabrepo/nips2025_utils/artifacts/method_metadata.py
+++ b/tabrepo/nips2025_utils/artifacts/method_metadata.py
@@ -362,6 +362,23 @@ class MethodMetadata:
             path_raw = self.path_raw
         return load_raw(path_raw=path_raw, engine=engine, as_holdout=as_holdout)
 
+    def load_processed(
+        self,
+        path_processed: str | Path = None,
+        prediction_format: Literal["memmap", "memopt", "mem"] = "memmap",
+        as_holdout: bool = False,
+    ) -> EvaluationRepository:
+        if path_processed is None:
+            if as_holdout:
+                path_processed = self.path_processed_holdout
+            else:
+                path_processed = self.path_processed
+        repo = EvaluationRepository.from_dir(
+            path=path_processed,
+            prediction_format=prediction_format,
+        )
+        return repo
+
     def generate_repo(
         self,
         results_lst: list = None,
@@ -418,8 +435,8 @@ class MethodMetadata:
         results_lst: list[BaselineResult],
     ):
         path = self.path_raw
-        n_results = len(results_lst)
-        for i, result in enumerate(results_lst):
-            if i % 100 == 0:
-                print(f"{i + 1}/{n_results}")
+        for result in results_lst:
             result.to_dir(path=path)
+
+    def cache_processed(self, repo: EvaluationRepository):
+        repo.to_dir(self.path_processed)

--- a/tabrepo/nips2025_utils/artifacts/method_metadata.py
+++ b/tabrepo/nips2025_utils/artifacts/method_metadata.py
@@ -170,7 +170,7 @@ class MethodMetadata:
         assert method_type == "config"
 
         unique_model_types = result_df["model_type"].unique()
-        assert len(unique_model_types) == 1
+        assert len(unique_model_types) == 1, f"MethodMetadata requires exactly 1 model type, found: {unique_model_types}"
 
         unique_num_gpus = result_df["num_gpus"].unique()
         assert len(unique_num_gpus) == 1

--- a/tabrepo/nips2025_utils/artifacts/method_uploader.py
+++ b/tabrepo/nips2025_utils/artifacts/method_uploader.py
@@ -1,72 +1,150 @@
 from __future__ import annotations
 
+import io
 import os
-import shutil
+import zipfile
 from pathlib import Path
 
-from autogluon.common.utils.s3_utils import upload_file
+from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
+
+from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
 
 
-class MethodUploader:
+# TODO: Make `MethodDownloaderS3`
+class MethodUploaderS3:
     def __init__(
         self,
-        method: str,
+        method_metadata: MethodMetadata,
         bucket: str,
-        prefix: str,
-        local_path: str | Path,
+        s3_prefix_root: str = "cache",
         upload_as_public: bool = False,
     ):
-        self.method = method
+        self.method_metadata = method_metadata
+        self.method = method_metadata.method
         self.bucket = bucket
-        self.prefix = prefix
-        self.local_path = Path(local_path)
+        self.s3_prefix_root = s3_prefix_root
+        self.prefix = Path(self.s3_prefix_root) / method_metadata.relative_to_cache_root(method_metadata.path)
         self.upload_as_public = upload_as_public
 
-    def _local_path_raw(self) -> Path:
-        return self.local_path / "raw"
+    @property
+    def s3_cache_root(self) -> str:
+        return f"s3://{self.bucket}/{self.s3_prefix_root}"
 
-    def _local_path_processed(self) -> Path:
-        return self.local_path / "processed"
+    def upload_all(self):
+        self.upload_metadata()
+        self.upload_raw()
+        self.upload_processed()
+        self.upload_results()
 
-    def _local_path_results(self) -> Path:
-        return self.local_path / "results"
+    def upload_metadata(self):
+        fileobj = self.method_metadata.to_yaml_fileobj()
+        path_local = self.method_metadata.path_metadata
+        s3_key = self.local_to_s3_path(path_local=path_local)
+        self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
 
     def upload_raw(self):
-        path_data_method = self._local_path_raw()
+        path_raw = Path(self.method_metadata.path_raw)
 
-        tmp_dir = Path("tmp")
-        file_prefix = tmp_dir / self.method / "raw"
-        shutil.make_archive(file_prefix, 'zip', root_dir=path_data_method)
-        file_name = f"{file_prefix}.zip"
+        fileobj = self._zip(path=path_raw)
+        s3_key = self.prefix / "raw.zip"
 
-        self._upload_file(file_name=file_name, prefix=self.prefix)
-        # os.remove(file_name)
+        # Upload to S3 directly from memory
+        self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
 
-    def _upload_file(self, file_name: str | Path, prefix: str):
+    def upload_processed(self):
+        path_processed = self.method_metadata.path_processed
+
+        fileobj = self._zip(path=path_processed)
+        s3_key = self.prefix / "processed.zip"
+
+        # Upload to S3 directly from memory
+        self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
+
+        # Upload configs_hyperparameters as a standalone file for fast access
+        self.upload_configs_hyperparameters()
+
+    def _upload_fileobj(self, fileobj: io.BytesIO, s3_key: str | Path):
+        import boto3
+
+        if isinstance(s3_key, Path):
+            s3_key = s3_key.as_posix()
+
         kwargs = {}
         if self.upload_as_public:
             kwargs = {"ExtraArgs": {"ACL": "public-read"}}
-        upload_file(file_name=file_name, bucket=self.bucket, prefix=prefix, **kwargs)
 
-    def upload_processed(self):
-        path_data_method = self._local_path_processed()
+        s3_client = boto3.client("s3")
+        s3_client.upload_fileobj(Fileobj=fileobj, Bucket=self.bucket, Key=s3_key, **kwargs)
 
-        tmp_dir = Path("tmp")
-        file_prefix = tmp_dir / self.method / "processed"
-        shutil.make_archive(file_prefix, 'zip', root_dir=path_data_method)
-        file_name = f"{file_prefix}.zip"
+    def _upload_to_s3(self, path_local: str | Path, s3_key: str | Path | None = None):
+        import boto3
 
-        self._upload_file(file_name=file_name, prefix=self.prefix)
-        # os.remove(file_name)
+        if s3_key is None:
+            s3_key = self.local_to_s3_path(path_local=path_local)
 
-    def upload_results(self):
-        path_method_results = self._local_path_results()
-        prefix = f"{self.prefix}/results"
+        if isinstance(path_local, Path):
+            path_local = str(path_local)
+        if isinstance(s3_key, Path):
+            s3_key = s3_key.as_posix()
 
-        file_names = [
-            "model_results.parquet",
-            "hpo_results.parquet",
-        ]
-        for file_name in file_names:
-            local_file_path = path_method_results / file_name
-            self._upload_file(file_name=local_file_path, prefix=prefix)
+        kwargs = {}
+        if self.upload_as_public:
+            kwargs = {"ExtraArgs": {"ACL": "public-read"}}
+
+        # Upload the file
+        s3_client = boto3.client("s3")
+        s3_client.upload_file(Filename=path_local, Bucket=self.bucket, Key=s3_key, **kwargs)
+
+    def upload_configs_hyperparameters(self, holdout: bool = False):
+        path_local = self.method_metadata.path_configs_hyperparameters(holdout=holdout)
+        self._upload_to_s3(path_local=path_local)
+
+    def local_to_s3_path(self, path_local: str | Path) -> str:
+        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.s3_cache_root)
+        _, s3_key = s3_path_to_bucket_prefix(s3_path_loc)
+        return s3_key
+
+    def upload_results(self, holdout: bool = False):
+        file_names = self.method_metadata.path_results_files(holdout=holdout)
+        for path_local in file_names:
+            self._upload_to_s3(path_local=path_local)
+
+    # TODO: Move to util file
+    def _zip(self, path: Path) -> io.BytesIO:
+        """
+        Create an in-memory ZIP archive of a directory.
+
+        This method recursively traverses the given directory, compresses
+        all contained files into a ZIP archive, and returns the archive
+        as an in-memory `io.BytesIO` buffer. Paths inside the archive
+        are stored relative to the provided root directory.
+
+        Parameters
+        ----------
+        path : Path
+            The root directory whose contents will be compressed into
+            the ZIP archive.
+
+        Returns
+        -------
+        io.BytesIO
+            A binary buffer positioned at the beginning, containing the
+            ZIP archive data. The caller can read from this buffer or
+            upload it directly (e.g., to S3) without writing a local file.
+
+        """
+        # Create an in-memory buffer
+        buffer = io.BytesIO()
+
+        # Write the zip archive into the buffer
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _, files in os.walk(path):
+                for file in files:
+                    file_path = Path(root) / file
+                    # Store relative path inside the zip
+                    arcname = file_path.relative_to(path)
+                    zf.write(file_path, arcname=arcname)
+
+        # Reset buffer position for reading
+        buffer.seek(0)
+        return buffer

--- a/tabrepo/nips2025_utils/artifacts/tabarena51_artifact_uploader.py
+++ b/tabrepo/nips2025_utils/artifacts/tabarena51_artifact_uploader.py
@@ -10,7 +10,6 @@ from autogluon.common.utils.s3_utils import upload_file
 from tabrepo.loaders import Paths
 
 from .abstract_artifact_uploader import AbstractArtifactUploader
-from .method_uploader import MethodUploader
 from .method_metadata import MethodMetadata
 from . import tabarena_method_metadata_map
 

--- a/tabrepo/nips2025_utils/artifacts/tabarena51_artifact_uploader.py
+++ b/tabrepo/nips2025_utils/artifacts/tabarena51_artifact_uploader.py
@@ -14,6 +14,7 @@ from .method_metadata import MethodMetadata
 from . import tabarena_method_metadata_map
 
 
+# TODO: Make this use MethodUploaderS3
 class TabArena51ArtifactUploader(AbstractArtifactUploader):
     def __init__(self):
         self.artifact_name = "tabarena-2025-06-12"

--- a/tabrepo/nips2025_utils/compare.py
+++ b/tabrepo/nips2025_utils/compare.py
@@ -16,7 +16,6 @@ def compare_on_tabarena(
     filter_dataset_fold: bool = False,
     df_results_extra: pd.DataFrame = None,
     subset: str | list[str] | None = None,
-    new_result_prefix: str | None = None,
 ) -> pd.DataFrame:
     df_metrics = df_metrics.copy(deep=True)
     if df_results_extra is not None:
@@ -28,10 +27,6 @@ def compare_on_tabarena(
 
     fillna_method = "RF (default)"
     paper_results = tabarena_context.load_results_paper(download_results="auto")
-
-    if new_result_prefix is not None:
-        for col in ["method", "config_type", "ta_name", "ta_suite"]:
-            df_metrics[col] = new_result_prefix + df_metrics[col]
 
     if filter_dataset_fold:
         paper_results = filter_to_valid_tasks(

--- a/tabrepo/nips2025_utils/compare.py
+++ b/tabrepo/nips2025_utils/compare.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
+from tabrepo.paper.tabarena_evaluator import TabArenaEvaluator
+
+
+def compare_on_tabarena(
+    output_dir: str | Path,
+    df_metrics: pd.DataFrame,
+    baselines_extra: list[str] = None,
+    *,
+    filter_dataset_fold: bool = False,
+    df_results_extra: pd.DataFrame = None,
+    subset: str | list[str] | None = None,
+    new_result_prefix: str | None = None,
+) -> pd.DataFrame:
+    df_metrics = df_metrics.copy(deep=True)
+    if df_results_extra is not None:
+        df_results_extra = df_results_extra.copy(deep=True)
+
+    output_dir = Path(output_dir)
+
+    tabarena_context = TabArenaContext()
+
+    fillna_method = "RF (default)"
+    paper_results = tabarena_context.load_results_paper(download_results="auto")
+
+    if new_result_prefix is not None:
+        for col in ["method", "config_type", "ta_name", "ta_suite"]:
+            df_metrics[col] = new_result_prefix + df_metrics[col]
+
+    if filter_dataset_fold:
+        paper_results = filter_to_valid_tasks(
+            df_to_filter=paper_results,
+            df_filter=df_metrics,
+        )
+        if df_results_extra is not None:
+            df_results_extra = filter_to_valid_tasks(
+                df_to_filter=df_results_extra,
+                df_filter=df_metrics,
+            )
+
+    # FIXME: Nick: After imputing: ta_name, ta_suite, config_type, etc. are incorrect,
+    #  need to use original, not filled values
+    #  This doesn't impact the evaluation, but could introduce bugs in future if we use these columns
+    #  Fixing this is do-able, but requires some complex pandas tricks, so I haven't had time to implement it yet
+    df_metrics = TabArenaContext.fillna_metrics(
+        df_metrics=df_metrics,
+        df_fillna=paper_results[paper_results["method"] == fillna_method],
+    )
+
+    df_results = pd.concat([paper_results, df_metrics], ignore_index=True)
+
+    if df_results_extra is not None:
+        if filter_dataset_fold:
+            df_results = filter_to_valid_tasks(
+                df_to_filter=df_results,
+                df_filter=df_results_extra,
+            )
+
+        df_results_extra = TabArenaContext.fillna_metrics(
+            df_metrics=df_results_extra,
+            df_fillna=df_results[df_results["method"] == fillna_method],
+        )
+
+        df_results = pd.concat([df_results, df_results_extra], ignore_index=True)
+        baselines_extra += list(df_results_extra[df_results_extra["method_type"].isin(['baseline', 'portfolio'])]["method"].unique())
+
+    if subset is not None:
+        if isinstance(subset, str):
+            subset = [subset]
+        df_results = subset_tasks(df_results=df_results, subset=subset)
+
+    # Handle imputation of names
+    imputed_names = list(df_results["method"][df_results["imputed"] > 0].unique())
+    if len(imputed_names) == 0:
+        imputed_names = None
+    if imputed_names is not None:
+        from tabrepo.paper.paper_utils import get_method_rename_map
+
+        # remove suffix
+        imputed_names = [n.split(" (")[0] for n in imputed_names]
+        imputed_names = [get_method_rename_map().get(n, n) for n in imputed_names]
+        imputed_names = list(set(imputed_names))
+        if "KNN" in imputed_names:
+            imputed_names.remove("KNN")
+        print(f"Model for which results were imputed: {imputed_names}")
+
+    baselines = [
+        "AutoGluon 1.3 (4h)",
+    ]
+    baselines += baselines_extra
+
+    plotter = TabArenaEvaluator(
+        output_dir=output_dir,
+    )
+    return plotter.eval(
+        df_results=df_results,
+        baselines=baselines,
+        plot_extra_barplots=False,
+        plot_times=True,
+        plot_other=False,
+        imputed_names=imputed_names,
+    )
+
+
+def filter_to_valid_tasks(df_to_filter: pd.DataFrame, df_filter: pd.DataFrame) -> pd.DataFrame:
+    dataset_fold_map = df_filter.groupby("dataset")["fold"].apply(set)
+
+    def is_in(dataset: str, fold: int) -> bool:
+        return (dataset in dataset_fold_map.index) and (fold in dataset_fold_map.loc[dataset])
+
+    # filter `df_to_filter` to only the dataset, fold pairs that are present in `df_filter`
+    is_in_lst = [
+        is_in(dataset, fold) for dataset, fold in zip(
+            df_to_filter["dataset"],
+            df_to_filter["fold"],
+        )]
+    df_filtered = df_to_filter[is_in_lst]
+    return df_filtered
+
+
+def subset_tasks(df_results: pd.DataFrame, subset: list[str]) -> pd.DataFrame:
+    from tabrepo.nips2025_utils.fetch_metadata import load_task_metadata
+
+    df_results = df_results.copy(deep=True)
+    for filter_subset in subset:
+        if filter_subset == "classification":
+            df_results = df_results[
+                df_results["problem_type"].isin(["binary", "multiclass"])
+            ]
+        elif filter_subset == "regression":
+            df_results = df_results[df_results["problem_type"] == "regression"]
+        elif filter_subset == "medium+":
+            task_metadata = load_task_metadata()
+            task_metadata = task_metadata[task_metadata["n_samples_train_per_fold"] >= 10000]
+            valid_datasets = task_metadata["dataset"].unique()
+            df_results = df_results[df_results["dataset"].isin(valid_datasets)]
+        elif filter_subset == "small":
+            task_metadata = load_task_metadata()
+            task_metadata = task_metadata[task_metadata["n_samples_train_per_fold"] < 10000]
+            valid_datasets = task_metadata["dataset"].unique()
+            df_results = df_results[df_results["dataset"].isin(valid_datasets)]
+        elif filter_subset == "lite":
+            df_results = df_results[df_results["fold"] == 0]
+        elif filter_subset == "tabicl":
+            allowed_dataset = load_task_metadata(subset="TabICL")[
+                "dataset"
+            ].tolist()
+            df_results = df_results[df_results["dataset"].isin(allowed_dataset)]
+        elif filter_subset == "tabpfn":
+            allowed_dataset = load_task_metadata(subset="TabPFNv2")[
+                "dataset"
+            ].tolist()
+            df_results = df_results[df_results["dataset"].isin(allowed_dataset)]
+        elif filter_subset == "tabpfn/tabicl":
+            ad_tabicl = load_task_metadata(subset="TabICL")["dataset"].tolist()
+            ad_tabpfn = load_task_metadata(subset="TabPFNv2")["dataset"].tolist()
+            allowed_dataset = list(set(ad_tabicl).intersection(set(ad_tabpfn)))
+            df_results = df_results[df_results["dataset"].isin(allowed_dataset)]
+        else:
+            raise ValueError(f"Invalid subset {subset} name!")
+        df_results = df_results.reset_index(drop=True)
+    return df_results

--- a/tabrepo/nips2025_utils/compare.py
+++ b/tabrepo/nips2025_utils/compare.py
@@ -12,7 +12,7 @@ def compare_on_tabarena(
     new_results: pd.DataFrame,
     output_dir: str | Path,
     *,
-    filter_dataset_fold: bool = False,
+    only_valid_tasks: bool = False,
     subset: str | list[str] | None = None,
 ) -> pd.DataFrame:
     new_results = new_results.copy(deep=True)
@@ -27,7 +27,7 @@ def compare_on_tabarena(
         methods_drop=["Portfolio-N200-4h"],  # TODO: Clean this up by not including by default
     )
 
-    if filter_dataset_fold:
+    if only_valid_tasks:
         paper_results = filter_to_valid_tasks(
             df_to_filter=paper_results,
             df_filter=new_results,

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -10,7 +10,7 @@ from tabrepo.nips2025_utils.end_to_end_single import EndToEndSingle, EndToEndRes
 from tabrepo.nips2025_utils.method_processor import get_info_from_result
 
 
-class EndToEndMulti:
+class EndToEnd:
     def __init__(
         self,
         results_lst: list[BaselineResult | dict],
@@ -37,13 +37,13 @@ class EndToEndMulti:
             cur_end_to_end = EndToEndSingle(results_lst=cur_results_lst, task_metadata=task_metadata, cache=cache)
             self.end_to_end_lst.append(cur_end_to_end)
 
-    def to_results(self) -> EndToEndResultsMulti:
-        return EndToEndResultsMulti(
+    def to_results(self) -> EndToEndResults:
+        return EndToEndResults(
             end_to_end_results_lst=[end_to_end.to_results() for end_to_end in self.end_to_end_lst],
         )
 
 
-class EndToEndResultsMulti:
+class EndToEndResults:
     def __init__(
         self,
         end_to_end_results_lst: list[EndToEndResultsSingle],

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
-from typing_extensions import Self
 
 import pandas as pd
 
-from tabrepo.benchmark.result import BaselineResult, ConfigResult
-from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
+from tabrepo.benchmark.result import BaselineResult
 from tabrepo.nips2025_utils.compare import compare_on_tabarena
-from tabrepo.nips2025_utils.method_processor import get_info_from_result, generate_task_metadata, load_raw
-from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
-
-if TYPE_CHECKING:
-    from tabrepo.repository import EvaluationRepository
+from tabrepo.nips2025_utils.end_to_end_single import EndToEndSingle, EndToEndResultsSingle
+from tabrepo.nips2025_utils.method_processor import get_info_from_result
 
 
 class EndToEndMulti:
@@ -24,7 +18,7 @@ class EndToEndMulti:
         cache: bool = True,
     ):
         # raw
-        self.results_lst: list[BaselineResult] = EndToEnd.clean_raw(results_lst=results_lst)
+        self.results_lst: list[BaselineResult] = EndToEndSingle.clean_raw(results_lst=results_lst)
 
         result_types_dict = {}
         for r in self.results_lst:
@@ -40,7 +34,7 @@ class EndToEndMulti:
         for cur_type in unique_types:
             # TODO: Avoid fetching task_metadata repeatedly from OpenML in each iteration
             cur_results_lst = result_types_dict[cur_type]
-            cur_end_to_end = EndToEnd(results_lst=cur_results_lst, task_metadata=task_metadata, cache=cache)
+            cur_end_to_end = EndToEndSingle(results_lst=cur_results_lst, task_metadata=task_metadata, cache=cache)
             self.end_to_end_lst.append(cur_end_to_end)
 
     def to_results(self) -> EndToEndResultsMulti:
@@ -49,85 +43,10 @@ class EndToEndMulti:
         )
 
 
-class EndToEnd:
-    def __init__(
-        self,
-        results_lst: list[BaselineResult | dict],
-        task_metadata: pd.DataFrame | None = None,
-        cache: bool = True,
-    ):
-        # raw
-        self.results_lst: list[BaselineResult] = self.clean_raw(results_lst=results_lst)
-        self.method_metadata: MethodMetadata = MethodMetadata.from_raw(
-            results_lst=self.results_lst
-        )
-
-        if cache:
-            print(
-                f'Artifacts for method {self.method_metadata.method} will be saved in: "{self.method_metadata.path}"'
-            )
-
-        if cache:
-            self.method_metadata.to_yaml()
-            self.method_metadata.cache_raw(results_lst=self.results_lst)
-
-        if task_metadata is None:
-            tids = list({r.task_metadata["tid"] for r in self.results_lst})
-            task_metadata = generate_task_metadata(tids=tids)
-        self.task_metadata = task_metadata
-
-        # processed
-        self.repo: EvaluationRepository = self.method_metadata.generate_repo(
-            results_lst=self.results_lst,
-            task_metadata=self.task_metadata,
-            cache=cache,
-        )
-
-        # results
-        tabarena_context = TabArenaContext()
-        self.hpo_results, self.model_results = tabarena_context.simulate_repo(
-            method=self.method_metadata,
-            repo=self.repo,
-            use_rf_config_fallback=False,
-            cache=cache,
-        )
-
-    @classmethod
-    def clean_raw(cls, results_lst: list[BaselineResult | dict]) -> list[BaselineResult]:
-        return [r if not isinstance(r, dict) else BaselineResult.from_dict(result=r) for r in results_lst]
-
-    @classmethod
-    def from_path_raw(cls, path_raw: str | Path, name: str = None, name_suffix: str = None) -> Self:
-        results_lst: list[BaselineResult] = load_raw(path_raw=path_raw)
-        if name is not None or name_suffix is not None:
-            for r in results_lst:
-                r.update_name(name=name, name_suffix=name_suffix)
-                if isinstance(r, ConfigResult):
-                    r.update_model_type(name=name, name_suffix=name_suffix)
-        return cls(results_lst=results_lst)
-
-    @classmethod
-    def from_cache(cls, method: str, artifact_name: str | None = None) -> Self:
-        if artifact_name is None:
-            artifact_name = method
-        method_metadata = MethodMetadata.from_yaml(
-            method=method, artifact_name=artifact_name
-        )
-        results_lst = method_metadata.load_raw()
-        return cls(results_lst=results_lst)
-
-    def to_results(self) -> EndToEndResults:
-        return EndToEndResults(
-            method_metadata=self.method_metadata,
-            hpo_results=self.hpo_results,
-            model_results=self.model_results,
-        )
-
-
 class EndToEndResultsMulti:
     def __init__(
         self,
-        end_to_end_results_lst: list[EndToEndResults],
+        end_to_end_results_lst: list[EndToEndResultsSingle],
     ):
         self.end_to_end_results_lst = end_to_end_results_lst
 
@@ -180,110 +99,3 @@ class EndToEndResultsMulti:
             ))
         df_results = pd.concat(df_results_lst, ignore_index=True)
         return df_results
-
-
-class EndToEndResults:
-    def __init__(
-        self,
-        method_metadata: MethodMetadata,
-        hpo_results: pd.DataFrame = None,
-        model_results: pd.DataFrame = None,
-    ):
-        self.method_metadata = method_metadata
-        if hpo_results is None and self.method_metadata.method_type == "config":
-            hpo_results = self.method_metadata.load_hpo_results()
-        if model_results is None:
-            model_results = self.method_metadata.load_model_results()
-        self.hpo_results = hpo_results
-        self.model_results = model_results
-
-    @classmethod
-    def from_cache(cls, method: str, artifact_name: str | None = None) -> Self:
-        if artifact_name is None:
-            artifact_name = method
-        method_metadata = MethodMetadata.from_yaml(
-            method=method, artifact_name=artifact_name
-        )
-        return cls(method_metadata=method_metadata)
-
-    def compare_on_tabarena(
-        self,
-        output_dir: str | Path,
-        *,
-        filter_dataset_fold: bool = False,
-        subset: str | None | list = None,
-        new_result_prefix: str | None = None,
-        use_model_results: bool = False,
-    ) -> pd.DataFrame:
-        """Compare results on TabArena leaderboard.
-
-        Args:
-            output_dir (str | Path): Directory to save the results.
-            subset (str | None | list): Subset of tasks to evaluate on.
-                Options are "classification", "regression", "lite"  for TabArena-Lite,
-                "tabicl", "tabpfn", "tabpfn/tabicl", or None for all tasks.
-                Or a list of subset names to filter for.
-            new_result_prefix (str | None): If not None, add a prefix to the new
-                results to distinguish new results from the original TabArena results.
-                Use this, for example, if you re-run a model from TabArena.
-        """
-        results = self.get_results(
-            new_result_prefix=new_result_prefix,
-            use_model_results=use_model_results,
-            fillna=not filter_dataset_fold,
-        )
-
-        return compare_on_tabarena(
-            new_results=results,
-            output_dir=output_dir,
-            filter_dataset_fold=filter_dataset_fold,
-            subset=subset,
-        )
-
-    def get_results(
-        self,
-        new_result_prefix: str | None = None,
-        use_model_results: bool = False,
-        fillna: bool = False,
-    ) -> pd.DataFrame:
-        """
-        Get data to compare results on TabArena leaderboard.
-            Args:
-                new_result_prefix (str | None): If not None, add a prefix to the new
-                    results to distinguish new results from the original TabArena results.
-                    Use this, for example, if you re-run a model from TabArena.
-        """
-        use_model_results = self.method_metadata.method_type != "config" or use_model_results
-
-        if use_model_results:
-            df_results = self.model_results
-        else:
-            df_results = self.hpo_results
-
-        if new_result_prefix is not None:
-            for col in ["method", "config_type", "ta_name", "ta_suite"]:
-                df_results[col] = new_result_prefix + df_results[col]
-
-        if fillna:
-            df_results = self.fillna_results_on_tabarena(df_results=df_results)
-
-        return df_results
-
-    @classmethod
-    def fillna_results_on_tabarena(cls, df_results: pd.DataFrame) -> pd.DataFrame:
-        tabarena_context = TabArenaContext()
-        fillna_method = "RF (default)"
-        fillna_method_name = "RandomForest"
-
-        df_fillna = tabarena_context.load_results_paper(methods=[fillna_method_name])
-        df_fillna = df_fillna[df_fillna["method"] == fillna_method]
-        assert not df_fillna.empty
-
-        # FIXME: Nick: After imputing: ta_name, ta_suite, config_type, etc. are incorrect,
-        #  need to use original, not filled values
-        #  This doesn't impact the evaluation, but could introduce bugs in future if we use these columns
-        #  Fixing this is do-able, but requires some complex pandas tricks, so I haven't had time to implement it yet
-        return TabArenaContext.fillna_metrics(
-            df_to_fill=df_results,
-            df_fillna=df_fillna,
-        )

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -136,7 +136,6 @@ class EndToEndResultsMulti:
         output_dir: str | Path,
         *,
         filter_dataset_fold: bool = False,
-        df_results_extra: pd.DataFrame = None,
         subset: str | None | list = None,
         new_result_prefix: str | None = None,
         use_model_results: bool = False,
@@ -154,13 +153,12 @@ class EndToEndResultsMulti:
                 Use this, for example, if you re-run a model from TabArena.
         """
 
-        df_metrics = self.get_results(use_model_results=use_model_results, new_result_prefix=new_result_prefix)
+        results = self.get_results(use_model_results=use_model_results, new_result_prefix=new_result_prefix)
 
         return compare_on_tabarena(
+            new_results=results,
             output_dir=output_dir,
-            df_metrics=df_metrics,
             filter_dataset_fold=filter_dataset_fold,
-            df_results_extra=df_results_extra,
             subset=subset,
         )
 
@@ -204,7 +202,6 @@ class EndToEndResults:
         output_dir: str | Path,
         *,
         filter_dataset_fold: bool = False,
-        df_results_extra: pd.DataFrame = None,
         subset: str | None | list = None,
         new_result_prefix: str | None = None,
         use_model_results: bool = False,
@@ -222,16 +219,15 @@ class EndToEndResults:
                 Use this, for example, if you re-run a model from TabArena.
         """
 
-        df_metrics = self.get_results(
+        results = self.get_results(
             use_model_results=use_model_results,
             new_result_prefix=new_result_prefix,
         )
 
         return compare_on_tabarena(
+            new_results=results,
             output_dir=output_dir,
-            df_metrics=df_metrics,
             filter_dataset_fold=filter_dataset_fold,
-            df_results_extra=df_results_extra,
             subset=subset,
         )
 

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -154,30 +154,25 @@ class EndToEndResultsMulti:
                 Use this, for example, if you re-run a model from TabArena.
         """
 
-        df_metrics, baselines_extra = self.get_results(use_model_results=use_model_results, new_result_prefix=new_result_prefix)
+        df_metrics = self.get_results(use_model_results=use_model_results, new_result_prefix=new_result_prefix)
 
         return compare_on_tabarena(
             output_dir=output_dir,
             df_metrics=df_metrics,
             filter_dataset_fold=filter_dataset_fold,
-            baselines_extra=baselines_extra,
             df_results_extra=df_results_extra,
             subset=subset,
         )
 
-    def get_results(self, use_model_results: bool, new_result_prefix: str | None = None) -> tuple[pd.DataFrame, list[str]]:
+    def get_results(self, use_model_results: bool, new_result_prefix: str | None = None) -> pd.DataFrame:
         df_metrics_lst = []
-        baselines_extra_lst = []
         for result in self.end_to_end_results_lst:
-            df_metrics, baselines_extra = result.get_results(
+            df_metrics_lst.append(result.get_results(
                 use_model_results=use_model_results,
                 new_result_prefix=new_result_prefix,
-            )
-            df_metrics_lst.append(df_metrics)
-            baselines_extra_lst.append(baselines_extra)
+            ))
         df_metrics = pd.concat(df_metrics_lst, ignore_index=True)
-        baselines_extra = [b for baselines_extra in baselines_extra_lst for b in baselines_extra]
-        return df_metrics, baselines_extra
+        return df_metrics
 
 
 class EndToEndResults:
@@ -227,7 +222,7 @@ class EndToEndResults:
                 Use this, for example, if you re-run a model from TabArena.
         """
 
-        df_metrics, baselines_extra = self.get_results(
+        df_metrics = self.get_results(
             use_model_results=use_model_results,
             new_result_prefix=new_result_prefix,
         )
@@ -236,12 +231,11 @@ class EndToEndResults:
             output_dir=output_dir,
             df_metrics=df_metrics,
             filter_dataset_fold=filter_dataset_fold,
-            baselines_extra=baselines_extra,
             df_results_extra=df_results_extra,
             subset=subset,
         )
 
-    def get_results(self, use_model_results: bool, new_result_prefix: str | None = None) -> tuple[pd.DataFrame, list[str]]:
+    def get_results(self, use_model_results: bool, new_result_prefix: str | None = None) -> pd.DataFrame:
         use_model_results = self.method_metadata.method_type != "config" or use_model_results
 
         if use_model_results:
@@ -253,8 +247,4 @@ class EndToEndResults:
             for col in ["method", "config_type", "ta_name", "ta_suite"]:
                 df_metrics[col] = new_result_prefix + df_metrics[col]
 
-        if use_model_results:
-            baselines_extra = list(df_metrics["method"].unique())
-        else:
-            baselines_extra = []
-        return df_metrics, baselines_extra
+        return df_metrics

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -8,9 +8,9 @@ import pandas as pd
 
 from tabrepo.benchmark.result import BaselineResult, ConfigResult
 from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
+from tabrepo.nips2025_utils.compare import compare_on_tabarena
 from tabrepo.nips2025_utils.method_processor import get_info_from_result, generate_task_metadata, load_raw
 from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
-from tabrepo.paper.tabarena_evaluator import TabArenaEvaluator
 
 if TYPE_CHECKING:
     from tabrepo.repository import EvaluationRepository
@@ -156,7 +156,7 @@ class EndToEndResultsMulti:
 
         df_metrics, baselines_extra = self.get_results(use_model_results=use_model_results)
 
-        return EndToEndResults._compare_on_tabarena(
+        return compare_on_tabarena(
             output_dir=output_dir,
             df_metrics=df_metrics,
             filter_dataset_fold=filter_dataset_fold,
@@ -227,7 +227,7 @@ class EndToEndResults:
 
         df_metrics, baselines_extra = self.get_results(use_model_results=use_model_results)
 
-        return self._compare_on_tabarena(
+        return compare_on_tabarena(
             output_dir=output_dir,
             df_metrics=df_metrics,
             filter_dataset_fold=filter_dataset_fold,
@@ -249,165 +249,3 @@ class EndToEndResults:
             df_metrics = self.model_results
             baselines_extra = list(df_metrics["method"].unique())
         return df_metrics, baselines_extra
-
-    # TODO: Move to a separate file
-    @classmethod
-    def _compare_on_tabarena(
-            cls,
-            output_dir: str | Path,
-            df_metrics: pd.DataFrame,
-            baselines_extra: list[str] = None,
-            *,
-            filter_dataset_fold: bool = False,
-            df_results_extra: pd.DataFrame = None,
-            subset: str | list[str] | None = None,
-            new_result_prefix: str | None = None,
-    ) -> pd.DataFrame:
-        df_metrics = df_metrics.copy(deep=True)
-        if df_results_extra is not None:
-            df_results_extra = df_results_extra.copy(deep=True)
-
-        output_dir = Path(output_dir)
-
-        tabarena_context = TabArenaContext()
-
-        fillna_method = "RF (default)"
-        paper_results = tabarena_context.load_results_paper(download_results="auto")
-
-        if new_result_prefix is not None:
-            for col in ["method", "config_type", "ta_name", "ta_suite"]:
-                df_metrics[col] = new_result_prefix + df_metrics[col]
-
-        if filter_dataset_fold:
-            paper_results = cls._filter_to_valid_tasks(
-                df_to_filter=paper_results,
-                df_filter=df_metrics,
-            )
-            if df_results_extra is not None:
-                df_results_extra = cls._filter_to_valid_tasks(
-                    df_to_filter=df_results_extra,
-                    df_filter=df_metrics,
-                )
-
-        # FIXME: Nick: After imputing: ta_name, ta_suite, config_type, etc. are incorrect,
-        #  need to use original, not filled values
-        #  This doesn't impact the evaluation, but could introduce bugs in future if we use these columns
-        #  Fixing this is do-able, but requires some complex pandas tricks, so I haven't had time to implement it yet
-        df_metrics = TabArenaContext.fillna_metrics(
-            df_metrics=df_metrics,
-            df_fillna=paper_results[paper_results["method"] == fillna_method],
-        )
-
-        df_results = pd.concat([paper_results, df_metrics], ignore_index=True)
-
-        if df_results_extra is not None:
-            if filter_dataset_fold:
-                df_results = cls._filter_to_valid_tasks(
-                    df_to_filter=df_results,
-                    df_filter=df_results_extra,
-                )
-
-            df_results_extra = TabArenaContext.fillna_metrics(
-                df_metrics=df_results_extra,
-                df_fillna=df_results[df_results["method"] == fillna_method],
-            )
-
-            df_results = pd.concat([df_results, df_results_extra], ignore_index=True)
-            baselines_extra += list(df_results_extra[df_results_extra["method_type"].isin(['baseline', 'portfolio'])]["method"].unique())
-
-        if subset is not None:
-            if isinstance(subset, str):
-                subset = [subset]
-            df_results = cls._subset_tasks(df_results=df_results, subset=subset)
-
-        # Handle imputation of names
-        imputed_names = list(df_results["method"][df_results["imputed"] > 0].unique())
-        if len(imputed_names) == 0:
-            imputed_names = None
-        if imputed_names is not None:
-            from tabrepo.paper.paper_utils import get_method_rename_map
-
-            # remove suffix
-            imputed_names = [n.split(" (")[0] for n in imputed_names]
-            imputed_names = [get_method_rename_map().get(n, n) for n in imputed_names]
-            imputed_names = list(set(imputed_names))
-            if "KNN" in imputed_names:
-                imputed_names.remove("KNN")
-            print(f"Model for which results were imputed: {imputed_names}")
-
-        baselines = [
-            "AutoGluon 1.3 (4h)",
-        ]
-        baselines += baselines_extra
-
-        plotter = TabArenaEvaluator(
-            output_dir=output_dir,
-        )
-        return plotter.eval(
-            df_results=df_results,
-            baselines=baselines,
-            plot_extra_barplots=False,
-            plot_times=True,
-            plot_other=False,
-            imputed_names=imputed_names,
-        )
-
-    @classmethod
-    def _filter_to_valid_tasks(cls, *, df_to_filter: pd.DataFrame, df_filter: pd.DataFrame) -> pd.DataFrame:
-        dataset_fold_map = df_filter.groupby("dataset")["fold"].apply(set)
-
-        def is_in(dataset: str, fold: int) -> bool:
-            return (dataset in dataset_fold_map.index) and (fold in dataset_fold_map.loc[dataset])
-
-        # filter `df_to_filter` to only the dataset, fold pairs that are present in `df_filter`
-        is_in_lst = [
-            is_in(dataset, fold) for dataset, fold in zip(
-                df_to_filter["dataset"],
-                df_to_filter["fold"],
-            )]
-        df_filtered = df_to_filter[is_in_lst]
-        return df_filtered
-
-    @classmethod
-    def _subset_tasks(cls, df_results: pd.DataFrame, subset: list[str]) -> pd.DataFrame:
-        from tabrepo.nips2025_utils.fetch_metadata import load_task_metadata
-
-        df_results = df_results.copy(deep=True)
-        for filter_subset in subset:
-            if filter_subset == "classification":
-                df_results = df_results[
-                    df_results["problem_type"].isin(["binary", "multiclass"])
-                ]
-            elif filter_subset == "regression":
-                df_results = df_results[df_results["problem_type"] == "regression"]
-            elif filter_subset == "medium+":
-                task_metadata = load_task_metadata()
-                task_metadata = task_metadata[task_metadata["n_samples_train_per_fold"] >= 10000]
-                valid_datasets = task_metadata["dataset"].unique()
-                df_results = df_results[df_results["dataset"].isin(valid_datasets)]
-            elif filter_subset == "small":
-                task_metadata = load_task_metadata()
-                task_metadata = task_metadata[task_metadata["n_samples_train_per_fold"] < 10000]
-                valid_datasets = task_metadata["dataset"].unique()
-                df_results = df_results[df_results["dataset"].isin(valid_datasets)]
-            elif filter_subset == "lite":
-                df_results = df_results[df_results["fold"] == 0]
-            elif filter_subset == "tabicl":
-                allowed_dataset = load_task_metadata(subset="TabICL")[
-                    "dataset"
-                ].tolist()
-                df_results = df_results[df_results["dataset"].isin(allowed_dataset)]
-            elif filter_subset == "tabpfn":
-                allowed_dataset = load_task_metadata(subset="TabPFNv2")[
-                    "dataset"
-                ].tolist()
-                df_results = df_results[df_results["dataset"].isin(allowed_dataset)]
-            elif filter_subset == "tabpfn/tabicl":
-                ad_tabicl = load_task_metadata(subset="TabICL")["dataset"].tolist()
-                ad_tabpfn = load_task_metadata(subset="TabPFNv2")["dataset"].tolist()
-                allowed_dataset = list(set(ad_tabicl).intersection(set(ad_tabpfn)))
-                df_results = df_results[df_results["dataset"].isin(allowed_dataset)]
-            else:
-                raise ValueError(f"Invalid subset {subset} name!")
-            df_results = df_results.reset_index(drop=True)
-        return df_results

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -19,6 +19,16 @@ class EndToEnd:
     ):
         self.end_to_end_lst = end_to_end_lst
 
+    def configs_hyperparameters(self) -> dict[str, dict | None]:
+        configs_hyperparameters_per_method = [e2e.configs_hyperparameters() for e2e in self.end_to_end_lst]
+        configs_hyperparameters = {}
+        for d in configs_hyperparameters_per_method:
+            for k, v in d.items():
+                if k in configs_hyperparameters:
+                    raise ValueError(f"Duplicate key detected: {k!r}")
+                configs_hyperparameters[k] = v
+        return configs_hyperparameters
+
     @classmethod
     def from_raw(
         cls,
@@ -111,6 +121,24 @@ class EndToEndResults:
         end_to_end_results_lst: list[EndToEndResultsSingle],
     ):
         self.end_to_end_results_lst = end_to_end_results_lst
+
+    @property
+    def model_results(self) -> pd.DataFrame | None:
+        model_results_lst = [e2e.model_results for e2e in self.end_to_end_results_lst]
+        model_results_lst = [model_results for model_results in model_results_lst if model_results is not None]
+        if not model_results_lst:
+            return None
+
+        return pd.concat(model_results_lst, ignore_index=True)
+
+    @property
+    def hpo_results(self) -> pd.DataFrame | None:
+        hpo_results_lst = [e2e.hpo_results for e2e in self.end_to_end_results_lst]
+        hpo_results_lst = [hpo_results for hpo_results in hpo_results_lst if hpo_results is not None]
+        if not hpo_results_lst:
+            return None
+
+        return pd.concat(hpo_results_lst, ignore_index=True)
 
     def compare_on_tabarena(
         self,

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -46,7 +46,6 @@ class EndToEnd:
 
         end_to_end_lst = []
         for cur_type in unique_types:
-            # TODO: Avoid fetching task_metadata repeatedly from OpenML in each iteration
             cur_results_lst = result_types_dict[cur_type]
             cur_end_to_end = EndToEndSingle.from_raw(
                 results_lst=cur_results_lst,

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -8,12 +8,45 @@ import pandas as pd
 
 from tabrepo.benchmark.result import BaselineResult, ConfigResult
 from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
-from tabrepo.nips2025_utils.method_processor import generate_task_metadata, load_raw
+from tabrepo.nips2025_utils.method_processor import get_info_from_result, generate_task_metadata, load_raw
 from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
 from tabrepo.paper.tabarena_evaluator import TabArenaEvaluator
 
 if TYPE_CHECKING:
     from tabrepo.repository import EvaluationRepository
+
+
+class EndToEndMulti:
+    def __init__(
+        self,
+        results_lst: list[BaselineResult | dict],
+        task_metadata: pd.DataFrame | None = None,
+        cache: bool = True,
+    ):
+        # raw
+        self.results_lst: list[BaselineResult] = EndToEnd.clean_raw(results_lst=results_lst)
+
+        result_types_dict = {}
+        for r in self.results_lst:
+            cur_result = get_info_from_result(result=r)
+            cur_tuple = (cur_result["method_type"], cur_result["model_type"])
+            if cur_tuple not in result_types_dict:
+                result_types_dict[cur_tuple] = []
+            result_types_dict[cur_tuple].append(r)
+
+        unique_types = list(result_types_dict.keys())
+
+        self.end_to_end_lst = []
+        for cur_type in unique_types:
+            # TODO: Avoid fetching task_metadata repeatedly from OpenML in each iteration
+            cur_results_lst = result_types_dict[cur_type]
+            cur_end_to_end = EndToEnd(results_lst=cur_results_lst, task_metadata=task_metadata, cache=cache)
+            self.end_to_end_lst.append(cur_end_to_end)
+
+    def to_results(self) -> EndToEndResultsMulti:
+        return EndToEndResultsMulti(
+            end_to_end_results_lst=[end_to_end.to_results() for end_to_end in self.end_to_end_lst],
+        )
 
 
 class EndToEnd:
@@ -24,9 +57,7 @@ class EndToEnd:
         cache: bool = True,
     ):
         # raw
-        self.results_lst: list[BaselineResult] = [
-            r if not isinstance(r, dict) else BaselineResult.from_dict(result=r) for r in results_lst
-        ]
+        self.results_lst: list[BaselineResult] = self.clean_raw(results_lst=results_lst)
         self.method_metadata: MethodMetadata = MethodMetadata.from_raw(
             results_lst=self.results_lst
         )
@@ -62,6 +93,10 @@ class EndToEnd:
         )
 
     @classmethod
+    def clean_raw(cls, results_lst: list[BaselineResult | dict]) -> list[BaselineResult]:
+        return [r if not isinstance(r, dict) else BaselineResult.from_dict(result=r) for r in results_lst]
+
+    @classmethod
     def from_path_raw(cls, path_raw: str | Path, name: str = None, name_suffix: str = None) -> Self:
         results_lst: list[BaselineResult] = load_raw(path_raw=path_raw)
         if name is not None or name_suffix is not None:
@@ -87,6 +122,60 @@ class EndToEnd:
             hpo_results=self.hpo_results,
             model_results=self.model_results,
         )
+
+
+class EndToEndResultsMulti:
+    def __init__(
+        self,
+        end_to_end_results_lst: list[EndToEndResults],
+    ):
+        self.end_to_end_results_lst = end_to_end_results_lst
+
+    def compare_on_tabarena(
+        self,
+        output_dir: str | Path,
+        *,
+        filter_dataset_fold: bool = False,
+        df_results_extra: pd.DataFrame = None,
+        subset: str | None | list = None,
+        new_result_prefix: str | None = None,
+        use_model_results: bool = False,
+    ) -> pd.DataFrame:
+        """Compare results on TabArena leaderboard.
+
+        Args:
+            output_dir (str | Path): Directory to save the results.
+            subset (str | None | list): Subset of tasks to evaluate on.
+                Options are "classification", "regression", "lite"  for TabArena-Lite,
+                "tabicl", "tabpfn", "tabpfn/tabicl", or None for all tasks.
+                Or a list of subset names to filter for.
+            new_result_prefix (str | None): If not None, add a prefix to the new
+                results to distinguish new results from the original TabArena results.
+                Use this, for example, if you re-run a model from TabArena.
+        """
+
+        df_metrics, baselines_extra = self.get_results(use_model_results=use_model_results)
+
+        return EndToEndResults._compare_on_tabarena(
+            output_dir=output_dir,
+            df_metrics=df_metrics,
+            filter_dataset_fold=filter_dataset_fold,
+            baselines_extra=baselines_extra,
+            df_results_extra=df_results_extra,
+            subset=subset,
+            new_result_prefix=new_result_prefix,
+        )
+
+    def get_results(self, use_model_results: bool) -> tuple[pd.DataFrame, list[str]]:
+        df_metrics_lst = []
+        baselines_extra_lst = []
+        for result in self.end_to_end_results_lst:
+            df_metrics, baselines_extra = result.get_results(use_model_results=use_model_results)
+            df_metrics_lst.append(df_metrics)
+            baselines_extra_lst.append(baselines_extra)
+        df_metrics = pd.concat(df_metrics_lst, ignore_index=True)
+        baselines_extra = [b for baselines_extra in baselines_extra_lst for b in baselines_extra]
+        return df_metrics, baselines_extra
 
 
 class EndToEndResults:
@@ -136,16 +225,7 @@ class EndToEndResults:
                 Use this, for example, if you re-run a model from TabArena.
         """
 
-        if self.method_metadata.method_type == "config":
-            if use_model_results:
-                df_metrics = self.model_results
-                baselines_extra = list(df_metrics["method"].unique())
-            else:
-                df_metrics = self.hpo_results
-                baselines_extra = []
-        else:
-            df_metrics = self.model_results
-            baselines_extra = list(df_metrics["method"].unique())
+        df_metrics, baselines_extra = self.get_results(use_model_results=use_model_results)
 
         return self._compare_on_tabarena(
             output_dir=output_dir,
@@ -156,6 +236,19 @@ class EndToEndResults:
             subset=subset,
             new_result_prefix=new_result_prefix,
         )
+
+    def get_results(self, use_model_results: bool) -> tuple[pd.DataFrame, list[str]]:
+        if self.method_metadata.method_type == "config":
+            if use_model_results:
+                df_metrics = self.model_results
+                baselines_extra = list(df_metrics["method"].unique())
+            else:
+                df_metrics = self.hpo_results
+                baselines_extra = []
+        else:
+            df_metrics = self.model_results
+            baselines_extra = list(df_metrics["method"].unique())
+        return df_metrics, baselines_extra
 
     # TODO: Move to a separate file
     @classmethod

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -127,7 +127,7 @@ class EndToEndSingle:
             method=method, artifact_name=artifact_name
         )
         results_lst = method_metadata.load_raw()
-        return cls(results_lst=results_lst)
+        return cls.from_raw(results_lst=results_lst)
 
     def to_results(self) -> EndToEndResultsSingle:
         return EndToEndResultsSingle(

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -64,7 +64,7 @@ class EndToEndSingle:
             method_metadata.cache_raw(results_lst=results_lst)
 
         if task_metadata is None:
-            tids = list({r.task_metadata["tid"] for r in self.results_lst})
+            tids = list({r.task_metadata["tid"] for r in results_lst})
             task_metadata = generate_task_metadata(tids=tids)
 
         # processed

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing_extensions import Self
+
+import pandas as pd
+
+from tabrepo.benchmark.result import BaselineResult, ConfigResult
+from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
+from tabrepo.nips2025_utils.compare import compare_on_tabarena
+from tabrepo.nips2025_utils.method_processor import generate_task_metadata, load_raw
+from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
+
+if TYPE_CHECKING:
+    from tabrepo.repository import EvaluationRepository
+
+
+class EndToEndSingle:
+    def __init__(
+        self,
+        results_lst: list[BaselineResult | dict],
+        task_metadata: pd.DataFrame | None = None,
+        cache: bool = True,
+    ):
+        # raw
+        self.results_lst: list[BaselineResult] = self.clean_raw(results_lst=results_lst)
+        self.method_metadata: MethodMetadata = MethodMetadata.from_raw(
+            results_lst=self.results_lst
+        )
+
+        if cache:
+            print(
+                f'Artifacts for method {self.method_metadata.method} will be saved in: "{self.method_metadata.path}"'
+            )
+
+        if cache:
+            self.method_metadata.to_yaml()
+            self.method_metadata.cache_raw(results_lst=self.results_lst)
+
+        if task_metadata is None:
+            tids = list({r.task_metadata["tid"] for r in self.results_lst})
+            task_metadata = generate_task_metadata(tids=tids)
+        self.task_metadata = task_metadata
+
+        # processed
+        self.repo: EvaluationRepository = self.method_metadata.generate_repo(
+            results_lst=self.results_lst,
+            task_metadata=self.task_metadata,
+            cache=cache,
+        )
+
+        # results
+        tabarena_context = TabArenaContext()
+        self.hpo_results, self.model_results = tabarena_context.simulate_repo(
+            method=self.method_metadata,
+            repo=self.repo,
+            use_rf_config_fallback=False,
+            cache=cache,
+        )
+
+    @classmethod
+    def clean_raw(cls, results_lst: list[BaselineResult | dict]) -> list[BaselineResult]:
+        return [r if not isinstance(r, dict) else BaselineResult.from_dict(result=r) for r in results_lst]
+
+    @classmethod
+    def from_path_raw(cls, path_raw: str | Path, name: str = None, name_suffix: str = None) -> Self:
+        results_lst: list[BaselineResult] = load_raw(path_raw=path_raw)
+        if name is not None or name_suffix is not None:
+            for r in results_lst:
+                r.update_name(name=name, name_suffix=name_suffix)
+                if isinstance(r, ConfigResult):
+                    r.update_model_type(name=name, name_suffix=name_suffix)
+        return cls(results_lst=results_lst)
+
+    @classmethod
+    def from_cache(cls, method: str, artifact_name: str | None = None) -> Self:
+        if artifact_name is None:
+            artifact_name = method
+        method_metadata = MethodMetadata.from_yaml(
+            method=method, artifact_name=artifact_name
+        )
+        results_lst = method_metadata.load_raw()
+        return cls(results_lst=results_lst)
+
+    def to_results(self) -> EndToEndResultsSingle:
+        return EndToEndResultsSingle(
+            method_metadata=self.method_metadata,
+            hpo_results=self.hpo_results,
+            model_results=self.model_results,
+        )
+
+
+class EndToEndResultsSingle:
+    def __init__(
+        self,
+        method_metadata: MethodMetadata,
+        hpo_results: pd.DataFrame = None,
+        model_results: pd.DataFrame = None,
+    ):
+        self.method_metadata = method_metadata
+        if hpo_results is None and self.method_metadata.method_type == "config":
+            hpo_results = self.method_metadata.load_hpo_results()
+        if model_results is None:
+            model_results = self.method_metadata.load_model_results()
+        self.hpo_results = hpo_results
+        self.model_results = model_results
+
+    @classmethod
+    def from_cache(cls, method: str, artifact_name: str | None = None) -> Self:
+        if artifact_name is None:
+            artifact_name = method
+        method_metadata = MethodMetadata.from_yaml(
+            method=method, artifact_name=artifact_name
+        )
+        return cls(method_metadata=method_metadata)
+
+    def compare_on_tabarena(
+        self,
+        output_dir: str | Path,
+        *,
+        filter_dataset_fold: bool = False,
+        subset: str | None | list = None,
+        new_result_prefix: str | None = None,
+        use_model_results: bool = False,
+    ) -> pd.DataFrame:
+        """Compare results on TabArena leaderboard.
+
+        Args:
+            output_dir (str | Path): Directory to save the results.
+            subset (str | None | list): Subset of tasks to evaluate on.
+                Options are "classification", "regression", "lite"  for TabArena-Lite,
+                "tabicl", "tabpfn", "tabpfn/tabicl", or None for all tasks.
+                Or a list of subset names to filter for.
+            new_result_prefix (str | None): If not None, add a prefix to the new
+                results to distinguish new results from the original TabArena results.
+                Use this, for example, if you re-run a model from TabArena.
+        """
+        results = self.get_results(
+            new_result_prefix=new_result_prefix,
+            use_model_results=use_model_results,
+            fillna=not filter_dataset_fold,
+        )
+
+        return compare_on_tabarena(
+            new_results=results,
+            output_dir=output_dir,
+            filter_dataset_fold=filter_dataset_fold,
+            subset=subset,
+        )
+
+    def get_results(
+        self,
+        new_result_prefix: str | None = None,
+        use_model_results: bool = False,
+        fillna: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get data to compare results on TabArena leaderboard.
+            Args:
+                new_result_prefix (str | None): If not None, add a prefix to the new
+                    results to distinguish new results from the original TabArena results.
+                    Use this, for example, if you re-run a model from TabArena.
+        """
+        use_model_results = self.method_metadata.method_type != "config" or use_model_results
+
+        if use_model_results:
+            df_results = self.model_results
+        else:
+            df_results = self.hpo_results
+
+        if new_result_prefix is not None:
+            for col in ["method", "config_type", "ta_name", "ta_suite"]:
+                df_results[col] = new_result_prefix + df_results[col]
+
+        if fillna:
+            df_results = self.fillna_results_on_tabarena(df_results=df_results)
+
+        return df_results
+
+    @classmethod
+    def fillna_results_on_tabarena(cls, df_results: pd.DataFrame) -> pd.DataFrame:
+        tabarena_context = TabArenaContext()
+        fillna_method = "RF (default)"
+        fillna_method_name = "RandomForest"
+
+        df_fillna = tabarena_context.load_results_paper(methods=[fillna_method_name])
+        df_fillna = df_fillna[df_fillna["method"] == fillna_method]
+        assert not df_fillna.empty
+
+        # FIXME: Nick: After imputing: ta_name, ta_suite, config_type, etc. are incorrect,
+        #  need to use original, not filled values
+        #  This doesn't impact the evaluation, but could introduce bugs in future if we use these columns
+        #  Fixing this is do-able, but requires some complex pandas tricks, so I haven't had time to implement it yet
+        return TabArenaContext.fillna_metrics(
+            df_to_fill=df_results,
+            df_fillna=df_fillna,
+        )

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -119,6 +119,9 @@ class EndToEndSingle:
     def task_metadata(self) -> pd.DataFrame:
         return self.repo.task_metadata
 
+    def configs_hyperparameters(self) -> dict[str, dict | None]:
+        return self.repo.configs_hyperparameters()
+
     @classmethod
     def clean_raw(cls, results_lst: list[BaselineResult | dict]) -> list[BaselineResult]:
         return [r if not isinstance(r, dict) else BaselineResult.from_dict(result=r) for r in results_lst]

--- a/tabrepo/nips2025_utils/generate_repo.py
+++ b/tabrepo/nips2025_utils/generate_repo.py
@@ -55,10 +55,7 @@ def generate_repo_from_results_lst(
 
     exp_results = ExperimentResults(task_metadata=task_metadata)
 
-    ts = time.time()
     repo: EvaluationRepository = exp_results.repo_from_results(results_lst=results_lst)
-    te = time.time()
-    print(f"{te-ts:.2f}s ExperimentResults.repo_from_results")
     return repo
 
 

--- a/tabrepo/nips2025_utils/tabarena_context.py
+++ b/tabrepo/nips2025_utils/tabarena_context.py
@@ -231,7 +231,26 @@ class TabArenaContext:
         metadata = self._method_metadata(method=method)
         return metadata.load_portfolio_results(holdout=holdout)
 
-    def load_results_paper(self, methods: list[str] | None = None, holdout: bool = False, download_results: str | bool = False) -> pd.DataFrame:
+    def load_results_paper(
+        self,
+        methods: list[str] | None = None,
+        holdout: bool = False,
+        download_results: str | bool = "auto",
+        methods_drop: list[str] | None = None,
+    ) -> pd.DataFrame:
+        if methods is None:
+            methods = _methods_paper
+            if holdout:
+                # only include methods that can have holdout
+                methods = [m for m in methods if self._method_metadata(m).is_bag]
+        if methods_drop is not None:
+            for method in methods_drop:
+                if method not in methods:
+                    raise AssertionError(
+                        f"Specified '{method}' in `methods_drop`, "
+                        f"but '{method}' is not present in methods: {methods}"
+                    )
+            methods = [method for method in methods if method not in methods_drop]
         if isinstance(download_results, bool) and download_results:
             loader = TabArena51ArtifactLoader()
             loader.download_results(holdout=holdout)
@@ -248,12 +267,7 @@ class TabArenaContext:
                 raise err
         return df_results
 
-    def _load_results_paper(self, methods: list[str] | None = None, holdout: bool = False) -> pd.DataFrame:
-        if methods is None:
-            methods = _methods_paper
-            if holdout:
-                # only include methods that can have holdout
-                methods = [m for m in methods if self._method_metadata(m).is_bag]
+    def _load_results_paper(self, methods: list[str], holdout: bool = False) -> pd.DataFrame:
         assert methods is not None and len(methods) > 0
         df_metadata_lst = []
         for method in methods:
@@ -400,13 +414,13 @@ class TabArenaContext:
         return df_missing
 
     @classmethod
-    def fillna_metrics(cls, df_metrics: pd.DataFrame, df_fillna: pd.DataFrame) -> pd.DataFrame:
+    def fillna_metrics(cls, df_to_fill: pd.DataFrame, df_fillna: pd.DataFrame) -> pd.DataFrame:
         """
-        Fills missing (dataset, fold, framework) rows in df_metrics with the (dataset, fold) row in df_fillna.
+        Fills missing (dataset, fold, framework) rows in df_to_fill with the (dataset, fold) row in df_fillna.
 
         Parameters
         ----------
-        df_metrics
+        df_to_fill
         df_fillna
 
         Returns
@@ -418,10 +432,10 @@ class TabArenaContext:
         split_col = "fold"
         dataset_col = "dataset"
 
-        df_metrics = df_metrics.set_index([dataset_col, split_col, method_col], drop=True)
+        df_to_fill = df_to_fill.set_index([dataset_col, split_col, method_col], drop=True)
         df_fillna = df_fillna.set_index([dataset_col, split_col], drop=True).drop(columns=[method_col])
 
-        unique_frameworks = list(df_metrics.index.unique(level=method_col))
+        unique_frameworks = list(df_to_fill.index.unique(level=method_col))
 
         df_filled = df_fillna.index.to_frame().merge(
             pd.Series(data=unique_frameworks, name=method_col),
@@ -430,13 +444,13 @@ class TabArenaContext:
         df_filled = df_filled.set_index(keys=list(df_filled.columns))
 
         # missing results
-        nan_vals = df_filled.index.difference(df_metrics.index)
+        nan_vals = df_filled.index.difference(df_to_fill.index)
 
         # fill valid values
-        fill_cols = list(df_metrics.columns)
+        fill_cols = list(df_to_fill.columns)
         df_filled[fill_cols] = np.nan
-        df_filled[fill_cols] = df_filled[fill_cols].astype(df_metrics.dtypes)
-        df_filled.loc[df_metrics.index] = df_metrics
+        df_filled[fill_cols] = df_filled[fill_cols].astype(df_to_fill.dtypes)
+        df_filled.loc[df_to_fill.index] = df_to_fill
 
         a = df_fillna.loc[nan_vals.droplevel(level=method_col)]
         a.index = nan_vals
@@ -445,8 +459,8 @@ class TabArenaContext:
         df_filled["imputed"] = False
         df_filled.loc[nan_vals, "imputed"] = True
 
-        df_metrics = df_filled
+        df_to_fill = df_filled
 
-        df_metrics = df_metrics.reset_index(drop=False)
+        df_to_fill = df_to_fill.reset_index(drop=False)
 
-        return df_metrics
+        return df_to_fill

--- a/tabrepo/nips2025_utils/tabarena_context.py
+++ b/tabrepo/nips2025_utils/tabarena_context.py
@@ -456,7 +456,8 @@ class TabArenaContext:
         a.index = nan_vals
         df_filled.loc[nan_vals] = a
 
-        df_filled["imputed"] = False
+        if "imputed" not in df_filled.columns:
+            df_filled["imputed"] = False
         df_filled.loc[nan_vals, "imputed"] = True
 
         df_to_fill = df_filled

--- a/tabrepo/paper/tabarena_evaluator.py
+++ b/tabrepo/paper/tabarena_evaluator.py
@@ -161,6 +161,28 @@ class TabArenaEvaluator:
         ])
         return config_types
 
+    # TODO: Remove the need for this, have the original results have the correct name to begin with
+    @classmethod
+    def _rename_dict(cls) -> dict:
+        return {
+            "AutoGluon_v130_bq_4h8c": "AutoGluon 1.3 (4h)",
+
+            "RandomForest_r1_BAG_L1_HOLDOUT": "RF (holdout)",
+            "ExtraTrees_r1_BAG_L1_HOLDOUT": "XT (holdout)",
+            "LinearModel_c1_BAG_L1_HOLDOUT": "LR (holdout)",
+
+            "LightGBM_c1_BAG_L1_HOLDOUT": "GBM (holdout)",
+            "XGBoost_c1_BAG_L1_HOLDOUT": "XGB (holdout)",
+            "CatBoost_c1_BAG_L1_HOLDOUT": "CAT (holdout)",
+            "NeuralNetTorch_c1_BAG_L1_HOLDOUT": "NN_TORCH (holdout)",
+            "NeuralNetFastAI_c1_BAG_L1_HOLDOUT": "FASTAI (holdout)",
+
+            "RealMLP_c1_BAG_L1_HOLDOUT": "REALMLP (holdout)",
+            "ExplainableBM_c1_BAG_L1_HOLDOUT": "EBM (holdout)",
+            "TabM_c1_BAG_L1_HOLDOUT": "TABM (holdout)",
+            "ModernNCA_c1_BAG_L1_HOLDOUT": "MNCA (holdout)",
+        }
+
     def eval(
         self,
         df_results: pd.DataFrame,
@@ -206,6 +228,14 @@ class TabArenaEvaluator:
             df_results["imputed"] = False
         df_results["imputed"] = df_results["imputed"].astype("boolean").fillna(False).astype(bool)
         df_results["seed"] = df_results["seed"].fillna(0).astype(int)
+
+        # rename methods
+        _rename_dict = self._rename_dict()
+        df_results[self.method_col] = df_results[self.method_col].map(_rename_dict).fillna(df_results[self.method_col])
+        baselines = [_rename_dict.get(b, b) for b in baselines]
+        assert len(baselines) == len(list(set(baselines))), f"Duplicates keys found in baselines: {baselines}"
+        if calibration_framework is not None:
+            calibration_framework = _rename_dict.get(calibration_framework, calibration_framework)
 
         # don't allow duplicate results
         dupes = df_results[df_results.duplicated(
@@ -257,27 +287,6 @@ class TabArenaEvaluator:
             dataset_to_n_samples_train)
         df_results['time_infer_s_per_1K'] = df_results['time_infer_s'] * 1000 / df_results["dataset"].map(
             dataset_to_n_samples_test)
-
-        df_results[self.method_col] = df_results[self.method_col].map({
-            "AutoGluon_v130_bq_4h8c": "AutoGluon 1.3 (4h)",
-
-            "RandomForest_r1_BAG_L1_HOLDOUT": "RF (holdout)",
-            "ExtraTrees_r1_BAG_L1_HOLDOUT": "XT (holdout)",
-            "LinearModel_c1_BAG_L1_HOLDOUT": "LR (holdout)",
-
-            "LightGBM_c1_BAG_L1_HOLDOUT": "GBM (holdout)",
-            "XGBoost_c1_BAG_L1_HOLDOUT": "XGB (holdout)",
-            "CatBoost_c1_BAG_L1_HOLDOUT": "CAT (holdout)",
-            "NeuralNetTorch_c1_BAG_L1_HOLDOUT": "NN_TORCH (holdout)",
-            "NeuralNetFastAI_c1_BAG_L1_HOLDOUT": "FASTAI (holdout)",
-
-            "RealMLP_c1_BAG_L1_HOLDOUT": "REALMLP (holdout)",
-            "ExplainableBM_c1_BAG_L1_HOLDOUT": "EBM (holdout)",
-            "TabM_c1_BAG_L1_HOLDOUT": "TABM (holdout)",
-            "ModernNCA_c1_BAG_L1_HOLDOUT": "MNCA (holdout)",
-
-        }).fillna(df_results[self.method_col])
-        # print(df_results)
 
         df_results_rank_compare = copy.deepcopy(df_results)
         df_results_unfiltered = copy.deepcopy(df_results)

--- a/tabrepo/tabarena/website_format.py
+++ b/tabrepo/tabarena/website_format.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+class Constants:
+    col_name: str = "method_type"
+    tree: str = "Tree-based"
+    foundational: str = "Foundation Model"
+    neural_network: str ="Neural Network"
+    baseline: str = "Baseline"
+    reference: str ="Reference Pipeline"
+    # Not Used
+    other: str = "Other"
+
+model_type_emoji = {
+    Constants.tree: "🌳",
+    Constants.foundational: "🧠⚡",
+    Constants.neural_network: "🧠🔁",
+    Constants.baseline: "📏",
+    # Not used
+    Constants.other: "❓",
+    Constants.reference: "📊",
+}
+
+
+def get_model_family(model_name: str) -> str:
+    prefixes_mapping = {
+        Constants.reference: ["AutoGluon"],
+        Constants.neural_network: ["REALMLP", "TabM", "FASTAI", "MNCA", "NN_TORCH"],
+        Constants.tree: ["GBM", "CAT", "EBM", "XGB", "XT", "RF"],
+        Constants.foundational: ["TABDPT", "TABICL", "TABPFN"],
+        Constants.baseline: ["KNN", "LR"],
+    }
+
+    for method_type, prefixes in prefixes_mapping.items():
+        for prefix in prefixes:
+            if prefix.lower() in model_name.lower():
+                return method_type
+    return Constants.other
+
+
+def rename_map(model_name: str) -> str:
+    rename_map = {
+        "TABM": "TabM",
+        "REALMLP": "RealMLP",
+        "GBM": "LightGBM",
+        "CAT": "CatBoost",
+        "XGB": "XGBoost",
+        "XT": "ExtraTrees",
+        "RF": "RandomForest",
+        "MNCA": "ModernNCA",
+        "NN_TORCH": "TorchMLP",
+        "FASTAI": "FastaiMLP",
+        "TABPFNV2": "TabPFNv2",
+        "EBM": "EBM",
+        "TABDPT": "TabDPT",
+        "TABICL": "TabICL",
+        "KNN": "KNN",
+        "LR": "Linear",
+    }
+
+    for prefix in rename_map:
+        if prefix in model_name:
+            return model_name.replace(prefix, rename_map[prefix])
+
+    return model_name
+
+
+def format_leaderboard(df_leaderboard: pd.DataFrame, include_type: bool = False) -> pd.DataFrame:
+    df_leaderboard = df_leaderboard.copy(deep=True)
+
+    # Add Model Family Information
+    df_leaderboard["Type"] = df_leaderboard.loc[:, "method"].apply(
+        lambda s: model_type_emoji[get_model_family(s)]
+    )
+    df_leaderboard["TypeName"] = df_leaderboard.loc[:, "method"].apply(
+        lambda s: get_model_family(s)
+    )
+    df_leaderboard["method"] = df_leaderboard["method"].apply(rename_map)
+
+    # elo,elo+,elo-,mrr
+    df_leaderboard["Elo 95% CI"] = (
+        "+"
+        + df_leaderboard["elo+"].round(0).astype(int).astype(str)
+        + "/-"
+        + df_leaderboard["elo-"].round(0).astype(int).astype(str)
+    )
+    # select only the columns we want to display
+    df_leaderboard["normalized-score"] = 1 - df_leaderboard["normalized-error"]
+    df_leaderboard["hmr"] = 1 / df_leaderboard["mrr"]
+    df_leaderboard["improvability"] = 100 * df_leaderboard["champ_delta"]
+
+    # Imputed logic
+    if "imputed" in df_leaderboard.columns:
+        df_leaderboard["imputed"] = (100 * df_leaderboard["imputed"]).round(2)
+        df_leaderboard["imputed_bool"] = False
+        # Filter methods that are fully imputed.
+        df_leaderboard = df_leaderboard[~(df_leaderboard["imputed"] == 100)]
+        # Add imputed column and add name postfix
+        imputed_mask = df_leaderboard["imputed"] != 0
+        df_leaderboard.loc[imputed_mask, "imputed_bool"] = True
+        df_leaderboard.loc[imputed_mask, "method"] = df_leaderboard.loc[
+            imputed_mask, ["method", "imputed"]
+        ].apply(lambda row: row["method"] + f" [{row['imputed']:.2f}% IMPUTED]", axis=1)
+    else:
+        df_leaderboard["imputed_bool"] = None
+        df_leaderboard["imputed"] = None
+
+    # Resolve GPU postfix
+    gpu_postfix = "_GPU"
+    df_leaderboard["Hardware"] = df_leaderboard["method"].apply(
+        lambda x: "CPU" if gpu_postfix not in x else "GPU"
+    )
+    df_leaderboard["method"] = df_leaderboard["method"].str.replace(gpu_postfix, "")
+
+    df_leaderboard = df_leaderboard.loc[
+        :,
+        [
+            "Type",
+            "TypeName",
+            "method",
+            "elo",
+            "Elo 95% CI",
+            "normalized-score",
+            "rank",
+            "hmr",
+            "improvability",
+            "median_time_train_s_per_1K",
+            "median_time_infer_s_per_1K",
+            "imputed",
+            "imputed_bool",
+            "Hardware",
+        ],
+    ]
+
+    # round for better display
+    df_leaderboard[["elo", "Elo 95% CI"]] = df_leaderboard[["elo", "Elo 95% CI"]].round(
+        0
+    )
+    df_leaderboard[["median_time_train_s_per_1K", "rank", "hmr"]] = df_leaderboard[
+        ["median_time_train_s_per_1K", "rank", "hmr"]
+    ].round(2)
+    df_leaderboard[
+        ["normalized-score", "median_time_infer_s_per_1K", "improvability"]
+    ] = df_leaderboard[
+        ["normalized-score", "median_time_infer_s_per_1K", "improvability"]
+    ].round(3)
+
+    df_leaderboard = df_leaderboard.sort_values(by="elo", ascending=False)
+    df_leaderboard = df_leaderboard.reset_index(drop=True)
+    df_leaderboard = df_leaderboard.reset_index(names="#")
+
+    if not include_type:
+        df_leaderboard = df_leaderboard.drop(columns=["Type", "TypeName"])
+
+    # rename some columns
+    return df_leaderboard.rename(
+        columns={
+            "median_time_train_s_per_1K": "Median Train Time (s/1K) [⬇️]",
+            "median_time_infer_s_per_1K": "Median Predict Time (s/1K) [⬇️]",
+            "method": "Model",
+            "elo": "Elo [⬆️]",
+            "rank": "Rank [⬇️]",
+            "normalized-score": "Score [⬆️]",
+            "hmr": "Harmonic Rank [⬇️]",
+            "improvability": "Improvability (%) [⬇️]",
+            "imputed": "Imputed (%) [⬇️]",
+            "imputed_bool": "Imputed",
+        }
+    )

--- a/tabrepo/utils/pickle_utils.py
+++ b/tabrepo/utils/pickle_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from pathlib import Path
 from typing import Any


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Enhance EndToEnd Logic
- Renamed EndToEnd -> EndToEndSingle, for a version that only supports a single method type.
- Enable EndToEnd to take results_lst directly from `ExperimentBatchRunner.run` output.
- Support passing task_metadata
- Support enabling/disabling caching
- Make EndToEnd support multiple different methods in the same `results_lst`, internally it will create a list of `EndToEndSingle`. Ditto for `EndToEndResults`.
- Update `run_quickstart_tabarena.py` to use EndToEnd
- Separated `compute_on_tabarena` into its own function.

TODO in follow-up PR:

- [ ] accept s3 paths as input
- [x] method call in EndToEnd to cache the artifacts in s3 / on the cloud so that others can access them.
- [ ] method call in EndToEnd to run portfolio simulations.
- [x] method to load EndToEnd without re-running simulations if they were cached.
- [ ] script that re-runs all of TabArena (Sequentially) -> more for reference than as a recommended script to run.
- [ ] script to re-run any result artifact.
- [ ] script to generate the experiment object used to generate a given artifact
- [ ] Add docstrings

You can refer to `examples/tabarena/run_extra_methods_end_to_end.py` for an example of comparing multiple new methods together with TabArena's leaderboard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
