### PR TITLE
fix: avoid use_child_oof for default configs for RF and XT

### DIFF
--- a/tabarena/tabarena/models/extra_trees/generate.py
+++ b/tabarena/tabarena/models/extra_trees/generate.py
@@ -54,7 +54,7 @@ def generate_configs_xt(num_random_configs=200):
 gen_extratrees = CustomAGConfigGenerator(
     model_cls=XTModel,
     search_space_func=generate_configs_xt,
-    manual_configs=[{}],
+    manual_configs=[{"ag_args_ensemble": {"use_child_oof": False}}],
 )
 
 if __name__ == "__main__":

--- a/tabarena/tabarena/models/random_forest/generate.py
+++ b/tabarena/tabarena/models/random_forest/generate.py
@@ -49,7 +49,7 @@ def generate_configs_rf(num_random_configs=200):
 gen_randomforest = CustomAGConfigGenerator(
     model_cls=RFModel,
     search_space_func=generate_configs_rf,
-    manual_configs=[{}],
+    manual_configs=[{"ag_args_ensemble": {"use_child_oof": False}}],
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
