### PR TITLE
Add weighted ELO calculation, Fix 95% CI ELO calculation, 1000x ELO bootstrapping speedup

### DIFF
--- a/examples/tabarena/run_generate_paper_figures.py
+++ b/examples/tabarena/run_generate_paper_figures.py
@@ -8,7 +8,7 @@ from tabrepo.nips2025_utils.artifacts import tabarena_method_metadata_collection
 
 if __name__ == '__main__':
     download_results: bool | str = "auto"  # results must be downloaded for the script to work
-    elo_bootstrap_rounds = 100  # 1 for toy, 100 for paper
+    elo_bootstrap_rounds = 200  # 1 for toy, 200 for paper
     save_path = "output_paper_results"  # folder to save all figures and tables
     use_latex: bool = False  # Set to True if you have the appropriate latex packages installed for nicer figure style
 

--- a/tabrepo/nips2025_utils/compare.py
+++ b/tabrepo/nips2025_utils/compare.py
@@ -19,6 +19,7 @@ def compare_on_tabarena(
     tabarena_context: TabArenaContext | None = None,
     fillna: str | pd.DataFrame | None = "RF (default)",
     score_on_val: bool = False,
+    per_split_elo: bool = False,
     tmp_treat_tasks_independently: bool = False,
 ) -> pd.DataFrame:
     output_dir = Path(output_dir)
@@ -60,6 +61,7 @@ def compare_on_tabarena(
         fillna=fillna,
         calibration_framework=fillna,
         score_on_val=score_on_val,
+        per_split_elo=per_split_elo,
         tmp_treat_tasks_independently=tmp_treat_tasks_independently,
     )
 
@@ -71,6 +73,7 @@ def compare(
     calibration_framework: str | None = None,
     fillna: str | pd.DataFrame | None = None,
     score_on_val: bool = False,
+    per_split_elo: bool = False,
     tmp_treat_tasks_independently: bool = False,  # FIXME: Update
 ):
     df_results = df_results.copy()
@@ -120,6 +123,7 @@ def compare(
         plot_times=True,
         plot_other=False,
         calibration_framework=calibration_framework,
+        per_split_elo=per_split_elo,
         tmp_treat_tasks_independently=tmp_treat_tasks_independently,
     )
 

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -338,6 +338,7 @@ class EndToEndResults:
         use_artifact_name_in_prefix: bool | None = None,
         use_model_results: bool = False,
         score_on_val: bool = False,
+        per_split_elo: bool = False,
     ) -> pd.DataFrame:
         """Compare results on TabArena leaderboard.
 
@@ -364,6 +365,7 @@ class EndToEndResults:
             only_valid_tasks=only_valid_tasks,
             subset=subset,
             score_on_val=score_on_val,
+            per_split_elo=per_split_elo,
         )
 
     def get_results(

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -539,6 +539,7 @@ class EndToEndResultsSingle:
         use_artifact_name_in_prefix: bool | None = None,
         use_model_results: bool = False,
         score_on_val: bool = False,
+        per_split_elo: bool = False,
     ) -> pd.DataFrame:
         """Compare results on TabArena leaderboard.
 
@@ -565,6 +566,7 @@ class EndToEndResultsSingle:
             only_valid_tasks=only_valid_tasks,
             subset=subset,
             score_on_val=score_on_val,
+            per_split_elo=per_split_elo,
         )
 
     def get_results(

--- a/tabrepo/nips2025_utils/tabarena_context.py
+++ b/tabrepo/nips2025_utils/tabarena_context.py
@@ -111,6 +111,7 @@ class TabArenaContext:
         subset: str | None = None,
         folds: list[int] | None = None,
         score_on_val: bool = False,
+        per_split_elo: bool = False,
         tmp_treat_tasks_independently: bool = False,
     ) -> pd.DataFrame:
         from tabrepo.nips2025_utils.compare import compare_on_tabarena
@@ -122,6 +123,7 @@ class TabArenaContext:
             folds=folds,
             tabarena_context=self,
             score_on_val=score_on_val,
+            per_split_elo=per_split_elo,
             tmp_treat_tasks_independently=tmp_treat_tasks_independently,
         )
 

--- a/tabrepo/paper/tabarena_evaluator.py
+++ b/tabrepo/paper/tabarena_evaluator.py
@@ -204,6 +204,7 @@ class TabArenaEvaluator:
         plot_pareto: bool = True,
         plot_other: bool = False,
         calibration_framework: str | None = "auto",
+        per_split_elo: bool = False,
         tmp_treat_tasks_independently: bool = False,  # FIXME: Need to make a weighted elo logic
     ) -> pd.DataFrame:
         if calibration_framework is not None and calibration_framework == "auto":
@@ -396,10 +397,17 @@ class TabArenaEvaluator:
                     show=False,
                 )
 
+        elo_kwargs = dict(
+            calibration_framework=calibration_framework,
+            calibration_elo=1000,
+            BOOTSTRAP_ROUNDS=self.elo_bootstrap_rounds,
+        )
+
         if tmp_treat_tasks_independently:
-            # df_results_rank_compare = df_results_rank_compare[df_results_rank_compare["fold"] < 9]
             df_results_rank_compare["dataset"] = df_results_rank_compare["dataset"] + "_" + df_results_rank_compare["fold"].astype(str)
             df_results_rank_compare["fold"] = 0
+        if per_split_elo:
+            elo_kwargs["per_split"] = True
 
         tabarena = TabArena(
             method_col=method_col,
@@ -427,11 +435,7 @@ class TabArenaEvaluator:
             include_mrr=True,
             include_rank_counts=True,
             include_elo=True,
-            elo_kwargs=dict(
-                calibration_framework=calibration_framework,
-                calibration_elo=1000,
-                BOOTSTRAP_ROUNDS=self.elo_bootstrap_rounds,
-            )
+            elo_kwargs=elo_kwargs,
         )
         elo_map = leaderboard["elo"]
         leaderboard = leaderboard.reset_index(drop=False)

--- a/tabrepo/paper/tabarena_evaluator.py
+++ b/tabrepo/paper/tabarena_evaluator.py
@@ -56,7 +56,7 @@ class TabArenaEvaluator:
         datasets: list[str] | None = None,
         problem_types: list[str] | None = None,
         banned_model_types: list[str] | None = None,
-        elo_bootstrap_rounds: int = 100,
+        elo_bootstrap_rounds: int = 200,
         keep_best: bool = False,
         figure_file_type: str = "pdf",
         use_latex: bool = False,

--- a/tabrepo/tabarena/elo_utils.py
+++ b/tabrepo/tabarena/elo_utils.py
@@ -842,8 +842,8 @@ class EloHelper:
         INIT_RATING: float,
         solver: str,
         max_iter: int,
-        calibration_framework: str | None,
-        calibration_elo: float | None,
+        calibration_framework: str | None = None,
+        calibration_elo: float | None = None,
     ) -> pd.Series:
         """
         One bootstrap draw using the pair-compressed MLE path.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, the results we see on the official leaderboard differ noticeably from the results on the `lite` leaderboard (the `lite` leaderboard only uses 1 split for each dataset).
1. The best methods have much higher elo on the official leaderboard than the lite leaderboard
2. The methods that are better on datasets with 30 splits have relatively higher elo than on the official leaderboard than the lite leaderboard.

The reasons for this are as follows:

1. We calculate elo by first averaging the error of each split for each dataset. This means that if method A has a 60% chance of beating method B on a given split, after averaging 30 splits the chance is much higher than 60% that method A would beat method B. This is the cause of the difference between the `lite` and `official` leaderboards.
2. Because small datasets use 30 splits and large datasets use 9 splits, the probability that the "stronger model on average" will be the winner after averaging is much higher for 30 splits than for 9 splits. Therefore, the methods that are strong on the 30 split datasets are given an unfair advantage over the methods strong on the 9 split datasets.

This PR resolves both issues, and is able to closely match the ELO achieved on the `lite` subset, but using all the splits:
- Add weighted ELO calculation
- Now we can calculate ELO on a per-split basis, weighted equally per dataset. This allows us to calculate the proper elo in cases where the number of splits per dataset differ (such as 9 and 30).
- We can now calculate this ELO alternatively to the current ELO logic which calculates it per dataset after averaging results across splits.
- This is possible by specifying the `per_split_elo=True` argument added in this PR.

Whether we switch to using this ELO calculation method by default is an open question. Note that the other metrics such as rank, harmonic rank, improvability, etc. also are impacted by this, but I have not implemented weighted calculations for those metrics yet.

# Example Script
```python
from pathlib import Path

from tabrepo.nips2025_utils.tabarena_context import TabArenaContext
from tabrepo.tabarena.website_format import format_leaderboard


if __name__ == '__main__':
    save_path = "output_leaderboard"  # folder to save all figures and tables
    output_path_verified = Path(save_path) / "verified"

    tabarena_context = TabArenaContext(include_unverified=False)
    leaderboard_verified = tabarena_context.compare(output_dir=output_path_verified)
    leaderboard_website_verified = format_leaderboard(df_leaderboard=leaderboard_verified)

    tabarena_context = TabArenaContext(include_unverified=False)
    leaderboard_verified = tabarena_context.compare(output_dir=output_path_verified, subset="lite")
    leaderboard_website_verified_lite = format_leaderboard(df_leaderboard=leaderboard_verified)

    tabarena_context = TabArenaContext(include_unverified=False)
    leaderboard_verified = tabarena_context.compare(output_dir=output_path_verified, per_split_elo=True)
    leaderboard_website_verified_per_split = format_leaderboard(df_leaderboard=leaderboard_verified)

    print(f"Verified Leaderboard (per_split_elo=False):")
    print(leaderboard_website_verified.to_markdown(index=False))
    print("")

    print(f"Verified Leaderboard (subset='lite', per_split_elo=False):")
    print(leaderboard_website_verified_lite.to_markdown(index=False))
    print("")

    print(f"Verified Leaderboard (per_split_elo=True):")
    print(leaderboard_website_verified_per_split.to_markdown(index=False))
    print("")
```

# Example Output
```
Verified Leaderboard (per_split_elo=False):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1826 | +39/-31      |
|   1 | RealMLP (tuned + ensemble)                   |       1629 | +24/-29      |
|   2 | AutoGluon 1.3 (4h)                           |       1583 | +24/-24      |
|   3 | TabM (tuned + ensemble)                      |       1531 | +26/-30      |
|   4 | LightGBM (tuned + ensemble)                  |       1514 | +21/-27      |
|   5 | RealMLP (tuned)                              |       1488 | +27/-24      |
|   6 | CatBoost (tuned + ensemble)                  |       1478 | +26/-22      |
|   7 | CatBoost (tuned)                             |       1461 | +25/-21      |
|   8 | TabM (tuned)                                 |       1441 | +20/-26      |
|   9 | LightGBM (tuned)                             |       1440 | +26/-21      |
|  10 | ModernNCA (tuned + ensemble)                 |       1435 | +26/-24      |
```

```
Verified Leaderboard (subset='lite', per_split_elo=False):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1640 | +29/-25      |
|   1 | AutoGluon 1.3 (4h)                           |       1533 | +32/-22      |
|   2 | RealMLP (tuned + ensemble)                   |       1525 | +26/-23      |
|   3 | RealMLP (tuned)                              |       1445 | +22/-22      |
|   4 | LightGBM (tuned + ensemble)                  |       1422 | +28/-22      |
|   5 | TabM (tuned + ensemble)                      |       1415 | +20/-19      |
|   6 | CatBoost (tuned + ensemble)                  |       1398 | +25/-18      |
|   7 | ModernNCA (tuned + ensemble)                 |       1386 | +26/-22      |
|   8 | CatBoost (tuned)                             |       1373 | +18/-20      |
|   9 | XGBoost (tuned + ensemble)                   |       1373 | +24/-18      |
|  10 | LightGBM (tuned)                             |       1358 | +20/-19      |
```

```
Verified Leaderboard (per_split_elo=True):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1664 | +6/-8        |
|   1 | AutoGluon 1.3 (4h)                           |       1521 | +6/-6        |
|   2 | RealMLP (tuned + ensemble)                   |       1521 | +6/-7        |
|   3 | TabM (tuned + ensemble)                      |       1451 | +6/-7        |
|   4 | LightGBM (tuned + ensemble)                  |       1436 | +6/-6        |
|   5 | RealMLP (tuned)                              |       1430 | +5/-6        |
|   6 | CatBoost (tuned + ensemble)                  |       1418 | +5/-6        |
|   7 | CatBoost (tuned)                             |       1406 | +4/-7        |
|   8 | ModernNCA (tuned + ensemble)                 |       1393 | +5/-6        |
|   9 | TabM (tuned)                                 |       1391 | +6/-7        |
|  10 | LightGBM (tuned)                             |       1388 | +7/-7        |
```

# Update: Fix CI calculation & 1000x speedup

Our CI calculation for ELO was not bootstrapping on tasks but rather on battles. I've now fixed it to bootstrap on battles.

This leads to larger 95% CI than before, since we only have 51 datasets:

```
Verified Leaderboard (per_split_elo=False):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1826 | +105/-76     |
|   1 | RealMLP (tuned + ensemble)                   |       1630 | +89/-74      |
|   2 | AutoGluon 1.3 (4h)                           |       1584 | +104/-92     |
|   3 | TabM (tuned + ensemble)                      |       1531 | +98/-79      |
|   4 | LightGBM (tuned + ensemble)                  |       1514 | +66/-68      |
|   5 | RealMLP (tuned)                              |       1488 | +81/-86      |
|   6 | CatBoost (tuned + ensemble)                  |       1479 | +76/-66      |
|   7 | CatBoost (tuned)                             |       1462 | +74/-71      |
|   8 | TabM (tuned)                                 |       1441 | +88/-83      |
|   9 | LightGBM (tuned)                             |       1440 | +63/-64      |
|  10 | ModernNCA (tuned + ensemble)                 |       1435 | +104/-78     |
```

```
Verified Leaderboard (subset='lite', per_split_elo=False):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1640 | +139/-114    |
|   1 | AutoGluon 1.3 (4h)                           |       1533 | +90/-85      |
|   2 | RealMLP (tuned + ensemble)                   |       1525 | +93/-76      |
|   3 | RealMLP (tuned)                              |       1445 | +82/-84      |
|   4 | LightGBM (tuned + ensemble)                  |       1422 | +81/-73      |
|   5 | TabM (tuned + ensemble)                      |       1415 | +120/-98     |
|   6 | CatBoost (tuned + ensemble)                  |       1399 | +99/-90      |
|   7 | ModernNCA (tuned + ensemble)                 |       1386 | +113/-83     |
|   8 | CatBoost (tuned)                             |       1373 | +85/-80      |
|   9 | XGBoost (tuned + ensemble)                   |       1373 | +74/-65      |
|  10 | LightGBM (tuned)                             |       1358 | +85/-78      |
```

```
Verified Leaderboard (per_split_elo=True):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1664 | +98/-73      |
|   1 | RealMLP (tuned + ensemble)                   |       1522 | +80/-68      |
|   2 | AutoGluon 1.3 (4h)                           |       1521 | +87/-71      |
|   3 | TabM (tuned + ensemble)                      |       1451 | +83/-68      |
|   4 | LightGBM (tuned + ensemble)                  |       1436 | +65/-60      |
|   5 | RealMLP (tuned)                              |       1431 | +71/-76      |
|   6 | CatBoost (tuned + ensemble)                  |       1418 | +63/-64      |
|   7 | CatBoost (tuned)                             |       1406 | +61/-58      |
|   8 | ModernNCA (tuned + ensemble)                 |       1393 | +91/-74      |
|   9 | TabM (tuned)                                 |       1391 | +83/-76      |
|  10 | LightGBM (tuned)                             |       1388 | +61/-61      |
```

## 1000x Speedup

By vectorizing the logic and using sample weights to compress the row count passed into the logistic regression model, I was able to get a 1000x speedup over the prior mainline logic. Along with this, I've updated the default bootstrap rounds from 100 to 200.

Now bootstrapping that previously took 10 minutes now takes under 1 second:

### Mainline
```
bootstrap: 100%|██████████| 100/100 [04:15<00:00,  2.56s/it]
```

### This PR
```
bootstrap: 100%|██████████| 200/200 [00:00<00:00, 264.01it/s]
```

### Iterative Improvement
```
# Starting point after incorporating per_fold_elo=True
bootstrap: 100%|██████████| 100/100 [04:15<00:00,  2.56s/it]

# Use sample weight to up-weight samples during bootstrapping rather than duplicating them
bootstrap: 100%|██████████| 100/100 [02:47<00:00,  1.68s/it]

# Optimize compute_mle_elo to be vectorized and use sample_weight across tasks to deduplicate
bootstrap: 100%|██████████| 100/100 [00:42<00:00,  2.38it/s]

# Optimize get_bootstrap_result to keep X, Y constant for all fit calls across bootstraps, only changing sample weights.
bootstrap: 100%|██████████| 200/200 [00:00<00:00, 264.01it/s]
```

# Update 2: Further Improve 95% CI via making it independent of the calibration_framework

By calculating the 95% CI before calibrating the elo, this allows for a tighter CI due to the mean elo of each bootstrap being equal, rather than dependent on the calibration framework's performance.


## Previously
```
Verified Leaderboard (per_split_elo=True):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1664 | +98/-73      |
|   1 | RealMLP (tuned + ensemble)                   |       1522 | +80/-68      |
|   2 | AutoGluon 1.3 (4h)                           |       1521 | +87/-71      |
|   3 | TabM (tuned + ensemble)                      |       1451 | +83/-68      |
|   4 | LightGBM (tuned + ensemble)                  |       1436 | +65/-60      |
|   5 | RealMLP (tuned)                              |       1431 | +71/-76      |
|   6 | CatBoost (tuned + ensemble)                  |       1418 | +63/-64      |
|   7 | CatBoost (tuned)                             |       1406 | +61/-58      |
|   8 | ModernNCA (tuned + ensemble)                 |       1393 | +91/-74      |
|   9 | TabM (tuned)                                 |       1391 | +83/-76      |
|  10 | LightGBM (tuned)                             |       1388 | +61/-61      |
```

## After Fix
```
Verified Leaderboard (per_split_elo=True):
|   # | Model                                        |   Elo [⬆️] | Elo 95% CI   |
|----:|:---------------------------------------------|-----------:|:-------------|
|   0 | AutoGluon 1.4 (4h)                           |       1664 | +76/-52      |
|   1 | RealMLP (tuned + ensemble)                   |       1522 | +57/-47      |
|   2 | AutoGluon 1.3 (4h)                           |       1521 | +63/-49      |
|   3 | TabM (tuned + ensemble)                      |       1451 | +58/-41      |
|   4 | LightGBM (tuned + ensemble)                  |       1436 | +38/-31      |
|   5 | RealMLP (tuned)                              |       1431 | +45/-43      |
|   6 | CatBoost (tuned + ensemble)                  |       1418 | +44/-43      |
|   7 | CatBoost (tuned)                             |       1406 | +44/-40      |
|   8 | ModernNCA (tuned + ensemble)                 |       1393 | +82/-55      |
|   9 | TabM (tuned)                                 |       1391 | +52/-47      |
|  10 | LightGBM (tuned)                             |       1388 | +34/-30      |
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
