### PR TITLE
[New Model] TabPFN-Wide model

### DIFF
--- a/tabarena/pyproject.toml
+++ b/tabarena/pyproject.toml
@@ -65,7 +65,7 @@ limix = [
   "einops",
   "kditransform",
 ]
-tabpfnwide = ["tabpfnwide>=0.1.0"]
+tabpfnwide = ["tabpfnwide>=0.2.0"]
 
 # union of all above extras (mirrors your "benchmark" extra)
 benchmark = [
@@ -85,6 +85,7 @@ benchmark = [
   "einops",
   "kditransform",
   "tabtune @ git+https://github.com/Lexsi-Labs/TabTune.git",
+  "tabpfnwide>=0.2.0",
 ]
 
 [project.urls]

--- a/tabarena/pyproject.toml
+++ b/tabarena/pyproject.toml
@@ -65,7 +65,7 @@ limix = [
   "einops",
   "kditransform",
 ]
-tabpfnwide = ["tabpfnwide>=0.2.0"]
+tabpfnwide = ["tabpfnwide>=0.3.0"]
 
 # union of all above extras (mirrors your "benchmark" extra)
 benchmark = [
@@ -85,7 +85,7 @@ benchmark = [
   "einops",
   "kditransform",
   "tabtune @ git+https://github.com/Lexsi-Labs/TabTune.git",
-  "tabpfnwide>=0.2.0",
+  "tabpfnwide>=0.3.0",
 ]
 
 [project.urls]

--- a/tabarena/pyproject.toml
+++ b/tabarena/pyproject.toml
@@ -65,6 +65,7 @@ limix = [
   "einops",
   "kditransform",
 ]
+tabpfnwide = ["tabpfnwide>=0.1.0"]
 
 # union of all above extras (mirrors your "benchmark" extra)
 benchmark = [

--- a/tabarena/tabarena/benchmark/models/ag/__init__.py
+++ b/tabarena/tabarena/benchmark/models/ag/__init__.py
@@ -18,6 +18,7 @@ from tabarena.benchmark.models.ag.tabpfnv2_5.tabpfnv2_5_model import (
     TabPFNv26Model,
 )
 from tabarena.benchmark.models.ag.tabpfnv3.tabpfn_3_model import TabPFN3Model
+from tabarena.benchmark.models.ag.tabpfnwide.tabpfnwide_model import TabPFNWideModel
 from tabarena.benchmark.models.ag.tabstar.tabstar_model import TabSTARModel
 from tabarena.benchmark.models.ag.xrfm.xrfm_model import XRFMModel
 
@@ -36,6 +37,7 @@ __all__ = [
     "TabICLv2Model",
     "TabMModel",
     "TabPFN3Model",
+    "TabPFNWideModel",
     "TabPFNv26Model",
     "TabSTARModel",
     "XRFMModel",

--- a/tabarena/tabarena/benchmark/models/ag/tabpfnwide/__init__.py
+++ b/tabarena/tabarena/benchmark/models/ag/tabpfnwide/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
+++ b/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
@@ -23,7 +23,6 @@ class TabPFNWideModel(AbstractTorchModel):
     Authors: Christopher Kolberg, Jules Kreuer, Jonas Huurdeman, Sofiane Ouaari,
         Katharina Eggensperger, Nico Pfeifer
     Codebase: https://github.com/not-a-feature/TabPFN-Wide
-    License: Prior Labs License Version 1.1
     """
 
     ag_key = "TA-TABPFN-WIDE"

--- a/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
+++ b/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
@@ -26,7 +26,7 @@ class TabPFNWideModel(AbstractTorchModel):
     License: Prior Labs License Version 1.1
     """
 
-    ag_key = "TA-TabPFN-Wide"
+    ag_key = "TA-TABPFN-WIDE"
     ag_name = "TA-TabPFN-Wide"
     ag_priority = 65
     seed_name = "random_state"

--- a/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
+++ b/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from autogluon.common.utils.resource_utils import ResourceManager
+from autogluon.features.generators import LabelEncoderFeatureGenerator
+from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class TabPFNWideModel(AbstractTorchModel):
+    """TabPFN-Wide: a TabPFN variant specialized for wide tabular datasets
+    (many features, few samples).
+
+    Paper: TabPFN-Wide (arXiv:2510.06162)
+    Authors: Christopher Kolberg, Jules Kreuer, Jonas Huurdeman, Sofiane Ouaari,
+        Katharina Eggensperger, Nico Pfeifer
+    Codebase: https://github.com/not-a-feature/TabPFN-Wide
+    License: Prior Labs License Version 1.1
+    """
+
+    ag_key = "TabPFN-Wide"
+    ag_name = "TabPFN-Wide"
+    ag_priority = 65
+    seed_name = "random_state"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._feature_generator = None
+
+    def _preprocess(self, X: pd.DataFrame, is_train: bool = False, **kwargs) -> pd.DataFrame:
+        X = super()._preprocess(X, **kwargs)
+
+        if is_train:
+            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
+            self._feature_generator.fit(X=X)
+
+        if self._feature_generator.features_in:
+            X = X.copy()
+            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+
+        return X
+
+    def _fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        X_val: pd.DataFrame | None = None,
+        y_val: pd.Series | None = None,
+        time_limit: float | None = None,
+        num_cpus: int = 1,
+        num_gpus: int = 0,
+        **kwargs,
+    ):
+        import torch
+
+        available_num_gpus = ResourceManager.get_gpu_count_torch(cuda_only=True)
+        if num_gpus > available_num_gpus:
+            raise AssertionError(
+                f"Fit specified to use {num_gpus} GPU, but only {available_num_gpus} "
+                "CUDA GPUs are available. Please activate CUDA or switch to CPU usage.",
+            )
+        device = "cuda" if num_gpus != 0 else "cpu"
+        if (device == "cuda") and (not torch.cuda.is_available()):
+            raise AssertionError(
+                "Fit specified to use GPU, but CUDA is not available on this machine. "
+                "Please switch to CPU usage instead.",
+            )
+
+        from tabpfnwide.classifier import TabPFNWideClassifier
+
+        if self.problem_type not in ["binary", "multiclass"]:
+            raise AssertionError(
+                f"Unsupported problem_type: {self.problem_type}. "
+                "TabPFN-Wide supports only classification."
+            )
+
+        hps = self._get_model_params()
+
+        X = self.preprocess(X, y=y, is_train=True)
+
+        self.model = TabPFNWideClassifier(
+            device=device,
+            **hps,
+        )
+        self.model.fit(X, y)
+
+    def _set_default_params(self):
+        default_params = {}
+        for param, val in default_params.items():
+            self._set_default_param_value(param, val)
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass"]
+
+    def get_device(self) -> str:
+        if hasattr(self.model, "device"):
+            return self.model.device
+        return "cpu"
+
+    def _set_device(self, device: str):
+        if hasattr(self.model, "to"):
+            self.model.to(device)
+
+    def _get_default_resources(self) -> tuple[int, int]:
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
+        return num_cpus, num_gpus
+
+    def get_minimum_resources(self, is_gpu_available: bool = False) -> dict[str, int | float]:
+        return {
+            "num_cpus": 1,
+            "num_gpus": 1 if is_gpu_available else 0,
+        }
+
+    @classmethod
+    def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
+        """Set fold_fitting_strategy to sequential_local to avoid crashes
+        if model weights aren't pre-downloaded when fitting in parallel.
+        """
+        default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
+        default_ag_args_ensemble.update({"fold_fitting_strategy": "sequential_local"})
+        return default_ag_args_ensemble
+
+    @classmethod
+    def _class_tags(cls) -> dict:
+        return {"can_estimate_memory_usage_static": False}
+
+    def _more_tags(self) -> dict:
+        return {"can_refit_full": True}

--- a/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
+++ b/tabarena/tabarena/benchmark/models/ag/tabpfnwide/tabpfnwide_model.py
@@ -17,6 +17,8 @@ class TabPFNWideModel(AbstractTorchModel):
     """TabPFN-Wide: a TabPFN variant specialized for wide tabular datasets
     (many features, few samples).
 
+    The current default (v0.3.0) of TabPFN-Wide is based on TabPFNv2.
+
     Paper: TabPFN-Wide (arXiv:2510.06162)
     Authors: Christopher Kolberg, Jules Kreuer, Jonas Huurdeman, Sofiane Ouaari,
         Katharina Eggensperger, Nico Pfeifer
@@ -24,8 +26,8 @@ class TabPFNWideModel(AbstractTorchModel):
     License: Prior Labs License Version 1.1
     """
 
-    ag_key = "TabPFN-Wide"
-    ag_name = "TabPFN-Wide"
+    ag_key = "TA-TabPFN-Wide"
+    ag_name = "TA-TabPFN-Wide"
     ag_priority = 65
     seed_name = "random_state"
 
@@ -81,17 +83,21 @@ class TabPFNWideModel(AbstractTorchModel):
             )
 
         hps = self._get_model_params()
+        default_hps = dict(
+            model_name="wide-v2-8k",
+        )
+        hps = {**default_hps, **hps}
 
         X = self.preprocess(X, y=y, is_train=True)
-
         self.model = TabPFNWideClassifier(
-            device=device,
             **hps,
         )
         self.model.fit(X, y)
 
     def _set_default_params(self):
-        default_params = {}
+        default_params = {
+            "model_name": "wide-v2-8k",
+        }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
@@ -121,11 +127,13 @@ class TabPFNWideModel(AbstractTorchModel):
 
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
-        """Set fold_fitting_strategy to sequential_local to avoid crashes
-        if model weights aren't pre-downloaded when fitting in parallel.
-        """
+        """Ensure one fold is fit at a time and refits is enabled by default."""
         default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
-        default_ag_args_ensemble.update({"fold_fitting_strategy": "sequential_local"})
+        extra_ag_args_ensemble = {
+            "fold_fitting_strategy": "sequential_local",
+            "refit_folds": default_ag_args_ensemble.pop("refit_folds", True),
+        }
+        default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
 
     @classmethod
@@ -134,3 +142,13 @@ class TabPFNWideModel(AbstractTorchModel):
 
     def _more_tags(self) -> dict:
         return {"can_refit_full": True}
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        default_auxiliary_params.update(
+            {
+                "max_rows": 10_000,
+                "max_classes": 10,
+            }
+        )
+        return default_auxiliary_params

--- a/tabarena/tabarena/benchmark/models/model_registry.py
+++ b/tabarena/tabarena/benchmark/models/model_registry.py
@@ -19,6 +19,7 @@ from tabarena.benchmark.models.ag import (
     TabICLv2Model,
     TabMModel,
     TabPFN3Model,
+    TabPFNWideModel,
     TabPFNv26Model,
     TabSTARModel,
     XRFMModel,
@@ -43,6 +44,7 @@ _models_to_add = [
     TabPFNv26Model,
     LimiXModel,
     TabPFN3Model,
+    TabPFNWideModel,
     OrionMSPModel,
 ]
 

--- a/tabarena/tabarena/models/tabpfnwide/__init__.py
+++ b/tabarena/tabarena/models/tabpfnwide/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tabarena/tabarena/models/tabpfnwide/generate.py
+++ b/tabarena/tabarena/models/tabpfnwide/generate.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from tabarena.benchmark.models.ag.tabpfnwide.tabpfnwide_model import TabPFNWideModel
+from tabarena.utils.config_utils import ConfigGenerator
+
+gen_tabpfnwide = ConfigGenerator(
+    model_cls=TabPFNWideModel,
+    search_space={},
+    manual_configs=[{}],
+)
+
+if __name__ == "__main__":
+    from tabarena.benchmark.experiment import YamlExperimentSerializer
+
+    print(
+        YamlExperimentSerializer.to_yaml_str(
+            experiments=gen_tabpfnwide.generate_all_bag_experiments(num_random_configs=0),
+        ),
+    )

--- a/tabarena/tabarena/models/utils.py
+++ b/tabarena/tabarena/models/utils.py
@@ -55,6 +55,7 @@ def get_configs_generator_from_name(model_name: str):
         "OrionMSP": lambda: importlib.import_module("tabarena.models.orionmsp.generate").gen_orionmsp,
         "LimiX": lambda: importlib.import_module("tabarena.models.limix.generate").gen_limix,
         "TabPFN-3": lambda: importlib.import_module("tabarena.models.tabpfn_3.generate").gen_tabpfn_3,
+        "TabPFN-Wide": lambda: importlib.import_module("tabarena.models.tabpfnwide.generate").gen_tabpfnwide,
     }
 
     if model_name not in name_to_import_map:

--- a/tabflow_slurm/benchmark_log/benchmark_setups_history_new.py
+++ b/tabflow_slurm/benchmark_log/benchmark_setups_history_new.py
@@ -1,4 +1,4 @@
-"""Code for running the benchmark on a full node in a GCP cluster."""
+"""History of benchmark setups for TabArenaV0.1 Single Node Benchmark."""
 
 from __future__ import annotations
 
@@ -37,12 +37,19 @@ class TabArenaV0pt1SingleNodeBenchmarkSetup(BenchmarkSetup2026):
 
 
 TabArenaV0pt1SingleNodeBenchmarkSetup(
-    benchmark_name="benchmark_xxx_22052026",
+    benchmark_name="benchmark_tabpfn_wide_22052026",
     task_metadata="tabarena-v0.1",
     num_gpus=1,
     models=[
-        ("XXX", 0),
+        ("TabPFN-Wide", 0),
     ],
+    custom_model_constraints={
+        "TA-TABPFN-WIDE": {
+            "max_n_samples_train_per_fold": 10_000,
+            "max_n_classes": 10,
+            "regression_support": False,
+        },
+    },
     # Can overwrite these classes as needed.
     path_setup=ExtraPathSetup(),
     slurm_setup=SlurmSetup(

--- a/tabflow_slurm/run_setup_tabarena_v0pt1.py
+++ b/tabflow_slurm/run_setup_tabarena_v0pt1.py
@@ -1,0 +1,61 @@
+"""Code for running the benchmark on a full node in a GCP cluster."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from tabflow_slurm.setup_slurm_base_v2 import BenchmarkSetup2026, PathSetup, SlurmSetup
+
+
+@dataclass
+class ExtraPathSetup(PathSetup):
+    """Path setup for environment."""
+
+    base_path: str = "/path/to/workspace/"
+    tabarena_repo_name: str = "XXX"
+    venv_name: str = "XXXX"
+    openml_cache_from_base_path: str | Literal["auto"] = "auto"
+    """We do not have workspace drives, so we can save in homedir"""
+
+
+@dataclass
+class TabArenaV0pt1SingleNodeBenchmarkSetup(BenchmarkSetup2026):
+    """Benchmark setup for single node environment for TabArena-v0.1."""
+
+    shuffle_features: bool = False
+    """Was False by default in TabArena."""
+    n_random_configs: int = 200
+    """TabArena-v0.1 default"""
+    dynamic_tabarena_validation_protocol: bool = False
+    """Only used in v0.2 or larger with new data foundry task metadata integration."""
+    preprocessing_pipelines: list[str] = field(default_factory=lambda: ["default"])
+
+    # Auto-detect all cpus and memory on the node (can restrict jobs with this further)
+    memory_limit: None = None
+    num_cpus: None = None
+
+
+TabArenaV0pt1SingleNodeBenchmarkSetup(
+    benchmark_name="benchmark_tabpfn_wide_22052026",
+    task_metadata="tabarena-v0.1",
+    num_gpus=1,
+    models=[
+        ("TabPFN-Wide", 0),
+    ],
+    custom_model_constraints={
+        "TA-TABPFN-WIDE": {
+            "max_n_samples_train_per_fold": 10_000,
+            "max_n_classes": 10,
+            "regression_support": False,
+        },
+    },
+    # Can overwrite these classes as needed.
+    path_setup=ExtraPathSetup(),
+    slurm_setup=SlurmSetup(
+        gpu_partition="gpua100highmemoryspotmt",
+        cpu_partition="cpuhighmem16mtspot",
+        extra_gres=None,
+        exclusive_node=True,
+    ),
+).setup_jobs(array_job_limit=100)

--- a/tabflow_slurm/setup_slurm_base_v2.py
+++ b/tabflow_slurm/setup_slurm_base_v2.py
@@ -13,8 +13,9 @@ from typing import Literal
 import pandas as pd
 import ray
 import yaml
-from tabarena.benchmark.experiment.experiment_constructor import Experiment
+from tabarena.benchmark.experiment.experiment_constructor import Experiment, resolve_class
 from tabarena.benchmark.experiment.experiment_utils import check_cache_hit
+from tabarena.benchmark.models.model_registry import infer_model_cls
 from tabarena.benchmark.task.user_task import SplitMetadata, TabArenaTaskMetadata
 from tabarena.utils.cache import CacheFunctionPickle
 from tabarena.utils.ray_utils import ray_map_list, to_batch_list
@@ -702,6 +703,7 @@ class BenchmarkSetup2026:
                         "n_samples_train_per_fold": split_md.num_instances_train,
                         "n_features": split_md.num_features_train,
                         "n_classes": split_md.num_classes_train,
+                        "problem_type": ta_task_metadata.problem_type,
                     }
 
         jobs_to_check = list(yield_all_jobs())
@@ -1079,6 +1081,7 @@ class BenchmarkSetup2026:
         n_classes: int,
         n_samples_train_per_fold: int,
         models_to_constraints: dict[str, dict[str, int]],
+        problem_type: str | None = None,
     ) -> bool:
         """Check if the model constraints are valid for the given model and dataset.
 
@@ -1090,11 +1093,15 @@ class BenchmarkSetup2026:
             The number of features in the dataset.
         n_classes: int
             The number of classes in the dataset.
-            0 for regression tasks.
+            For regression tasks this may be 0, -1, or NaN/None depending on the
+            metadata source — prefer `problem_type` for the regression check.
         n_samples_train_per_fold: int
             The number of training samples per fold in the dataset.
         models_to_constraints: dict[str, dict[str, int]]
             Mapping of model names to their potential constraints.
+        problem_type: str | None
+            "binary" | "multiclass" | "regression". Authoritative source for
+            the `regression_support` check.
 
         Returns:
         --------
@@ -1106,7 +1113,7 @@ class BenchmarkSetup2026:
             return True  # No constraints for this model
 
         regression_support = model_constraints.get("regression_support", True)
-        if (n_classes == 0) and (not regression_support):
+        if (problem_type == "regression") and (not regression_support):
             return False
 
         max_n_features = model_constraints.get("max_n_features", None)
@@ -1158,14 +1165,17 @@ def should_run_job(
 
     # Filter out-of-constraints datasets.
     # `model_cls` (AGModelExperiment) and `method_cls` (plain Experiment) both
-    # carry the class identifier; either is fine to use as the constraints key,
-    # since `are_model_constraints_valid` returns True when the key is absent
-    # from `models_to_constraints`. Fall back to "AutoGluon" only for the
-    # full-pipeline AutoGluon experiments (which expose neither field).
-    if "model_cls" in config:
-        model_cls = config["model_cls"]
-    elif "method_cls" in config:
-        model_cls = config["method_cls"]
+    # carry the class identifier — serialized to YAML as a dotted import path.
+    # Resolve back to the class and use `ag_key` so the lookup matches the
+    # AG-key-based `models_to_constraints` dict. Fall back to "AutoGluon" for
+    # the full-pipeline AutoGluon experiments (which expose neither field).
+    raw_cls = config.get("model_cls") or config.get("method_cls")
+    if raw_cls is not None:
+        try:
+            cls_obj = resolve_class(raw_cls, registry_resolver=infer_model_cls)
+            model_cls = getattr(cls_obj, "ag_key", None) or raw_cls
+        except (ImportError, AttributeError, ValueError, TypeError):
+            model_cls = raw_cls
     elif config.get("name", "").startswith("AutoGluon"):
         model_cls = "AutoGluon"
     else:
@@ -1176,6 +1186,7 @@ def should_run_job(
         n_classes=input_data["n_classes"],
         n_samples_train_per_fold=input_data["n_samples_train_per_fold"],
         models_to_constraints=models_to_constraints,
+        problem_type=input_data.get("problem_type"),
     ):
         return False
 

--- a/tst/benchmark/models/test_tabpfnwide.py
+++ b/tst/benchmark/models/test_tabpfnwide.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_tabpfnwide():
+    try:
+        from autogluon.tabular.testing import FitHelper
+        from tabarena.benchmark.models.ag.tabpfnwide.tabpfnwide_model import (
+            TabPFNWideModel,
+        )
+
+        model_cls = TabPFNWideModel
+        FitHelper.verify_model(model_cls=model_cls, model_hyperparameters={})
+    except ImportError as err:
+        pytest.skip(
+            f"Import Error, skipping test... "
+            f"Ensure you have the proper dependencies installed to run this test:\n"
+            f"{err}"
+        )

--- a/tst/benchmark/models/test_tabpfnwide.py
+++ b/tst/benchmark/models/test_tabpfnwide.py
@@ -11,7 +11,7 @@ def test_tabpfnwide():
         )
 
         model_cls = TabPFNWideModel
-        FitHelper.verify_model(model_cls=model_cls, model_hyperparameters={})
+        FitHelper.verify_model(model_cls=model_cls, model_hyperparameters={"device": "cpu"})
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "


### PR DESCRIPTION
This PR adds support for the TabPFN-Wide model [^1] [^2] a variant of TabPFN specialized for wide tabular datasets (many features, few samples).

~~As the TabPFN-Wide package performs a monkey patch on TabPFN-2.0 (and package version 6.0.6) it requires an separate environment to the other models (especially TabPFN which is pinned to >= 8.0.0~~

Edit: I updated TabPFN-Wide to use tabpfn=8.0.3, so no extra env is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[^1]: https://github.com/not-a-feature/TabPFN-Wide
[^2]: https://arxiv.org/abs/2510.06162)