### PR TITLE
Add split support to eval

### DIFF
--- a/tabrepo/nips2025_utils/compare.py
+++ b/tabrepo/nips2025_utils/compare.py
@@ -19,7 +19,7 @@ def compare_on_tabarena(
     tabarena_context: TabArenaContext | None = None,
     fillna: str | pd.DataFrame | None = "RF (default)",
     score_on_val: bool = False,
-    per_split_elo: bool = False,
+    average_seeds: bool = True,
     tmp_treat_tasks_independently: bool = False,
 ) -> pd.DataFrame:
     output_dir = Path(output_dir)
@@ -61,7 +61,7 @@ def compare_on_tabarena(
         fillna=fillna,
         calibration_framework=fillna,
         score_on_val=score_on_val,
-        per_split_elo=per_split_elo,
+        average_seeds=average_seeds,
         tmp_treat_tasks_independently=tmp_treat_tasks_independently,
     )
 
@@ -73,7 +73,7 @@ def compare(
     calibration_framework: str | None = None,
     fillna: str | pd.DataFrame | None = None,
     score_on_val: bool = False,
-    per_split_elo: bool = False,
+    average_seeds: bool = True,
     tmp_treat_tasks_independently: bool = False,  # FIXME: Update
 ):
     df_results = df_results.copy()
@@ -123,7 +123,7 @@ def compare(
         plot_times=True,
         plot_other=False,
         calibration_framework=calibration_framework,
-        per_split_elo=per_split_elo,
+        average_seeds=average_seeds,
         tmp_treat_tasks_independently=tmp_treat_tasks_independently,
     )
 

--- a/tabrepo/nips2025_utils/end_to_end.py
+++ b/tabrepo/nips2025_utils/end_to_end.py
@@ -338,7 +338,7 @@ class EndToEndResults:
         use_artifact_name_in_prefix: bool | None = None,
         use_model_results: bool = False,
         score_on_val: bool = False,
-        per_split_elo: bool = False,
+        average_seeds: bool = True,
     ) -> pd.DataFrame:
         """Compare results on TabArena leaderboard.
 
@@ -365,7 +365,7 @@ class EndToEndResults:
             only_valid_tasks=only_valid_tasks,
             subset=subset,
             score_on_val=score_on_val,
-            per_split_elo=per_split_elo,
+            average_seeds=average_seeds,
         )
 
     def get_results(

--- a/tabrepo/nips2025_utils/end_to_end_single.py
+++ b/tabrepo/nips2025_utils/end_to_end_single.py
@@ -539,7 +539,7 @@ class EndToEndResultsSingle:
         use_artifact_name_in_prefix: bool | None = None,
         use_model_results: bool = False,
         score_on_val: bool = False,
-        per_split_elo: bool = False,
+        average_seeds: bool = True,
     ) -> pd.DataFrame:
         """Compare results on TabArena leaderboard.
 
@@ -566,7 +566,7 @@ class EndToEndResultsSingle:
             only_valid_tasks=only_valid_tasks,
             subset=subset,
             score_on_val=score_on_val,
-            per_split_elo=per_split_elo,
+            average_seeds=average_seeds,
         )
 
     def get_results(

--- a/tabrepo/nips2025_utils/scripts/run_amlb2025.py
+++ b/tabrepo/nips2025_utils/scripts/run_amlb2025.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             "calibration_elo": 1000,
             "BOOTSTRAP_ROUNDS": 100,
         },
-        baseline_relative_error=baseline_method,
+        baseline_method=baseline_method,
         relative_error_kwargs={"agg": "gmean"},
     )
     with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):

--- a/tabrepo/nips2025_utils/scripts/run_amlb2025.py
+++ b/tabrepo/nips2025_utils/scripts/run_amlb2025.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
         data=df_results_fillna,
         # include_error=True,
         include_elo=True,
-        include_failure_counts=True,
+        # include_failure_counts=True,
         include_mrr=True,
         include_rank_counts=True,
         include_winrate=True,

--- a/tabrepo/nips2025_utils/tabarena_context.py
+++ b/tabrepo/nips2025_utils/tabarena_context.py
@@ -111,7 +111,7 @@ class TabArenaContext:
         subset: str | None = None,
         folds: list[int] | None = None,
         score_on_val: bool = False,
-        per_split_elo: bool = False,
+        average_seeds: bool = True,
         tmp_treat_tasks_independently: bool = False,
     ) -> pd.DataFrame:
         from tabrepo.nips2025_utils.compare import compare_on_tabarena
@@ -123,7 +123,7 @@ class TabArenaContext:
             folds=folds,
             tabarena_context=self,
             score_on_val=score_on_val,
-            per_split_elo=per_split_elo,
+            average_seeds=average_seeds,
             tmp_treat_tasks_independently=tmp_treat_tasks_independently,
         )
 

--- a/tabrepo/paper/tabarena_evaluator.py
+++ b/tabrepo/paper/tabarena_evaluator.py
@@ -204,7 +204,7 @@ class TabArenaEvaluator:
         plot_pareto: bool = True,
         plot_other: bool = False,
         calibration_framework: str | None = "auto",
-        per_split_elo: bool = False,
+        average_seeds: bool = True,
         tmp_treat_tasks_independently: bool = False,  # FIXME: Need to make a weighted elo logic
     ) -> pd.DataFrame:
         if calibration_framework is not None and calibration_framework == "auto":
@@ -406,8 +406,6 @@ class TabArenaEvaluator:
         if tmp_treat_tasks_independently:
             df_results_rank_compare["dataset"] = df_results_rank_compare["dataset"] + "_" + df_results_rank_compare["fold"].astype(str)
             df_results_rank_compare["fold"] = 0
-        if per_split_elo:
-            elo_kwargs["per_split"] = True
 
         tabarena = TabArena(
             method_col=method_col,
@@ -431,6 +429,7 @@ class TabArenaEvaluator:
 
         leaderboard = tabarena.leaderboard(
             data=df_results_rank_compare,
+            average_seeds=average_seeds,
             include_winrate=True,
             include_mrr=True,
             include_rank_counts=True,

--- a/tabrepo/tabarena/elo_utils.py
+++ b/tabrepo/tabarena/elo_utils.py
@@ -234,6 +234,7 @@ class EloHelper:
         BASE: int = 10,
         solver: str = "lbfgs",
         max_iter: int = 1000,
+        show_process: bool = True,
     ):
         """
         Task-level bootstrap with pair-compressed MLE.
@@ -264,7 +265,7 @@ class EloHelper:
             raise ValueError("No (method_1, method_2) pairs present; cannot bootstrap.")
 
         rows = []
-        for _ in tqdm(range(num_round), desc="bootstrap"):
+        for _ in tqdm(range(num_round), desc="bootstrap", disable=not show_process):
             # Sample task indices with replacement; convert to multiplicity vector
             sampled = _rng.choice(np.arange(n_tasks), size=n_tasks, replace=True)
             counts = np.bincount(sampled, minlength=n_tasks).astype(float)
@@ -384,6 +385,7 @@ class EloHelper:
         INIT_RATING: float = 1000,
         BOOTSTRAP_ROUNDS: int = 100,
         SCALE: int = 400,
+        show_process: bool = True,
     ) -> pd.DataFrame:
         rng = np.random.default_rng(seed=seed)
         bootstrap_elo_lu = self.get_bootstrap_result(
@@ -396,7 +398,8 @@ class EloHelper:
                 "SCALE": SCALE,
                 "calibration_framework": calibration_framework,
                 "calibration_elo": calibration_elo,
-            }
+            },
+            show_process=show_process,
         )
         return bootstrap_elo_lu
 

--- a/tabrepo/tabarena/mean_utils.py
+++ b/tabrepo/tabarena/mean_utils.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+import pandas as pd
+import numpy as np
+
+
+def compute_weighted_mean_by_task(
+    df: pd.DataFrame,
+    value_col: str,
+    task_col: str | list[str] = "task",
+    seed_col: str | None = None,
+    method_col: str = "method",
+    weight_col: str | None = None,
+    sort_asc: bool = True,
+) -> pd.Series:
+    """
+    Compute the equal-task-weighted mean of a column for each method.
+
+    - If seed_col is provided:
+        * Aggregate values per (task, seed, method) first.
+        * Average over seeds within each task so every task contributes equally.
+    - If seed_col is None:
+        * Treat each task as having a single dummy seed.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input DataFrame containing task, method, and value columns.
+    value_col : str
+        Name of the column to average.
+    task_col : str or list[str], default="task"
+        Column(s) identifying tasks.
+    seed_col : str or None, default=None
+        Optional seed column for multiple runs per task.
+    method_col : str, default="method"
+        Column identifying methods.
+    weight_col : str or None, default=None
+        Optional column of numeric weights to compute a weighted mean within groups.
+    sort_asc : bool, default=True
+        Whether to sort output in ascending order (True) or descending order (False)
+
+    Returns
+    -------
+    pd.Series
+        Index = methods, Values = equal-task-weighted mean of `value_col`.
+    """
+    df = df.copy()
+
+    if not isinstance(task_col, list):
+        task_col = [task_col]
+
+    group_task = [*task_col, method_col]
+    if seed_col is not None:
+        group_task_seed = group_task + [seed_col]
+    else:
+        group_task_seed = group_task
+
+    # Step 1: Aggregate to per-(task, seed, method)
+    if weight_col is not None:
+        agg_df = (
+            df.groupby(group_task_seed, sort=False)
+            .apply(lambda g: np.average(g[value_col], weights=g[weight_col]))
+            .reset_index(name=value_col)
+        )
+    else:
+        agg_df = (
+            df.groupby(group_task_seed, sort=False)[value_col]
+            .mean()
+            .reset_index()
+        )
+
+    # Step 2: Average over seeds within each (task, method)
+    task_avg = agg_df.groupby(group_task, sort=False)[value_col].mean().reset_index()
+
+    # Step 3: Average across tasks equally per method
+    mean_per_method = task_avg.groupby(method_col, sort=False)[value_col].mean().sort_values(ascending=sort_asc)
+
+    return mean_per_method

--- a/tabrepo/tabarena/tabarena.py
+++ b/tabrepo/tabarena/tabarena.py
@@ -60,7 +60,6 @@ class TabArena:
         include_improvability: bool = True,
         include_rescaled_loss: bool = True,
         include_rank_counts: bool = False,
-        include_failure_counts: bool = False,
         include_elo: bool = False,
         include_winrate: bool = False,
         include_mrr: bool = False,
@@ -89,8 +88,6 @@ class TabArena:
 
         if include_rank_counts:
             results_lst.append(self.compute_ranks(results_per_task=results_per_task))
-        if include_failure_counts:
-            results_lst.append(self.compute_failure_count(results_per_task=results_per_task).to_frame())
         if include_elo:
             per_split = elo_kwargs.get("per_split", False)
             if per_split:
@@ -453,17 +450,6 @@ class TabArena:
         results_mrr = results_mrr_per_task.groupby(self.method_col).mean()
         results_mrr.name = "mrr"
         return results_mrr
-
-    def compute_failure_count(self, results_per_task: pd.DataFrame) -> pd.Series:
-        datasets = sorted(list(results_per_task[self.task_col].unique()))
-        frameworks = list(results_per_task[self.method_col].unique())
-        num_datasets = len(datasets)
-        results_framework = results_per_task.drop_duplicates(self.groupby_columns)
-        framework_counts = results_framework[self.method_col].value_counts()
-        framework_failure_counts = -framework_counts + num_datasets
-        framework_failure_counts.name = "error_count"
-        framework_failure_counts = framework_failure_counts.reindex(frameworks)
-        return framework_failure_counts
 
     def compute_skill_score(
         self,

--- a/tabrepo/tabarena/tabarena.py
+++ b/tabrepo/tabarena/tabarena.py
@@ -376,12 +376,10 @@ class TabArena:
             assert df_fillna is None, f"df_fillna must be None if fillna_method='worst'"
             idx_worst = data.groupby(task_columns)[self.error_col].idxmax()
             df_fillna = data.loc[idx_worst]
+        if self.method_col in df_fillna.columns:
             df_fillna = df_fillna.drop(columns=[self.method_col])
-            pass
 
         data = data.set_index([*task_columns, self.method_col], drop=True)
-
-        assert self.method_col not in df_fillna.columns, f"Method column '{self.method_col}' must not be in df_fillna"
 
         df_filled = df_fillna[task_columns].merge(
             pd.Series(data=unique_methods, name=self.method_col),

--- a/tabrepo/tabarena/tabarena.py
+++ b/tabrepo/tabarena/tabarena.py
@@ -584,6 +584,7 @@ class TabArena:
                 INIT_RATING=INIT_RATING,
                 BOOTSTRAP_ROUNDS=BOOTSTRAP_ROUNDS,
                 SCALE=SCALE,
+                show_process=False,
             )
             bootstrap_median = bootstrap_elo_lu.quantile(.5)
 

--- a/tabrepo/tabarena/tabarena.py
+++ b/tabrepo/tabarena/tabarena.py
@@ -436,7 +436,10 @@ class TabArena:
         """Compute mean reciprocal rank"""
         results_per_task = results_per_task.copy()
         results_per_task["mrr"] = 1 / results_per_task["rank"]
-        results_mrr = results_per_task.groupby(self.method_col)["mrr"].mean()
+        results_mrr_per_task = results_per_task.groupby(self.groupby_columns)["mrr"].mean()
+
+        results_mrr = results_mrr_per_task.groupby(self.method_col).mean()
+        results_mrr.name = "mrr"
         return results_mrr
 
     def compute_failure_count(self, results_per_task: pd.DataFrame) -> pd.Series:

--- a/tabrepo/tabarena/tabarena.py
+++ b/tabrepo/tabarena/tabarena.py
@@ -375,7 +375,7 @@ class TabArena:
     def compute_results_per_task(self, data: pd.DataFrame, include_seed_col: bool = False) -> pd.DataFrame:
         groupby_cols = self.groupby_columns
         task_groupby_cols = self.task_groupby_columns
-        if include_seed_col:
+        if include_seed_col and self.seed_column is not None:
             groupby_cols = groupby_cols + [self.seed_column]
             task_groupby_cols = task_groupby_cols + [self.seed_column]
         columns_to_agg = self.columns_to_agg


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add split support to eval so we can calculate all metrics correctly aggregated at the task level even if they have different numbers of splits per task via a weighted contribution of the splits.
- Ensure that each metric is aggregated using `self.groupby_columns` rather than `self.task_col`.

## TODO

- [x] Add split support for rescaled error
- [x] Add split support for skill_score

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
