### PR TITLE
Fix max_calls, streamline logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ requirements = [
     "openml>=0.14.1",  # consider making optional
     "pyyaml",
     "pytest",
+    "tqdm",
     "typing-extensions>=4.11,<5",  # used for `Self` type hint
     "huggingface-hub",
 ]

--- a/tabrepo/nips2025_utils/artifacts/method_metadata.py
+++ b/tabrepo/nips2025_utils/artifacts/method_metadata.py
@@ -37,6 +37,7 @@ class MethodMetadata:
         has_processed: bool = False,
         has_results: bool = False,
         upload_as_public: bool = False,
+        custom_artifact_name: bool = False,
     ):
         self.method = method
         if artifact_name is None:
@@ -56,6 +57,7 @@ class MethodMetadata:
         if can_hpo is None:
             can_hpo = self.method_type == "config"
         self.can_hpo = can_hpo
+        self.custom_artifact_name = custom_artifact_name
 
         assert isinstance(self.method, str) and len(self.method) > 0
         assert isinstance(self.artifact_name, str) and len(self.artifact_name) > 0

--- a/tabrepo/nips2025_utils/artifacts/method_metadata.py
+++ b/tabrepo/nips2025_utils/artifacts/method_metadata.py
@@ -37,7 +37,6 @@ class MethodMetadata:
         has_processed: bool = False,
         has_results: bool = False,
         upload_as_public: bool = False,
-        custom_artifact_name: bool = False,
     ):
         self.method = method
         if artifact_name is None:
@@ -57,7 +56,6 @@ class MethodMetadata:
         if can_hpo is None:
             can_hpo = self.method_type == "config"
         self.can_hpo = can_hpo
-        self.custom_artifact_name = custom_artifact_name
 
         assert isinstance(self.method, str) and len(self.method) > 0
         assert isinstance(self.artifact_name, str) and len(self.artifact_name) > 0

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -270,6 +270,8 @@ class EndToEndResults:
             new_result_prefix (str | None): If not None, add a prefix to the new
                 results to distinguish new results from the original TabArena results.
                 Use this, for example, if you re-run a model from TabArena.
+                Note, this prefix will be added on top of model-specific prefixes that
+                might have been set during caching.
         """
         results = self.get_results(
             new_result_prefix=new_result_prefix,
@@ -292,9 +294,15 @@ class EndToEndResults:
     ) -> pd.DataFrame:
         df_results_lst = []
         for result in self.end_to_end_results_lst:
+            prefix = new_result_prefix
+            if result.method_metadata.custom_artifact_name:
+                if prefix is None:
+                    prefix = f"[{result.method_metadata.artifact_name}] "
+                else:
+                    prefix = prefix + f" [{result.method_metadata.artifact_name}] "
             df_results_lst.append(
                 result.get_results(
-                    new_result_prefix=new_result_prefix,
+                    new_result_prefix=prefix,
                     use_model_results=use_model_results,
                     fillna=fillna,
                 )

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -270,8 +270,6 @@ class EndToEndResults:
             new_result_prefix (str | None): If not None, add a prefix to the new
                 results to distinguish new results from the original TabArena results.
                 Use this, for example, if you re-run a model from TabArena.
-                Note, this prefix will be added on top of model-specific prefixes that
-                might have been set during caching.
         """
         results = self.get_results(
             new_result_prefix=new_result_prefix,
@@ -294,15 +292,9 @@ class EndToEndResults:
     ) -> pd.DataFrame:
         df_results_lst = []
         for result in self.end_to_end_results_lst:
-            prefix = new_result_prefix
-            if result.method_metadata.custom_artifact_name:
-                if prefix is None:
-                    prefix = f"[{result.method_metadata.artifact_name}] "
-                else:
-                    prefix = prefix + f" [{result.method_metadata.artifact_name}] "
             df_results_lst.append(
                 result.get_results(
-                    new_result_prefix=prefix,
+                    new_result_prefix=new_result_prefix,
                     use_model_results=use_model_results,
                     fillna=fillna,
                 )

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -19,7 +19,7 @@ from tabrepo.nips2025_utils.method_processor import (
     load_raw,
 )
 from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
-from tabrepo.utils.pickle_utils import fetch_all_pickles_fast
+from tabrepo.utils.pickle_utils import fetch_all_pickles
 from tabrepo.utils.ray_utils import ray_map_list
 
 if TYPE_CHECKING:
@@ -356,9 +356,16 @@ class EndToEndSingle:
             num_cpus = len(os.sched_getaffinity(0))
 
         print("Get results paths...")
-        all_file_paths_method = fetch_all_pickles_fast(
+        file_paths = fetch_all_pickles(
             dir_path=path_raw, suffix="results.pkl"
         )
+
+        all_file_paths_method = {}
+        for file_path in file_paths:
+            did_sid = f"{file_path.parts[-3]}/{file_path.parts[-2]}"
+            if did_sid not in all_file_paths_method:
+                all_file_paths_method[did_sid] = []
+            all_file_paths_method[did_sid].append(file_path)
 
         if task_metadata is None:
             print("Get task metadata...")

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -422,11 +422,13 @@ class EndToEndResultsSingle:
         if isinstance(method, MethodMetadata):
             method_metadata = method
         else:
+            custom_artifact_name = artifact_name is not None
             if artifact_name is None:
                 artifact_name = method
             method_metadata = MethodMetadata.from_yaml(
                 method=method, artifact_name=artifact_name
             )
+            method_metadata.custom_artifact_name = custom_artifact_name
         return cls(method_metadata=method_metadata)
 
     def compare_on_tabarena(

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -422,13 +422,11 @@ class EndToEndResultsSingle:
         if isinstance(method, MethodMetadata):
             method_metadata = method
         else:
-            custom_artifact_name = artifact_name is not None
             if artifact_name is None:
                 artifact_name = method
             method_metadata = MethodMetadata.from_yaml(
                 method=method, artifact_name=artifact_name
             )
-            method_metadata.custom_artifact_name = custom_artifact_name
         return cls(method_metadata=method_metadata)
 
     def compare_on_tabarena(

--- a/tabrepo/nips2025_utils/load_artifacts.py
+++ b/tabrepo/nips2025_utils/load_artifacts.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from autogluon.common.loaders import load_pkl
 from tabrepo.benchmark.result import AGBagResult, BaselineResult, ExperimentResults
 from tabrepo.utils.parallel_for import parallel_for
-import time
 
 
 def load_and_align(path, convert_to_holdout: bool = False) -> BaselineResult:
@@ -38,13 +37,10 @@ def load_all_artifacts(
             }
         )
 
-    ts = time.time()
     results_lst: list[BaselineResult] = parallel_for(
         f=load_and_align,
         inputs=file_paths_lst,
         engine=engine,
         progress_bar=progress_bar,
     )
-    te = time.time()
-    print(f"{te - ts:.2f}s\t{engine}")
     return results_lst

--- a/tabrepo/nips2025_utils/method_processor.py
+++ b/tabrepo/nips2025_utils/method_processor.py
@@ -100,7 +100,7 @@ def get_info_from_result(result: BaselineResult) -> dict:
 
 
 def load_raw(
-    path_raw: str | Path = None,
+    path_raw: str | Path | list[str | Path] = None,
     engine: str = "ray",
     as_holdout: bool = False,
 ) -> list[BaselineResult]:

--- a/tabrepo/paper/paper_runner.py
+++ b/tabrepo/paper/paper_runner.py
@@ -209,6 +209,14 @@ class PaperRun:
         df_results_configs["config_type"] = df_results_configs["framework"].map(configs_types)
         return df_results_configs
 
+    def run_config_family(self, config_type: str) -> pd.DataFrame:
+        configs = self.repo.configs(config_types=[config_type])
+        df_results_configs = self.evaluator.compare_metrics(configs=configs, baselines=[], include_metric_error_val=True).reset_index()
+        df_results_configs["method_type"] = "config"
+        configs_types = self.repo.configs_type()
+        df_results_configs["config_type"] = df_results_configs["framework"].map(configs_types)
+        return df_results_configs
+
     def run(self) -> pd.DataFrame:
         df_results_hpo_all = self.run_hpo_by_family()
         # df_zeroshot_portfolio = self.run_zs()

--- a/tabrepo/paper/paper_runner_tabarena.py
+++ b/tabrepo/paper/paper_runner_tabarena.py
@@ -98,7 +98,7 @@ class PaperRunTabArena(PaperRun):
         return self.run_zs(n_portfolios=n_portfolio, n_ensemble=None, n_ensemble_in_name=False)
 
     # FIXME: This is a hack
-    def _config_default(self, config_type: str) -> str:
+    def _config_default(self, config_type: str, return_none_if_missing=False) -> str | None:
         configs = self.repo.configs(config_types=[config_type])
         configs_default = [c for c in configs if "_c1_" in c]
         if len(configs_default) == 1:
@@ -106,6 +106,8 @@ class PaperRunTabArena(PaperRun):
         elif len(configs_default) == 0:
             configs_default = [c for c in configs if "_r1_" in c]
             if len(configs_default) == 0:
+                if return_none_if_missing:
+                    return None
                 raise ValueError(
                     f"Could not find any default config for config_type='{config_type}'"
                     f"\n\tconfigs={configs}"
@@ -122,21 +124,30 @@ class PaperRunTabArena(PaperRun):
     def run_configs_default(self, model_types: list[str] | None = None) -> pd.DataFrame:
         df_results_configs_lst = []
         for model_type in model_types:
-            config_default = self._config_default(config_type=model_type)
-            df_results_config = self.evaluator.compare_metrics(
-                configs=[config_default],
-                baselines=[],
-                include_metric_error_val=True,
-            ).reset_index()
-            configs_types = self.repo.configs_type()
-            df_results_config["method_type"] = "config"
-            df_results_config["method_subtype"] = "default"
-            df_results_config["config_type"] = df_results_config["framework"].map(configs_types)
-            df_results_config["framework"] = f"{model_type} (default)"
+            df_results_config = self.run_config_default(model_type=model_type)
             df_results_configs_lst.append(df_results_config)
 
         df_results_configs = pd.concat(df_results_configs_lst, ignore_index=True)
         return df_results_configs
+
+    def run_config(self, config: str) -> pd.DataFrame:
+        configs = [config]
+        df_results_config = self.evaluator.compare_metrics(
+            configs=configs,
+            baselines=[],
+            include_metric_error_val=True,
+        ).reset_index()
+        return df_results_config
+
+    def run_config_default(self, model_type: str) -> pd.DataFrame:
+        config_default = self._config_default(config_type=model_type)
+        df_results_config = self.run_config(config=config_default)
+        configs_types = self.repo.configs_type()
+        df_results_config["method_type"] = "config"
+        df_results_config["method_subtype"] = "default"
+        df_results_config["config_type"] = df_results_config["framework"].map(configs_types)
+        df_results_config["framework"] = f"{model_type} (default)"
+        return df_results_config
 
     def run_minimal_paper(self, model_types: list[str] | None = None, tune: bool = True) -> pd.DataFrame:
         """
@@ -163,6 +174,39 @@ class PaperRunTabArena(PaperRun):
         to_concat_lst = [
             df_results_configs_default,
             df_results_hpo_all,
+        ]
+        to_concat_lst = [df for df in to_concat_lst if df is not None]
+
+        df_results_all = pd.concat(to_concat_lst, ignore_index=True)
+
+        return df_results_all
+
+    def run_minimal_single(self, model_type: str, tune: bool = True) -> pd.DataFrame:
+        """
+        Run logic that isn't impacted by other methods or other datasets
+
+        Returns
+        -------
+
+        """
+        config_default = self._config_default(config_type=model_type, return_none_if_missing=True)
+        if config_default is not None:
+            df_results_config_default = self.run_config_default(model_type=model_type)
+        else:
+            df_results_config_default = None
+
+        if tune:
+            df_results_hpo = self.run_hpo(
+                family=model_type,
+                include_uncapped=True,
+                include_4h=False,
+            )
+        else:
+            df_results_hpo = None
+
+        to_concat_lst = [
+            df_results_config_default,
+            df_results_hpo,
         ]
         to_concat_lst = [df for df in to_concat_lst if df is not None]
 

--- a/tabrepo/utils/pickle_utils.py
+++ b/tabrepo/utils/pickle_utils.py
@@ -6,7 +6,7 @@ from typing import Any
 
 
 def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
-    """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
+    """Recursively find every file ending in “.pkl” under *dir_path*
     and un‑pickle its contents.
 
     Parameters
@@ -14,13 +14,13 @@ def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
     dir_path : str | pathlib.Path
         Root directory to search.
 
-    Returns:
+    Returns
     -------
     List[Any]
         A list whose elements are the Python objects obtained from each
         successfully un‑pickled file, in depth‑first lexical order.
 
-    Notes:
+    Notes
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.
@@ -31,19 +31,10 @@ def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
 
     file_paths: list[Path] = []
 
-    # Look for *.pkl, case‑insensitive
-    patterns = (f"*{suffix}",)
-    i = 0
-    for pattern in patterns:
-        pattern_suffix = pattern[1:]
-        for file_path in root.rglob(pattern):
-            if not str(file_path).endswith(pattern_suffix):
-                continue
-            if file_path.is_file():
-                i += 1
-                if i % 10000 == 0:
-                    print(i, file_path)
-                file_paths.append(file_path)
+    # Look for *.pkl
+    pattern = f"*{suffix}"
+    for file_path in root.rglob(pattern):
+        file_paths.append(file_path)
 
     return file_paths
 

--- a/tabrepo/utils/pickle_utils.py
+++ b/tabrepo/utils/pickle_utils.py
@@ -4,8 +4,12 @@ import pickle
 from pathlib import Path
 from typing import Any
 
+import tqdm
 
-def fetch_all_pickles(dir_path: str | Path | list[str | Path], suffix: str = ".pkl") -> list[Path]:
+
+def fetch_all_pickles(
+    dir_path: str | Path | list[str | Path], suffix: str = ".pkl"
+) -> list[Path]:
     """Recursively find every file ending in “.pkl” under *dir_path*
     and un‑pickle its contents.
 
@@ -15,12 +19,12 @@ def fetch_all_pickles(dir_path: str | Path | list[str | Path], suffix: str = ".p
         Root directory to search.
         If a list of directories, will search over all directories.
 
-    Returns
+    Returns:
     -------
     list[Path]
         A list of paths to .pkl files.
 
-    Notes
+    Notes:
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.
@@ -36,49 +40,10 @@ def fetch_all_pickles(dir_path: str | Path | list[str | Path], suffix: str = ".p
 
         # Look for *.pkl
         pattern = f"*{suffix}"
-        for file_path in root.rglob(pattern):
+        for file_path in tqdm.tqdm(
+            root.rglob(pattern), desc=f"Searching for pickles in {cur_dir_path}"
+        ):
             file_paths.append(file_path)
-
-    return file_paths
-
-
-def fetch_all_pickles_fast(
-    dir_path: str | Path, suffix: str = ".pkl"
-) -> dict[str, list[Path]]:
-    """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
-    and un‑pickle its contents.
-
-    Parameters
-    ----------
-    dir_path : str | pathlib.Path
-        Root directory to search.
-
-    Returns
-    -------
-    file_paths : dict[str, list[Paths]]
-        List of file paths for each dataset-split-id combination.
-
-    Notes
-    -----
-    Never un-pickle data you do not trust.
-    Malicious pickle data can execute arbitrary code.
-    """
-    import tqdm
-
-    root = Path(dir_path).expanduser().resolve()
-    if not root.is_dir():
-        raise NotADirectoryError(f"{root} is not a directory")
-
-    file_paths: dict[str, list[Path]] = {}
-
-    print("Root dir:", root)
-    for file_path in tqdm.tqdm(
-        root.glob(f"*/*/*/{suffix}"), desc="Searching for pickles"
-    ):
-        did_sid = f"{file_path.parts[-3]}/{file_path.parts[-2]}"
-        if did_sid not in file_paths:
-            file_paths[did_sid] = []
-        file_paths[did_sid].append(file_path)
 
     return file_paths
 
@@ -92,13 +57,13 @@ def load_all_pickles(dir_path: str | Path) -> list[Any]:
     dir_path : str | pathlib.Path
         Root directory to search.
 
-    Returns
+    Returns:
     -------
     List[Any]
         A list whose elements are the Python objects obtained from each
         successfully un‑pickled file, in depth‑first lexical order.
 
-    Notes
+    Notes:
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.

--- a/tabrepo/utils/pickle_utils.py
+++ b/tabrepo/utils/pickle_utils.py
@@ -59,12 +59,12 @@ def fetch_all_pickles_fast(
     dir_path : str | pathlib.Path
         Root directory to search.
 
-    Returns:
+    Returns
     -------
     file_paths : dict[str, list[Paths]]
         List of file paths for each dataset-split-id combination.
 
-    Notes:
+    Notes
     -----
     Never un-pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.
@@ -88,6 +88,7 @@ def fetch_all_pickles_fast(
 
     return file_paths
 
+
 def load_all_pickles(dir_path: str | Path) -> list[Any]:
     """Recursively find every file ending in “.pkl” or “.pickle” under *dir_path*
     and un‑pickle its contents.
@@ -97,13 +98,13 @@ def load_all_pickles(dir_path: str | Path) -> list[Any]:
     dir_path : str | pathlib.Path
         Root directory to search.
 
-    Returns:
+    Returns
     -------
     List[Any]
         A list whose elements are the Python objects obtained from each
         successfully un‑pickled file, in depth‑first lexical order.
 
-    Notes:
+    Notes
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.

--- a/tabrepo/utils/pickle_utils.py
+++ b/tabrepo/utils/pickle_utils.py
@@ -5,36 +5,39 @@ from pathlib import Path
 from typing import Any
 
 
-def fetch_all_pickles(dir_path: str | Path, suffix: str = ".pkl") -> list[Path]:
+def fetch_all_pickles(dir_path: str | Path | list[str | Path], suffix: str = ".pkl") -> list[Path]:
     """Recursively find every file ending in “.pkl” under *dir_path*
     and un‑pickle its contents.
 
     Parameters
     ----------
-    dir_path : str | pathlib.Path
+    dir_path : str | Path | list[str | Path]
         Root directory to search.
+        If a list of directories, will search over all directories.
 
     Returns
     -------
-    List[Any]
-        A list whose elements are the Python objects obtained from each
-        successfully un‑pickled file, in depth‑first lexical order.
+    list[Path]
+        A list of paths to .pkl files.
 
     Notes
     -----
     Never un‑pickle data you do not trust.
     Malicious pickle data can execute arbitrary code.
     """
-    root = Path(dir_path).expanduser().resolve()
-    if not root.is_dir():
-        raise NotADirectoryError(f"{root} is not a directory")
+    if not isinstance(dir_path, list):
+        dir_path = [dir_path]
 
     file_paths: list[Path] = []
+    for cur_dir_path in dir_path:
+        root = Path(cur_dir_path).expanduser().resolve()
+        if not root.is_dir():
+            raise NotADirectoryError(f"{root} is not a directory")
 
-    # Look for *.pkl
-    pattern = f"*{suffix}"
-    for file_path in root.rglob(pattern):
-        file_paths.append(file_path)
+        # Look for *.pkl
+        pattern = f"*{suffix}"
+        for file_path in root.rglob(pattern):
+            file_paths.append(file_path)
 
     return file_paths
 

--- a/tabrepo/utils/ray_utils.py
+++ b/tabrepo/utils/ray_utils.py
@@ -72,8 +72,9 @@ def ray_map_list(
     remote_kwargs = deepcopy(DEFAULT_REMOTE_KWARGS)
     if ray_remote_kwargs is not None:
         remote_kwargs.update(ray_remote_kwargs)
-    remote_kwargs["max_calls"] = max(len(list_to_map) // num_workers, 1)
-    remote_p = ray.remote(**DEFAULT_REMOTE_KWARGS)(func)
+    if ray_remote_kwargs is None or "max_calls" not in ray_remote_kwargs:
+        remote_kwargs["max_calls"] = max(len(list_to_map) // num_workers, 1)
+    remote_p = ray.remote(**remote_kwargs)(func)
     remote_p_options = {
         "num_cpus": num_cpus_per_worker,
         "num_gpus": num_gpus_per_worker,


### PR DESCRIPTION
*Issue #, if available:*

#206 

*Description of changes:*

Runtimes based on 96 CPU cores from raw data of LightGBM_aio_0808.

- Fix max_calls, speeds up `create_and_cache_end_to_end_results` from 93s -> 56s
- Ensure we reload repo from cache if `cache=True` in `EndToEndSingle.from_raw`, speedup of HPO simulation from 1400s -> 30s.
- Update paper_runner and paper_runner_tabarena to handle edge-cases in `create_and_cache_end_to_end_results` due to only running a single task at a time in parallel.
- Streamline `_process_result_list` to call `EndToEndSingle.from_raw`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
