### PR TITLE
Unify Experiment API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ autogluon/
 /examples/experiments/
 /examples/eval/
 /examples/**/AutogluonModels/
+AutogluonModels/
 /examples/benchmarking/custom_tabarena_model/evals/
 /examples/benchmarking/custom_tabarena_model/tabarena_out/
 /examples/benchmarking/eval/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,18 +12,21 @@ This repo is a **uv workspace** (root `pyproject.toml`). Its installable package
 
 - `packages/tabarena/` — Core package. Repository pattern for benchmark data, model wrappers, simulation, evaluation, plotting. Depends on AutoGluon and `bencheval`.
 - `packages/bencheval/` — Standalone lightweight metrics/leaderboard package (ELO, win-rates, ranks, improvability). Computes leaderboards from results DataFrames. No dependency on `tabarena`.
-- `packages/tabflow/` — AWS SageMaker workflow orchestration. CLI entry points: `tabflow` (launch jobs) and `tabflow-download` (download results). Depends on `tabarena`.
-- `packages/tabflow_slurm/` — Package (own `pyproject.toml`, a uv-workspace member) for running experiments on SLURM clusters. See `packages/tabflow_slurm/README.md` and `packages/tabflow_slurm/AGENTS.md`.
+- `packages/tabflow_slurm/` — Package (own `pyproject.toml`, a uv-workspace member) for running experiments on SLURM clusters. Depends on `tabarena`. See `packages/tabflow_slurm/README.md` and `packages/tabflow_slurm/AGENTS.md`.
 - `examples/` — Usage examples for benchmarking, plotting, meta-learning, custom models.
 - `tst/` — Tests (note: `tst/`, **not** `tests/`).
 
 ## Setup Commands
 
-Requires Python 3.11–3.13 and [uv](https://docs.astral.sh/uv/).
+Requires Python 3.11–3.13 and [uv](https://docs.astral.sh/uv/). This is a uv *virtual workspace*
+(the root `pyproject.toml` has no `[project]` table), so install the `tabarena` package directly
+from `packages/tabarena` rather than running `uv sync` at the root. `--prerelease=allow` is required
+for the pre-release AutoGluon dependency. From the repo root, after creating/activating a venv
+(`uv venv --seed --python 3.12 && source .venv/bin/activate`):
 
 ```bash
-uv sync                    # Evaluation-only install (leaderboard/metrics)
-uv sync --extra benchmark  # Full install including model fitting
+uv pip install --prerelease=allow -e "./packages/tabarena"               # Evaluation-only (leaderboard/metrics)
+uv pip install --prerelease=allow -e "./packages/tabarena[benchmark]"    # Full install including model fitting
 ```
 
 For editable AutoGluon development (one directory up):

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ TabArena currently consists of:
 ```bash
 pip install uv
 git clone https://github.com/autogluon/tabarena.git && cd tabarena
-uv sync --extra benchmark
-uv run python examples/benchmarking/run_quickstart_tabarena.py
+uv venv --seed --python 3.12 && source .venv/bin/activate
+uv pip install --prerelease=allow -e "./packages/tabarena[benchmark]"
+python examples/benchmarking/run_quickstart_tabarena.py
 ```
 
 For other install paths (eval-only, editable AutoGluon, dependency), see [Installation](#-installation) below.
@@ -67,15 +68,27 @@ TabArena code is currently being polished. Detailed Documentation for TabArena w
 > [!IMPORTANT]
 > Requires Python **3.11–3.13** and [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
-Pick the install path that matches what you want to do:
+TabArena is a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/); its installable
+packages live under `packages/` (`tabarena`, `bencheval`, `tabflow_slurm`). Install the `tabarena`
+package directly from `packages/tabarena` with the extras you need. The `--prerelease=allow` flag is
+required so uv resolves the pre-release dependency.
+
+First clone the repo and create a virtual environment (one time):
+
+```bash
+git clone https://github.com/autogluon/tabarena.git
+cd tabarena
+uv venv --seed --python 3.12
+source .venv/bin/activate
+```
+
+Then pick the install path that matches what you want to do:
 
 <details>
 <summary><b>📊 Evaluation only</b> — leaderboards & metrics, no model fitting</summary>
 
 ```bash
-git clone https://github.com/autogluon/tabarena.git
-cd tabarena
-uv sync
+uv pip install --prerelease=allow -e "./packages/tabarena"
 ```
 </details>
 
@@ -85,9 +98,7 @@ uv sync
 Installs the core models used for standard benchmarking: `tabpfn`, `tabicl`, `ebm`, `search_spaces`, `realmlp`, `tabdpt`, `tabm`.
 
 ```bash
-git clone https://github.com/autogluon/tabarena.git
-cd tabarena
-uv sync --extra benchmark
+uv pip install --prerelease=allow -e "./packages/tabarena[benchmark]"
 ```
 </details>
 
@@ -101,17 +112,13 @@ uv sync --extra benchmark
 Layers the extended model set (`modernnca`, `xrfm`, `sap-rpt-oss`, ...) on top of the core benchmark set.
 
 ```bash
-git clone https://github.com/autogluon/tabarena.git
-cd tabarena
-uv sync --extra benchmark --extra extended
+uv pip install --prerelease=allow -e "./packages/tabarena[benchmark,extended]"
 ```
 
 To install only one extended model on top of `benchmark` (recommended over `extended` when you only need a single extra model), pass its extra by name — for example, just `xrfm`:
 
 ```bash
-git clone https://github.com/autogluon/tabarena.git
-cd tabarena
-uv sync --extra benchmark --extra xrfm
+uv pip install --prerelease=allow -e "./packages/tabarena[benchmark,xrfm]"
 ```
 </details>
 

--- a/packages/tabarena/src/tabarena/benchmark/experiment/__init__.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/__init__.py
@@ -21,7 +21,6 @@ from tabarena.benchmark.experiment.experiment_runner import (
 )
 from tabarena.benchmark.experiment.experiment_utils import (
     ExperimentBatchRunner,
-    run_experiments,
 )
 from tabarena.benchmark.experiment.experiment_runner_api import run_experiments_new
 
@@ -40,6 +39,5 @@ __all__ = [
     "TabArenaExperimentBundle",
     "TabArenaV0pt1ExperimentBundle",
     "YamlExperimentSerializer",
-    "run_experiments",
     "run_experiments_new",
 ]

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner_api.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner_api.py
@@ -7,7 +7,7 @@ import numpy as np
 from tabarena.benchmark.experiment import Experiment, ExperimentBatchRunner
 from tabarena.benchmark.task.openml import OpenMLS3TaskWrapper, OpenMLTaskWrapper
 from tabarena.benchmark.task.user_task import UserTask
-from tabarena.utils.cache import CacheFunctionPickle
+from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionPickle
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -163,6 +163,59 @@ def _parse_repetitions_mode_and_args(
     raise ValueError(f"Unknown `repetitions_mode` str: {repetitions_mode}")
 
 
+def _resolve_task_display_name(
+    task_id_or_object: int | UserTask,
+    tasks_metadata: pd.DataFrame | None,
+) -> str | None:
+    """Resolve the display name used as the results ``dataset`` key from metadata.
+
+    When ``tasks_metadata`` carries a name column (``dataset`` or ``name``) keyed
+    by a task-id column (``task_id`` or ``tid``), return the matching value so the
+    results join cleanly with ``tasks_metadata`` — matching the behavior of the
+    legacy ``run_experiments``/``ExperimentBatchRunner``. Returns ``None`` when no
+    usable mapping is found, in which case the caller derives the name from the
+    task object (OpenML dataset name) or the ``UserTask`` slug.
+    """
+    if tasks_metadata is None:
+        return None
+    id_col = next((c for c in ("task_id", "tid") if c in tasks_metadata.columns), None)
+    name_col = next((c for c in ("dataset", "name") if c in tasks_metadata.columns), None)
+    if id_col is None or name_col is None:
+        return None
+    t_id = task_id_or_object.task_id_str if isinstance(task_id_or_object, UserTask) else str(task_id_or_object)
+    matches = tasks_metadata[tasks_metadata[id_col].astype(str) == t_id]
+    if matches.empty:
+        return None
+    return str(matches.iloc[0][name_col])
+
+
+def _build_cache_prefix(
+    *,
+    method_name: str,
+    cache_task_key: int | str,
+    fold: int,
+    repeat: int,
+    cache_path_format: Literal["name_first", "task_first"],
+    include_repeat_in_cache_name: bool,
+) -> str:
+    """Build the cache directory prefix (relative to the base cache path).
+
+    ``cache_path_format`` selects the directory layout and
+    ``include_repeat_in_cache_name`` toggles the legacy single-repeat subtask
+    name (``{fold}`` instead of ``{repeat}_{fold}``) so caches written by the
+    legacy ``run_experiments``/``ExperimentBatchRunner`` remain discoverable.
+    """
+    subtask_cache_name = ExperimentBatchRunner._subtask_name(
+        fold=fold, repeat=repeat if include_repeat_in_cache_name else None
+    )
+    if cache_path_format == "name_first":
+        return f"data/{method_name}/{cache_task_key}/{subtask_cache_name}"
+    if cache_path_format == "task_first":
+        # Legacy format from early prototyping.
+        return f"data/tasks/{cache_task_key}/{subtask_cache_name}/{method_name}"
+    raise ValueError(f"Invalid cache_path_format: {cache_path_format}")
+
+
 def run_experiments_new(
     *,
     output_dir: str,
@@ -170,9 +223,15 @@ def run_experiments_new(
     tasks: list[int | UserTask],
     repetitions_mode: Literal["TabArena-Lite", "TabArena", "matrix", "individual"],
     tasks_metadata: pd.DataFrame | None = None,
+    use_metadata_task_name: bool = False,
     repetitions_mode_args: tuple | list | None = None,
     run_mode: str = "local",
     cache_mode: Literal["default", "ignore", "only"] = "default",
+    cache_path_format: Literal["name_first", "task_first"] = "name_first",
+    include_repeat_in_cache_name: bool = True,
+    write_model_failures: bool = False,
+    cache_cls: type[AbstractCacheFunction] = CacheFunctionPickle,
+    cache_cls_kwargs: dict | None = None,
     s3_kwargs: dict | None = None,
     raise_on_failure: bool = True,
     debug_mode: bool = False,
@@ -206,6 +265,7 @@ def run_experiments_new(
                 See `repetitions_mode_args`.
     tasks_metadata: pd.DataFrame | None, default None
         Metadata about each task in `tasks`. Required if `repetitions_mode="TabArena"`.
+        Also consumed for the display name when `use_metadata_task_name=True`.
 
         If None, we assume that the `tasks` contain tasks from the official curated
         TabArena benchmark and load the metadata internally. If it contains tasks
@@ -221,6 +281,13 @@ def run_experiments_new(
                 See tabarena.nips2025_utils.fetch_metadata._get_n_repeats for details.
             "num_folds": int
                 The number of folds for the task.
+    use_metadata_task_name: bool, default False
+        If True, each task's display name (the results `dataset` key) is taken from
+        `tasks_metadata`: a name column (`dataset` or `name`) keyed by a task-id
+        column (`task_id` or `tid`). Enable this to make results join cleanly with
+        custom metadata (the legacy `ExperimentBatchRunner` behavior). If False
+        (default), the name is derived from the task object (OpenML dataset name)
+        or the `UserTask` slug.
     repetitions_mode_args: list | tuple | None, default None
         Determine how many repetitions of the experiments to run per task, i.e., how
         many folds and repeats to run for each task. Note, all tasks come with
@@ -275,6 +342,35 @@ def run_experiments_new(
                 overwrite the cache file upon completion.
             - "only": Only load results from cache. This does not run the experiment
                 if cache does not exist.
+    cache_path_format: Literal["name_first", "task_first"], default "name_first"
+        Determines the on-disk layout of cached artifacts, relative to the base
+        cache path:
+            - "name_first": `data/{method}/{task}/{subtask}/results`
+            - "task_first": `data/tasks/{task}/{subtask}/{method}/results`
+                (legacy format from early prototyping)
+        Provided for backward compatibility with caches written by the legacy
+        `run_experiments`/`ExperimentBatchRunner`.
+    include_repeat_in_cache_name: bool, default True
+        Determines the `{subtask}` component of the cache path:
+            - True: `{repeat}_{fold}` (e.g. `0_0`).
+            - False: `{fold}` (e.g. `0`), the legacy single-repeat layout used by
+                `ExperimentBatchRunner` when called without `repeats`. Set to False
+                to keep such legacy caches discoverable. Note that the repeat is then
+                absent from the path, so distinct repeats of the same fold collide;
+                only use this for single-repeat runs.
+    write_model_failures: bool, default False
+        If True, a failed fit in benchmark mode (`debug_mode=False`) additionally
+        writes a `model_failures` artifact next to the `results` cache (matching the
+        legacy `ExperimentBatchRunner` behavior). This does not affect the `results`
+        cache file itself (path, format, or hit logic). Implemented via the cacher's
+        `include_self_in_call`; an explicit `cache_cls_kwargs["include_self_in_call"]`
+        takes precedence.
+    cache_cls: type[AbstractCacheFunction], default CacheFunctionPickle
+        The cache class used to read/write each experiment's `results`. Must accept
+        `cache_name` and `cache_path` constructor arguments (e.g. `CacheFunctionPickle`
+        or a drop-in replacement).
+    cache_cls_kwargs: dict | None, default None
+        Extra keyword arguments forwarded to `cache_cls(...)` (e.g. `compress`).
     s3_kwargs: dict | None, default None
         Additional keyword arguments for S3 operations. Required when mode="aws".
         Supported kwargs:
@@ -354,11 +450,16 @@ def run_experiments_new(
     experiment_missing_count, experiment_cache_exists_count = 0, 0
     experiment_count_total = n_splits * len(model_experiments)
     for dataset_index, task_id_or_object in enumerate(tasks):
-        task, tabarena_task_name, eval_metric_name = None, None, None
+        task, eval_metric_name = None, None
+        # Display name used as the results `dataset` key. Only resolved from
+        # `tasks_metadata` when explicitly requested; otherwise it is derived from the
+        # task object (OpenML name) / UserTask slug when the task is loaded below.
+        tabarena_task_name = (
+            _resolve_task_display_name(task_id_or_object, tasks_metadata) if use_metadata_task_name else None
+        )
         print(f"Starting Dataset {dataset_index + 1}/{len(tasks)}...")
 
         for split_index, (fold, repeat) in enumerate(fold_repeat_pairs_per_task[dataset_index], start=1):
-            subtask_cache_name = ExperimentBatchRunner._subtask_name(fold=fold, repeat=repeat)
             print(
                 f"Starting Split {split_index}/{len(fold_repeat_pairs_per_task[dataset_index])} (Fold {fold}, Repeat {repeat})..."
             )
@@ -379,9 +480,25 @@ def run_experiments_new(
 
                 # Setup Cache
                 cache_name = "results"
-                cache_prefix = f"data/{model_experiment.name}/{cache_task_key}/{subtask_cache_name}"
+                cache_prefix = _build_cache_prefix(
+                    method_name=model_experiment.name,
+                    cache_task_key=cache_task_key,
+                    fold=fold,
+                    repeat=repeat,
+                    cache_path_format=cache_path_format,
+                    include_repeat_in_cache_name=include_repeat_in_cache_name,
+                )
                 cache_path = f"{base_cache_path}/{cache_prefix}"
-                cacher = CacheFunctionPickle(cache_name=cache_name, cache_path=cache_path)
+                # `include_self_in_call` passes the cacher into the runner so a failed fit
+                # (in benchmark mode) can drop a `model_failures` artifact next to the
+                # results (see `write_model_failures`). It does not affect the `results`
+                # cache file's path, format, or hit logic. An explicit `cache_cls_kwargs`
+                # entry takes precedence over the `write_model_failures` default.
+                cacher = cache_cls(
+                    cache_name=cache_name,
+                    cache_path=cache_path,
+                    **{"include_self_in_call": write_model_failures, **(cache_cls_kwargs or {})},
+                )
                 cache_exists = cacher.exists
 
                 # Check cache state
@@ -406,10 +523,11 @@ def run_experiments_new(
                                 )
                             else:
                                 task = OpenMLTaskWrapper.from_task_id(task_id=task_id_or_object)
-                            # TODO: maybe add a prefix to this.
-                            tabarena_task_name = task.task.get_dataset().name
+                            if tabarena_task_name is None:
+                                tabarena_task_name = task.task.get_dataset().name
                         else:
-                            tabarena_task_name = task_id_or_object.tabarena_task_name
+                            if tabarena_task_name is None:
+                                tabarena_task_name = task_id_or_object.tabarena_task_name
                             task = OpenMLTaskWrapper(
                                 task=task_id_or_object.load_local_openml_task(),
                                 use_task_eval_metric=True,

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Literal, Type
 
-import json
 import pandas as pd
 from pathlib import Path
-import traceback
 
 from tabarena.benchmark.result import BaselineResult, ExperimentResults
-from tabarena.benchmark.task.openml import OpenMLTaskWrapper, OpenMLS3TaskWrapper
 from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionPickle, CacheFunctionDummy
 from tabarena.repository import EvaluationRepository
 from tabarena.benchmark.experiment.experiment_constructor import Experiment
@@ -149,24 +146,56 @@ class ExperimentBatchRunner:
         self._validate_folds(folds=folds)
         self._validate_repeats(repeats=repeats)
 
-        tids = [self._dataset_to_tid_dict[dataset] for dataset in datasets]
-        return run_experiments(
-            expname=self.expname,
-            tids=tids,
-            folds=folds,
-            repeats=repeats,
-            methods=methods,
-            task_metadata=self.task_metadata,
-            ignore_cache=ignore_cache,
+        # Lazy import to avoid a circular import (experiment_runner_api imports this module).
+        from tabarena.benchmark.experiment.experiment_runner_api import run_experiments_new
+
+        tids = [int(self._dataset_to_tid_dict[dataset]) for dataset in datasets]
+
+        # Translate folds/repeats into explicit (fold, repeat) pairs run for every task.
+        if repeats is None:
+            # Legacy single-repeat layout: run repeat 0 and cache under `{fold}` (no repeat
+            # in the path), matching the cache files written before this delegation.
+            fold_repeat_pairs = [(fold, 0) for fold in folds]
+            include_repeat_in_cache_name = False
+        else:
+            fold_repeat_pairs = [(fold, repeat) for repeat in repeats for fold in folds]
+            include_repeat_in_cache_name = True
+
+        if self.only_cache:
+            cache_mode = "only"
+        elif ignore_cache:
+            cache_mode = "ignore"
+        else:
+            cache_mode = "default"
+
+        if self.mode == "aws":
+            s3_kwargs = {"bucket": self.s3_bucket}
+            if self.s3_dataset_cache is not None:
+                s3_kwargs["dataset_cache"] = self.s3_dataset_cache
+        else:
+            s3_kwargs = None
+
+        return run_experiments_new(
+            output_dir=self.expname,
+            model_experiments=methods,
+            tasks=tids,
+            tasks_metadata=self.task_metadata,
+            # Legacy behavior: the results `dataset` key comes from the metadata.
+            use_metadata_task_name=True,
+            repetitions_mode="individual",
+            repetitions_mode_args=fold_repeat_pairs,
+            run_mode=self.mode,
+            cache_mode=cache_mode,
+            cache_path_format=self.cache_path_format,
+            include_repeat_in_cache_name=include_repeat_in_cache_name,
+            # Forward the configured cache backend. The default `cache_cls_kwargs`
+            # carries `include_self_in_call=True`, preserving the legacy
+            # `model_failures` artifact on failure.
             cache_cls=self.cache_cls,
             cache_cls_kwargs=self.cache_cls_kwargs,
-            cache_path_format=self.cache_path_format,
-            mode=self.mode,
-            s3_bucket=self.s3_bucket,
-            only_cache=self.only_cache,
+            s3_kwargs=s3_kwargs,
             raise_on_failure=raise_on_failure,
             debug_mode=self.debug_mode,
-            s3_dataset_cache=self.s3_dataset_cache
         )
 
     def load_results(
@@ -338,213 +367,3 @@ def check_cache_hit(
         Path(cacher.cache_file).unlink(missing_ok=True)
 
     return cacher.exists
-
-
-def run_experiments(
-    expname: str,
-    tids: list[int],
-    folds: list[int] | None,
-    methods: list[Experiment],
-    task_metadata: pd.DataFrame | dict,
-    ignore_cache: bool,
-    repeats: list[int] | None = None,
-    cache_cls: Type[AbstractCacheFunction] | None = CacheFunctionPickle,
-    cache_cls_kwargs: dict = None,
-    cache_path_format: Literal["name_first", "task_first"] = "name_first",
-    mode: str = "local",
-    s3_bucket: str | None = None,
-    only_cache: bool = False,
-    raise_on_failure: bool = True,
-    debug_mode: bool = True,
-    s3_dataset_cache: str | None = None,
-    repeat_fold_pairs: list[tuple[int | None, int]] | None = None,
-) -> list[dict]:
-    """
-
-    Parameters
-    ----------
-    expname: str, Name of the experiment given by the user
-    tids: list[int], List of OpenML task IDs given by the user
-    folds: list[int], Number of folds present for the given task
-    repeats: list[int] | None, Number of repeats present for the given task. If None, defaults to [0]
-    methods: list[Experiment], Models used for fit() and predict() in this experiment
-    task_metadata: pd.DataFrame or None, OpenML task metadata
-         If dict, it is a map from TID to task name. As only task name is used here.
-    ignore_cache: bool, whether to use cached results (if present)
-    cache_cls: WIP
-    cache_cls_kwargs: WIP
-    cache_path_format: {"name_first", "task_first"}, default "name_first"
-    mode: {"local", "aws"}, default "local"
-    s3_bucket: str, default None
-        Required when mode="aws". The S3 bucket where artifacts will be stored.
-    raise_on_failure: bool, default True
-        If True, will raise exceptions that occur during experiments, stopping all runs.
-        If False, will ignore exceptions and continue fitting queued experiments. Experiments with exceptions will not be included in the output list.
-    s3_dataset_cache: str, default None
-        Full S3 URI to the openml dataset cache (format: s3://bucket/prefix)
-        If None, skip S3 download attempt
-    repeat_fold_pairs: list[tuple[int | None, int]] | None, default None
-        alternative to `repeats` and `folds` parameters to specify the repeat and fold pairs to run.
-
-    Returns
-    -------
-    result_lst: list[dict], containing all metrics from fit() and predict() of all the given OpenML tasks
-    """
-    if mode == "aws" and (s3_bucket is None or s3_bucket == ""):
-        raise ValueError(f"s3_bucket parameter is required when mode is 'aws', got {s3_bucket}")
-
-    if cache_cls is None:
-        cache_cls = CacheFunctionDummy
-    if cache_cls_kwargs is None:
-        cache_cls_kwargs = {}
-
-    if folds is None:
-        assert repeat_fold_pairs is not None, "If folds is None, repeat_fold_pairs must be provided"
-
-    # Modify cache path based on mode
-    if mode == "local":
-        base_cache_path = expname
-    else:
-        base_cache_path = f"s3://{s3_bucket}/{expname}"
-
-    methods_og = methods
-    methods = []
-    for method in methods_og:
-        # TODO: remove tuple input option, doing it to keep old scripts working
-        if not isinstance(method, Experiment):
-            method = Experiment(name=method[0], method_cls=method[1], method_kwargs=method[2])
-        methods.append(method)
-
-    unique_names = set()
-    for method in methods:
-        if method.name in unique_names:
-            raise AssertionError(f"Duplicate experiment name found. All names must be unique. name: {method.name}")
-        unique_names.add(method.name)
-
-    # FIXME: dataset or name? Where does `dataset` come from, why can it be different from `name`?
-    #  Using dataset for now because for some datasets like "GAMETES", the name is slightly different with `.` in `name` being replaced with `_` in `dataset`.
-    #  This is probably because `.` isn't a valid name in a file in s3.
-    #  TODO: What if `dataset` doesn't exist as a column? Maybe fallback to `name`? Or do the `name` -> `dataset` conversion, or use tid.
-    dataset_name_column = "dataset"
-    if isinstance(task_metadata, dict):
-        dataset_names = [task_metadata[tid] for tid in tids]
-    else:
-        dataset_names = [task_metadata[task_metadata["tid"] == tid][dataset_name_column].iloc[0] for tid in tids]
-
-    if repeat_fold_pairs is None:
-        n_splits = len(folds)
-        if repeats is not None:
-            n_splits *= len(repeats)
-    else:
-        n_splits = len(repeat_fold_pairs)
-    if repeat_fold_pairs is None:
-        if repeats is not None:
-            repeat_fold_pairs = [(r, f) for r in repeats for f in folds]
-        else:
-            repeat_fold_pairs = [(None, f) for f in folds]
-    print(
-        f"Running Experiments for expname: '{expname}'..."
-        f"\n\tFitting {len(tids)} datasets and {n_splits} repeat-fold splits for a total of {len(tids) * n_splits} tasks"
-        f"\n\tFitting {len(methods)} methods on {len(tids) *n_splits} tasks for a total of {len(tids) * n_splits * len(methods)} jobs..."
-        f"\n\tTIDs    : {tids}"
-        f"\n\tDatasets: {dataset_names}"
-        f"\n\tFolds   : {folds}"
-        f"\n\tRepeats : {repeats}"
-        f"\n\tRepeat-Fold-Pairs: {repeat_fold_pairs}"
-        f"\n\tMethods : {[method.name for method in methods]}"
-    )
-    result_lst = []
-    num_datasets = len(tids)
-    missing_tasks = []
-    cur_experiment_idx = -1
-    experiment_success_count = 0
-    experiment_fail_count = 0
-    experiment_missing_count = 0
-    experiment_cache_exists_count = 0
-    experiment_count_total = len(tids) * len(methods) * n_splits
-    for i, tid in enumerate(tids):
-        task = None  # lazy task loading
-        if isinstance(task_metadata, dict):
-            task_name = task_metadata[tid]
-        else:
-            task_name = task_metadata[task_metadata["tid"] == tid][dataset_name_column].iloc[0]
-        print(f"Starting Dataset {i+1}/{num_datasets}...")
-        for repeat, fold in repeat_fold_pairs:
-            subtask_cache_name = ExperimentBatchRunner._subtask_name(fold=fold, repeat=repeat)
-            for method in methods:
-                cur_experiment_idx += 1
-                if cache_path_format == "name_first":
-                    cache_prefix = f"data/{method.name}/{tid}/{subtask_cache_name}"
-                    cache_name = "results"
-                elif cache_path_format == "task_first":
-                    # Legacy format from early prototyping
-                    cache_prefix = f"data/tasks/{tid}/{subtask_cache_name}/{method.name}"
-                    cache_name = "results"
-                else:
-                    raise ValueError(f"Invalid cache_path_format: {cache_path_format}")
-                print(
-                    f"\t"
-                    f"{cur_experiment_idx}/{experiment_count_total} ran | "
-                    f"{experiment_success_count} success | "
-                    f"{experiment_fail_count} fail | "
-                    f"{experiment_cache_exists_count} cache_exists | "
-                    f"{experiment_missing_count} missing | "
-                    f"Fitting {task_name} on repeat {repeat}, fold {fold} for method {method.name}"
-                )
-                cache_path = f"{base_cache_path}/{cache_prefix}"
-
-                cacher = cache_cls(cache_name=cache_name, cache_path=cache_path, **cache_cls_kwargs)
-
-                cache_exists = cacher.exists
-                if cache_exists and not ignore_cache:
-                    experiment_cache_exists_count += 1
-
-                if only_cache:
-                    if not cache_exists:
-                        missing_tasks.append(cache_name)
-                        experiment_missing_count += 1
-                        continue
-                    else:
-                        out = cacher.load_cache()
-                else:
-                    if task is None:
-                        if ignore_cache or not cache_exists:
-                            if s3_dataset_cache:
-                                task = OpenMLS3TaskWrapper.from_task_id(task_id=tid, s3_dataset_cache=s3_dataset_cache)
-                            else:
-                                task = OpenMLTaskWrapper.from_task_id(task_id=tid)
-
-                    if repeat is not None:
-                        run_kwargs = {
-                            "repeat": repeat,
-                        }
-                    else:
-                        run_kwargs = {}
-
-                    try:
-                        out = method.run(
-                            task=task,
-                            fold=fold,
-                            task_name=task_name,
-                            cacher=cacher,
-                            ignore_cache=ignore_cache,
-                            debug_mode=debug_mode,
-                            **run_kwargs,
-                        )
-                    except Exception as exc:
-                        error_cacher = cache_cls(cache_name="error", cache_path=cache_path, **cache_cls_kwargs)
-                        exception_info = json.dumps({"error": str(exc), "traceback": traceback.format_exc()})
-                        error_cacher.save_cache(exception_info)
-                        if raise_on_failure:
-                            raise
-                        print(exc.__class__)
-                        print(f"Exception Info:")
-                        print(exception_info)
-                        out = None
-                if out is not None:
-                    experiment_success_count += 1
-                    result_lst.append(out)
-                else:
-                    experiment_fail_count += 1
-
-    return result_lst

--- a/packages/tabflow_slurm/AGENTS.md
+++ b/packages/tabflow_slurm/AGENTS.md
@@ -7,9 +7,8 @@ Repo-wide guidance: [`../../AGENTS.md`](../../AGENTS.md).
 
 A package that generates and launches **SLURM** array jobs for TabArena benchmarks. The user
 composes a `TabArenaBenchmarkPlan`, calls `setup_jobs()`, and gets `sbatch` command(s); each array
-task fits one `(task, fold, repeat, config)` item at a time and caches the result. It is the SLURM
-counterpart to `../tabflow` (SageMaker) and mirrors its batching design, but only depends on
-`tabarena`.
+task fits one `(task, fold, repeat, config)` item at a time and caches the result. It is
+self-contained and only depends on `tabarena`.
 
 > It **is** a package (`pyproject.toml`, `tabflow_slurm/__init__.py`) and a uv-workspace member,
 > installed editable from `packages/tabflow_slurm/`.

--- a/packages/tabflow_slurm/README.md
+++ b/packages/tabflow_slurm/README.md
@@ -15,8 +15,7 @@ ready-to-run `sbatch` commands. You compose a **plan** from a few typed building
 Each array task then runs one bundled item at a time via a small runner script, caching results
 into the workspace where the evaluation code can pick them up.
 
-It is the SLURM counterpart to [`tabflow`](../tabflow) (the AWS SageMaker orchestrator) and shares
-its batching design, but is self-contained and only depends on `tabarena`.
+It is self-contained and only depends on `tabarena`.
 
 ---
 

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/scheduler.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/scheduler.py
@@ -37,7 +37,19 @@ class SchedulerSetup:
     bundle_size_per_dataset: dict[str, int] | None = None
     """Optional per-dataset override of `bundle_size`, keyed by `dataset_name`.
     Items from datasets not listed here use `bundle_size`. Items belonging to
-    different effective bundle sizes are not mixed in the same bundle."""
+    different effective bundle sizes are not mixed in the same bundle.
+    An explicit entry here takes precedence over the large-dataset auto-rule
+    below (so it doubles as an escape hatch for large datasets)."""
+
+    large_dataset_n_features: int | None = 5_000
+    """Wide datasets (`n_features` greater than this) are bundled one item per
+    array task (effective `bundle_size=1`), since each fit is expensive enough
+    that batching hurts scheduling. Set to `None` to disable the feature check."""
+
+    large_dataset_n_samples: int | None = 100_000
+    """Large datasets (`n_samples_train_per_fold` greater than this) are bundled
+    one item per array task (effective `bundle_size=1`). Set to `None` to
+    disable the sample-count check."""
 
     def get_run_commands(
         self,
@@ -82,19 +94,16 @@ class SchedulerSetup:
     def bundle_items(self, approved: list[JobCandidate]) -> tuple[list[dict], int]:
         """Group approved candidates into array-task bundles.
 
-        Candidates are partitioned by their effective bundle size
-        (`bundle_size_per_dataset[dataset_name]` if present, else
-        `bundle_size`) so candidates with different effective sizes never
-        share a task. Returns `(jobs, max_configs_per_job)` where each job is
-        `{"items": [...]}` (JSON-serializable, only the identifying-tuple
+        Candidates are partitioned by their effective bundle size (see
+        `_effective_bundle_size`) so candidates with different effective sizes
+        never share a task. Returns `(jobs, max_configs_per_job)` where each job
+        is `{"items": [...]}` (JSON-serializable, only the identifying-tuple
         fields), and `max_configs_per_job` is the largest bundle observed
         (used by schedulers to budget the per-task time limit).
         """
-        overrides = self.bundle_size_per_dataset or {}
         by_size: dict[int, list[JobCandidate]] = {}
         for c in approved:
-            size = overrides.get(c.dataset_name, self.bundle_size)
-            by_size.setdefault(size, []).append(c)
+            by_size.setdefault(self._effective_bundle_size(c), []).append(c)
 
         jobs: list[dict] = []
         max_configs_per_job = 1
@@ -116,6 +125,26 @@ class SchedulerSetup:
                     },
                 )
         return jobs, max_configs_per_job
+
+    def _effective_bundle_size(self, c: JobCandidate) -> int:
+        """Effective bundle size for a single candidate.
+
+        Precedence: an explicit `bundle_size_per_dataset` entry wins; otherwise
+        large datasets (see `_is_large_dataset`) collapse to 1; otherwise the
+        default `bundle_size` applies.
+        """
+        overrides = self.bundle_size_per_dataset or {}
+        if c.dataset_name in overrides:
+            return overrides[c.dataset_name]
+        if self._is_large_dataset(c):
+            return 1
+        return self.bundle_size
+
+    def _is_large_dataset(self, c: JobCandidate) -> bool:
+        """Whether a candidate's dataset exceeds either large-dataset threshold."""
+        return (self.large_dataset_n_features is not None and c.n_features > self.large_dataset_n_features) or (
+            self.large_dataset_n_samples is not None and c.n_samples_train_per_fold > self.large_dataset_n_samples
+        )
 
 
 @dataclass(kw_only=True)

--- a/tst/benchmark/experiment/test_experiment_utils.py
+++ b/tst/benchmark/experiment/test_experiment_utils.py
@@ -1,13 +1,43 @@
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 from tabarena.benchmark.experiment.experiment_runner_api import (
+    _build_cache_prefix,
     _clean_repetitions_mode_args_for_matrix,
     _parse_repetitions_mode_and_args,
+    _resolve_task_display_name,
     run_experiments_new,
 )
+from tabarena.utils.cache import AbstractCacheFunction
 
 RES_2_2 = [(f, r) for f in range(2) for r in range(2)]
+
+
+class _RecordingCache(AbstractCacheFunction):
+    """Minimal cache class that records its constructions and never has a cache hit."""
+
+    instances: list = []
+
+    def __init__(self, cache_name, cache_path, **kwargs):
+        super().__init__(include_self_in_call=kwargs.get("include_self_in_call", False))
+        self.cache_name = cache_name
+        self.cache_path = cache_path
+        type(self).instances.append((cache_name, cache_path, kwargs))
+
+    @property
+    def cache_file(self):
+        return None
+
+    @property
+    def exists(self) -> bool:
+        return False
+
+    def save_cache(self, data) -> None:
+        pass
+
+    def load_cache(self):
+        return None
 
 
 @pytest.mark.parametrize(
@@ -377,3 +407,177 @@ class TestRunExperimentsNewCacheOnly:
             cache_mode="only",
         )
         assert result == []
+
+
+class TestResolveTaskDisplayName:
+    def test_none_metadata_returns_none(self):
+        assert _resolve_task_display_name(360, None) is None
+
+    def test_no_name_column_returns_none(self):
+        meta = pd.DataFrame({"tid": [360], "tabarena_num_repeats": [1]})
+        assert _resolve_task_display_name(360, meta) is None
+
+    def test_no_id_column_returns_none(self):
+        meta = pd.DataFrame({"dataset": ["anneal"]})
+        assert _resolve_task_display_name(360, meta) is None
+
+    def test_tid_dataset_columns(self):
+        meta = pd.DataFrame({"tid": [360, 361], "dataset": ["anneal", "credit-g"]})
+        assert _resolve_task_display_name(360, meta) == "anneal"
+        assert _resolve_task_display_name(361, meta) == "credit-g"
+
+    def test_task_id_preferred_over_tid(self):
+        meta = pd.DataFrame(
+            {"task_id": [360], "tid": [999], "dataset": ["from_task_id"], "name": ["from_name"]}
+        )
+        # task_id is matched and dataset is the chosen name column
+        assert _resolve_task_display_name(360, meta) == "from_task_id"
+
+    def test_name_column_fallback(self):
+        meta = pd.DataFrame({"tid": [360], "name": ["anneal"]})
+        assert _resolve_task_display_name(360, meta) == "anneal"
+
+    def test_missing_task_returns_none(self):
+        meta = pd.DataFrame({"tid": [360], "dataset": ["anneal"]})
+        assert _resolve_task_display_name(999, meta) is None
+
+    def test_user_task_matched_by_task_id_str(self):
+        from tabarena.benchmark.task.user_task import UserTask
+
+        task = UserTask(task_name="my_task")
+        meta = pd.DataFrame({"task_id": [task.task_id_str], "dataset": ["pretty_name"]})
+        assert _resolve_task_display_name(task, meta) == "pretty_name"
+
+
+class TestBuildCachePrefix:
+    def test_name_first_with_repeat(self):
+        prefix = _build_cache_prefix(
+            method_name="m",
+            cache_task_key=360,
+            fold=2,
+            repeat=1,
+            cache_path_format="name_first",
+            include_repeat_in_cache_name=True,
+        )
+        assert prefix == "data/m/360/1_2"
+
+    def test_name_first_without_repeat_is_legacy_layout(self):
+        prefix = _build_cache_prefix(
+            method_name="m",
+            cache_task_key=360,
+            fold=2,
+            repeat=1,
+            cache_path_format="name_first",
+            include_repeat_in_cache_name=False,
+        )
+        assert prefix == "data/m/360/2"
+
+    def test_task_first(self):
+        prefix = _build_cache_prefix(
+            method_name="m",
+            cache_task_key="slug-abc",
+            fold=0,
+            repeat=0,
+            cache_path_format="task_first",
+            include_repeat_in_cache_name=True,
+        )
+        assert prefix == "data/tasks/slug-abc/0_0/m"
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="cache_path_format"):
+            _build_cache_prefix(
+                method_name="m",
+                cache_task_key=360,
+                fold=0,
+                repeat=0,
+                cache_path_format="bogus",
+                include_repeat_in_cache_name=True,
+            )
+
+
+class TestExperimentBatchRunnerDelegation:
+    """ExperimentBatchRunner.run() now delegates to run_experiments_new."""
+
+    @staticmethod
+    def _runner(tmp_path, **kwargs):
+        from tabarena.benchmark.experiment import ExperimentBatchRunner
+
+        task_metadata = pd.DataFrame({"tid": [0, 1], "dataset": ["d0", "d1"]})
+        return ExperimentBatchRunner(
+            expname=str(tmp_path), task_metadata=task_metadata, **kwargs
+        )
+
+    def test_only_cache_no_cache_returns_empty(self, tmp_path):
+        # only_cache => cache_mode="only"; with no cache present, returns [] without
+        # loading any task or training (exercises the full delegation wiring).
+        runner = self._runner(tmp_path, only_cache=True)
+        result = runner.run(
+            methods=[_make_minimal_experiment()],
+            datasets=["d0", "d1"],
+            folds=[0],
+        )
+        assert result == []
+
+    def test_only_cache_with_repeats(self, tmp_path):
+        runner = self._runner(tmp_path, only_cache=True)
+        result = runner.run(
+            methods=[_make_minimal_experiment()],
+            datasets=["d0"],
+            folds=[0, 1],
+            repeats=[0, 1],
+        )
+        assert result == []
+
+    def test_custom_cache_cls_is_forwarded(self, tmp_path):
+        # A non-Pickle cache class is threaded through to run_experiments_new and used.
+        _RecordingCache.instances.clear()
+        runner = self._runner(tmp_path, only_cache=True, cache_cls=_RecordingCache)
+        result = runner.run(
+            methods=[_make_minimal_experiment()],
+            datasets=["d0"],
+            folds=[0],
+        )
+        assert result == []
+        assert _RecordingCache.instances, "custom cache_cls was not used"
+        # ExperimentBatchRunner's default cache_cls_kwargs forwards include_self_in_call=True.
+        assert all(kw.get("include_self_in_call") is True for *_, kw in _RecordingCache.instances)
+
+    def test_unknown_dataset_raises(self, tmp_path):
+        runner = self._runner(tmp_path, only_cache=True)
+        with pytest.raises(ValueError, match="present in task_metadata"):
+            runner.run(
+                methods=[_make_minimal_experiment()],
+                datasets=["does_not_exist"],
+                folds=[0],
+            )
+
+
+class TestRunExperimentsNewCacheCls:
+    def test_custom_cache_cls_used(self, tmp_path):
+        _RecordingCache.instances.clear()
+        result = run_experiments_new(
+            output_dir=str(tmp_path),
+            model_experiments=[_make_minimal_experiment()],
+            tasks=[360],
+            repetitions_mode="individual",
+            repetitions_mode_args=[(0, 0)],
+            cache_mode="only",
+            cache_cls=_RecordingCache,
+        )
+        assert result == []
+        assert _RecordingCache.instances, "custom cache_cls was not used"
+
+    def test_cache_cls_kwargs_forwarded(self, tmp_path):
+        _RecordingCache.instances.clear()
+        run_experiments_new(
+            output_dir=str(tmp_path),
+            model_experiments=[_make_minimal_experiment()],
+            tasks=[360],
+            repetitions_mode="individual",
+            repetitions_mode_args=[(0, 0)],
+            cache_mode="only",
+            cache_cls=_RecordingCache,
+            cache_cls_kwargs={"include_self_in_call": True},
+        )
+        # Explicit cache_cls_kwargs wins over the write_model_failures default (False).
+        assert all(kw.get("include_self_in_call") is True for *_, kw in _RecordingCache.instances)

--- a/tst/models/test_tabpfnv26.py
+++ b/tst/models/test_tabpfnv26.py
@@ -23,7 +23,7 @@ def test_tabpfn26():
         )
 
 
-def test_tabpfnv26_many_class():
+def test_tabpfnv26_many_class(tmp_path):
     """Test that RealTabPFNv25 handles >10 classes via ManyClassClassifier."""
     try:
         import numpy as np
@@ -60,6 +60,7 @@ def test_tabpfnv26_many_class():
         y_test = label_cleaner.transform(y_test)
 
         model = TabPFNv26Model(
+            path=str(tmp_path),  # avoid writing model artifacts to ./AutogluonModels
             problem_type=task_type,
             hyperparameters={"n_estimators": 1},
         )

--- a/tst/tabflow_slurm/test_setup.py
+++ b/tst/tabflow_slurm/test_setup.py
@@ -23,6 +23,7 @@ from tabarena.benchmark.task.metadata import TabArenaMetadataBundle
 pytest.importorskip("tabflow_slurm.setup", reason="tabflow_slurm is not installed")
 
 from tabflow_slurm.setup.benchmark import TabArenaBenchmarkSetup  # noqa: E402
+from tabflow_slurm.setup.candidates import JobCandidate  # noqa: E402
 from tabflow_slurm.setup.paths import PathSetup  # noqa: E402
 from tabflow_slurm.setup.resources import ResourcesSetup  # noqa: E402
 from tabflow_slurm.setup.scheduler import SlurmSetup  # noqa: E402
@@ -151,6 +152,73 @@ class TestSlurmSetup:
         assert ss.exclusive_node is True
         assert ss.time_limit_overhead == 2
         assert ss.bundle_size == 10
+
+
+# ---------------------------------------------------------------------------
+# SchedulerSetup bundling (bundle_size + large-dataset auto-rule)
+# ---------------------------------------------------------------------------
+
+
+def _candidate(*, dataset_name="d", n_features=10, n_samples_train_per_fold=1000) -> JobCandidate:
+    return JobCandidate(
+        task_id="1",
+        dataset_name=dataset_name,
+        fold=0,
+        repeat=0,
+        config_index=0,
+        config={"name": "cfg"},
+        n_features=n_features,
+        n_classes=2,
+        n_samples_train_per_fold=n_samples_train_per_fold,
+        problem_type="binary",
+    )
+
+
+class TestEffectiveBundleSize:
+    def test_default_large_thresholds(self):
+        ss = _slurm()
+        assert ss.large_dataset_n_features == 5_000
+        assert ss.large_dataset_n_samples == 100_000
+
+    def test_small_dataset_uses_bundle_size(self):
+        ss = _slurm(bundle_size=5)
+        assert ss._effective_bundle_size(_candidate(n_features=10, n_samples_train_per_fold=1000)) == 5
+
+    def test_wide_dataset_collapses_to_one(self):
+        ss = _slurm(bundle_size=5)
+        assert ss._effective_bundle_size(_candidate(n_features=5001)) == 1
+
+    def test_large_sample_dataset_collapses_to_one(self):
+        ss = _slurm(bundle_size=5)
+        assert ss._effective_bundle_size(_candidate(n_samples_train_per_fold=100_001)) == 1
+
+    def test_at_threshold_is_not_large(self):
+        ss = _slurm(bundle_size=5)
+        assert ss._effective_bundle_size(_candidate(n_features=5000, n_samples_train_per_fold=100_000)) == 5
+
+    def test_per_dataset_override_wins_over_auto_rule(self):
+        ss = _slurm(bundle_size=5, bundle_size_per_dataset={"big": 3})
+        assert ss._effective_bundle_size(_candidate(dataset_name="big", n_features=5001)) == 3
+
+    def test_feature_check_disabled(self):
+        ss = _slurm(bundle_size=5, large_dataset_n_features=None)
+        assert ss._effective_bundle_size(_candidate(n_features=5001)) == 5
+
+    def test_sample_check_disabled(self):
+        ss = _slurm(bundle_size=5, large_dataset_n_samples=None)
+        assert ss._effective_bundle_size(_candidate(n_samples_train_per_fold=100_001)) == 5
+
+
+class TestBundleItems:
+    def test_large_datasets_get_singleton_bundles(self):
+        ss = _slurm(bundle_size=5)
+        small = [_candidate(dataset_name="small") for _ in range(3)]
+        wide = [_candidate(dataset_name="wide", n_features=6000) for _ in range(2)]
+        jobs, max_configs = ss.bundle_items([*small, *wide])
+        sizes = sorted(len(j["items"]) for j in jobs)
+        # 3 small batched into one bundle, 2 wide as singletons.
+        assert sizes == [1, 1, 3]
+        assert max_configs == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Unify experiment runners onto `run_experiments_new`

## Summary

TabArena had two parallel implementations of the same "fit each method on each
task × fold × repeat, with caching" loop:

- `run_experiments` (in `experiment_utils.py`), wrapped by `ExperimentBatchRunner` and used
  by the quickstart examples, and
- `run_experiments_new` (in `experiment_runner_api.py`), used by tabflow-slurm and the newer
  examples.

This PR makes **`run_experiments_new` the single fit loop**: `ExperimentBatchRunner.run()` now
delegates to it, and the old `run_experiments` is deleted. `run_experiments_new` gains a few
opt-in parameters so it can reproduce the legacy runner's naming and on-disk cache layout,
keeping all existing callers and examples working unchanged.

## Motivation

Two copies of the same ~200-line loop had drifted apart (different cache-path handling, task
naming, failure handling, and feature support such as the dynamic validation protocol and the
text-embedding cache). Consolidating removes the duplication and gives us one API to maintain
and extend.

## What changed

### `run_experiments_new` — new opt-in parameters (defaults preserve current behavior)

- **`cache_path_format: "name_first" | "task_first"`** and **`include_repeat_in_cache_name: bool`** —
  reproduce the legacy on-disk cache layouts, including the single-repeat `{fold}` subtask
  path (vs the default `{repeat}_{fold}`), so existing caches stay discoverable.
- **`use_metadata_task_name: bool = False`** — when set, the results `dataset` key is resolved
  from `tasks_metadata` (a `dataset`/`name` column keyed by `task_id`/`tid`) so results join
  cleanly with custom metadata. Off by default; the name otherwise comes from the OpenML
  dataset name / `UserTask` slug.
- **`write_model_failures: bool = False`** — opt-in to writing the `model_failures` artifact on
  a failed fit (benchmark mode). Maps to the cacher's `include_self_in_call`; does not affect
  the `results` cache file.
- **`cache_cls` / `cache_cls_kwargs`** — pluggable cache backend (default
  `CacheFunctionPickle`); any drop-in cache class with a `(cache_name, cache_path, ...)`
  constructor can be used.

Path building and name resolution are factored into small helpers (`_build_cache_prefix`,
`_resolve_task_display_name`).

### `ExperimentBatchRunner.run()` — re-pointed at `run_experiments_new`

Argument translation:

- `datasets` (names) → task ids via the existing `_dataset_to_tid_dict`.
- `folds` / `repeats` → `repetitions_mode="individual"` pairs. `repeats=None` keeps the legacy
  single-repeat `{fold}` cache layout (`include_repeat_in_cache_name=False`).
- `only_cache` / `ignore_cache` → `cache_mode`.
- `mode` / `s3_bucket` / `s3_dataset_cache` → `run_mode` / `s3_kwargs`.
- Forwards `task_metadata`, `cache_cls`, and `cache_cls_kwargs`, and sets
  `use_metadata_task_name=True` — preserving the legacy display-name and caching behavior
  (its default `cache_cls_kwargs` carries `include_self_in_call=True`, so the `model_failures`
  artifact is still written).

### Removed

- `run_experiments` and its export from `tabarena.benchmark.experiment`.
- The write-only `error.pkl` artifact (nothing in tabarena or tabarena-slurm-setup read it).
- Now-dead imports in `experiment_utils.py`.

`check_cache_hit` and `ExperimentBatchRunner._subtask_name` are kept (used by tabflow-slurm).

## Backward compatibility

- **Caches still hit.** `include_self_in_call` never affected the `results` cache path, format,
  `exists`, or `load_cache`, so artifacts written by the old runner are read unchanged.
- **Examples unchanged.** They go through `ExperimentBatchRunner`, now backed by the new
  runner; no example edits required.
- The only dropped artifact (`error.pkl`) was never consumed. We (or Claude) can trivially add this idea again if we need it / use it. 

## Testing

Added unit tests for the new helpers (`_resolve_task_display_name`, `_build_cache_prefix`), the
pluggable cache backend, and `ExperimentBatchRunner.run()` delegation
(`TestExperimentBatchRunnerDelegation`). Full suite green:
`tst/benchmark/experiment/`, `tst/benchmark/test_results.py`,
`tst/benchmark/test_yaml_experiment_serialization.py` — 192 passed.


---

_Note: the commit also includes minor README/AGENTS.md doc touch-ups (install instructions /
package layout), unrelated to the runner change._
