### PR TITLE
Optional tie_decimals tolerance for win-rate and pairwise tie detection 

### DIFF
--- a/bencheval/bencheval/winrate_utils.py
+++ b/bencheval/bencheval/winrate_utils.py
@@ -10,6 +10,7 @@ def compute_winrate_matrix(
     method_col: str = "method",
     error_col: str = "error",
     seed_col: str | None = None,
+    tie_decimals: int | None = None,
 ) -> pd.DataFrame:
     """
     Pairwise win-rate matrix with optional seeding.
@@ -19,6 +20,11 @@ def compute_winrate_matrix(
         * Each task contributes equally, regardless of #seeds.
     - If seed_col is None:
         * Treat each task as having a single dummy seed.
+    - If tie_decimals is set:
+        * Round error to this many decimals before comparison so two methods
+          that hit the same metric via different code paths (floating-point
+          noise in the last few bits) still count as tied. Default None
+          preserves the original exact-equality behavior.
 
     Returns
     -------
@@ -31,6 +37,10 @@ def compute_winrate_matrix(
         seed_col = "__dummy_seed__"
         results_per_task = results_per_task.copy()
         results_per_task[seed_col] = 0
+
+    if tie_decimals is not None:
+        results_per_task = results_per_task.copy()
+        results_per_task[error_col] = results_per_task[error_col].round(tie_decimals)
 
     methods = pd.Index(results_per_task[method_col].unique())
     midx = {m: i for i, m in enumerate(methods)}
@@ -98,6 +108,7 @@ def compute_winrate(
     error_col: str = "error",
     seed_col: str | None = None,
     sort_desc: bool = True,
+    tie_decimals: int | None = None,
 ) -> pd.Series:
     """
     Average win-rate per method.
@@ -132,6 +143,7 @@ def compute_winrate(
         method_col=method_col,
         error_col=error_col,
         seed_col=seed_col,
+        tie_decimals=tie_decimals,
     )
 
     avg_wr = winrate_matrix.mean(axis=1, skipna=True)

--- a/tabarena/tabarena/paper/tabarena_evaluator.py
+++ b/tabarena/tabarena/paper/tabarena_evaluator.py
@@ -348,6 +348,7 @@ class TabArenaEvaluator:
         error_col: str = "metric_error",
         tie_policy: str = "half",  # {"ignore", "half", "count_as_disagree"}
         min_splits: int = 2,
+        tie_decimals: int | None = None,
     ) -> dict[str, float]:
         """
         Compute average split agreement across all method pairs within ONE dataset.
@@ -382,11 +383,17 @@ class TabArenaEvaluator:
         X = wide.to_numpy(dtype=float)  # shape (S, M)
         S, M = X.shape
 
+        # Optional: round to tie_decimals so two methods that hit the same
+        # metric via different code paths (floating-point noise in the last
+        # few bits) still count as tied. Default None preserves the original
+        # exact-equality behavior.
+        X_cmp = np.round(X, tie_decimals) if tie_decimals is not None else X
+
         # Broadcast comparisons: for each split s, compare all method pairs (i,j)
         # win[s,i,j] = 1 if X[s,i] < X[s,j]
         # tie[s,i,j] = 1 if X[s,i] == X[s,j]
-        win = (X[:, :, None] < X[:, None, :])
-        tie = (X[:, :, None] == X[:, None, :])
+        win = (X_cmp[:, :, None] < X_cmp[:, None, :])
+        tie = (X_cmp[:, :, None] == X_cmp[:, None, :])
 
         # Handle missing values: comparisons where either side is NaN should not count
         valid = np.isfinite(X)


### PR DESCRIPTION
  ## Summary

  Win-rate and pairwise comparisons detect ties with strict `==`. When two methods reach the same metric via different code paths, they tend to differ in the last few floating-point bits and so are not counted as tied, even when the difference is well below any reporting precision.

  This PR adds an opt-in `tie_decimals: int | None` parameter to:
  - `bencheval/winrate_utils.py::compute_winrate_matrix` (and `compute_winrate`)
  - `tabarena/paper/tabarena_evaluator.py::dataset_pairwise_split_agreement`

  The default `None` preserves the current behavior, so no existing outputs change unless a caller explicitly opts in.

  ## Motivation

  While porting the trivial-dataset criterion to our benchmark, we noticed that the strict-equality check is quite conservative — it effectively only catches bitwise-identical metric values. The TabArena paper notes:

  > "Note that after applying our set of criteria, none of the considered datasets was found to be trivial."

  With `tie_decimals=4`, the same criterion flags a few datasets in our setting. We thought it might be of interest to re-run the audit on the TabArena datasets under this slightly looser reading — happy to help if useful.

  ## Not changed in this PR

  To keep the change minimal and avoid shifting any published numbers, the following spots still use strict `==`:
  - `bencheval/tabarena.py::compute_ranks`
  - `tabarena/utils/rank_utils.py::get_rank`
  - `bencheval/elo_utils.py` (inherits the tolerance via the win-rate layer)

  We would be happy to extend `tie_decimals` to these as a follow-up if you think it's worthwhile.