### PR TITLE
[WIP] Allow TabRepo to run custom models that subclass AbstractExecModel and is present in S3

### DIFF
--- a/tabflow/tabflow/cli/evaluate.py
+++ b/tabflow/tabflow/cli/evaluate.py
@@ -16,13 +16,29 @@ from tabrepo.benchmark.models.ag import *
 logger = setup_logging(level=logging.INFO)
 
 
+import importlib.util, pathlib
+
+def expanded_globals(custom_model_path: str):
+    # NOTE: The custom model MUST be named ExecModel
+    program_path = pathlib.Path(custom_model_path).expanduser().resolve()
+    spec = importlib.util.spec_from_file_location("program", program_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return {**globals(), "ExecModel": module.ExecModel}
+
+
 def load_tasks(
     tasks_s3_path: str,
     methods_s3_path: str,
+    custom_model_s3_path: str,
 ) -> list[dict]:
     # Download methods and tasks to parse from S3
     methods_config_path = download_from_s3(s3_path=methods_s3_path, destination_path=None)
     methods_config: list[dict] = YamlExperimentSerializer.load_yaml(path=methods_config_path)
+    if custom_model_s3_path:
+        custom_model_path = download_from_s3(s3_path=custom_model_s3_path, destination_path=None)
+    else:
+        custom_model_path = None
 
     tasks: list[dict] = load_json.load(path=tasks_s3_path, verbose=False)
 
@@ -35,7 +51,8 @@ def load_tasks(
         fold = task["fold"]
         method_name = task["method_name"]
         method_kwargs = find_method_by_name(methods_config, method_name)
-        method: Experiment = YamlSingleExperimentSerializer.parse_method(method_kwargs, globals())
+        context = expanded_globals(custom_model_path) if custom_model_path else globals()
+        method: Experiment = YamlSingleExperimentSerializer.parse_method(method_kwargs, context)
 
         task_dict = dict(
             method=method,
@@ -59,6 +76,7 @@ def evaluate(
     debug_mode: bool = False,
     s3_dataset_cache: str = None,
     task_metadata_path: str = None,
+    custom_model_s3_path: str = None,
 ):
     # Load Context
     expname = experiment_name
@@ -78,6 +96,7 @@ def evaluate(
     tasks = load_tasks(
         tasks_s3_path=tasks_s3_path,
         methods_s3_path=methods_s3_path,
+        custom_model_s3_path=custom_model_s3_path
     )
 
     experiment_batch_runner = ExperimentBatchRunner(
@@ -140,6 +159,9 @@ if __name__ == '__main__':
     parser.add_argument('--run_mode', type=str, default='aws', choices=['aws', 'local'], help="Run mode: aws or local")
     parser.add_argument('--s3_dataset_cache', type=str, required=False, default=None, help="S3 path for dataset cache")
     parser.add_argument('--task_metadata_path', type=str, required=False, default=None, help="S3 path for dataset cache")
+    parser.add_argument('--custom_model_s3_path', type=str, required=False, default=None,
+                        help="S3 path for a Python class that extends AbstractExecModel")
+    parser.add_argument('--raise_on_failure', type=bool, required=False, default=False, help="Crashes if the program fails")
 
     args = parser.parse_args()
     if args.s3_dataset_cache == "":
@@ -159,4 +181,6 @@ if __name__ == '__main__':
         run_mode=args.run_mode,
         s3_dataset_cache=args.s3_dataset_cache,
         task_metadata_path=args.task_metadata_path,
+        custom_model_s3_path=args.custom_model_s3_path,
+        raise_on_failure=args.raise_on_failure,
     )

--- a/tabrepo/benchmark/experiment/experiment_constructor.py
+++ b/tabrepo/benchmark/experiment/experiment_constructor.py
@@ -200,9 +200,9 @@ class AGModelOuterExperiment(Experiment):
 
     @classmethod
     def from_yaml(cls, model_cls, _context=None, **kwargs) -> Self:
-        model_cls = infer_model_cls(model_cls)
         if _context is None:
             _context = globals()
+        model_cls = _context.get(model_cls, infer_model_cls(model_cls))
 
         # Evaluate all values in ag_args_fit
         if "model_hyperparameters" in kwargs:
@@ -371,9 +371,9 @@ class AGModelExperiment(Experiment):
 
     @classmethod
     def from_yaml(cls, model_cls, _context=None, **kwargs) -> Self:
-        model_cls = infer_model_cls(model_cls)
         if _context is None:
             _context = globals()
+        model_cls = _context.get(model_cls, infer_model_cls(model_cls))
 
         # Evaluate all values in ag_args_fit
         if "model_hyperparameters" in kwargs:
@@ -493,7 +493,7 @@ class YamlSingleExperimentSerializer:
             context = globals()
 
         method_type = eval(method_config.pop('type'), context)
-        method_obj = method_type.from_yaml(**method_config)
+        method_obj = method_type.from_yaml(**method_config, _context=context)
         return method_obj
 
     @classmethod

--- a/tabrepo/utils/s3_utils.py
+++ b/tabrepo/utils/s3_utils.py
@@ -96,7 +96,7 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
 
         logger.info(f"Attempting to download task {task_id} from S3 bucket {s3_bucket}")
         s3_key_prefix = f"{s3_prefix}/tasks/{task_id}/org/openml/www/tasks/{task_id}"
-
+        logger.info(f"s3_key_prefix set to: " + s3_key_prefix)
         try:
             task_xml_path = task_cache_dir / "task.xml"
             if not task_xml_path.exists():


### PR DESCRIPTION
TabRepo currently only supports models present in the codebase's `ModelRegistry`. This PR allows TabRepo to run any model that subclasses AbstractExecModel if the model is present in Experiment.from_yaml's `_context` argument. Additionally, we extend TabFlow to be able to evaluate custom models if the model code S3 path is passed to the `evaluate` function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
