### PR TITLE
fix: make c++ roc_auc compile safe on read-only filesystems

### DIFF
--- a/tabarena/tabarena/metrics/_roc_auc_cpp/__init__.py
+++ b/tabarena/tabarena/metrics/_roc_auc_cpp/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import os
 import subprocess
@@ -17,8 +19,8 @@ class CppAuc:
 
         if not self.plugin_path().exists():
             self._compile()
-            assert self.plugin_path().exists(), f'Missing cpp_auc.so compiled file... ' \
-                                          f'You must first compile the C++ code to use this metric. '
+            assert self.plugin_path().exists(), "Missing cpp_auc.so compiled file... " \
+                                          "You must first compile the C++ code to use this metric. "
         self._handle = ctypes.CDLL(self.plugin_path())
         self._handle.cpp_auc_ext.argtypes = [ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
                                              ndpointer(ctypes.c_bool, flags="C_CONTIGUOUS"),
@@ -27,31 +29,42 @@ class CppAuc:
         self._handle.cpp_auc_ext.restype = ctypes.c_double
 
     def roc_auc_score(self, y_true: np.array, y_score: np.array) -> float:
-        """a method to calculate AUC via C++ lib.
+        """A method to calculate AUC via C++ lib.
+
         Args:
             y_true (np.array): 1D numpy array of dtype=np.bool_ as true labels.
             y_score (np.array): 1D numpy array of dtype=np.float32 as probability predictions.
+
         Returns:
-            float: AUC score
+            float: AUC score.
         """
         n = len(y_true)
-        result = self._handle.cpp_auc_ext(y_score.astype(np.float32), y_true, n)
-        return result
+        return self._handle.cpp_auc_ext(y_score.astype(np.float32), y_true, n)
 
     def _compile(self):
         # load compilation command
-        with open(self.compile_script_path(), "r") as f:
+        with open(self.compile_script_path()) as f:
             # remove \n character from the command line
             compile_command = f.readlines()[1].replace("\n", "")
         assert compile_command.startswith("g++")
 
         # execute compilation command
-        print(f"Running \"{compile_command}\" to compile c++ auc implementation.")
-        with open("std.out", "w") as stdout:
-            proc = subprocess.Popen(compile_command.split(" "), shell=False, stdout=stdout, cwd=Path(__file__).parent)
+        print(f'Running "{compile_command}" to compile c++ auc implementation.')
+        # Discard g++ stdout. It was previously redirected to a "std.out" file in the
+        # *current working directory* (the `cwd` arg below only applies to the subprocess,
+        # not to `open`), which littered the launch dir and crashed on read-only
+        # filesystems (e.g. Singularity containers) with OSError(EROFS). g++ emits its
+        # diagnostics on stderr, which we leave attached to the parent so genuine compile
+        # errors remain visible.
+        proc = subprocess.Popen(
+            compile_command.split(" "),
+            shell=False,
+            stdout=subprocess.DEVNULL,
+            cwd=Path(__file__).parent,
+        )
 
         # wait command completion
-        for max_trials in range(600):
+        for _max_trials in range(600):
             if proc.poll() is not None:
                 break
             time.sleep(0.1)
@@ -59,7 +72,7 @@ class CppAuc:
         # handle potential failure: timeout or error while compiling
         if proc.poll() is None:
             raise ValueError("Could not compile after 60 secs.")
-        elif proc.poll() != 0:
+        if proc.poll() != 0:
             raise ValueError(f"Got an error while compiling, you can try to run manually {self.compile_script_path()}")
 
     @staticmethod

--- a/tabarena/tabarena/simulation/ensemble_selection_config_scorer.py
+++ b/tabarena/tabarena/simulation/ensemble_selection_config_scorer.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 import copy
 import os
 from functools import lru_cache
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 import numpy as np
-
-from autogluon.core.metrics import get_metric, Scorer
+from autogluon.core.metrics import Scorer, get_metric
 from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
+
+from tabarena.metrics import _fast_log_loss
+from tabarena.utils import task_to_tid_fold
+from tabarena.utils.aux_metric import get_aux_metric_map
+from tabarena.utils.parallel_for import parallel_for
+
 from .configuration_list_scorer import ConfigurationListScorer
 
-from ..utils.aux_metric import get_aux_metric_map
-from ..utils.parallel_for import parallel_for
-from ..utils.rank_utils import RankScorer
-from ..utils import task_to_tid_fold
-from ..metrics import _fast_log_loss
-
 if TYPE_CHECKING:
-    from ..repository.evaluation_repository import EvaluationRepository
+    from tabarena.repository.evaluation_repository import EvaluationRepository
+    from tabarena.utils.rank_utils import RankScorer
 
 
 @lru_cache(maxsize=1)
@@ -34,16 +34,22 @@ def get_fast_roc_auc() -> Scorer:
         return get_metric(metric="roc_auc", problem_type="binary")
     try:
         # FIXME: Requires g++, can lead to an exception on import as it needs to compile C code.
-        from ..metrics._fast_roc_auc import fast_roc_auc_cpp
-    except FileNotFoundError:
-        print("Warning: Failed to compile c++ metric... Try installing g++. Falling back to sklearn implementation...")
+        from tabarena.metrics._fast_roc_auc import fast_roc_auc_cpp
+    except (OSError, ValueError) as e:
+        # OSError covers g++ missing (FileNotFoundError) and read-only filesystems
+        # (EROFS, e.g. Singularity containers); ValueError covers a non-zero/timed-out
+        # g++ run, including being unable to write cpp_auc.so into a read-only install dir.
+        print(
+            f"Warning: Failed to obtain c++ roc_auc metric ({type(e).__name__}: {e}). "
+            "Try installing g++ or set TABARENA_SKIP_FAST_ROC_AUC=1. "
+            "Falling back to sklearn implementation..."
+        )
         return get_metric(metric="roc_auc", problem_type="binary")
     return fast_roc_auc_cpp
 
 
 class TaskEvaluator:
-    """
-    Minimal per-task evaluator:
+    """Minimal per-task evaluator:
       - knows how to fit an ensemble given (y_train, pred_train)
       - knows how to predict/score given (y, pred)
     It does NOT know anything about repo/dataset/fold/models or optimize_on.
@@ -51,7 +57,7 @@ class TaskEvaluator:
     def __init__(
         self,
         *,
-        ensemble_method: Type,
+        ensemble_method: type,
         ensemble_kwargs: dict,
         eval_metric: Scorer,
         fit_eval_metric: Scorer,
@@ -156,18 +162,17 @@ class TaskEvaluator:
 class EnsembleScorer:
     def __init__(
         self,
-        repo: "EvaluationRepository",
+        repo: EvaluationRepository,
         task_metrics_metadata,
-        evaluator_cls: Type[TaskEvaluator] = TaskEvaluator,
-        ensemble_method: Type = EnsembleSelection,
+        evaluator_cls: type[TaskEvaluator] = TaskEvaluator,
+        ensemble_method: type = EnsembleSelection,
         ensemble_method_kwargs: dict | None = None,
         proxy_fit_metric_map: dict | None = None,
         use_fast_metrics: bool = True,
         optimize_on: str = "val",
         return_metric_error_val: bool = True,
     ):
-        """
-        Parameters
+        """Parameters
         ----------
         repo: EvaluationRepository
         task_metrics_metadata
@@ -192,7 +197,7 @@ class EnsembleScorer:
 
         self.repo = repo
         self.evaluator_cls = evaluator_cls
-        self.ensemble_method: Type = ensemble_method
+        self.ensemble_method: type = ensemble_method
         self.ensemble_method_kwargs = ensemble_method_kwargs
         self.task_metrics_metadata = task_metrics_metadata
         self.proxy_fit_metric_map = proxy_fit_metric_map
@@ -208,7 +213,7 @@ class EnsembleScorer:
     def filter_models(self, dataset: str, fold: int, models: list[str]) -> list[str]:
         return models
 
-    def get_ensemble_method_for_task(self, dataset: str, fold: int, models: list[str]) -> Type:
+    def get_ensemble_method_for_task(self, dataset: str, fold: int, models: list[str]) -> type:
         return self.ensemble_method
 
     def get_ensemble_method_kwargs_for_task(self, dataset: str, fold: int, models: list[str]) -> dict:
@@ -267,10 +272,9 @@ class EnsembleScorer:
     ) -> tuple[np.ndarray, np.ndarray]:
         if self.optimize_on == "val":
             return y_val, pred_val
-        elif self.optimize_on == "test":
+        if self.optimize_on == "test":
             return y_test, pred_test
-        else:
-            raise ValueError(f"Invalid value for `optimize_on`: {self.optimize_on}")
+        raise ValueError(f"Invalid value for `optimize_on`: {self.optimize_on}")
 
     # -------------------------
     # Main entry
@@ -310,7 +314,7 @@ class EnsembleScorer:
             aux_eval_metric=aux_eval_metric,
         )
 
-        results, fitted_ensemble = evaluator.run(
+        results, _fitted_ensemble = evaluator.run(
             pred_train=pred_train,
             y_train=y_train,
             pred_test=pred_test,
@@ -347,8 +351,7 @@ class EnsembleScorer:
 
 
 class EnsembleScorerMaxModels(EnsembleScorer):
-    """
-    Identical to EnsembleScorer, with the addition of `max_models` and `max_models_per_type`.
+    """Identical to EnsembleScorer, with the addition of `max_models` and `max_models_per_type`.
 
     Parameters
     ----------
@@ -359,7 +362,7 @@ class EnsembleScorerMaxModels(EnsembleScorer):
         If specified, will limit ensemble candidates of a given model type to the top `max_models_per_type` highest validation score models.
         If "auto", scales dynamically with the number of rows in the dataset.
     """
-    def __init__(self, repo: "EvaluationRepository", max_models: int = None, max_models_per_type: int | str = None, **kwargs):
+    def __init__(self, repo: EvaluationRepository, max_models: int | None = None, max_models_per_type: int | str | None = None, **kwargs):
         super().__init__(repo=repo, **kwargs)
         assert self.repo is not None
         if max_models is not None:
@@ -373,9 +376,7 @@ class EnsembleScorerMaxModels(EnsembleScorer):
         self.max_models_per_type = max_models_per_type
 
     def filter_models(self, dataset: str, fold: int, models: list[str]) -> list[str]:
-        """
-        Filters models by user-defined logic. Used in class extensions.
-        """
+        """Filters models by user-defined logic. Used in class extensions."""
         if self.max_models is not None or self.max_models_per_type is not None:
             if self.max_models_per_type is not None and isinstance(self.max_models_per_type, str) and self.max_models_per_type == "auto":
                 max_models_per_type = self._get_max_models_per_type_auto(dataset=dataset)
@@ -391,9 +392,7 @@ class EnsembleScorerMaxModels(EnsembleScorer):
         return models
 
     def _get_max_models_per_type_auto(self, dataset: str) -> int:
-        """
-        Logic to mimic AutoGluon's default setting for `max_models_per_type`.
-        """
+        """Logic to mimic AutoGluon's default setting for `max_models_per_type`."""
         # TODO: Make it easier to get this info without accessing private variables in repo
         df_metadata = self.repo._zeroshot_context.df_metadata
         num_rows = int(df_metadata[df_metadata["dataset"] == dataset].iloc[0]["NumberOfInstances"] * 9 / 10)
@@ -428,20 +427,19 @@ class EnsembleScorerMaxModels(EnsembleScorer):
 class EnsembleSelectionConfigScorer(ConfigurationListScorer):
     def __init__(self,
                  tasks: list[str],
-                 repo: "EvaluationRepository",
+                 repo: EvaluationRepository,
                  ranker: RankScorer,
                  tid_to_dataset_name_dict: dict[int, str],
                  task_metrics_metadata: dict[int, dict[str, str]],
                  ensemble_size=100,
                  ensemble_selection_kwargs=None,
-                 backend: str = 'native',
+                 backend: str = "native",
                  use_fast_metrics: bool = True,
                  proxy_fit_metric_map: dict | str | None = None,  # TODO: Add unit test
-                 ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
-                 ensemble_kwargs: dict = None,
+                 ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+                 ensemble_kwargs: dict | None = None,
                  ):
-        """
-        A scorer object to evaluate configs via simulating ensemble selection.
+        """A scorer object to evaluate configs via simulating ensemble selection.
 
         :param tasks: The list of tasks to consider for scoring.
         :param ranker: The ranking object used to compute scores on each task.
@@ -470,7 +468,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         if ensemble_selection_kwargs is None:
             ensemble_selection_kwargs = {}
         self.ensemble_selection_kwargs = ensemble_selection_kwargs
-        assert backend in ['native', 'ray']
+        assert backend in ["native", "ray"]
         self.backend = backend
         self.use_fast_metrics = ensemble_kwargs.pop("use_fast_metrics", use_fast_metrics)
         if "proxy_fit_metric_map" in ensemble_kwargs:
@@ -478,8 +476,8 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         if proxy_fit_metric_map is None:
             proxy_fit_metric_map = {}
         elif isinstance(proxy_fit_metric_map, str):
-            assert proxy_fit_metric_map == 'roc_auc_to_log_loss'
-            proxy_fit_metric_map = {'roc_auc': 'log_loss'}  # log_loss is fast to compute and a good proxy for roc_auc
+            assert proxy_fit_metric_map == "roc_auc_to_log_loss"
+            proxy_fit_metric_map = {"roc_auc": "log_loss"}  # log_loss is fast to compute and a good proxy for roc_auc
         self.proxy_fit_metric_map = proxy_fit_metric_map
 
         ensemble_selection_kwargs = copy.deepcopy(ensemble_selection_kwargs)
@@ -495,10 +493,10 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         )
 
     @classmethod
-    def from_repo(cls, repo: "EvaluationRepository", **kwargs):
+    def from_repo(cls, repo: EvaluationRepository, **kwargs):
         zeroshot_simulator_context = repo._zeroshot_context
-        if 'tasks' not in kwargs:
-            kwargs['tasks'] = zeroshot_simulator_context.get_tasks()
+        if "tasks" not in kwargs:
+            kwargs["tasks"] = zeroshot_simulator_context.get_tasks()
 
         dataset_to_tid_dict = zeroshot_simulator_context.dataset_to_tid_dict
         task_metrics_metadata = zeroshot_simulator_context.df_metrics
@@ -521,8 +519,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         return self.ensemble_scorer.evaluate_task(dataset=dataset, fold=fold, models=models)
 
     def compute_errors(self, configs: list[str]) -> dict[str, dict[str, object]]:
-        """
-        Compute and return test errors and ensemble weights for all tasks on the user-specified list of configs.
+        """Compute and return test errors and ensemble weights for all tasks on the user-specified list of configs.
 
         :param configs: List of model config names to ensemble and compute test errors with.
         :return: dict:
@@ -540,10 +537,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             models=configs,
         )
 
-        if engine == "sequential":
-            progress_bar = False
-        else:
-            progress_bar = True
+        progress_bar = engine != "sequential"
 
         inputs = [{"task": task} for task in self.tasks]
         results_rows = parallel_for(
@@ -553,8 +547,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             engine=engine,
             progress_bar=progress_bar,
         )
-        results = {task: result for task, result in zip(self.tasks, results_rows)}
-        return results
+        return dict(zip(self.tasks, results_rows))
 
     def compute_ranks(self, errors: dict[str, float]) -> dict[str, float]:
         ranks = {}
@@ -565,16 +558,14 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
 
     def compute_rank_mean(self, errors: dict[str, float]) -> float:
         ranks = self.compute_ranks(errors=errors)
-        average_rank = np.mean(list(ranks.values()))
-        return average_rank
+        return np.mean(list(ranks.values()))
 
     def score(self, configs: list[str]) -> float:
-        errors, ensemble_weights = self.compute_errors(configs=configs)
-        rank = self.compute_rank_mean(errors)
-        return rank
+        errors, _ensemble_weights = self.compute_errors(configs=configs)
+        return self.compute_rank_mean(errors)
 
     def score_per_dataset(self, configs: list[str]) -> dict[str, float]:
-        errors, ensemble_weights = self.compute_errors(configs=configs)
+        errors, _ensemble_weights = self.compute_errors(configs=configs)
         return self.compute_ranks(errors=errors)
 
     def subset(self, tasks):


### PR DESCRIPTION
The lazy C++ roc_auc compile crashed in read-only containers (e.g. Singularity) with `OSError: [Errno 30] Read-only file system: 'std.out'`.

- _compile(): discard g++ stdout via subprocess.DEVNULL instead of redirecting it to a "std.out" file in the process CWD. The previous open("std.out", "w") wrote to the launch dir (the cwd= arg applies only to the subprocess, not to open()), littering the dir and crashing on a read-only FS. g++ diagnostics go to stderr, which stays attached to the parent so genuine compile errors remain visible.
- get_fast_roc_auc(): broaden `except FileNotFoundError` to `except (OSError, ValueError)` so the metric degrades to the sklearn implementation instead of crashing. OSError covers g++ missing and read-only filesystems (EROFS); ValueError covers a non-zero/timed-out g++ run, including being unable to write cpp_auc.so into a read-only install dir.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
