### PR TITLE
New Parallel End to End

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ requirements = [
     "openml>=0.14.1",  # consider making optional
     "pyyaml",
     "pytest",
+    "tqdm",
     "typing-extensions>=4.11,<5",  # used for `Self` type hint
     "huggingface-hub",
 ]

--- a/tabrepo/models/tabpfnv2/generate.py
+++ b/tabrepo/models/tabpfnv2/generate.py
@@ -4,7 +4,7 @@ import numpy as np
 from hyperopt import hp
 from hyperopt.pyll import stochastic
 
-from autogluon.tabular.models import TabPFNV2Model
+from tabrepo.benchmark.models.ag.tabpfnv2.tabpfnv2_model import TabPFNV2Model
 from tabrepo.utils.config_utils import CustomAGConfigGenerator
 
 

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -1,15 +1,29 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing_extensions import Self
 
 import pandas as pd
-from typing_extensions import Self
+from autogluon.common.savers import save_pd
 
 from tabrepo.benchmark.result import BaselineResult
 from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
 from tabrepo.nips2025_utils.compare import compare_on_tabarena
-from tabrepo.nips2025_utils.end_to_end_single import EndToEndSingle, EndToEndResultsSingle
-from tabrepo.nips2025_utils.method_processor import generate_task_metadata, get_info_from_result, load_raw
+from tabrepo.nips2025_utils.end_to_end_single import (
+    EndToEndResultsSingle,
+    EndToEndSingle,
+)
+from tabrepo.nips2025_utils.fetch_metadata import load_task_metadata
+from tabrepo.nips2025_utils.method_processor import (
+    generate_task_metadata,
+    get_info_from_result,
+    load_all_artifacts,
+    load_raw,
+)
+from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
+from tabrepo.utils.pickle_utils import fetch_all_pickles_fast
+from tabrepo.utils.ray_utils import ray_map_list
 
 
 class EndToEnd:
@@ -20,7 +34,9 @@ class EndToEnd:
         self.end_to_end_lst = end_to_end_lst
 
     def configs_hyperparameters(self) -> dict[str, dict | None]:
-        configs_hyperparameters_per_method = [e2e.configs_hyperparameters() for e2e in self.end_to_end_lst]
+        configs_hyperparameters_per_method = [
+            e2e.configs_hyperparameters() for e2e in self.end_to_end_lst
+        ]
         configs_hyperparameters = {}
         for d in configs_hyperparameters_per_method:
             for k, v in d.items():
@@ -44,7 +60,9 @@ class EndToEnd:
         log = print if verbose else (lambda *a, **k: None)
 
         # raw
-        results_lst: list[BaselineResult] = EndToEndSingle.clean_raw(results_lst=results_lst)
+        results_lst: list[BaselineResult] = EndToEndSingle.clean_raw(
+            results_lst=results_lst
+        )
 
         if task_metadata is None:
             tids = list({r.task_metadata["tid"] for r in results_lst})
@@ -60,7 +78,9 @@ class EndToEnd:
 
         unique_types = list(result_types_dict.keys())
 
-        log(f"Constructing EndToEnd from raw results... Found {len(unique_types)} unique methods: {unique_types}")
+        log(
+            f"Constructing EndToEnd from raw results... Found {len(unique_types)} unique methods: {unique_types}"
+        )
         end_to_end_lst = []
         for cur_type in unique_types:
             cur_results_lst = result_types_dict[cur_type]
@@ -109,14 +129,123 @@ class EndToEnd:
                 method, artifact_name = method
             else:
                 artifact_name = None
-            end_to_end_single = EndToEndSingle.from_cache(method=method, artifact_name=artifact_name)
+            end_to_end_single = EndToEndSingle.from_cache(
+                method=method, artifact_name=artifact_name
+            )
             end_to_end_lst.append(end_to_end_single)
         return cls(end_to_end_lst=end_to_end_lst)
 
     def to_results(self) -> EndToEndResults:
         return EndToEndResults(
-            end_to_end_results_lst=[end_to_end.to_results() for end_to_end in self.end_to_end_lst],
+            end_to_end_results_lst=[
+                end_to_end.to_results() for end_to_end in self.end_to_end_lst
+            ],
         )
+
+    @staticmethod
+    def create_and_cache_end_to_end_results(
+        path_raw: str | Path,
+        num_cpus: int | None = None,
+        artifact_name: str | None = None,
+    ) -> None:
+        """Create and cache end-to-end results for all methods in the given directory.
+
+        Args:
+            path_raw (str | Path): Path to the directory containing raw results.
+            num_cpus (int | None): Number of CPUs to use for parallel processing.
+                If None, it will use all available CPUs.
+            artifact_name (str | None): Optional name to distinguish different runs of
+                the same method.
+        """
+        if num_cpus is None:
+            num_cpus = len(os.sched_getaffinity(0))
+
+        print("Get results paths...")
+        all_file_paths_method = fetch_all_pickles_fast(
+            dir_path=path_raw, suffix="results.pkl"
+        )
+        print("Get task metadata...")
+        task_metadata = load_task_metadata()
+        # Below is too slow to use by default, TODO: get logic for any task that is fast
+        # task_metadata = generate_task_metadata(tids=list({r.split("/")[0] for r in all_file_paths_method}))
+
+        results = ray_map_list(
+            list_to_map=list(all_file_paths_method.values()),
+            func=_process_result_list,
+            func_element_key_string="file_paths_method",
+            num_workers=num_cpus,
+            num_cpus_per_worker=1,
+            func_put_kwargs={
+                "task_metadata": task_metadata,
+                "artifact_name": artifact_name,
+            },
+            track_progress=True,
+            tqdm_kwargs={"desc": "Processing Results"},
+            ray_remote_kwargs={"max_calls": 10},
+        )
+
+        print("Merging results...")
+        method_metadata, hpo_results, model_results = results[0]
+        for results_method in results[1:]:
+            method_metadata_other, hpo_results_other, model_results_other = (
+                results_method
+            )
+
+            # Capture the any() in metadata creation.
+            if method_metadata.is_bag or method_metadata_other.is_bag:
+                method_metadata.is_bag = True
+                method_metadata_other.is_bag = True
+
+            if method_metadata.__dict__ != method_metadata_other.__dict__:
+                raise ValueError(
+                    "Method metadata mismatch! "
+                    f"{method_metadata.__dict__} != {method_metadata_other.__dict__}"
+                )
+
+            # merge results
+            hpo_results = pd.concat([hpo_results, hpo_results_other], ignore_index=True)
+            model_results = pd.concat(
+                [model_results, model_results_other], ignore_index=True
+            )
+
+        print(f"Save metadata and results to {method_metadata.path}...")
+        method_metadata.to_yaml()
+        save_pd.save(path=str(method_metadata.path_results_hpo()), df=hpo_results)
+        save_pd.save(path=str(method_metadata.path_results_model()), df=model_results)
+
+
+def _process_result_list(
+    *,
+    file_paths_method: list[Path],
+    task_metadata: pd.DataFrame,
+    artifact_name: str | None,
+) -> tuple[MethodMetadata, pd.DataFrame, pd.DataFrame]:
+    results_lst = load_all_artifacts(
+        file_paths=file_paths_method, engine="sequential", progress_bar=False
+    )
+    # Get metadata
+    method_metadata: MethodMetadata = MethodMetadata.from_raw(
+        results_lst=results_lst, artifact_name=artifact_name
+    )
+
+    # Get evaluation repository
+    repo = method_metadata.generate_repo(
+        results_lst=results_lst,
+        task_metadata=task_metadata,
+    )
+
+    # Getting Tabarena context
+    tabarena_context = TabArenaContext()
+    tabarena_context.backend = "native"
+    tabarena_context.engine = "sequential"
+    hpo_results, model_results = tabarena_context.simulate_repo(
+        repo=repo,
+        method=method_metadata,
+        use_rf_config_fallback=False,
+        cache=False,
+    )
+
+    return method_metadata, hpo_results, model_results
 
 
 class EndToEndResults:
@@ -129,7 +258,11 @@ class EndToEndResults:
     @property
     def model_results(self) -> pd.DataFrame | None:
         model_results_lst = [e2e.model_results for e2e in self.end_to_end_results_lst]
-        model_results_lst = [model_results for model_results in model_results_lst if model_results is not None]
+        model_results_lst = [
+            model_results
+            for model_results in model_results_lst
+            if model_results is not None
+        ]
         if not model_results_lst:
             return None
 
@@ -138,7 +271,9 @@ class EndToEndResults:
     @property
     def hpo_results(self) -> pd.DataFrame | None:
         hpo_results_lst = [e2e.hpo_results for e2e in self.end_to_end_results_lst]
-        hpo_results_lst = [hpo_results for hpo_results in hpo_results_lst if hpo_results is not None]
+        hpo_results_lst = [
+            hpo_results for hpo_results in hpo_results_lst if hpo_results is not None
+        ]
         if not hpo_results_lst:
             return None
 
@@ -186,11 +321,13 @@ class EndToEndResults:
     ) -> pd.DataFrame:
         df_results_lst = []
         for result in self.end_to_end_results_lst:
-            df_results_lst.append(result.get_results(
-                new_result_prefix=new_result_prefix,
-                use_model_results=use_model_results,
-                fillna=fillna,
-            ))
+            df_results_lst.append(
+                result.get_results(
+                    new_result_prefix=new_result_prefix,
+                    use_model_results=use_model_results,
+                    fillna=fillna,
+                )
+            )
         df_results = pd.concat(df_results_lst, ignore_index=True)
         return df_results
 
@@ -202,6 +339,8 @@ class EndToEndResults:
                 method, artifact_name = method
             else:
                 artifact_name = None
-            end_to_end_results = EndToEndResultsSingle.from_cache(method=method, artifact_name=artifact_name)
+            end_to_end_results = EndToEndResultsSingle.from_cache(
+                method=method, artifact_name=artifact_name
+            )
             end_to_end_results_lst.append(end_to_end_results)
         return cls(end_to_end_results_lst=end_to_end_results_lst)

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Literal
 from typing_extensions import Self
 
 import pandas as pd
-from autogluon.common.savers import save_pd
 
 from tabrepo.benchmark.result import BaselineResult
 from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
@@ -21,8 +21,7 @@ from tabrepo.nips2025_utils.method_processor import (
     load_all_artifacts,
     load_raw,
 )
-from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
-from tabrepo.utils.pickle_utils import fetch_all_pickles_fast
+from tabrepo.utils.pickle_utils import fetch_all_pickles
 from tabrepo.utils.ray_utils import ray_map_list
 
 
@@ -55,6 +54,7 @@ class EndToEnd:
         name: str | None = None,
         name_suffix: str | None = None,
         artifact_name: str | None = None,
+        backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
         log = print if verbose else (lambda *a, **k: None)
@@ -92,6 +92,7 @@ class EndToEnd:
                 name=name,
                 name_suffix=name_suffix,
                 artifact_name=artifact_name,
+                backend=backend,
                 verbose=verbose,
             )
             end_to_end_lst.append(cur_end_to_end)
@@ -100,16 +101,18 @@ class EndToEnd:
     @classmethod
     def from_path_raw(
         cls,
-        path_raw: str | Path,
+        path_raw: str | Path | list[str | Path],
         task_metadata: pd.DataFrame | None = None,
         cache: bool = True,
         cache_raw: bool = True,
         name: str = None,
         name_suffix: str = None,
         artifact_name: str | None = None,
+        backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
-        results_lst: list[BaselineResult] = load_raw(path_raw=path_raw)
+        engine = "ray" if backend == "ray" else "sequential"
+        results_lst: list[BaselineResult] = load_raw(path_raw=path_raw, engine=engine)
         return cls.from_raw(
             results_lst=results_lst,
             task_metadata=task_metadata,
@@ -118,6 +121,7 @@ class EndToEnd:
             name=name,
             name_suffix=name_suffix,
             artifact_name=artifact_name,
+            backend=backend,
             verbose=verbose,
         )
 
@@ -135,23 +139,17 @@ class EndToEnd:
             end_to_end_lst.append(end_to_end_single)
         return cls(end_to_end_lst=end_to_end_lst)
 
-    def to_results(self) -> EndToEndResults:
-        return EndToEndResults(
-            end_to_end_results_lst=[
-                end_to_end.to_results() for end_to_end in self.end_to_end_lst
-            ],
-        )
-
     @staticmethod
     def create_and_cache_end_to_end_results(
-        path_raw: str | Path,
-        num_cpus: int | None = None,
-        artifact_name: str | None = None,
-    ) -> None:
+            path_raw: str | Path | list[str | Path],
+            num_cpus: int | None = None,
+            artifact_name: str | None = None,
+            task_metadata: pd.DataFrame | None = None,
+    ) -> EndToEndResults:
         """Create and cache end-to-end results for all methods in the given directory.
 
         Args:
-            path_raw (str | Path): Path to the directory containing raw results.
+            path_raw (str | Path | list[str | Path): Path to the directory containing raw results.
             num_cpus (int | None): Number of CPUs to use for parallel processing.
                 If None, it will use all available CPUs.
             artifact_name (str | None): Optional name to distinguish different runs of
@@ -161,15 +159,24 @@ class EndToEnd:
             num_cpus = len(os.sched_getaffinity(0))
 
         print("Get results paths...")
-        all_file_paths_method = fetch_all_pickles_fast(
+        file_paths = fetch_all_pickles(
             dir_path=path_raw, suffix="results.pkl"
         )
-        print("Get task metadata...")
-        task_metadata = load_task_metadata()
-        # Below is too slow to use by default, TODO: get logic for any task that is fast
-        # task_metadata = generate_task_metadata(tids=list({r.split("/")[0] for r in all_file_paths_method}))
 
-        results = ray_map_list(
+        all_file_paths_method = {}
+        for file_path in file_paths:
+            did_sid = f"{file_path.parts[-3]}/{file_path.parts[-2]}"
+            if did_sid not in all_file_paths_method:
+                all_file_paths_method[did_sid] = []
+            all_file_paths_method[did_sid].append(file_path)
+
+        if task_metadata is None:
+            print("Get task metadata...")
+            task_metadata = load_task_metadata()
+            # Below is too slow to use by default, TODO: get logic for any task that is fast
+            # task_metadata = generate_task_metadata(tids=list({r.split("/")[0] for r in all_file_paths_method}))
+
+        results: list[EndToEndResults] = ray_map_list(
             list_to_map=list(all_file_paths_method.values()),
             func=_process_result_list,
             func_element_key_string="file_paths_method",
@@ -181,71 +188,35 @@ class EndToEnd:
             },
             track_progress=True,
             tqdm_kwargs={"desc": "Processing Results"},
-            ray_remote_kwargs={"max_calls": 10},
+            ray_remote_kwargs={"max_calls": 0},
         )
+        results: list[EndToEndResultsSingle] = [
+            e2e_single for e2e in results for e2e_single in e2e.end_to_end_results_lst
+        ]
 
         print("Merging results...")
-        method_metadata, hpo_results, model_results = results[0]
-        for results_method in results[1:]:
-            method_metadata_other, hpo_results_other, model_results_other = (
-                results_method
-            )
+        results_per_method = {}
+        for e2e_single in results:
+            method = e2e_single.method_metadata.method
+            if method not in results_per_method:
+                results_per_method[method] = []
+            results_per_method[method].append(e2e_single)
+        e2e_single_lst = []
+        for method, e2e_lst in results_per_method.items():
+            cur_e2e = EndToEndResultsSingle.concat(e2e_lst=e2e_lst)
+            e2e_single_lst.append(cur_e2e)
+        e2e_results = EndToEndResults(end_to_end_results_lst=e2e_single_lst)
 
-            # Capture the any() in metadata creation.
-            if method_metadata.is_bag or method_metadata_other.is_bag:
-                method_metadata.is_bag = True
-                method_metadata_other.is_bag = True
+        print(f"Save metadata and results...")
+        e2e_results.cache()
+        return e2e_results
 
-            if method_metadata.__dict__ != method_metadata_other.__dict__:
-                raise ValueError(
-                    "Method metadata mismatch! "
-                    f"{method_metadata.__dict__} != {method_metadata_other.__dict__}"
-                )
-
-            # merge results
-            hpo_results = pd.concat([hpo_results, hpo_results_other], ignore_index=True)
-            model_results = pd.concat(
-                [model_results, model_results_other], ignore_index=True
-            )
-
-        print(f"Save metadata and results to {method_metadata.path}...")
-        method_metadata.to_yaml()
-        save_pd.save(path=str(method_metadata.path_results_hpo()), df=hpo_results)
-        save_pd.save(path=str(method_metadata.path_results_model()), df=model_results)
-
-
-def _process_result_list(
-    *,
-    file_paths_method: list[Path],
-    task_metadata: pd.DataFrame,
-    artifact_name: str | None,
-) -> tuple[MethodMetadata, pd.DataFrame, pd.DataFrame]:
-    results_lst = load_all_artifacts(
-        file_paths=file_paths_method, engine="sequential", progress_bar=False
-    )
-    # Get metadata
-    method_metadata: MethodMetadata = MethodMetadata.from_raw(
-        results_lst=results_lst, artifact_name=artifact_name
-    )
-
-    # Get evaluation repository
-    repo = method_metadata.generate_repo(
-        results_lst=results_lst,
-        task_metadata=task_metadata,
-    )
-
-    # Getting Tabarena context
-    tabarena_context = TabArenaContext()
-    tabarena_context.backend = "native"
-    tabarena_context.engine = "sequential"
-    hpo_results, model_results = tabarena_context.simulate_repo(
-        repo=repo,
-        method=method_metadata,
-        use_rf_config_fallback=False,
-        cache=False,
-    )
-
-    return method_metadata, hpo_results, model_results
+    def to_results(self) -> EndToEndResults:
+        return EndToEndResults(
+            end_to_end_results_lst=[
+                end_to_end.to_results() for end_to_end in self.end_to_end_lst
+            ],
+        )
 
 
 class EndToEndResults:
@@ -344,3 +315,31 @@ class EndToEndResults:
             )
             end_to_end_results_lst.append(end_to_end_results)
         return cls(end_to_end_results_lst=end_to_end_results_lst)
+
+    def cache(self):
+        for e2e_results_single in self.end_to_end_results_lst:
+            e2e_results_single.cache()
+
+
+def _process_result_list(
+    *,
+    file_paths_method: list[Path],
+    task_metadata: pd.DataFrame,
+    artifact_name: str | None,
+) -> EndToEndResults:
+    results_lst = load_all_artifacts(
+        file_paths=file_paths_method, engine="sequential", progress_bar=False
+    )
+
+    e2e = EndToEnd.from_raw(
+        results_lst=results_lst,
+        task_metadata=task_metadata,
+        artifact_name=artifact_name,
+        cache=False,
+        cache_raw=False,
+        backend="native",
+        verbose=False,
+    )
+    e2e_results = e2e.to_results()
+
+    return e2e_results

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
 
 import copy
+import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Literal, TYPE_CHECKING
 from typing_extensions import Self
 
 import pandas as pd
+from autogluon.common.savers import save_pd
 
 from tabrepo.benchmark.result import BaselineResult, ConfigResult
 from tabrepo.nips2025_utils.artifacts.method_metadata import MethodMetadata
 from tabrepo.nips2025_utils.compare import compare_on_tabarena
-from tabrepo.nips2025_utils.method_processor import generate_task_metadata, load_raw
+from tabrepo.nips2025_utils.fetch_metadata import load_task_metadata
+from tabrepo.nips2025_utils.method_processor import (
+    generate_task_metadata,
+    load_all_artifacts,
+    load_raw,
+)
 from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
+from tabrepo.utils.pickle_utils import fetch_all_pickles
+from tabrepo.utils.ray_utils import ray_map_list
 
 if TYPE_CHECKING:
     from tabrepo.repository import EvaluationRepository
@@ -130,6 +139,7 @@ class EndToEndSingle:
     def from_raw(
         cls,
         results_lst: list[BaselineResult | dict],
+        method_metadata: MethodMetadata | None = None,
         task_metadata: pd.DataFrame | None = None,
         cache: bool = True,
         cache_raw: bool = True,
@@ -137,6 +147,7 @@ class EndToEndSingle:
         name_suffix: str | None = None,
         method: str | None = None,
         artifact_name: str | None = None,
+        backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
         """
@@ -153,7 +164,11 @@ class EndToEndSingle:
         ----------
         results_lst : list[BaselineResult | dict]
             The raw results of the method on all tasks and configs.
-        task_metadata : pd.DataFrame or None
+        method_metadata : MethodMetadata or None = None
+            The method_metadata containing information about the method.
+            If unspecified, will be inferred from ``results_lst``.
+            If specified, ``method`` and ``artifact_name`` will be ignored.
+        task_metadata : pd.DataFrame or None = None
             The task_metadata containing information for each task,
             such as the target evaluation metric and problem_type.
             If unspecified, will be inferred from ``results_lst``.
@@ -176,6 +191,9 @@ class EndToEndSingle:
             The name of the upper directory in the cache:
                 ~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/
             If unspecified, will default to ``{method}``
+        backend : "ray" or "native" = "ray"
+            If "ray", will parallelize the calculation of hpo_results and model_results.
+            If "native", will sequentially compute hpo_results and model_results.
         verbose : bool = True
             If True will log info about the data processing and simulation.
 
@@ -189,11 +207,12 @@ class EndToEndSingle:
         # raw
         results_lst: list[BaselineResult] = cls.clean_raw(results_lst=results_lst)
         results_lst = cls._rename(results_lst=results_lst, name=name, name_suffix=name_suffix)
-        method_metadata: MethodMetadata = MethodMetadata.from_raw(
-            results_lst=results_lst,
-            method=method,
-            artifact_name=artifact_name,
-        )
+        if method_metadata is None:
+            method_metadata: MethodMetadata = MethodMetadata.from_raw(
+                results_lst=results_lst,
+                method=method,
+                artifact_name=artifact_name,
+            )
 
         log(
             f"{method_metadata.method}: Creating EndToEndSingle from raw results... "
@@ -222,9 +241,14 @@ class EndToEndSingle:
             cache=cache,
         )
 
+        if cache:
+            # TODO: Add this as a user flag?
+            # reload into mem-map mode, otherwise can be very slow for large datasets
+            repo = method_metadata.load_processed()
+
         log(f"\tSimulating HPO...")
         # results
-        tabarena_context = TabArenaContext()
+        tabarena_context = TabArenaContext(backend=backend)
         hpo_results, model_results = tabarena_context.simulate_repo(
             method=method_metadata,
             repo=repo,
@@ -243,24 +267,31 @@ class EndToEndSingle:
     @classmethod
     def from_path_raw(
         cls,
-        path_raw: str | Path,
+        path_raw: str | Path | list[str | Path],
+        method_metadata: MethodMetadata | None = None,
+        task_metadata: pd.DataFrame | None = None,
         cache: bool = True,
         cache_raw: bool = True,
         name: str = None,
         name_suffix: str = None,
         method: str | None = None,
         artifact_name: str | None = None,
+        backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
-        results_lst: list[BaselineResult] = load_raw(path_raw=path_raw)
+        engine = "ray" if backend == "ray" else "sequential"
+        results_lst: list[BaselineResult] = load_raw(path_raw=path_raw, engine=engine)
         return cls.from_raw(
             results_lst=results_lst,
+            method_metadata=method_metadata,
+            task_metadata=task_metadata,
             cache=cache,
             cache_raw=cache_raw,
             name=name,
             name_suffix=name_suffix,
             method=method,
             artifact_name=artifact_name,
+            backend=backend,
             verbose=verbose,
         )
 
@@ -306,6 +337,68 @@ class EndToEndSingle:
             model_results=self.model_results,
             hpo_results=self.hpo_results,
         )
+
+    # FIXME: Refactor
+    @staticmethod
+    def create_and_cache_end_to_end_results(
+        path_raw: str | Path | list[str | Path],
+        num_cpus: int | None = None,
+        artifact_name: str | None = None,
+        task_metadata: pd.DataFrame | None = None,
+    ) -> EndToEndResultsSingle:
+        """Create and cache end-to-end results for the method in the given directory.
+
+        Args:
+            path_raw (str | Path | list[str | Path]): Path to the directory containing raw results.
+            num_cpus (int | None): Number of CPUs to use for parallel processing.
+                If None, it will use all available CPUs.
+            artifact_name (str | None): Optional name to distinguish different runs of
+                the same method.
+        """
+        if num_cpus is None:
+            num_cpus = len(os.sched_getaffinity(0))
+
+        print("Get results paths...")
+        file_paths = fetch_all_pickles(
+            dir_path=path_raw, suffix="results.pkl"
+        )
+
+        all_file_paths_method = {}
+        for file_path in file_paths:
+            did_sid = f"{file_path.parts[-3]}/{file_path.parts[-2]}"
+            if did_sid not in all_file_paths_method:
+                all_file_paths_method[did_sid] = []
+            all_file_paths_method[did_sid].append(file_path)
+
+        if task_metadata is None:
+            print("Get task metadata...")
+            task_metadata = load_task_metadata()
+            # Below is too slow to use by default, TODO: get logic for any task that is fast
+            # task_metadata = generate_task_metadata(tids=list({r.split("/")[0] for r in all_file_paths_method}))
+
+        results: list[EndToEndResultsSingle] = ray_map_list(
+            list_to_map=list(all_file_paths_method.values()),
+            func=_process_result_list,
+            func_element_key_string="file_paths_method",
+            num_workers=num_cpus,
+            num_cpus_per_worker=1,
+            func_put_kwargs={
+                "task_metadata": task_metadata,
+                "artifact_name": artifact_name,
+            },
+            track_progress=True,
+            tqdm_kwargs={"desc": "Processing Results"},
+            ray_remote_kwargs={"max_calls": 0},
+        )
+
+        print("Merging results...")
+
+        e2e_results: EndToEndResultsSingle = EndToEndResultsSingle.concat(results)
+        method_metadata = e2e_results.method_metadata
+
+        print(f"Save metadata and results to {method_metadata.path}...")
+        e2e_results.cache()
+        return e2e_results
 
 
 class EndToEndResultsSingle:
@@ -399,6 +492,13 @@ class EndToEndResultsSingle:
 
         return df_results
 
+    def cache(self):
+        self.method_metadata.to_yaml()
+        if self.hpo_results is not None:
+            save_pd.save(path=str(self.method_metadata.path_results_hpo()), df=self.hpo_results)
+        if self.model_results is not None:
+            save_pd.save(path=str(self.method_metadata.path_results_model()), df=self.model_results)
+
     @classmethod
     def fillna_results_on_tabarena(cls, df_results: pd.DataFrame) -> pd.DataFrame:
         tabarena_context = TabArenaContext()
@@ -417,3 +517,62 @@ class EndToEndResultsSingle:
             df_to_fill=df_results,
             df_fillna=df_fillna,
         )
+
+    @classmethod
+    def concat(cls, e2e_lst: list[EndToEndResultsSingle]) -> EndToEndResultsSingle:
+        method_metadata = copy.deepcopy(e2e_lst[0].method_metadata)
+        hpo_results = copy.deepcopy(e2e_lst[0].hpo_results)
+        model_results = copy.deepcopy(e2e_lst[0].model_results)
+        for e2e_other in e2e_lst[1:]:
+            method_metadata_other = e2e_other.method_metadata
+            hpo_results_other = e2e_other.hpo_results
+            model_results_other = e2e_other.model_results
+
+            # Capture the any() in metadata creation.
+            if method_metadata.is_bag or method_metadata_other.is_bag:
+                method_metadata.is_bag = True
+                method_metadata_other = copy.deepcopy(method_metadata_other)
+                method_metadata_other.is_bag = True
+
+            if method_metadata.__dict__ != method_metadata_other.__dict__:
+                raise ValueError(
+                    "Method metadata mismatch! "
+                    f"{method_metadata.__dict__} != {method_metadata_other.__dict__}"
+                )
+
+            # merge results
+            hpo_results_to_concat = [r for r in [hpo_results, hpo_results_other] if r is not None]
+            if hpo_results_to_concat:
+                hpo_results = pd.concat(hpo_results_to_concat, ignore_index=True)
+            model_results_to_concat = [r for r in [model_results, model_results_other] if r is not None]
+            if model_results_to_concat:
+                model_results = pd.concat(model_results_to_concat, ignore_index=True)
+        return EndToEndResultsSingle(
+            method_metadata=method_metadata,
+            hpo_results=hpo_results,
+            model_results=model_results,
+        )
+
+
+def _process_result_list(
+    *,
+    file_paths_method: list[Path],
+    task_metadata: pd.DataFrame,
+    artifact_name: str | None,
+) -> EndToEndResultsSingle:
+    results_lst = load_all_artifacts(
+        file_paths=file_paths_method, engine="sequential", progress_bar=False
+    )
+
+    e2e = EndToEndSingle.from_raw(
+        results_lst=results_lst,
+        task_metadata=task_metadata,
+        artifact_name=artifact_name,
+        cache=False,
+        cache_raw=False,
+        backend="native",
+        verbose=False,
+    )
+    e2e_results = e2e.to_results()
+
+    return e2e_results

--- a/tabrepo/nips2025_utils/load_artifacts.py
+++ b/tabrepo/nips2025_utils/load_artifacts.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from autogluon.common.loaders import load_pkl
 from tabrepo.benchmark.result import AGBagResult, BaselineResult, ExperimentResults
 from tabrepo.utils.parallel_for import parallel_for
-import time
 
 
 def load_and_align(path, convert_to_holdout: bool = False) -> BaselineResult:
@@ -38,13 +37,10 @@ def load_all_artifacts(
             }
         )
 
-    ts = time.time()
     results_lst: list[BaselineResult] = parallel_for(
         f=load_and_align,
         inputs=file_paths_lst,
         engine=engine,
         progress_bar=progress_bar,
     )
-    te = time.time()
-    print(f"{te - ts:.2f}s\t{engine}")
     return results_lst

--- a/tabrepo/nips2025_utils/load_artifacts.py
+++ b/tabrepo/nips2025_utils/load_artifacts.py
@@ -27,6 +27,7 @@ def load_all_artifacts(
     file_paths: list[str | Path],
     engine: str = "sequential",
     convert_to_holdout: bool = False,
+    progress_bar: bool = True,
 ) -> list[BaselineResult]:
     file_paths_lst = []
     for file_path in file_paths:
@@ -42,6 +43,7 @@ def load_all_artifacts(
         f=load_and_align,
         inputs=file_paths_lst,
         engine=engine,
+        progress_bar=progress_bar,
     )
     te = time.time()
     print(f"{te - ts:.2f}s\t{engine}")

--- a/tabrepo/nips2025_utils/method_processor.py
+++ b/tabrepo/nips2025_utils/method_processor.py
@@ -100,7 +100,7 @@ def get_info_from_result(result: BaselineResult) -> dict:
 
 
 def load_raw(
-    path_raw: str | Path = None,
+    path_raw: str | Path | list[str | Path] = None,
     engine: str = "ray",
     as_holdout: bool = False,
 ) -> list[BaselineResult]:

--- a/tabrepo/paper/paper_runner.py
+++ b/tabrepo/paper/paper_runner.py
@@ -209,6 +209,14 @@ class PaperRun:
         df_results_configs["config_type"] = df_results_configs["framework"].map(configs_types)
         return df_results_configs
 
+    def run_config_family(self, config_type: str) -> pd.DataFrame:
+        configs = self.repo.configs(config_types=[config_type])
+        df_results_configs = self.evaluator.compare_metrics(configs=configs, baselines=[], include_metric_error_val=True).reset_index()
+        df_results_configs["method_type"] = "config"
+        configs_types = self.repo.configs_type()
+        df_results_configs["config_type"] = df_results_configs["framework"].map(configs_types)
+        return df_results_configs
+
     def run(self) -> pd.DataFrame:
         df_results_hpo_all = self.run_hpo_by_family()
         # df_zeroshot_portfolio = self.run_zs()

--- a/tabrepo/paper/paper_runner_tabarena.py
+++ b/tabrepo/paper/paper_runner_tabarena.py
@@ -98,7 +98,7 @@ class PaperRunTabArena(PaperRun):
         return self.run_zs(n_portfolios=n_portfolio, n_ensemble=None, n_ensemble_in_name=False)
 
     # FIXME: This is a hack
-    def _config_default(self, config_type: str) -> str:
+    def _config_default(self, config_type: str, return_none_if_missing=False) -> str | None:
         configs = self.repo.configs(config_types=[config_type])
         configs_default = [c for c in configs if "_c1_" in c]
         if len(configs_default) == 1:
@@ -106,6 +106,8 @@ class PaperRunTabArena(PaperRun):
         elif len(configs_default) == 0:
             configs_default = [c for c in configs if "_r1_" in c]
             if len(configs_default) == 0:
+                if return_none_if_missing:
+                    return None
                 raise ValueError(
                     f"Could not find any default config for config_type='{config_type}'"
                     f"\n\tconfigs={configs}"
@@ -122,21 +124,30 @@ class PaperRunTabArena(PaperRun):
     def run_configs_default(self, model_types: list[str] | None = None) -> pd.DataFrame:
         df_results_configs_lst = []
         for model_type in model_types:
-            config_default = self._config_default(config_type=model_type)
-            df_results_config = self.evaluator.compare_metrics(
-                configs=[config_default],
-                baselines=[],
-                include_metric_error_val=True,
-            ).reset_index()
-            configs_types = self.repo.configs_type()
-            df_results_config["method_type"] = "config"
-            df_results_config["method_subtype"] = "default"
-            df_results_config["config_type"] = df_results_config["framework"].map(configs_types)
-            df_results_config["framework"] = f"{model_type} (default)"
+            df_results_config = self.run_config_default(model_type=model_type)
             df_results_configs_lst.append(df_results_config)
 
         df_results_configs = pd.concat(df_results_configs_lst, ignore_index=True)
         return df_results_configs
+
+    def run_config(self, config: str) -> pd.DataFrame:
+        configs = [config]
+        df_results_config = self.evaluator.compare_metrics(
+            configs=configs,
+            baselines=[],
+            include_metric_error_val=True,
+        ).reset_index()
+        return df_results_config
+
+    def run_config_default(self, model_type: str) -> pd.DataFrame:
+        config_default = self._config_default(config_type=model_type)
+        df_results_config = self.run_config(config=config_default)
+        configs_types = self.repo.configs_type()
+        df_results_config["method_type"] = "config"
+        df_results_config["method_subtype"] = "default"
+        df_results_config["config_type"] = df_results_config["framework"].map(configs_types)
+        df_results_config["framework"] = f"{model_type} (default)"
+        return df_results_config
 
     def run_minimal_paper(self, model_types: list[str] | None = None, tune: bool = True) -> pd.DataFrame:
         """
@@ -163,6 +174,39 @@ class PaperRunTabArena(PaperRun):
         to_concat_lst = [
             df_results_configs_default,
             df_results_hpo_all,
+        ]
+        to_concat_lst = [df for df in to_concat_lst if df is not None]
+
+        df_results_all = pd.concat(to_concat_lst, ignore_index=True)
+
+        return df_results_all
+
+    def run_minimal_single(self, model_type: str, tune: bool = True) -> pd.DataFrame:
+        """
+        Run logic that isn't impacted by other methods or other datasets
+
+        Returns
+        -------
+
+        """
+        config_default = self._config_default(config_type=model_type, return_none_if_missing=True)
+        if config_default is not None:
+            df_results_config_default = self.run_config_default(model_type=model_type)
+        else:
+            df_results_config_default = None
+
+        if tune:
+            df_results_hpo = self.run_hpo(
+                family=model_type,
+                include_uncapped=True,
+                include_4h=False,
+            )
+        else:
+            df_results_hpo = None
+
+        to_concat_lst = [
+            df_results_config_default,
+            df_results_hpo,
         ]
         to_concat_lst = [df for df in to_concat_lst if df is not None]
 

--- a/tabrepo/paper/paper_runner_tabarena.py
+++ b/tabrepo/paper/paper_runner_tabarena.py
@@ -405,7 +405,7 @@ class PaperRunTabArena(PaperRun):
             framework_types_extra = []
         if calibration_framework is not None and calibration_framework == "auto":
             calibration_framework = "RF (default)"
-        if baselines is "auto":
+        if isinstance(baselines, str) and baselines == "auto":
             baselines = [
                 # "AutoGluon 1.3 (5m)",
                 # "AutoGluon 1.3 (1h)",

--- a/tabrepo/repository/ensemble_mixin.py
+++ b/tabrepo/repository/ensemble_mixin.py
@@ -324,6 +324,8 @@ class EnsembleMixin:
             inputs=inputs,
             context=context,
             engine=backend,
+            # To reduce log spam in outer parallel mode.
+            progress_bar=backend != "sequential",
         )
 
         df_out = pd.concat([l[0] for l in list_rows], axis=0)

--- a/tabrepo/utils/pickle_utils.py
+++ b/tabrepo/utils/pickle_utils.py
@@ -4,89 +4,49 @@ import pickle
 from pathlib import Path
 from typing import Any
 
+import tqdm
 
-def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
-    """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
+
+def fetch_all_pickles(
+    dir_path: str | Path | list[str | Path], suffix: str = ".pkl"
+) -> list[Path]:
+    """Recursively find every file ending in “.pkl” under *dir_path*
     and un‑pickle its contents.
 
     Parameters
     ----------
-    dir_path : str | pathlib.Path
+    dir_path : str | Path | list[str | Path]
         Root directory to search.
+        If a list of directories, will search over all directories.
 
     Returns:
     -------
-    List[Any]
-        A list whose elements are the Python objects obtained from each
-        successfully un‑pickled file, in depth‑first lexical order.
+    list[Path]
+        A list of paths to .pkl files.
 
     Notes:
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.
     """
-    root = Path(dir_path).expanduser().resolve()
-    if not root.is_dir():
-        raise NotADirectoryError(f"{root} is not a directory")
+    if not isinstance(dir_path, list):
+        dir_path = [dir_path]
 
     file_paths: list[Path] = []
+    for cur_dir_path in dir_path:
+        root = Path(cur_dir_path).expanduser().resolve()
+        if not root.is_dir():
+            raise NotADirectoryError(f"{root} is not a directory")
 
-    # Look for *.pkl, case‑insensitive
-    patterns = (f"*{suffix}",)
-    i = 0
-    for pattern in patterns:
-        pattern_suffix = pattern[1:]
-        for file_path in root.rglob(pattern):
-            if not str(file_path).endswith(pattern_suffix):
-                continue
-            if file_path.is_file():
-                i += 1
-                if i % 10000 == 0:
-                    print(i, file_path)
-                file_paths.append(file_path)
+        # Look for *.pkl
+        pattern = f"*{suffix}"
+        for file_path in tqdm.tqdm(
+            root.rglob(pattern), desc=f"Searching for pickles in {cur_dir_path}"
+        ):
+            file_paths.append(file_path)
 
     return file_paths
 
-
-def fetch_all_pickles_fast(
-    dir_path: str | Path, suffix: str = ".pkl"
-) -> dict[str, list[Path]]:
-    """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
-    and un‑pickle its contents.
-
-    Parameters
-    ----------
-    dir_path : str | pathlib.Path
-        Root directory to search.
-
-    Returns:
-    -------
-    file_paths : dict[str, list[Paths]]
-        List of file paths for each dataset-split-id combination.
-
-    Notes:
-    -----
-    Never un-pickle data you do not trust.
-    Malicious pickle data can execute arbitrary code.
-    """
-    import tqdm
-
-    root = Path(dir_path).expanduser().resolve()
-    if not root.is_dir():
-        raise NotADirectoryError(f"{root} is not a directory")
-
-    file_paths: dict[str, list[Path]] = {}
-
-    print("Root dir:", root)
-    for file_path in tqdm.tqdm(
-        root.glob(f"*/*/*/{suffix}"), desc="Searching for pickles"
-    ):
-        did_sid = f"{file_path.parts[-3]}/{file_path.parts[-2]}"
-        if did_sid not in file_paths:
-            file_paths[did_sid] = []
-        file_paths[did_sid].append(file_path)
-
-    return file_paths
 
 def load_all_pickles(dir_path: str | Path) -> list[Any]:
     """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*

--- a/tabrepo/utils/pickle_utils.py
+++ b/tabrepo/utils/pickle_utils.py
@@ -6,8 +6,7 @@ from typing import Any
 
 
 def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
-    """
-    Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
+    """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
     and un‑pickle its contents.
 
     Parameters
@@ -15,13 +14,13 @@ def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
     dir_path : str | pathlib.Path
         Root directory to search.
 
-    Returns
+    Returns:
     -------
     List[Any]
         A list whose elements are the Python objects obtained from each
         successfully un‑pickled file, in depth‑first lexical order.
 
-    Notes
+    Notes:
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.
@@ -49,9 +48,10 @@ def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
     return file_paths
 
 
-def load_all_pickles(dir_path: str | Path) -> list[Any]:
-    """
-    Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
+def fetch_all_pickles_fast(
+    dir_path: str | Path, suffix: str = ".pkl"
+) -> dict[str, list[Path]]:
+    """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
     and un‑pickle its contents.
 
     Parameters
@@ -59,13 +59,51 @@ def load_all_pickles(dir_path: str | Path) -> list[Any]:
     dir_path : str | pathlib.Path
         Root directory to search.
 
-    Returns
+    Returns:
+    -------
+    file_paths : dict[str, list[Paths]]
+        List of file paths for each dataset-split-id combination.
+
+    Notes:
+    -----
+    Never un-pickle data you do not trust.
+    Malicious pickle data can execute arbitrary code.
+    """
+    import tqdm
+
+    root = Path(dir_path).expanduser().resolve()
+    if not root.is_dir():
+        raise NotADirectoryError(f"{root} is not a directory")
+
+    file_paths: dict[str, list[Path]] = {}
+
+    print("Root dir:", root)
+    for file_path in tqdm.tqdm(
+        root.glob(f"*/*/*/{suffix}"), desc="Searching for pickles"
+    ):
+        did_sid = f"{file_path.parts[-3]}/{file_path.parts[-2]}"
+        if did_sid not in file_paths:
+            file_paths[did_sid] = []
+        file_paths[did_sid].append(file_path)
+
+    return file_paths
+
+def load_all_pickles(dir_path: str | Path) -> list[Any]:
+    """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
+    and un‑pickle its contents.
+
+    Parameters
+    ----------
+    dir_path : str | pathlib.Path
+        Root directory to search.
+
+    Returns:
     -------
     List[Any]
         A list whose elements are the Python objects obtained from each
         successfully un‑pickled file, in depth‑first lexical order.
 
-    Notes
+    Notes:
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.

--- a/tabrepo/utils/ray_utils.py
+++ b/tabrepo/utils/ray_utils.py
@@ -72,8 +72,9 @@ def ray_map_list(
     remote_kwargs = deepcopy(DEFAULT_REMOTE_KWARGS)
     if ray_remote_kwargs is not None:
         remote_kwargs.update(ray_remote_kwargs)
-    remote_kwargs["max_calls"] = max(len(list_to_map) // num_workers, 1)
-    remote_p = ray.remote(**DEFAULT_REMOTE_KWARGS)(func)
+    if ray_remote_kwargs is None or "max_calls" not in ray_remote_kwargs:
+        remote_kwargs["max_calls"] = max(len(list_to_map) // num_workers, 1)
+    remote_p = ray.remote(**remote_kwargs)(func)
     remote_p_options = {
         "num_cpus": num_cpus_per_worker,
         "num_gpus": num_gpus_per_worker,

--- a/tabrepo/utils/ray_utils.py
+++ b/tabrepo/utils/ray_utils.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import ray
+
+DEFAULT_REMOTE_KWARGS = {
+    "max_calls": 1,
+    "retry_exceptions": True,
+    "max_retries": 0,
+}
+
+
+def run_function_as_ray_task(
+    *, func: callable, num_cpus: int, num_gpus: int, func_kwargs: dict
+):
+    """Run a function as a ray task with the given number of cpus and gpus. Blocks until the function is done."""
+    remote_func = ray.remote(**DEFAULT_REMOTE_KWARGS)(func)
+
+    return ray.get(
+        remote_func.options(num_cpus=num_cpus, num_gpus=num_gpus).remote(**func_kwargs),
+    )
+
+
+def ray_map_list(
+    list_to_map: list,
+    *,
+    func: callable,
+    func_element_key_string: str,
+    num_workers: int,
+    num_cpus_per_worker: int,
+    num_gpus_per_worker: int = 0,
+    func_kwargs: dict | None = None,
+    func_put_kwargs: dict | None = None,
+    put_list_elements: bool = False,
+    output_handler: callable | None = None,
+    track_progress: bool = False,
+    tqdm_kwargs: dict | None = None,
+    ray_remote_kwargs: dict | None = None,
+) -> list:
+    """Map a function over a list using ray. Blocks until all functions are done.
+
+    Arguments:
+    ----------
+    list_to_map: list
+        The list to map the function over.
+    func: callable
+        The function to map over the list.
+    func_element_key_string: str
+        The key string to use to pass the element as a key-value pair to the function.
+        That is, the function will for example use `{func_element_key_string: list_to_map[0]}` as kwargs for `func`.
+    num_workers: int
+        The number of workers to use.
+    num_cpus_per_worker: int
+        The number of cpus to use per worker.
+    func_kwargs: dict, default=None
+        Additional kwargs to pass to the function.
+    func_put_kwargs: dict, default=None
+        Additional kwargs to pass to the function, where the values are put into the object store.
+    put_list_elements: bool, default=False
+        If True, put the elements of `list_to_map` into the object store before passing them to the function.
+    output_handler: callable, default=None
+        If not None, this should be a function that takes the output of `func` as input and uses it.
+        For example, this could log the output or save it to a file.
+    track_progress: bool, default=False
+        Track the progress of working on the list.
+    tqdm_kwargs: dict | None, default=None
+        Additional kwargs to pass to tqdm if `track_progress` is True.
+        For example, the decription for the progress bar: {"desc": "Processing list"}.
+    """
+    assert num_workers > 0, "Number of workers must be at least 1!"
+    remote_kwargs = deepcopy(DEFAULT_REMOTE_KWARGS)
+    if ray_remote_kwargs is not None:
+        remote_kwargs.update(ray_remote_kwargs)
+    remote_kwargs["max_calls"] = max(len(list_to_map) // num_workers, 1)
+    remote_p = ray.remote(**DEFAULT_REMOTE_KWARGS)(func)
+    remote_p_options = {
+        "num_cpus": num_cpus_per_worker,
+        "num_gpus": num_gpus_per_worker,
+    }
+
+    job_refs = []
+    job_refs_map = {}
+    job_index = 0
+
+    return_results = []
+
+    if track_progress:
+        from tqdm import tqdm
+
+        if tqdm_kwargs is None:
+            tqdm_kwargs = {}
+
+        pbar = tqdm(total=len(list_to_map), **tqdm_kwargs)
+
+    # Setup Kwargs
+    job_kwargs = {}
+    if func_kwargs is not None:
+        for key, value in func_kwargs.items():
+            job_kwargs[key] = value
+    if func_put_kwargs is not None:
+        for key, value in func_put_kwargs.items():
+            job_kwargs[key] = ray.put(value)
+
+    # Start initial jobs
+    for list_element in list_to_map[:num_workers]:
+        result_ref = remote_p.options(**remote_p_options).remote(
+            **{
+                func_element_key_string: ray.put(list_element)
+                if put_list_elements
+                else list_element
+            },
+            **job_kwargs,
+        )
+        job_refs.append(result_ref)
+        job_refs_map[result_ref] = job_index
+        job_index += 1
+
+    # Worker loop
+    unfinished_list = list_to_map[num_workers:]
+    unfinished = job_refs
+    while unfinished:
+        finished, unfinished = ray.wait(unfinished, num_returns=1)
+        job_i = job_refs_map[finished[0]]
+        job_res = ray.get(finished[0])
+
+        # Handle output (e.g. logging)
+        if output_handler is not None:
+            output_handler(job_res)
+        if track_progress:
+            pbar.update(n=1)
+
+        return_results.append((job_i, job_res))
+
+        # Re-schedule workers
+        while unfinished_list and (len(unfinished) < num_workers):
+            list_element = unfinished_list[0]
+            unfinished_list = unfinished_list[1:]
+            result_ref = remote_p.options(**remote_p_options).remote(
+                **{
+                    func_element_key_string: ray.put(list_element)
+                    if put_list_elements
+                    else list_element
+                },
+                **job_kwargs,
+            )
+            unfinished.append(result_ref)
+            job_refs_map[result_ref] = job_index
+            job_index += 1
+
+    if func_put_kwargs is not None:
+        ray.internal.free(object_refs=[job_kwargs[key] for key in func_put_kwargs])
+        for key in func_put_kwargs:
+            del job_kwargs[key]
+
+    if track_progress:
+        pbar.close()
+
+    return [r for _, r in sorted(return_results, key=lambda x: x[0])]
+
+
+def to_batch_list(lst: list, batch_size: int):
+    for i in range(0, len(lst), batch_size):
+        yield lst[i : i + batch_size]


### PR DESCRIPTION
## Changes 
* A small bug fix with the generate function of TabPFNv2
* Add logic I need to run eval on my slow I/O disk SLURM cluster.

## Problems
* Fetching pickle files for one method can still take 10 minutes or more, depending on load.
* I need to parallelize caching/loading the artifacts per dataset-split combination to make it fast enough. This is so far not possible in the workflow @Innixma is using. 
* I want to be able to control caching per model (see loop in code below)

## Usage Example / What I need in general:
```python
from __future__ import annotations

import os
from dataclasses import dataclass
from pathlib import Path


@dataclass
class ModelMetadata:
    """Metadata related to the result artifacts for a custom model to be evaluated on TabArena."""

    path_raw: Path
    """Path to the directory containing raw results from the custom model.
    If None, defaults to a predefined path."""
    method: str
    """Name of the custom method to be evaluated. This is the `ag_name` key in the method class."""
    new_result_prefix: str | None = None
    """Optional prefix for the new results. If None, defaults to the method name."""
    only_load_cache: bool = False
    """If False, the results will be computed and cached. If True, only loads the cache."""


def run_eval_for_new_models(
    models: list[ModelMetadata],
    *,
    fig_output_dir: Path,
    subset: str | None | list[str] = None,
    cache_path: str | None = None,
) -> None:
    """Run evaluation for a custom model on TabArena.

    Args:
        models: List of ModelMetadata instances for each custom model to be evaluated.
        fig_output_dir: Path to the directory where evaluation artifacts will be saved.
        subset: Optional subset of the TabArena dataset to evaluate on.
        cache_path: Optional path to the cache directory on the filesystem.

    """
    if cache_path is not None:
        os.environ["TABARENA_CACHE"] = cache_path
        print("Set cache to:", os.getenv("TABARENA_CACHE"))

    # Import here such that env var above is used correctly
    from tabrepo.nips2025_utils.end_to_end import EndToEnd, EndToEndResults
    from tabrepo.tabarena.website_format import format_leaderboard

    for model in models:
        if not model.only_load_cache:
            EndToEnd.create_and_cache_end_to_end_results(
                path_raw=model.path_raw / "data",
                artifact_name=model.new_result_prefix,
                num_cpus=8,
            )

    end_to_end_results = EndToEndResults.from_cache(
        methods=[(m.method, m.new_result_prefix) for m in models]
    )

    leaderboard = end_to_end_results.compare_on_tabarena(
        output_dir=fig_output_dir, subset=subset
    )
    leaderboard_website = format_leaderboard(df_leaderboard=leaderboard)
    print(leaderboard_website.to_markdown(index=False))


if __name__ == "__main__":
    fig_dir = Path(__file__).parent / "evals"
    out_dir = Path("/work/dlclarge2/purucker-tabarena/output")

    run_eval_for_new_models(
        [
            ModelMetadata(
                path_raw=out_dir / "tabflex",
                method="TabFlex",
            ),
            ModelMetadata(
                path_raw=out_dir / "mitra_12082025",
                method="Mitra",
            ),
        ],
        fig_output_dir=fig_dir / "realmlp_15082025",
        cache_path="/work/dlclarge2/purucker-tabarena/output/tabarena_cache",
        subset=["tabpfn"],
    )

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
