### PR TITLE
Roll out ruff lint + format across the codebase and enforce in CI

### DIFF
--- a/.github/workflows/pytest-pytest.yml
+++ b/.github/workflows/pytest-pytest.yml
@@ -51,8 +51,36 @@ jobs:
           uv pip install --system --prerelease=allow -e ./packages/tabarena
 
           # Optional tools
-          uv pip install --system flake8 pytest
+          uv pip install --system pytest
 
       - name: Test with pytest
         run: |
           pytest
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          uv --version
+
+      # Keep this version in sync with .pre-commit-config.yaml and the `lint`
+      # dependency group in packages/tabarena/pyproject.toml.
+      - name: Install ruff
+        run: uv pip install --system "ruff==0.14.0"
+
+      - name: "Ruff lint (config: ruff.toml)"
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# Pre-commit hooks for TabArena. One-time setup:
+#
+#     pip install pre-commit   # (or: uv tool install pre-commit)
+#     pre-commit install
+#
+# After that, `git commit` runs ruff on the staged files: it auto-fixes what it
+# can and reformats; if anything was changed the commit aborts so you can re-add
+# the files and commit again. Remaining (non-auto-fixable) violations block the
+# commit until fixed or explicitly `# noqa`-ed.
+#
+# Keep `rev` in sync with the ruff version in .github/workflows/pytest-pytest.yml
+# and the `lint` dependency group in packages/tabarena/pyproject.toml.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,15 @@ ruff check .               # Lint (config: ruff.toml)
 ruff format .              # Format
 ```
 
-Key rules: `from __future__ import annotations` is required in every file (enforced via isort `required-imports`). Line length 120. Google-style docstrings. Run ruff on touched files before finishing a task.
+Key rules: `from __future__ import annotations` is required in every file (enforced via isort `required-imports`). Line length 120 (the formatter is the authority — `E501` is not enforced). Google-style docstrings. Run ruff on touched files before finishing a task.
+
+**CI runs `ruff check .` and `ruff format --check .`** (see `.github/workflows/pytest-pytest.yml`), so lint/format violations fail the build. Optionally install the local pre-commit hook so commits are auto-fixed before they reach CI:
+
+```bash
+pip install pre-commit && pre-commit install   # one-time, per clone
+```
+
+After that, `git commit` runs ruff on staged files; if a hook reformats or fixes anything the commit aborts — re-`git add` and commit again. The ruff version is pinned identically in `.pre-commit-config.yaml`, the CI workflow, and the `lint` dependency group in `packages/tabarena/pyproject.toml`; keep all three in sync.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,6 @@ When the user describes work that matches a skill's trigger criteria, invoke the
 
 ## Working Style in This Repo
 
-- **Always run `ruff check --fix`** on touched files before reporting a task complete. The `from __future__ import annotations` requirement (isort `required-imports`) is the most common CI failure on new files.
+- **Always run `ruff check --fix`** on touched files before reporting a task complete. The `from __future__ import annotations` requirement (isort `required-imports`) is the most common CI failure on new files. CI now enforces `ruff check .` + `ruff format --check .`, and a pinned `.pre-commit-config.yaml` is available (`pre-commit install`) — see AGENTS.md "Lint & Format".
 - **Tests live in `tst/`** — when adding a test for `packages/tabarena/src/tabarena/<area>/foo.py`, mirror the path under `tst/<area>/test_foo.py`.
 - **Optional model deps**: when adding code that imports an optional library (e.g., `tabpfn`, `tabicl`, `xrfm`), keep the import inside the wrapper's `_fit` / class body, never at module top-level — top-level imports break installs without that extra.

--- a/examples/benchmarking/custom_tabarena_model/custom_random_forest_model.py
+++ b/examples/benchmarking/custom_tabarena_model/custom_random_forest_model.py
@@ -108,5 +108,6 @@ def get_configs_for_custom_rf(*, num_random_configs: int = 1):
         search_space=search_space,
     )
     return gen_custom_rf.generate_all_bag_experiments(
-        num_random_configs=num_random_configs, fold_fitting_strategy="sequential_local"
+        num_random_configs=num_random_configs,
+        fold_fitting_strategy="sequential_local",
     )

--- a/examples/benchmarking/run_any_openml_task.py
+++ b/examples/benchmarking/run_any_openml_task.py
@@ -9,10 +9,11 @@ from tabarena.benchmark.experiment import AGModelBagExperiment, ExperimentBatchR
 from tabarena.nips2025_utils.end_to_end import EndToEnd
 from tabarena.nips2025_utils.method_processor import generate_task_metadata
 
-
 # Example code for running any TabArena model on any OpenML task (even those not part of TabArena's original datasets)
-if __name__ == '__main__':
-    expname = str(Path(__file__).parent / "experiments" / "quickstart_any_openml_task")  # folder location to save all experiment artifacts
+if __name__ == "__main__":
+    expname = str(
+        Path(__file__).parent / "experiments" / "quickstart_any_openml_task"
+    )  # folder location to save all experiment artifacts
     eval_dir = Path(__file__).parent / "eval" / "quickstart_any_openml_task"
     ignore_cache = False  # set to True to overwrite existing caches and re-run experiments from scratch
 
@@ -42,7 +43,6 @@ if __name__ == '__main__':
         AGModelBagExperiment(  # Wrapper for fitting a single bagged model via AutoGluon
             # The name you want the config to have
             name="LightGBM_c1_BAG_L1_Reproduced",
-
             # The class of the model. Can also be a string if AutoGluon recognizes it, such as `"GBM"`
             # Supports any model that inherits from `autogluon.core.models.AbstractModel`
             model_cls=LGBModel,

--- a/examples/benchmarking/run_beta_tabpfn_end_to_end.py
+++ b/examples/benchmarking/run_beta_tabpfn_end_to_end.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from tabarena.nips2025_utils.artifacts.download_utils import download_and_extract_zip

--- a/examples/benchmarking/run_get_tabarena_datasets_from_openml.py
+++ b/examples/benchmarking/run_get_tabarena_datasets_from_openml.py
@@ -48,7 +48,8 @@ for task_id in task_ids:
     for repeat in range(tabarena_repeats):
         for fold in range(folds):
             X, y, categorical_indicator, attribute_names = dataset.get_data(
-                target=task.target_name, dataset_format="dataframe"
+                target=task.target_name,
+                dataset_format="dataframe",
             )
             train_indices, test_indices = task.get_train_test_split_indices(fold=fold, repeat=repeat)
             X_train = X.iloc[train_indices]

--- a/examples/benchmarking/run_quickstart_tabarena.py
+++ b/examples/benchmarking/run_quickstart_tabarena.py
@@ -10,9 +10,10 @@ from tabarena.nips2025_utils.end_to_end import EndToEnd
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 from tabarena.website.website_format import format_leaderboard
 
-
-if __name__ == '__main__':
-    expname = str(Path(__file__).parent / "experiments" / "quickstart")  # folder location to save all experiment artifacts
+if __name__ == "__main__":
+    expname = str(
+        Path(__file__).parent / "experiments" / "quickstart"
+    )  # folder location to save all experiment artifacts
     eval_dir = Path(__file__).parent / "eval" / "quickstart"
     ignore_cache = False  # set to True to overwrite existing caches and re-run experiments from scratch
 
@@ -24,8 +25,9 @@ if __name__ == '__main__':
     folds = [0]
 
     # import your model classes
-    from tabarena.models import RealMLPModel
     from autogluon.tabular.models import LGBModel
+
+    from tabarena.models import RealMLPModel
 
     # This list of methods will be fit sequentially on each task (dataset x fold)
     methods = [
@@ -33,7 +35,6 @@ if __name__ == '__main__':
         AGModelBagExperiment(  # Wrapper for fitting a single bagged model via AutoGluon
             # The name you want the config to have
             name="LightGBM_c1_BAG_L1_Reproduced",
-
             # The class of the model. Can also be a string if AutoGluon recognizes it, such as `"GBM"`
             # Supports any model that inherits from `autogluon.core.models.AbstractModel`
             model_cls=LGBModel,

--- a/examples/benchmarking/run_quickstart_tabarena_custom_datasets.py
+++ b/examples/benchmarking/run_quickstart_tabarena_custom_datasets.py
@@ -41,7 +41,8 @@ def get_custom_classification_task(task_cache_dir: str) -> UserTask:
     # Create a stratified 10-repeated 3-fold split (any other split can be used as well)
     n_repeats, n_splits = 10, 3
     sklearn_splits = RepeatedStratifiedKFold(n_repeats=n_repeats, n_splits=n_splits, random_state=42).split(
-        X=dataset.drop(columns=["target"]), y=dataset["target"]
+        X=dataset.drop(columns=["target"]),
+        y=dataset["target"],
     )
     # Transform the splits into a standard dictionary format expected by TabArena
     splits = {}
@@ -131,7 +132,7 @@ if __name__ == "__main__":
                 task.tabarena_task_name,
                 int(len(oml_task.get_dataset().get_data()) * 0.67),
                 int(len(oml_task.get_dataset().get_data()) * 0.33),
-            ]
+            ],
         )
     task_metadata = pd.DataFrame(
         task_metadata,
@@ -156,7 +157,7 @@ if __name__ == "__main__":
             config_generator.generate_all_bag_experiments(
                 num_random_configs=num_random_configs,
                 fold_fitting_strategy="sequential_local",
-            )
+            ),
         )
 
     results_lst = run_experiments_new(
@@ -185,5 +186,3 @@ if __name__ == "__main__":
     )
     leaderboard_website = format_leaderboard(df_leaderboard=leaderboard)
     print(leaderboard_website.to_markdown(index=False))
-
-

--- a/examples/benchmarking/run_quickstart_tabarena_custom_model.py
+++ b/examples/benchmarking/run_quickstart_tabarena_custom_model.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pandas as pd
 
-from tabarena.benchmark.experiment import ExperimentBatchRunner, Experiment
+from tabarena.benchmark.experiment import Experiment, ExperimentBatchRunner
 from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel
 from tabarena.nips2025_utils.end_to_end import EndToEnd
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
@@ -20,10 +20,11 @@ class SimpleLightGBM(AbstractExecModel):
 
     def get_model_cls(self):
         from lightgbm import LGBMClassifier, LGBMRegressor
-        is_classification = self.problem_type in ['binary', 'multiclass']
+
+        is_classification = self.problem_type in ["binary", "multiclass"]
         if is_classification:
             model_cls = LGBMClassifier
-        elif self.problem_type == 'regression':
+        elif self.problem_type == "regression":
             model_cls = LGBMRegressor
         else:
             raise AssertionError(f"LightGBM does not recognize the problem_type='{self.problem_type}'")
@@ -34,7 +35,7 @@ class SimpleLightGBM(AbstractExecModel):
         self.model = model_cls(**self.hyperparameters)
         self.model.fit(
             X=X,
-            y=y
+            y=y,
         )
         return self
 
@@ -47,9 +48,13 @@ class SimpleLightGBM(AbstractExecModel):
         return pd.DataFrame(y_pred_proba, columns=self.model.classes_, index=X.index)
 
 
-if __name__ == '__main__':
-    expname = str(Path(__file__).parent / "experiments" / "quickstart_custom_model")  # folder location to save all experiment artifacts
-    leaderboard_dir = str(Path(__file__).parent / "leaderboards" / "quickstart_custom_model")  # folder location to store tables, plots and figures
+if __name__ == "__main__":
+    expname = str(
+        Path(__file__).parent / "experiments" / "quickstart_custom_model"
+    )  # folder location to save all experiment artifacts
+    leaderboard_dir = str(
+        Path(__file__).parent / "leaderboards" / "quickstart_custom_model"
+    )  # folder location to store tables, plots and figures
     ignore_cache = False  # set to True to overwrite existing caches and re-run experiments from scratch
 
     ta_context = TabArenaContext()
@@ -66,8 +71,8 @@ if __name__ == '__main__':
             method_kwargs={
                 "hyperparameters": dict(
                     n_estimators=10,
-                )
-            }
+                ),
+            },
         ),
     ]
 
@@ -96,6 +101,6 @@ if __name__ == '__main__':
     )
     leaderboard_website = ta_context.leaderboard_to_website_format(leaderboard=leaderboard)
 
-    print(f"Leaderboard:")
+    print("Leaderboard:")
     print(leaderboard_website.to_markdown(index=False))
     print(f"View saved figures in {leaderboard_dir}")

--- a/examples/benchmarking/run_quickstart_tabarena_hpo.py
+++ b/examples/benchmarking/run_quickstart_tabarena_hpo.py
@@ -10,9 +10,10 @@ from tabarena.nips2025_utils.end_to_end import EndToEnd
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 from tabarena.website.website_format import format_leaderboard
 
-
-if __name__ == '__main__':
-    expname = str(Path(__file__).parent / "experiments" / "quickstart_hpo")  # folder location to save all experiment artifacts
+if __name__ == "__main__":
+    expname = str(
+        Path(__file__).parent / "experiments" / "quickstart_hpo"
+    )  # folder location to save all experiment artifacts
     eval_dir = Path(__file__).parent / "eval" / "quickstart_hpo"
     ignore_cache = False  # set to True to overwrite existing caches and re-run experiments from scratch
 

--- a/examples/benchmarking/run_quickstart_tabarena_one_dataset.py
+++ b/examples/benchmarking/run_quickstart_tabarena_one_dataset.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
             config_generator.generate_all_bag_experiments(
                 num_random_configs=num_random_configs,
                 fold_fitting_strategy="sequential_local",
-            )
+            ),
         )
 
     results_lst = run_experiments_new(
@@ -85,5 +85,3 @@ if __name__ == "__main__":
     plt.xlim(0.5)
     plt.tight_layout()
     plt.show()
-
-

--- a/examples/meta/inspect_processed_data.py
+++ b/examples/meta/inspect_processed_data.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pandas as pd
 
-from tabarena import EvaluationRepository
 from tabarena.nips2025_utils.artifacts import tabarena_method_metadata_collection
+
+if TYPE_CHECKING:
+    from tabarena import EvaluationRepository
 
 """
 TabArena Processed-Artifact Quickstart
@@ -32,7 +36,7 @@ Typical Uses
 - Prototype ensembling strategies on top of cached predictions.
 - Extract a method's **AutoGluon** hyperparameters and re-train that exact config on
   your own dataset with `TabularPredictor.fit(hyperparameters=...)`.
-  
+
 Data Volume Tips
 ----------------
 - For a very small, fast download use: `method = "Mitra_GPU"`.
@@ -76,7 +80,7 @@ if __name__ == "__main__":
     if not method_metadata.path_processed_exists:
         print(
             f"Downloading processed data to {method_metadata.path_processed} ... "
-            f"Ensure you have a fast internet connection. This download can be up to 15 GB."
+            f"Ensure you have a fast internet connection. This download can be up to 15 GB.",
         )
         method_metadata.method_downloader().download_processed()
 
@@ -89,7 +93,7 @@ if __name__ == "__main__":
     if method_metadata.method_type != "config":
         raise AssertionError(
             f"This tutorial only supports config methods. "
-            f"(method={method_metadata.method!r}, method_type={method_metadata.method_type!r})"
+            f"(method={method_metadata.method!r}, method_type={method_metadata.method_type!r})",
         )
 
     # ----------------------------------------------------------------------
@@ -113,14 +117,14 @@ if __name__ == "__main__":
 
     config_types = repo.config_types()
     assert len(config_types) == 1, (
-        f"There should be exactly 1 config_type for method {{method_metadata.method}}: {{config_types}}"
+        "There should be exactly 1 config_type for method {method_metadata.method}: {config_types}"
     )
     repo_config_type = config_types[0]
     if repo_config_type != method_metadata.config_type:
         print(
             f"Warning: Misaligned processed config_type with method_metadata config_type!\n"
             f"\tmethod_metadata config_type: {method_metadata.config_type}\n"
-            f"\t      processed config_type: {repo_config_type}\n"
+            f"\t      processed config_type: {repo_config_type}\n",
         )
 
     config = configs[0]
@@ -138,7 +142,7 @@ if __name__ == "__main__":
         f"\t                     Name: {config}\n"
         f"\t                     Type: {config_type}\n"
         f"\t          Hyperparameters: {config_hyperparameters}\n"
-        f"\tAutoGluon Hyperparameters: {autogluon_hyperparameters}\n"
+        f"\tAutoGluon Hyperparameters: {autogluon_hyperparameters}\n",
     )
 
     # ----------------------------------------------------------------------

--- a/examples/meta/inspect_processed_data.py
+++ b/examples/meta/inspect_processed_data.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
 
     config_types = repo.config_types()
     assert len(config_types) == 1, (
-        "There should be exactly 1 config_type for method {method_metadata.method}: {config_types}"
+        f"There should be exactly 1 config_type for method {method_metadata.method}: {config_types}"
     )
     repo_config_type = config_types[0]
     if repo_config_type != method_metadata.config_type:

--- a/examples/meta/inspect_raw_data.py
+++ b/examples/meta/inspect_raw_data.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
+
 from numpy.testing import assert_array_equal
 
 from tabarena.benchmark.result import AGBagResult
 from tabarena.benchmark.task.openml import OpenMLTaskWrapper
 from tabarena.nips2025_utils.artifacts import tabarena_method_metadata_collection
+
+if TYPE_CHECKING:
+    import numpy as np
 
 """
 TabArena → OpenML Split Verification Script
@@ -76,7 +80,7 @@ if __name__ == "__main__":
             f"dataset={task_result.dataset}, "
             f"fold={fold}, "
             f"repeat={repeat}, "
-            f"sample={sample}"
+            f"sample={sample}",
         )
 
         # OpenML task id associated with this run's dataset/splits.

--- a/examples/meta/run_download_raw.py
+++ b/examples/meta/run_download_raw.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from tabarena.models._method_metadata import MethodMetadata
+from typing import TYPE_CHECKING
+
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
+
+if TYPE_CHECKING:
+    from tabarena.models._method_metadata import MethodMetadata
 
 """
 This is an example script showcasing how to access the different types of artifacts in TabArena.

--- a/examples/plots/run_generate_main_leaderboard.py
+++ b/examples/plots/run_generate_main_leaderboard.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 
-
 if __name__ == "__main__":
     save_path = "output_leaderboard"  # folder to save all figures and tables
 
@@ -17,12 +16,14 @@ if __name__ == "__main__":
 
     tabarena_context_unverified = TabArenaContext(include_unverified=True)
     leaderboard_unverified = tabarena_context_unverified.compare(output_dir=output_path_unverified)
-    leaderboard_website_unverified = tabarena_context_unverified.leaderboard_to_website_format(leaderboard=leaderboard_unverified)
+    leaderboard_website_unverified = tabarena_context_unverified.leaderboard_to_website_format(
+        leaderboard=leaderboard_unverified
+    )
 
-    print(f"Verified Leaderboard:")
+    print("Verified Leaderboard:")
     print(leaderboard_website_verified.to_markdown(index=False))
     print("")
 
-    print(f"Unverified Leaderboard:")
+    print("Unverified Leaderboard:")
     print(leaderboard_website_unverified.to_markdown(index=False))
     print("")

--- a/examples/plots/run_generate_main_leaderboard_neurips2025.py
+++ b/examples/plots/run_generate_main_leaderboard_neurips2025.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tabarena.nips2025_utils.artifacts._tabarena_method_metadata import tabarena_method_metadata_2025_06_12_collection_main
+from tabarena.nips2025_utils.artifacts._tabarena_method_metadata import (
+    tabarena_method_metadata_2025_06_12_collection_main,
+)
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
-
 
 if __name__ == "__main__":
     output_path = Path("output_leaderboard_neurips2025")  # folder to save all figures and tables
 
     tabarena_context = TabArenaContext(
-        methods=tabarena_method_metadata_2025_06_12_collection_main.method_metadata_lst
+        methods=tabarena_method_metadata_2025_06_12_collection_main.method_metadata_lst,
     )
     leaderboard = tabarena_context.compare(
         output_dir=output_path,
@@ -19,6 +20,6 @@ if __name__ == "__main__":
         leaderboard=leaderboard,
     )
 
-    print(f"NeurIPS 2025 Leaderboard:")
+    print("NeurIPS 2025 Leaderboard:")
     print(leaderboard_website.to_markdown(index=False))
     print("")

--- a/examples/plots/run_generate_paper_figures.py
+++ b/examples/plots/run_generate_paper_figures.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
-
+from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories
 
 if __name__ == "__main__":
     download_results: bool | str = "auto"  # results must be downloaded for the script to work
@@ -25,7 +24,7 @@ if __name__ == "__main__":
     configs_hyperparameters = tabarena_context.load_configs_hyperparameters(download=download_results)
 
     tabarena_context_all = TabArenaContext(
-        methods=tabarena_context.method_metadata_collection.method_metadata_lst
+        methods=tabarena_context.method_metadata_collection.method_metadata_lst,
     )
 
     if plot_n_configs:
@@ -52,9 +51,10 @@ if __name__ == "__main__":
     zip_results = True
     upload_to_s3 = False
     if zip_results:
-        file_prefix = f"tabarena51_paper_results"
+        file_prefix = "tabarena51_paper_results"
         file_name = f"{file_prefix}.zip"
         shutil.make_archive(file_prefix, "zip", root_dir=save_path)
         if upload_to_s3:
             from autogluon.common.utils.s3_utils import upload_file
+
             upload_file(file_name=file_name, bucket="tabarena", prefix=save_path)

--- a/examples/plots/run_generate_synthetic_leaderboard.py
+++ b/examples/plots/run_generate_synthetic_leaderboard.py
@@ -1,5 +1,4 @@
-"""
-TabArena quickstart tutorial (synthetic data)
+"""TabArena quickstart tutorial (synthetic data).
 
 This script:
 1) Creates synthetic long-form results with columns:
@@ -28,8 +27,7 @@ def make_synthetic_results(
     seeds: list[int],
     rng_seed: int = 0,
 ) -> pd.DataFrame:
-    """
-    Create a dense (task, seed, method) results table with realistic-ish structure:
+    """Create a dense (task, seed, method) results table with realistic-ish structure:
     - Each task has its own difficulty scale.
     - Each method has a global skill offset.
     - Each seed adds small noise.
@@ -64,10 +62,10 @@ def make_synthetic_results(
 
                 # times: better methods might be slower (arbitrary example)
                 time_train_s = float(
-                    rng.lognormal(mean=2.5, sigma=0.4) * (1.0 + 0.30 * (methods.index(method)))
+                    rng.lognormal(mean=2.5, sigma=0.4) * (1.0 + 0.30 * (methods.index(method))),
                 )
                 time_infer_s = float(
-                    rng.lognormal(mean=0.2, sigma=0.25) * (1.0 + 0.15 * (methods.index(method)))
+                    rng.lognormal(mean=0.2, sigma=0.25) * (1.0 + 0.15 * (methods.index(method))),
                 )
 
                 rows.append(
@@ -78,14 +76,13 @@ def make_synthetic_results(
                         "metric_error": error,
                         "time_train_s": time_train_s,
                         "time_infer_s": time_infer_s,
-                    }
+                    },
                 )
 
     df = pd.DataFrame(rows)
 
     # Optional: enforce nice ordering
-    df = df.sort_values(["task", "seed", "method"]).reset_index(drop=True)
-    return df
+    return df.sort_values(["task", "seed", "method"]).reset_index(drop=True)
 
 
 def main() -> None:
@@ -100,7 +97,9 @@ def main() -> None:
 
     print("Synthetic results (head):")
     print(data.head(8).to_string(index=False))
-    print("\nRow count:", len(data), "(should be tasks * seeds * methods =", len(tasks) * len(seeds) * len(methods), ")")
+    print(
+        "\nRow count:", len(data), "(should be tasks * seeds * methods =", len(tasks) * len(seeds) * len(methods), ")"
+    )
 
     # ----------------------------
     # 2) Initialize TabArena

--- a/examples/plots/run_generate_website_artifacts.py
+++ b/examples/plots/run_generate_website_artifacts.py
@@ -82,7 +82,7 @@ def convert_to_website_format(input_path: str | Path, output_path: str | Path):
     for path in file_paths:
         base_input_path = Path(path).parent
         base_output_path = path_copy / base_input_path.relative_to(
-            path_to_output_to_use
+            path_to_output_to_use,
         )
         process_one_folder(
             base_input_path=Path(path).parent,

--- a/examples/plots/run_plot_pareto_over_tuning_time.py
+++ b/examples/plots/run_plot_pareto_over_tuning_time.py
@@ -1,5 +1,6 @@
-from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories
+from __future__ import annotations
 
+from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories
 
 if __name__ == "__main__":
     plot_tuning_trajectories()

--- a/examples/running_tabarena_models/data_utils.py
+++ b/examples/running_tabarena_models/data_utils.py
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
 
 
 def get_example_data_for_task_type(
-    *, task_type: str
+    *,
+    task_type: str,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
     """Return example data for a given task type."""
     if task_type == "binary":
@@ -24,13 +25,19 @@ def get_example_data_for_task_type(
     else:
         raise ValueError("Invalid task type")
     X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.5, random_state=42
+        X,
+        y,
+        test_size=0.5,
+        random_state=42,
     )
     return X_train, X_test, y_train, y_test
 
 
 def score_for_task_type(
-    y_test: pd.Series, y_pred: pd.Series | pd.DataFrame, *, task_type: str
+    y_test: pd.Series,
+    y_pred: pd.Series | pd.DataFrame,
+    *,
+    task_type: str,
 ) -> float:
     """Score (higher is better) the predictions for a given task type."""
     if task_type in ["binary", "multiclass"]:

--- a/examples/running_tabarena_models/run_autogluon_on_openml_task.py
+++ b/examples/running_tabarena_models/run_autogluon_on_openml_task.py
@@ -1,6 +1,8 @@
-from autogluon.tabular import TabularPredictor
-from tabarena.benchmark.task.openml import OpenMLTaskWrapper
+from __future__ import annotations
 
+from autogluon.tabular import TabularPredictor
+
+from tabarena.benchmark.task.openml import OpenMLTaskWrapper
 
 # supports any task on OpenML
 task_id = 363614  # anneal

--- a/examples/running_tabarena_models/run_autogluon_on_openml_task_with_hpo_configs.py
+++ b/examples/running_tabarena_models/run_autogluon_on_openml_task_with_hpo_configs.py
@@ -1,9 +1,11 @@
-from tabarena.benchmark.task.openml import OpenMLTaskWrapper
-from tabarena.export.autogluon import AutoGluonExporter
-from tabarena.models.lightgbm.hpo import gen_lightgbm
-from tabarena.models.catboost.hpo import gen_catboost
+from __future__ import annotations
 
 from autogluon.tabular import TabularPredictor
+
+from tabarena.benchmark.task.openml import OpenMLTaskWrapper
+from tabarena.export.autogluon import AutoGluonExporter
+from tabarena.models.catboost.hpo import gen_catboost
+from tabarena.models.lightgbm.hpo import gen_lightgbm
 
 # run the default config + 5 random configurations of lightgbm and the default catboost config
 experiments_lightgbm = gen_lightgbm.generate_all_bag_experiments(num_random_configs=5)

--- a/packages/bencheval/src/bencheval/elo_utils.py
+++ b/packages/bencheval/src/bencheval/elo_utils.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from collections import defaultdict
-from typing import List
 import logging
 import math
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
@@ -35,14 +34,13 @@ class EloHelper:
         SCALE: int | float = 400,
         BASE: int = 10,
         INIT_RATING: int | float = 1000,
-        calibration_framework: str = None,
-        calibration_elo: float = None,
+        calibration_framework: str | None = None,
+        calibration_elo: float | None = None,
         use_pair_aggregation: bool = True,
         force_iterative_elo: bool = False,
         max_iter: int = 1000,
     ) -> pd.Series:
-        """
-        MLE ELO with per-task equal weighting via sample_weight.
+        """MLE ELO with per-task equal weighting via sample_weight.
 
         Adapted from ChatBot Arena: https://colab.research.google.com/drive/1KdwokPjirkTmpO_P1WByFNFiqxWQquwH#scrollTo=4_x-vXL4yxvC
         """
@@ -55,9 +53,13 @@ class EloHelper:
             if len(Y) == 0 or (np.unique(Y).size < 2):
                 # Degenerate draw (e.g., total dominance in a bootstrap): fall back.
                 logger.warning(
-                    "compute_mle_elo: only one class present after aggregation; falling back to iterative ELO.")
+                    "compute_mle_elo: only one class present after aggregation; falling back to iterative ELO."
+                )
                 elo_scores = self.compute_iterative_elo_scores(
-                    df_original, INIT_RATING=INIT_RATING, SCALE=SCALE, models=models
+                    df_original,
+                    INIT_RATING=INIT_RATING,
+                    SCALE=SCALE,
+                    models=models,
                 )
                 SeriesOut = pd.Series(elo_scores, index=models.index)
             else:
@@ -85,7 +87,7 @@ class EloHelper:
 
             # tie handling: make half wins for each side
             tie_idx = battles["winner"] == "tie"
-            tie_idx[len(tie_idx) // 2:] = False
+            tie_idx[len(tie_idx) // 2 :] = False
             Y[tie_idx] = 1.0
 
             # Build sample weights so each task contributes total weight 1 across its splits
@@ -96,7 +98,7 @@ class EloHelper:
 
             if len(np.unique(Y)) == 1 or force_iterative_elo:
                 logger.warning(
-                    "compute_mle_elo fell back to iterative ELO (dominance in labels or forced)."
+                    "compute_mle_elo fell back to iterative ELO (dominance in labels or forced).",
                 )
                 elo_scores = self.compute_iterative_elo_scores(
                     df_original,
@@ -114,7 +116,7 @@ class EloHelper:
         if calibration_framework is not None:
             if calibration_elo is None:
                 calibration_elo = INIT_RATING
-            SeriesOut += (calibration_elo - SeriesOut[calibration_framework])
+            SeriesOut += calibration_elo - SeriesOut[calibration_framework]
 
         return SeriesOut.sort_values(ascending=False)
 
@@ -130,8 +132,7 @@ class EloHelper:
         shuffle: bool = True,
         seed: int | np.random.Generator | None = 0,
     ):
-        """
-        Iterative ELO with optional deterministic shuffling and multi-epoch passes.
+        """Iterative ELO with optional deterministic shuffling and multi-epoch passes.
 
         Parameters
         ----------
@@ -154,7 +155,7 @@ class EloHelper:
             Controls the shuffle order. If an int or Generator is provided and
             shuffle=True, the traversal order is deterministic across runs.
 
-        Returns
+        Returns:
         -------
         np.ndarray
             ELO scores aligned to `models.index` order.
@@ -195,10 +196,7 @@ class EloHelper:
         base_order = np.arange(n)
 
         for _ in range(max(1, int(epochs))):
-            if shuffle:
-                order = rng.permutation(n)
-            else:
-                order = base_order
+            order = rng.permutation(n) if shuffle else base_order
 
             for i in order:
                 a = m1_idx[i]
@@ -236,9 +234,7 @@ class EloHelper:
         max_iter: int = 1000,
         show_process: bool = True,
     ):
-        """
-        Task-level bootstrap with pair-compressed MLE.
-        """
+        """Task-level bootstrap with pair-compressed MLE."""
         if func_kwargs is None:
             func_kwargs = {}
 
@@ -257,8 +253,9 @@ class EloHelper:
             return df[df.median().sort_values(ascending=False).index]
 
         # One-time precompute
-        model_to_idx, pairs, X2, Y2, SU, SV, task_ids = self._precompute_pair_agg_for_bootstrap(
-            battles=battles, BASE=BASE
+        model_to_idx, _pairs, X2, Y2, SU, SV, task_ids = self._precompute_pair_agg_for_bootstrap(
+            battles=battles,
+            BASE=BASE,
         )
         n_tasks = SU.shape[0]
         if SU.shape[1] == 0:
@@ -301,8 +298,8 @@ class EloHelper:
     def convert_results_to_battles(
         self,
         results_df: pd.DataFrame,
-        frameworks: List[str] = None,
-        datasets: List[str] = None,
+        frameworks: list[str] | None = None,
+        datasets: list[str] | None = None,
     ) -> pd.DataFrame:
         # Keep only needed columns (+ split if available)
         cols = [self.method_col, self.task_col, self.error_col]
@@ -316,10 +313,7 @@ class EloHelper:
             results_df = results_df[results_df[self.method_col].isin(frameworks)]
 
         # Determine how to pair: by (task, split) if split_col is given; else by task only
-        if self.split_col is not None:
-            on_cols = [self.task_col, self.split_col]
-        else:
-            on_cols = [self.task_col]
+        on_cols = [self.task_col, self.split_col] if self.split_col is not None else [self.task_col]
 
         results_df_after_dedupe = results_df.drop_duplicates(subset=[self.method_col, *on_cols])
         if len(results_df_after_dedupe) != len(results_df):
@@ -330,8 +324,8 @@ class EloHelper:
             results_df,
             results_df,
             on=on_cols,
-            suffixes=('_1', '_2'),
-            how='inner',
+            suffixes=("_1", "_2"),
+            how="inner",
         )
 
         # Keep only pairs with different methods
@@ -341,22 +335,31 @@ class EloHelper:
         # Winner of the pair
         results_pairs_df["winner"] = [
             self.calc_battle_outcome(e1, e2)
-            for e1, e2 in zip(results_pairs_df[f"{self.error_col}_1"], results_pairs_df[f"{self.error_col}_2"])
+            for e1, e2 in zip(
+                results_pairs_df[f"{self.error_col}_1"], results_pairs_df[f"{self.error_col}_2"], strict=False
+            )
         ]
 
         # Avoid counting each battle twice (dedupe A vs B with B vs A) by method pair (orderless) within the same on_cols
         # Build a canonical key for the unordered pair
-        pair_key = list(zip(
-            np.minimum(results_pairs_df[self.method_1], results_pairs_df[self.method_2]),
-            np.maximum(results_pairs_df[self.method_1], results_pairs_df[self.method_2]),
-        ))
+        pair_key = list(
+            zip(
+                np.minimum(results_pairs_df[self.method_1], results_pairs_df[self.method_2]),
+                np.maximum(results_pairs_df[self.method_1], results_pairs_df[self.method_2]),
+                strict=False,
+            )
+        )
 
         # Create a boolean mask that keeps the first occurrence of each (task[, split], unordered pair)
         # Easiest way: use a DataFrame of keys and drop_duplicates, then reindex
-        key_df = pd.DataFrame({**{c: results_pairs_df[c].values for c in on_cols},
-                               "__a": [k[0] for k in pair_key],
-                               "__b": [k[1] for k in pair_key]})
-        keep_idx = key_df.drop_duplicates(subset=on_cols + ["__a", "__b"]).index
+        key_df = pd.DataFrame(
+            {
+                **{c: results_pairs_df[c].values for c in on_cols},
+                "__a": [k[0] for k in pair_key],
+                "__b": [k[1] for k in pair_key],
+            }
+        )
+        keep_idx = key_df.drop_duplicates(subset=[*on_cols, "__a", "__b"]).index
         results_pairs_df = results_pairs_df.iloc[keep_idx].copy()
 
         # Compute per-task weights so each task contributes total weight 1.
@@ -388,7 +391,7 @@ class EloHelper:
         show_process: bool = True,
     ) -> pd.DataFrame:
         rng = np.random.default_rng(seed=seed)
-        bootstrap_elo_lu = self.get_bootstrap_result(
+        return self.get_bootstrap_result(
             battles=battles,
             func_compute_elo=self.compute_mle_elo,
             num_round=BOOTSTRAP_ROUNDS,
@@ -401,7 +404,6 @@ class EloHelper:
             },
             show_process=show_process,
         )
-        return bootstrap_elo_lu
 
     def compute_elo_rating_dataset_contributon(
         self,
@@ -426,12 +428,14 @@ class EloHelper:
                 "SCALE": SCALE,
                 "calibration_framework": calibration_framework,
                 "calibration_elo": calibration_elo,
-            }
+            },
         )
 
-        bars = pd.DataFrame(dict(
-            rating=bootstrap_elo_lu.quantile(.5),
-        )).sort_values("rating", ascending=False)
+        bars = pd.DataFrame(
+            dict(
+                rating=bootstrap_elo_lu.quantile(0.5),
+            )
+        ).sort_values("rating", ascending=False)
 
         elo_impact_by_dataset_list = []
         for dataset_to_skip in datasets:
@@ -446,17 +450,18 @@ class EloHelper:
                     "SCALE": SCALE,
                     "calibration_framework": calibration_framework,
                     "calibration_elo": calibration_elo,
-                }
+                },
             )
-            bars_by_dataset = pd.DataFrame(dict(
-                rating=bootstrap_elo_lu_w_dataset_removed.quantile(.5),
-            ))
+            bars_by_dataset = pd.DataFrame(
+                dict(
+                    rating=bootstrap_elo_lu_w_dataset_removed.quantile(0.5),
+                )
+            )
 
             delta = bars["rating"] - bars_by_dataset["rating"]
             delta.name = dataset_to_skip
             elo_impact_by_dataset_list.append(delta)
-        elo_impact_by_dataset = pd.concat(elo_impact_by_dataset_list, axis=1)
-        return elo_impact_by_dataset
+        return pd.concat(elo_impact_by_dataset_list, axis=1)
 
     def get_rank_confidence(self, df: pd.DataFrame):
         df = df.copy()
@@ -472,7 +477,7 @@ class EloHelper:
         prev_lower = None
         num_models = len(elo_ratings)
         for i in range(num_models):
-            cur_elo = elo_ratings[i]
+            elo_ratings[i]
             cur_upper = uppers[i]
             cur_lower = lowers[i]
             if prev_lower is None or cur_upper < prev_lower:
@@ -485,7 +490,7 @@ class EloHelper:
         return df
 
     def predict_win_rate(self, elo_ratings: dict, SCALE=400, BASE=10):
-        names = sorted(list(elo_ratings.keys()))
+        names = sorted(elo_ratings.keys())
         wins = defaultdict(lambda: defaultdict(lambda: 0))
         for a in names:
             for b in names:
@@ -493,10 +498,7 @@ class EloHelper:
                 wins[a][b] = ea
                 wins[b][a] = 1 - ea
 
-        data = {
-            a: [wins[a][b] if a != b else np.NAN for b in names]
-            for a in names
-        }
+        data = {a: [wins[a][b] if a != b else np.nan for b in names] for a in names}
 
         df = pd.DataFrame(data, index=names)
         df.index.name = "model_a"
@@ -535,8 +537,7 @@ class EloHelper:
         for a in missing_A:
             if a not in df:
                 df[a] = 0
-        df = df.T
-        return df
+        return df.T
 
     def compute_pairwise_win_fraction(self, battles, max_num_models=30) -> pd.DataFrame:
         unique_A = list(battles[self.method_1].unique())
@@ -546,23 +547,28 @@ class EloHelper:
         unique_all = unique_A + missing_A
         # Times each model wins as Model A
         a_win_ptbl = pd.pivot_table(
-            battles[battles['winner'] == "1"],
-            index=self.method_1, columns=self.method_2, aggfunc="size", fill_value=0)
+            battles[battles["winner"] == "1"], index=self.method_1, columns=self.method_2, aggfunc="size", fill_value=0
+        )
 
         # Table counting times each model wins as Model B
         b_win_ptbl = pd.pivot_table(
-            battles[battles['winner'] == "2"],
-            index=self.method_1, columns=self.method_2, aggfunc="size", fill_value=0)
+            battles[battles["winner"] == "2"], index=self.method_1, columns=self.method_2, aggfunc="size", fill_value=0
+        )
 
         # Table counting times each model wins as Model B
         tie_ptbl = pd.pivot_table(
-            battles[battles['winner'] == "tie"],
-            index=self.method_1, columns=self.method_2, aggfunc="size", fill_value=0)
+            battles[battles["winner"] == "tie"],
+            index=self.method_1,
+            columns=self.method_2,
+            aggfunc="size",
+            fill_value=0,
+        )
         tie_ptbl *= 0.5
 
         # Table counting number of A-B pairs
-        num_battles_ptbl = pd.pivot_table(battles,
-            index=self.method_1, columns=self.method_2, aggfunc="size", fill_value=0)
+        num_battles_ptbl = pd.pivot_table(
+            battles, index=self.method_1, columns=self.method_2, aggfunc="size", fill_value=0
+        )
 
         missing_A = unique_all
         missing_B = unique_all
@@ -575,21 +581,18 @@ class EloHelper:
 
         # Computing the proportion of wins for each model as A and as B
         # against all other models
-        row_beats_col_freq = (
-            (a_win_ptbl + b_win_ptbl.T + tie_ptbl + tie_ptbl.T) /
-            (num_battles_ptbl + num_battles_ptbl.T)
+        row_beats_col_freq = (a_win_ptbl + b_win_ptbl.T + tie_ptbl + tie_ptbl.T) / (
+            num_battles_ptbl + num_battles_ptbl.T
         )
 
         # Arrange ordering according to proprition of wins
         prop_wins = row_beats_col_freq.mean(axis=1).sort_values(ascending=False)
         prop_wins = prop_wins[:max_num_models]
         model_names = list(prop_wins.keys())
-        row_beats_col = row_beats_col_freq.loc[model_names, model_names]
-        return row_beats_col
+        return row_beats_col_freq.loc[model_names, model_names]
 
     def _aggregate_battles_for_mle(self, battles: pd.DataFrame, BASE: int = 10):
-        """
-        Compress battles to two rows per unordered (A,B) pair for exact MLE equivalence.
+        """Compress battles to two rows per unordered (A,B) pair for exact MLE equivalence.
 
         For each unordered pair (A,B):
           - Build features X for "A vs B" once: +log(BASE) at A, -log(BASE) at B.
@@ -613,16 +616,16 @@ class EloHelper:
         # accumulate weighted wins/ties in canonical coordinates
         wins_u = {}  # A-side under (u,v)
         wins_v = {}
-        for ui, vi, ai, bi, wi, yi in zip(u, v, a, b, w, win):
+        for ui, vi, ai, bi, wi, yi in zip(u, v, a, b, w, win, strict=False):
             key = (ui, vi)
             su = wins_u.get(key, 0.0)
             sv = wins_v.get(key, 0.0)
-            if yi == '1':  # method_1 (ai) beat method_2 (bi)
+            if yi == "1":  # method_1 (ai) beat method_2 (bi)
                 if ui == ai:
                     su += wi
                 else:
                     sv += wi
-            elif yi == '2':  # method_2 (bi) beat method_1 (ai)
+            elif yi == "2":  # method_2 (bi) beat method_1 (ai)
                 if ui == bi:
                     su += wi
                 else:
@@ -639,7 +642,7 @@ class EloHelper:
         X_rows, y_rows, sw_rows = [], [], []
         logB = math.log(BASE)
 
-        for (ui, vi) in pairs:
+        for ui, vi in pairs:
             su = wins_u[(ui, vi)]
             sv = wins_v[(ui, vi)]
             if su == 0.0 and sv == 0.0:
@@ -666,15 +669,23 @@ class EloHelper:
         return X, y, sample_weight, model_to_idx
 
     def get_arena_leaderboard(self, bootstrap_elo_lu: pd.DataFrame, results_df: pd.DataFrame):
-        bars = pd.DataFrame(dict(
-            lower=bootstrap_elo_lu.quantile(.025),
-            rating=bootstrap_elo_lu.quantile(.5),
-            upper=bootstrap_elo_lu.quantile(.975))).reset_index(names="model").sort_values("rating", ascending=False)
-        bars['error_y'] = bars['upper'] - bars["rating"]
-        bars['error_y_minus'] = bars['rating'] - bars["lower"]
-        bars['rating_rounded'] = np.round(bars['rating'], 2)
+        bars = (
+            pd.DataFrame(
+                dict(
+                    lower=bootstrap_elo_lu.quantile(0.025),
+                    rating=bootstrap_elo_lu.quantile(0.5),
+                    upper=bootstrap_elo_lu.quantile(0.975),
+                )
+            )
+            .reset_index(names="model")
+            .sort_values("rating", ascending=False)
+        )
+        bars["error_y"] = bars["upper"] - bars["rating"]
+        bars["error_y_minus"] = bars["rating"] - bars["lower"]
+        bars["rating_rounded"] = np.round(bars["rating"], 2)
         battles = self.convert_results_to_battles(results_df=results_df)
         from collections import defaultdict
+
         framework_battle_counts = defaultdict(int)
         framework_win_counts = defaultdict(float)
         for f, win_val in [(self.method_1, "1"), (self.method_2, "2")]:
@@ -694,8 +705,11 @@ class EloHelper:
             return f"+{upper:.0f}/-{lower:.0f}"
 
         leaderboard = bars.copy()
-        leaderboard["95% CI"] = [_get_95_ci(upper, lower) for upper, lower in zip(leaderboard["error_y"], leaderboard["error_y_minus"])]
-        leaderboard["Arena Elo"] = np.round(leaderboard['rating'], 0).astype(int)
+        leaderboard["95% CI"] = [
+            _get_95_ci(upper, lower)
+            for upper, lower in zip(leaderboard["error_y"], leaderboard["error_y_minus"], strict=False)
+        ]
+        leaderboard["Arena Elo"] = np.round(leaderboard["rating"], 0).astype(int)
         leaderboard["Battles"] = leaderboard["model"].map(framework_battle_counts)
         leaderboard["Wins"] = np.round(leaderboard["model"].map(framework_win_counts), decimals=0).astype(int)
         leaderboard["Winrate"] = np.round(leaderboard["Wins"] / leaderboard["Battles"], decimals=2)
@@ -703,7 +717,9 @@ class EloHelper:
         leaderboard["Model"] = leaderboard["model"]
         leaderboard = self.get_rank_confidence(df=leaderboard)
 
-        results_mean_agg = results_df[[self.method_col, "rank", "bestdiff", "loss_rescaled"]].groupby("framework").mean()
+        results_mean_agg = (
+            results_df[[self.method_col, "rank", "bestdiff", "loss_rescaled"]].groupby("framework").mean()
+        )
         leaderboard["mean_rank"] = leaderboard["model"].map(results_mean_agg["rank"])
         leaderboard["mean_bestdiff"] = leaderboard["model"].map(results_mean_agg["bestdiff"])
         leaderboard["mean_loss_rescaled"] = leaderboard["model"].map(results_mean_agg["loss_rescaled"])
@@ -714,19 +730,21 @@ class EloHelper:
         leaderboard["Rescaled Acc"] = np.round(1 - leaderboard["mean_loss_rescaled"], decimals=2)
         leaderboard["Elo"] = leaderboard["Arena Elo"]
 
-        leaderboard_print = leaderboard[[
-            "Rank",
-            "Model",
-            "Elo",
-            "95% CI",
-            # "Battles",
-            # "Wins",
-            "Winrate",
-            "Rescaled Acc",
-            # "Rank Avg",
-            "Champ Delta %",
-            # "Champ Delta % 2",
-        ]]
+        leaderboard_print = leaderboard[
+            [
+                "Rank",
+                "Model",
+                "Elo",
+                "95% CI",
+                # "Battles",
+                # "Wins",
+                "Winrate",
+                "Rescaled Acc",
+                # "Rank Avg",
+                "Champ Delta %",
+                # "Champ Delta % 2",
+            ]
+        ]
 
         return leaderboard, leaderboard_print
 
@@ -735,10 +753,9 @@ class EloHelper:
         battles: pd.DataFrame,
         BASE: int = 10,
     ):
-        """
-        Precompute sufficient statistics for MLE ELO under task-cluster bootstrap.
+        """Precompute sufficient statistics for MLE ELO under task-cluster bootstrap.
 
-        Returns
+        Returns:
         -------
         model_to_idx : pd.Series
             Index mapping for models -> column index in design matrix.
@@ -789,20 +806,20 @@ class EloHelper:
                 seen[k] = i
         for j, k in enumerate(uniq_pairs):
             first_idx[j] = seen[k]
-        pairs = list(zip(u[first_idx], v[first_idx]))
+        pairs = list(zip(u[first_idx], v[first_idx], strict=False))
         n_pairs = len(pairs)
 
         # accumulate per-task, per-pair effective wins for u and v sides
         SU = np.zeros((n_tasks, n_pairs), dtype=float)
         SV = np.zeros((n_tasks, n_pairs), dtype=float)
 
-        for ti, pi, ai, bi, ui, vi, yi, wi in zip(task_inverse, pair_inverse, a, b, u, v, win, w):
-            if yi == '1':  # method_1 (a) beat method_2 (b)
+        for ti, pi, ai, bi, ui, vi, yi, wi in zip(task_inverse, pair_inverse, a, b, u, v, win, w, strict=False):
+            if yi == "1":  # method_1 (a) beat method_2 (b)
                 if ui == ai:
                     SU[ti, pi] += wi
                 else:
                     SV[ti, pi] += wi
-            elif yi == '2':
+            elif yi == "2":
                 if ui == bi:
                     SU[ti, pi] += wi
                 else:
@@ -833,14 +850,14 @@ class EloHelper:
     def _bootstrap_draw_compressed(
         self,
         *,
-        counts: np.ndarray,             # shape (n_tasks,)
-        task_ids: np.ndarray,           # shape (n_tasks,), aligns with counts
-        SU: np.ndarray,                 # shape (n_tasks, n_pairs)
-        SV: np.ndarray,                 # shape (n_tasks, n_pairs)
-        X2: np.ndarray,                 # shape (2*n_pairs, n_models)
-        Y2: np.ndarray,                 # shape (2*n_pairs,)
-        model_to_idx: pd.Series,        # index = model names, values = col indices
-        battles: pd.DataFrame,          # original battles (used only for fallback)
+        counts: np.ndarray,  # shape (n_tasks,)
+        task_ids: np.ndarray,  # shape (n_tasks,), aligns with counts
+        SU: np.ndarray,  # shape (n_tasks, n_pairs)
+        SV: np.ndarray,  # shape (n_tasks, n_pairs)
+        X2: np.ndarray,  # shape (2*n_pairs, n_models)
+        Y2: np.ndarray,  # shape (2*n_pairs,)
+        model_to_idx: pd.Series,  # index = model names, values = col indices
+        battles: pd.DataFrame,  # original battles (used only for fallback)
         SCALE: int,
         INIT_RATING: float,
         solver: str,
@@ -848,27 +865,25 @@ class EloHelper:
         calibration_framework: str | None = None,
         calibration_elo: float | None = None,
     ) -> pd.Series:
-        """
-        One bootstrap draw using the pair-compressed MLE path.
+        """One bootstrap draw using the pair-compressed MLE path.
         Returns a pd.Series of ELO scores indexed by model names.
         """
         # Totals per unordered pair from task multiplicities
-        SU_tot = counts @ SU    # (n_pairs,)
-        SV_tot = counts @ SV    # (n_pairs,)
+        SU_tot = counts @ SU  # (n_pairs,)
+        SV_tot = counts @ SV  # (n_pairs,)
 
         # If one class is missing, fall back to iterative path for this draw
         has_pos = np.any(SU_tot > 0.0)
         has_neg = np.any(SV_tot > 0.0)
         if not (has_pos and has_neg):
             # Build multiplicity map for tasks in this draw
-            mult_map = dict(zip(task_ids, counts))
+            mult_map = dict(zip(task_ids, counts, strict=False))
             battles_boot = battles.copy()
             if "weight" not in battles_boot.columns:
                 battles_boot["weight"] = 1.0
-            battles_boot["weight"] = (
-                battles_boot["weight"].to_numpy(dtype=float)
-                * battles_boot[self.task_col].map(mult_map).fillna(0.0).to_numpy(dtype=float)
-            )
+            battles_boot["weight"] = battles_boot["weight"].to_numpy(dtype=float) * battles_boot[self.task_col].map(
+                mult_map
+            ).fillna(0.0).to_numpy(dtype=float)
             elo_scores = self.compute_iterative_elo_scores(
                 battles_boot,
                 INIT_RATING=INIT_RATING,
@@ -899,7 +914,7 @@ class EloHelper:
             lr.fit(X_fit, Y_fit, sample_weight=sw_fit)
 
             # Map coefficients -> ELO
-            coef = lr.coef_[0]                  # aligned with model_to_idx order
+            coef = lr.coef_[0]  # aligned with model_to_idx order
             elo_vec = SCALE * coef + INIT_RATING
             out = np.ones(len(model_to_idx), dtype=float) * INIT_RATING
             out[:] = elo_vec

--- a/packages/bencheval/src/bencheval/mean_utils.py
+++ b/packages/bencheval/src/bencheval/mean_utils.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
-import pandas as pd
+
+from typing import TYPE_CHECKING
+
 import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def compute_weighted_mean_by_task(
@@ -12,8 +17,7 @@ def compute_weighted_mean_by_task(
     weight_col: str | None = None,
     sort_asc: bool = True,
 ) -> pd.Series:
-    """
-    Compute the equal-task-weighted mean of a column for each method.
+    """Compute the equal-task-weighted mean of a column for each method.
 
     - If seed_col is provided:
         * Aggregate values per (task, seed, method) first.
@@ -38,7 +42,7 @@ def compute_weighted_mean_by_task(
     sort_asc : bool, default=True
         Whether to sort output in ascending order (True) or descending order (False)
 
-    Returns
+    Returns:
     -------
     pd.Series
         Index = methods, Values = equal-task-weighted mean of `value_col`.
@@ -49,10 +53,7 @@ def compute_weighted_mean_by_task(
         task_col = [task_col]
 
     group_task = [*task_col, method_col]
-    if seed_col is not None:
-        group_task_seed = group_task + [seed_col]
-    else:
-        group_task_seed = group_task
+    group_task_seed = [*group_task, seed_col] if seed_col is not None else group_task
 
     # Step 1: Aggregate to per-(task, seed, method)
     if weight_col is not None:
@@ -62,16 +63,10 @@ def compute_weighted_mean_by_task(
             .reset_index(name=value_col)
         )
     else:
-        agg_df = (
-            df.groupby(group_task_seed, sort=False)[value_col]
-            .mean()
-            .reset_index()
-        )
+        agg_df = df.groupby(group_task_seed, sort=False)[value_col].mean().reset_index()
 
     # Step 2: Average over seeds within each (task, method)
     task_avg = agg_df.groupby(group_task, sort=False)[value_col].mean().reset_index()
 
     # Step 3: Average across tasks equally per method
-    mean_per_method = task_avg.groupby(method_col, sort=False)[value_col].mean().sort_values(ascending=sort_asc)
-
-    return mean_per_method
+    return task_avg.groupby(method_col, sort=False)[value_col].mean().sort_values(ascending=sort_asc)

--- a/packages/bencheval/src/bencheval/tabarena.py
+++ b/packages/bencheval/src/bencheval/tabarena.py
@@ -3,19 +3,20 @@ from __future__ import annotations
 import copy
 import os
 from dataclasses import dataclass
-from typing import Callable, Literal
-from collections.abc import Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
-
 from pandas.api.types import is_numeric_dtype
 from scipy.stats import gmean
 
 from .elo_utils import EloHelper
 from .mean_utils import compute_weighted_mean_by_task
 from .winrate_utils import compute_winrate, compute_winrate_matrix
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 RANK = "rank"
 IMPROVABILITY = "improvability"
@@ -28,8 +29,7 @@ InvalidSubsetPolicy = Literal["raise", "nan", "skip"]
 
 @dataclass(frozen=True, slots=True)
 class MetricSpec:
-    """
-    Defines how to (re)compute a metric from a subset of results_per_task and how to
+    """Defines how to (re)compute a metric from a subset of results_per_task and how to
     reduce it to a single scalar score for a given method.
 
     - compute(): returns either
@@ -37,11 +37,12 @@ class MetricSpec:
         * method-aligned Series (index == method names)         [alignment="method"]
     - score(): returns a float score for method_1 given the computed metric result
     """
+
     name: str
     direction: MetricDirection
     alignment: MetricAlignment
-    compute: Callable[["TabArena", pd.DataFrame], pd.Series]
-    score: Callable[["TabArena", pd.DataFrame, pd.Series, str], float]
+    compute: Callable[[TabArena, pd.DataFrame], pd.Series]
+    score: Callable[[TabArena, pd.DataFrame, pd.Series, str], float]
     # Methods that must be present in any subset (e.g., Elo calibration framework)
     required_methods: frozenset[str] = frozenset()
     # What to do if required methods are missing from a subset
@@ -68,11 +69,11 @@ class TabArena:
         elif columns_to_agg_extra == "auto":
             columns_to_agg_extra = ["time_train_s", "time_infer_s"]
         self.columns_to_agg_extra = columns_to_agg_extra
-        self.columns_to_agg = [self.error_col] + self.columns_to_agg_extra
+        self.columns_to_agg = [self.error_col, *self.columns_to_agg_extra]
         if groupby_columns is None:
             groupby_columns = []
-        self.groupby_columns = [self.method_col, self.task_col] + groupby_columns
-        self.task_groupby_columns = [self.task_col] + groupby_columns
+        self.groupby_columns = [self.method_col, self.task_col, *groupby_columns]
+        self.task_groupby_columns = [self.task_col, *groupby_columns]
         self.seed_column = seed_column
         self.negative_error_threshold = negative_error_threshold
 
@@ -95,13 +96,13 @@ class TabArena:
     def _get_task_groupby_cols(self, results: pd.DataFrame) -> list[str]:
         task_groupby_cols = self.task_groupby_columns
         if self.seed_column is not None and self.seed_column in results.columns:
-            task_groupby_cols = task_groupby_cols + [self.seed_column]
+            task_groupby_cols = [*task_groupby_cols, self.seed_column]
         return task_groupby_cols
 
     def _get_groupby_cols(self, results: pd.DataFrame) -> list[str]:
         groupby_cols = self.groupby_columns
         if self.seed_column is not None and self.seed_column in results.columns:
-            groupby_cols = groupby_cols + [self.seed_column]
+            groupby_cols = [*groupby_cols, self.seed_column]
         return groupby_cols
 
     def leaderboard(
@@ -128,7 +129,7 @@ class TabArena:
         if relative_error_kwargs is None:
             relative_error_kwargs = {}
         if baseline_method is None:
-            baseline_method = elo_kwargs.get("calibration_framework", None)
+            baseline_method = elo_kwargs.get("calibration_framework")
 
         self.verify_data(data=data)
 
@@ -160,17 +161,21 @@ class TabArena:
             )
             improvability = results_agg[IMPROVABILITY]
             results_agg = results_agg.drop(columns=[IMPROVABILITY])
-            improvability_quantiles = pd.DataFrame({
-                f"{IMPROVABILITY}+": improvability_bootstrap.quantile(.975) - improvability,
-                f"{IMPROVABILITY}-": improvability - improvability_bootstrap.quantile(.025),
-            })
+            improvability_quantiles = pd.DataFrame(
+                {
+                    f"{IMPROVABILITY}+": improvability_bootstrap.quantile(0.975) - improvability,
+                    f"{IMPROVABILITY}-": improvability - improvability_bootstrap.quantile(0.025),
+                }
+            )
 
             results_lst += [improvability, improvability_quantiles]
         if include_baseline_advantage and baseline_method is not None:
-            results_lst.append(self.compute_baseline_advantage(
-                results_per_task,
-                baseline_method=baseline_method,
-            ))
+            results_lst.append(
+                self.compute_baseline_advantage(
+                    results_per_task,
+                    baseline_method=baseline_method,
+                )
+            )
         if include_mrr:
             results_lst.append(self.compute_mrr(results_per_task=results_per_task).to_frame())
         if baseline_method is not None:
@@ -179,12 +184,12 @@ class TabArena:
                     self.compute_relative_error(
                         results_per_task=results_per_task,
                         baseline_method=baseline_method,
-                        **relative_error_kwargs
-                    ).to_frame()
+                        **relative_error_kwargs,
+                    ).to_frame(),
                 )
             if include_skill_score:
                 results_lst.append(
-                    self.compute_skill_score(results_per_task=results_per_task, baseline_method=baseline_method)
+                    self.compute_skill_score(results_per_task=results_per_task, baseline_method=baseline_method),
                 )
 
         if include_rank_counts:
@@ -255,7 +260,7 @@ class TabArena:
                 f"\n\tMissing columns ({len(missing_columns)}): {missing_columns}"
                 f"\n\tExisting columns ({len(present_columns)}): {present_columns}"
                 f"\n\tUnused columns ({len(unused_columns)}): {unused_columns}"
-                f"\n\tIndex names ({len(index_names)}): {index_names}"
+                f"\n\tIndex names ({len(index_names)}): {index_names}",
             )
         if unused_columns:
             print(f"Unused columns: {unused_columns}")
@@ -263,7 +268,7 @@ class TabArena:
         for c in self.groupby_columns:
             assert data[c].isnull().sum() == 0, f"groupby column {c!r} contains NaN!"
         for c in self.columns_to_agg:
-            assert is_numeric_dtype(data[c]), f"aggregation columns must be numeric!"
+            assert is_numeric_dtype(data[c]), "aggregation columns must be numeric!"
         for c in self.columns_to_agg:
             if data[c].isnull().sum() != 0:
                 invalid_samples = data[data[c].isnull()]
@@ -271,7 +276,7 @@ class TabArena:
                 raise AssertionError(
                     f"Column {c} should not contain null values. "
                     f"Found {data[c].isnull().sum()}/{len(data)} null values! "
-                    f"Invalid samples:\n{invalid_samples.head(100).to_markdown()}"
+                    f"Invalid samples:\n{invalid_samples.head(100).to_markdown()}",
                 )
 
         # TODO: Check no duplicates
@@ -302,11 +307,9 @@ class TabArena:
         valid_methods_per_task = data[task_cols].value_counts()
         invalid_tasks_per_method = (-valid_tasks_per_method + num_tasks).sort_values(ascending=False)
         invalid_methods_per_dataset = (
-                -valid_methods_per_dataset + valid_methods_per_dataset.index.map(unique_seeds_per_dataset) * num_methods
+            -valid_methods_per_dataset + valid_methods_per_dataset.index.map(unique_seeds_per_dataset) * num_methods
         ).sort_values(ascending=False)
-        invalid_methods_per_task = (
-                -valid_methods_per_task + num_methods
-        ).sort_values(ascending=False)
+        invalid_methods_per_task = (-valid_methods_per_task + num_methods).sort_values(ascending=False)
 
         if (invalid_tasks_per_method != 0).any():
             invalid_tasks_per_method_filtered = invalid_tasks_per_method[invalid_tasks_per_method != 0]
@@ -319,9 +322,15 @@ class TabArena:
                 pd.Series(data=methods, name=self.method_col),
                 how="cross",
             )
-            experiment_cols = task_cols + [self.method_col]
-            overlap = pd.merge(df_experiments_dense, data[experiment_cols], on=experiment_cols, how='left', indicator='exist')
-            df_missing_experiments = overlap[overlap["exist"] == "left_only"][experiment_cols].sort_values(by=experiment_cols).reset_index(drop=True)
+            experiment_cols = [*task_cols, self.method_col]
+            overlap = pd.merge(
+                df_experiments_dense, data[experiment_cols], on=experiment_cols, how="left", indicator="exist"
+            )
+            df_missing_experiments = (
+                overlap[overlap["exist"] == "left_only"][experiment_cols]
+                .sort_values(by=experiment_cols)
+                .reset_index(drop=True)
+            )
 
             with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
                 if len(df_missing_experiments) <= 500:
@@ -339,7 +348,7 @@ class TabArena:
                 f"{len(invalid_methods_per_dataset_filtered)}/{num_datasets} datasets with missing methods.\n"
                 f"{len(invalid_methods_per_task_filtered)}/{num_tasks} tasks with missing methods.\n"
                 f"Methods sorted by failure count:\n"
-                f"{invalid_tasks_per_method_filtered}"
+                f"{invalid_tasks_per_method_filtered}",
             )
 
     def verify_error(self, data: pd.DataFrame):
@@ -352,7 +361,7 @@ class TabArena:
                 f"Ensure your error is computed correctly."
                 f"\nMinimum value found: {min_error}"
                 f"\nSometimes floating point precision can result in a tiny negative value. "
-                f"You can fix this by doing: data['{self.error_col}'] = data['{self.error_col}'].clip(lower=0)"
+                f"You can fix this by doing: data['{self.error_col}'] = data['{self.error_col}'].clip(lower=0)",
             )
 
     # TODO: Consider moving this to a different class or finding a better separation.
@@ -377,8 +386,7 @@ class TabArena:
         df_fillna: pd.DataFrame | None = None,
         fillna_method: str = "worst",
     ) -> pd.DataFrame:
-        """
-        Fills missing (task, seed, method) rows in data with the (task, seed) row in df_fillna.
+        """Fills missing (task, seed, method) rows in data with the (task, seed) row in df_fillna.
 
         Parameters
         ----------
@@ -392,22 +400,19 @@ class TabArena:
             If "worst", will fill with the result of the method with the worst error on a given task.
             Ignored if `df_fillna` is specified.
 
-        Returns
+        Returns:
         -------
         pd.DataFrame
             The filled data.
 
         """
-        if self.seed_column:
-            task_columns = [self.task_col, self.seed_column]
-        else:
-            task_columns = [self.task_col]
+        task_columns = [self.task_col, self.seed_column] if self.seed_column else [self.task_col]
 
         unique_methods = list(data[self.method_col].unique())
 
         if df_fillna is None:
             if fillna_method == "worst":
-                assert df_fillna is None, f"df_fillna must be None if fillna_method='worst'"
+                assert df_fillna is None, "df_fillna must be None if fillna_method='worst'"
                 idx_worst = data.groupby(task_columns)[self.error_col].idxmax()
                 df_fillna = data.loc[idx_worst]
             elif isinstance(fillna_method, str) and fillna_method in data[self.method_col].unique():
@@ -415,7 +420,7 @@ class TabArena:
             else:
                 raise AssertionError(
                     f"df_fillna is None and fillna_method {fillna_method!r} is not present in data."
-                    f"\n\tValid methods: {list(data[self.method_col].unique())}"
+                    f"\n\tValid methods: {list(data[self.method_col].unique())}",
                 )
         if self.method_col in df_fillna.columns:
             df_fillna = df_fillna.drop(columns=[self.method_col])
@@ -443,22 +448,20 @@ class TabArena:
         df_filled.loc[nan_vals] = a
         data = df_filled
 
-        data = data.reset_index(drop=False)
-
-        return data
+        return data.reset_index(drop=False)
 
     def get_task_groupby_cols(self, include_seed_col: bool = False):
         task_groupby_cols = self.task_groupby_columns
         if include_seed_col and self.seed_column is not None:
-            task_groupby_cols = task_groupby_cols + [self.seed_column]
+            task_groupby_cols = [*task_groupby_cols, self.seed_column]
         return task_groupby_cols
 
     def compute_results_per_task(self, data: pd.DataFrame, include_seed_col: bool = False) -> pd.DataFrame:
         groupby_cols = self.groupby_columns
         task_groupby_cols = self.task_groupby_columns
         if include_seed_col and self.seed_column is not None:
-            groupby_cols = groupby_cols + [self.seed_column]
-            task_groupby_cols = task_groupby_cols + [self.seed_column]
+            groupby_cols = [*groupby_cols, self.seed_column]
+            task_groupby_cols = [*task_groupby_cols, self.seed_column]
         columns_to_agg = self.columns_to_agg
         results_per_task = data[groupby_cols + columns_to_agg].groupby(groupby_cols).mean().reset_index()
 
@@ -468,11 +471,13 @@ class TabArena:
         results_per_task_metrics[IMPROVABILITY] = self.compute_improvability_per(results_per_task, task_groupby_cols)
         results_per_task_metrics[LOSS_RESCALED] = self.compute_loss_rescaled_per(results_per_task, task_groupby_cols)
 
-        results_per_task = pd.concat([
-            results_per_task_metrics,
-            results_per_task,
-        ], axis=1)
-        return results_per_task
+        return pd.concat(
+            [
+                results_per_task_metrics,
+                results_per_task,
+            ],
+            axis=1,
+        )
 
     def aggregate(self, results_by_dataset: pd.DataFrame) -> pd.DataFrame:
         if self.seed_column is not None and self.seed_column in results_by_dataset.columns:
@@ -483,11 +488,10 @@ class TabArena:
 
         # Compute median and prefix column names
         median_df = results_agg.groupby([self.method_col]).median(numeric_only=True)
-        median_df.columns = [f'median_{col}' for col in median_df.columns]
+        median_df.columns = [f"median_{col}" for col in median_df.columns]
 
         # Combine mean and median
-        results_agg = pd.concat([mean_df, median_df], axis=1)
-        return results_agg
+        return pd.concat([mean_df, median_df], axis=1)
 
     def compute_ranks(self, results_per_task: pd.DataFrame) -> pd.DataFrame:
         df = results_per_task.copy()
@@ -495,7 +499,7 @@ class TabArena:
         group_cols = self.groupby_columns  # e.g., ["task"] or ["task", "seed"]
         task_cols = self.task_groupby_columns
         if self.seed_column is not None and self.seed_column in results_per_task.columns:
-            task_seed_cols = task_cols + [self.seed_column]
+            task_seed_cols = [*task_cols, self.seed_column]
         else:
             task_seed_cols = task_cols
 
@@ -504,11 +508,7 @@ class TabArena:
         max_rank = df.groupby(task_seed_cols)[RANK].rank(method="max", ascending=True)
 
         # Size of the tie a row belongs to (within group and exact error value)
-        tie_size = (
-            df.groupby(task_seed_cols + [RANK])[RANK]
-            .transform("size")
-            .astype(float)
-        )
+        tie_size = df.groupby([*task_seed_cols, RANK])[RANK].transform("size").astype(float)
 
         # Each position k contributes 1 unit per group; split equally across ties covering k
         df["rank=1_count"] = ((min_rank <= 1) & (max_rank >= 1)).astype(float) / tie_size
@@ -519,17 +519,15 @@ class TabArena:
         df["rank>3_count"] = 1.0 - (df["rank=1_count"] + df["rank=2_count"] + df["rank=3_count"])
 
         # Equal-task weighting: average over group_cols (e.g., seeds) then sum per method across tasks
-        results_ranked = (
+        return (
             df.groupby(group_cols)[["rank=1_count", "rank=2_count", "rank=3_count", "rank>3_count"]]
             .mean()
             .groupby(self.method_col)
             .sum()
         )
 
-        return results_ranked
-
     def compute_mrr(self, results_per_task: pd.DataFrame) -> pd.Series:
-        """Compute mean reciprocal rank"""
+        """Compute mean reciprocal rank."""
         results_per_task = results_per_task.copy()
         results_per_task["mrr"] = 1 / results_per_task["rank"]
         results_mrr_per_task = results_per_task.groupby(self.groupby_columns)["mrr"].mean()
@@ -544,7 +542,9 @@ class TabArena:
         baseline_method: str,
     ) -> pd.Series:
         relative_error_gmean = self.compute_relative_error(
-            results_per_task=results_per_task, baseline_method=baseline_method, agg="gmean",
+            results_per_task=results_per_task,
+            baseline_method=baseline_method,
+            agg="gmean",
         )
         skill_score = 1 - relative_error_gmean
         skill_score.name = "skill_score"
@@ -565,8 +565,7 @@ class TabArena:
         clip_negative_ci: bool = True,
         post_calibrate: bool = True,
     ) -> pd.DataFrame:
-        """
-        Compute Elo ratings for methods evaluated across multiple tasks.
+        """Compute Elo ratings for methods evaluated across multiple tasks.
 
         This aggregates per-task results into head-to-head “battles” and estimates
         per-method Elo scores either by maximum likelihood (single fit) or by a
@@ -611,7 +610,7 @@ class TabArena:
             so that the `calibration_framework` has an elo of `calibration_elo`.
             This makes the 95% CI +/- independent of the calibration_framework.
 
-        Returns
+        Returns:
         -------
         pd.DataFrame
             DataFrame indexed by method (index name = ``self.method_col``) sorted
@@ -642,7 +641,9 @@ class TabArena:
         if calibration_elo is None:
             calibration_elo = INIT_RATING
 
-        elo_helper = EloHelper(method_col=self.method_col, task_col=self.task_col, error_col=self.error_col, split_col=split_col)
+        elo_helper = EloHelper(
+            method_col=self.method_col, task_col=self.task_col, error_col=self.error_col, split_col=split_col
+        )
         battles = elo_helper.convert_results_to_battles(results_df=results_per_task)
 
         can_compute_elo = len(battles) > 0
@@ -651,17 +652,12 @@ class TabArena:
             if split_col is not None:
                 task_groupby_cols.append(split_col)
 
-            methods_per_task = (
-                results_per_task
-                .groupby(task_groupby_cols)[self.method_col]
-                .nunique()
-                .sort_values()
-            )
+            methods_per_task = results_per_task.groupby(task_groupby_cols)[self.method_col].nunique().sort_values()
 
             task_method_pairs = (
-                results_per_task[task_groupby_cols + [self.method_col]]
+                results_per_task[[*task_groupby_cols, self.method_col]]
                 .drop_duplicates()
-                .sort_values(task_groupby_cols + [self.method_col])
+                .sort_values([*task_groupby_cols, self.method_col])
             )
 
             observed_methods = sorted(results_per_task[self.method_col].dropna().unique())
@@ -679,7 +675,7 @@ class TabArena:
                 f"\n\nObserved task/method pairs:\n"
                 f"{task_method_pairs.head(100).to_string(index=False)}"
                 f"\n\nShowing first {min(len(task_method_pairs), 100)} "
-                f"of {len(task_method_pairs)} observed task/method pairs."
+                f"of {len(task_method_pairs)} observed task/method pairs.",
             )
 
         bootstrap_median = None
@@ -695,7 +691,7 @@ class TabArena:
                 SCALE=SCALE,
                 show_process=False,
             )
-            bootstrap_median = bootstrap_elo_lu.quantile(.5)
+            bootstrap_median = bootstrap_elo_lu.quantile(0.5)
 
         if use_bootstrap_median:
             elo = bootstrap_median
@@ -711,36 +707,39 @@ class TabArena:
         if include_quantiles:
             if BOOTSTRAP_ROUNDS > 1:
                 assert bootstrap_elo_lu is not None
-                bars_quantiles = pd.DataFrame(dict(
-                    lower=bootstrap_elo_lu.quantile(.025),
-                    upper=bootstrap_elo_lu.quantile(.975),
-                ))
+                bars_quantiles = pd.DataFrame(
+                    dict(
+                        lower=bootstrap_elo_lu.quantile(0.025),
+                        upper=bootstrap_elo_lu.quantile(0.975),
+                    )
+                )
             else:
                 print(
-                    f"Warning: Returning 95% CI quantiles for elo when BOOTSTRAP_ROUNDS<=1. "
-                    f"The CI is invalid and widths will be set to 0."
+                    "Warning: Returning 95% CI quantiles for elo when BOOTSTRAP_ROUNDS<=1. "
+                    "The CI is invalid and widths will be set to 0.",
                 )
-                bars_quantiles = pd.DataFrame(dict(
-                    lower=elo,
-                    upper=elo,
-                ))
+                bars_quantiles = pd.DataFrame(
+                    dict(
+                        lower=elo,
+                        upper=elo,
+                    )
+                )
 
-        bars = pd.DataFrame(dict(
-            elo=elo,
-        ))
+        bars = pd.DataFrame(
+            dict(
+                elo=elo,
+            )
+        )
 
         if include_quantiles:
             assert bars_quantiles is not None
-            if use_bootstrap_median_for_quantiles:
-                relative_to = bootstrap_median
-            else:
-                relative_to = elo
-            bars['elo+'] = bars_quantiles['upper'] - relative_to
-            bars['elo-'] = relative_to - bars_quantiles["lower"]
+            relative_to = bootstrap_median if use_bootstrap_median_for_quantiles else elo
+            bars["elo+"] = bars_quantiles["upper"] - relative_to
+            bars["elo-"] = relative_to - bars_quantiles["lower"]
 
             if clip_negative_ci:
-                bars['elo+'] = bars['elo+'].clip(lower=0)
-                bars['elo-'] = bars['elo-'].clip(lower=0)
+                bars["elo+"] = bars["elo+"].clip(lower=0)
+                bars["elo-"] = bars["elo-"].clip(lower=0)
 
         if post_calibrate and post_calibration_framework is not None:
             offset = calibration_elo - elo.loc[post_calibration_framework]
@@ -748,10 +747,10 @@ class TabArena:
 
         bars = bars.sort_values(by="elo", ascending=False)
         if round_decimals is not None:
-            bars['elo'] = np.round(bars['elo'], round_decimals)
+            bars["elo"] = np.round(bars["elo"], round_decimals)
             if include_quantiles:
-                bars['elo+'] = np.round(bars['elo+'], round_decimals)
-                bars['elo-'] = np.round(bars['elo-'], round_decimals)
+                bars["elo+"] = np.round(bars["elo+"], round_decimals)
+                bars["elo-"] = np.round(bars["elo-"], round_decimals)
 
         bars.index.name = self.method_col
 
@@ -790,9 +789,11 @@ class TabArena:
         if use_optimal:
             baseline_result = results_per_task.groupby(task_groupby_cols)[self.error_col].min()
         else:
-            assert baseline_method is not None, f"baseline_method must not be None!"
+            assert baseline_method is not None, "baseline_method must not be None!"
             # Collect the baseline error per task (one row per task group)
-            baseline_result = results_per_task.loc[results_per_task[self.method_col] == baseline_method, task_groupby_cols + [self.error_col]]
+            baseline_result = results_per_task.loc[
+                results_per_task[self.method_col] == baseline_method, [*task_groupby_cols, self.error_col]
+            ]
             assert len(baseline_result) > 0, f"Baseline '{baseline_method}' does not exist!"
 
         baseline_result = baseline_result.rename(columns={self.error_col: "baseline_error"})
@@ -804,35 +805,32 @@ class TabArena:
         return relative_error
 
     def compute_winrate(self, results_per_task: pd.DataFrame) -> pd.Series:
-        """
-        results_winrate = 1 - ((results_rank - 1) / (len(results)-1))
-        results_rank = len(results_winrate) - results_winrate * (len(results_winrate) - 1)
+        """results_winrate = 1 - ((results_rank - 1) / (len(results)-1))
+        results_rank = len(results_winrate) - results_winrate * (len(results_winrate) - 1).
         """
         if self.seed_column is not None and self.seed_column not in results_per_task.columns:
             seed_col = None
         else:
             seed_col = self.seed_column
-        results_winrate = compute_winrate(
+        return compute_winrate(
             results_per_task=results_per_task,
             task_col=self.task_groupby_columns,
             method_col=self.method_col,
             error_col=self.error_col,
             seed_col=seed_col,
         )
-        return results_winrate
 
     def compute_winrate_matrix(
         self,
         results_per_task: pd.DataFrame,
     ) -> pd.DataFrame:
-        """
-        Compute pairwise win-rates between methods.
+        """Compute pairwise win-rates between methods.
 
         Parameters
         ----------
         results_per_task : pd.DataFrame
 
-        Returns
+        Returns:
         -------
         pd.DataFrame
             Square DataFrame indexed and columned by methods.
@@ -842,14 +840,13 @@ class TabArena:
             seed_col = None
         else:
             seed_col = self.seed_column
-        winrate_matrix = compute_winrate_matrix(
+        return compute_winrate_matrix(
             results_per_task=results_per_task,
             task_col=self.task_groupby_columns,
             method_col=self.method_col,
             error_col=self.error_col,
             seed_col=seed_col,
         )
-        return winrate_matrix
 
     @staticmethod
     def plot_winrate_matrix(
@@ -858,6 +855,7 @@ class TabArena:
         title: str | None = None,
     ):
         import matplotlib.pyplot as plt
+
         z = winrate_matrix.copy()
         z = (z * 100).round().astype("Int64")
 
@@ -919,7 +917,6 @@ class TabArena:
                     color=text_color,
                 )
 
-
         # Colorbar
         from matplotlib.ticker import FuncFormatter
 
@@ -966,8 +963,7 @@ class TabArena:
         df: pd.DataFrame,
         task_groupby_cols: list[str],
     ) -> pd.Series:
-        """
-        Add a per-(task, seed) rank column based on error (lower is better).
+        """Add a per-(task, seed) rank column based on error (lower is better).
         - Ties receive average ranks.
         - If `seed_col` is None, each task is treated as a single group.
 
@@ -978,7 +974,7 @@ class TabArena:
         task_groupby_cols : list[str]
             The groupby columns for calculating rank.
 
-        Returns
+        Returns:
         -------
         pd.Series
             Ranks for each method on each task/split.
@@ -1014,7 +1010,7 @@ class TabArena:
             task_groupby_cols,
             baseline_method,
         )
-        results_baseline_advantage = compute_weighted_mean_by_task(
+        return compute_weighted_mean_by_task(
             df=results_per_task,
             value_col="baseline_advantage",
             task_col=self.task_groupby_columns,
@@ -1022,7 +1018,6 @@ class TabArena:
             method_col=self.method_col,
             sort_asc=True,
         )
-        return results_baseline_advantage
 
     def compute_baseline_advantage_per(
         self,
@@ -1033,9 +1028,8 @@ class TabArena:
         df = results_per_task.copy()
 
         # Collect the baseline error per task (one row per task group)
-        base = (
-            df.loc[df[self.method_col] == baseline_method, task_groupby_cols + [self.error_col]]
-            .rename(columns={self.error_col: "baseline_error"})
+        base = df.loc[df[self.method_col] == baseline_method, [*task_groupby_cols, self.error_col]].rename(
+            columns={self.error_col: "baseline_error"}
         )
 
         # Map (join) the baseline error back onto every row of its task group
@@ -1054,9 +1048,9 @@ class TabArena:
     def compute_loss_rescaled_per(self, results_per_task: pd.DataFrame, task_groupby_cols: list[str]) -> pd.Series:
         best_error_per = results_per_task.groupby(task_groupby_cols)[self.error_col].transform("min")
         worst_error_per = results_per_task.groupby(task_groupby_cols)[self.error_col].transform("max")
-        loss_rescaled = (results_per_task[self.error_col] - best_error_per) / (
-            worst_error_per - best_error_per
-        ).fillna(0)
+        loss_rescaled = (results_per_task[self.error_col] - best_error_per) / (worst_error_per - best_error_per).fillna(
+            0
+        )
         loss_rescaled.name = LOSS_RESCALED
         return loss_rescaled
 
@@ -1082,12 +1076,16 @@ class TabArena:
         raise NotImplementedError
 
     # TODO: Should plotting live in a separate class?
-    def plot_critical_diagrams(self, results_per_task, save_path: str | None = None, show: bool = False, reverse: bool = False):
+    def plot_critical_diagrams(
+        self, results_per_task, save_path: str | None = None, show: bool = False, reverse: bool = False
+    ):
         import matplotlib.pyplot as plt
-        with plt.rc_context({'text.usetex': False}):
+
+        with plt.rc_context({"text.usetex": False}):
             from autorank import autorank
             from autorank._util import cd_diagram
-            plt.rcParams.update({'font.size': 12})
+
+            plt.rcParams.update({"font.size": 12})
 
             fig = plt.figure(figsize=(10, 4))
             ax = fig.add_subplot(1, 1, 1)
@@ -1098,7 +1096,7 @@ class TabArena:
             try:
                 _ = cd_diagram(result, reverse=reverse, ax=ax, width=6)
             except KeyError:
-                print(f"Not enough methods to generate cd_diagram, skipping...")
+                print("Not enough methods to generate cd_diagram, skipping...")
                 return
 
             # plt.tight_layout()  # cuts off text
@@ -1136,8 +1134,7 @@ class TabArena:
         value_col: str,
         sort_asc: bool,
     ) -> pd.Series:
-        """
-        Returns a per-method Series of weighted means using the same equal-task weighting
+        """Returns a per-method Series of weighted means using the same equal-task weighting
         logic as other parts of TabArena.
         """
         seed_col = self._seed_col_if_present(df)
@@ -1158,8 +1155,7 @@ class TabArena:
         method_1: str,
         method_2: str,
     ) -> float:
-        """
-        Compute the scalar score for method_1 after removing method_2 and recomputing metric.
+        """Compute the scalar score for method_1 after removing method_2 and recomputing metric.
         Returns the resulting score (NOT delta).
         """
         # Keep your prior convention: if we remove method_1 itself, return baseline score on provided df.
@@ -1182,17 +1178,10 @@ class TabArena:
         *,
         method_1: str,
     ) -> pd.Series:
-        """
-        For a fixed method_1, return a Series indexed by method_2 with values = resulting score
+        """For a fixed method_1, return a Series indexed by method_2 with values = resulting score
         for method_1 if method_2 were removed.
         """
-        methods = (
-            results_per_task[self.method_col]
-            .dropna()
-            .astype(str)
-            .unique()
-            .tolist()
-        )
+        methods = results_per_task[self.method_col].dropna().astype(str).unique().tolist()
 
         scores: dict[str, float] = {}
         for method_2 in methods:
@@ -1218,8 +1207,7 @@ class TabArena:
         method_1: str,
         stop_at_score: float | None = None,
     ) -> pd.Series:
-        """
-        Iteratively remove method_2 that yields the best improvement for method_1
+        """Iteratively remove method_2 that yields the best improvement for method_1
         according to metric.direction, recomputing the metric each iteration.
 
         Returns:
@@ -1247,10 +1235,7 @@ class TabArena:
 
             remaining_methods = current[self.method_col].dropna().astype(str).unique().tolist()
             # Exclude method_1 and any required methods (e.g., calibration framework)
-            candidates = [
-                m for m in remaining_methods
-                if m != method_1 and m not in metric.required_methods
-            ]
+            candidates = [m for m in remaining_methods if m != method_1 and m not in metric.required_methods]
             if not candidates:
                 break
 
@@ -1270,10 +1255,7 @@ class TabArena:
                 break
 
             # Choose best candidate depending on direction
-            if metric.direction == "min":
-                best_method_2 = scores_s.idxmin()
-            else:
-                best_method_2 = scores_s.idxmax()
+            best_method_2 = scores_s.idxmin() if metric.direction == "min" else scores_s.idxmax()
 
             best_score = float(scores_s.loc[best_method_2])
             removed_in_order[best_method_2] = best_score
@@ -1291,16 +1273,13 @@ class TabArena:
         methods_1: Iterable[str] | None = None,
         stop_at_score: float | None = None,
     ) -> pd.DataFrame:
-        """
-        Build a DataFrame:
-          rows = method_2 (removed)
-          cols = method_1
-          cell = resulting score for method_1 at the iteration when method_2 was removed
+        """Build a DataFrame:
+        rows = method_2 (removed)
+        cols = method_1
+        cell = resulting score for method_1 at the iteration when method_2 was removed.
         """
         if methods_1 is None:
-            methods_1 = (
-                results_per_task[self.method_col].dropna().astype(str).unique().tolist()
-            )
+            methods_1 = results_per_task[self.method_col].dropna().astype(str).unique().tolist()
 
         col_series: dict[str, pd.Series] = {}
         for method_1 in methods_1:
@@ -1318,14 +1297,13 @@ class TabArena:
     # ----------------------------
 
     def metric_spec_error(self) -> MetricSpec:
-        """
-        Lower is better. Score = weighted mean error (equal task weighting).
-        """
-        def compute(self: "TabArena", df: pd.DataFrame) -> pd.Series:
+        """Lower is better. Score = weighted mean error (equal task weighting)."""
+
+        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
             # row-aligned; no recomputation needed
             return df[self.error_col]
 
-        def score(self: "TabArena", df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             groupby_columns = self._get_groupby_cols(df)
             tmp = df[groupby_columns].copy()
             tmp[self.error_col] = values.to_numpy()
@@ -1341,14 +1319,13 @@ class TabArena:
         )
 
     def metric_spec_rank(self) -> MetricSpec:
-        """
-        Lower is better. Score = weighted mean rank.
-        """
-        def compute(self: "TabArena", df: pd.DataFrame) -> pd.Series:
+        """Lower is better. Score = weighted mean rank."""
+
+        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
             task_groupby_cols = self._get_task_groupby_cols(results=df)
             return self.compare_rank_per(df=df, task_groupby_cols=task_groupby_cols)
 
-        def score(self: "TabArena", df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             groupby_columns = self._get_groupby_cols(df)
             tmp = df[groupby_columns].copy()
             tmp[RANK] = values.to_numpy()
@@ -1364,14 +1341,13 @@ class TabArena:
         )
 
     def metric_spec_improvability(self) -> MetricSpec:
-        """
-        Lower is better (0 is ideal). Score = weighted mean improvability.
-        """
-        def compute(self: "TabArena", df: pd.DataFrame) -> pd.Series:
+        """Lower is better (0 is ideal). Score = weighted mean improvability."""
+
+        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
             task_groupby_cols = self._get_task_groupby_cols(results=df)
             return self.compute_improvability_per(results_per_task=df, task_groupby_cols=task_groupby_cols)
 
-        def score(self: "TabArena", df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             groupby_columns = self._get_groupby_cols(df)
             tmp = df[groupby_columns].copy()
             tmp[IMPROVABILITY] = values.to_numpy()
@@ -1387,13 +1363,11 @@ class TabArena:
         )
 
     def metric_spec_elo(self, **elo_kwargs) -> MetricSpec:
-        """
-        Higher is better. Score = Elo value for method_1 computed on the subset.
-        """
-        calibration_framework = elo_kwargs.get("calibration_framework", None)
+        """Higher is better. Score = Elo value for method_1 computed on the subset."""
+        calibration_framework = elo_kwargs.get("calibration_framework")
         required = frozenset([calibration_framework]) if calibration_framework else frozenset()
 
-        def compute(self: "TabArena", df: pd.DataFrame) -> pd.Series:
+        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
             bars = self.compute_elo(
                 results_per_task=df,
                 include_quantiles=False,
@@ -1403,7 +1377,7 @@ class TabArena:
             # method-aligned Series
             return bars["elo"]
 
-        def score(self: "TabArena", df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             return float(values.get(method_1, float("nan")))
 
         return MetricSpec(
@@ -1427,7 +1401,7 @@ class TabArena:
         if metric.invalid_subset_policy == "raise":
             raise ValueError(
                 f"Metric {metric.name!r} requires methods {sorted(metric.required_methods)}, "
-                f"but subset is missing {sorted(missing)}."
+                f"but subset is missing {sorted(missing)}.",
             )
         if metric.invalid_subset_policy == "nan":
             return False
@@ -1449,8 +1423,7 @@ class TabArena:
         save_path: str | None = None,
         title: str | None = None,
     ):
-        """
-        Plot a single dataset's metric distribution across methods.
+        """Plot a single dataset's metric distribution across methods.
 
         Parameters
         ----------
@@ -1479,13 +1452,14 @@ class TabArena:
         title : str | None, default None
             Optional plot title.
 
-        Returns
+        Returns:
         -------
         fig : plotly.graph_objects.Figure
         df_plot : pd.DataFrame
             Filtered dataframe used for plotting (one row per observation).
         """
         import os
+
         import plotly.express as px
 
         if metric_col is None:
@@ -1496,14 +1470,14 @@ class TabArena:
         if missing:
             raise ValueError(
                 f"results_per_task is missing required columns: {missing}\n"
-                f"Available columns: {list(results_per_task.columns)}"
+                f"Available columns: {list(results_per_task.columns)}",
             )
 
         df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
         if df.empty:
             raise ValueError(
                 f"No rows found for {self.task_col} == {dataset!r}.\n"
-                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}"
+                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}",
             )
 
         # Drop NaNs in the plotted metric (shouldn’t normally exist, but be safe)
@@ -1601,8 +1575,7 @@ class TabArena:
         score_mode: str = "to_population",  # {"to_population", "mean_pairwise"}
         min_methods: int | None = None,
     ) -> dict:
-        """
-        Quantify how similar each dataset is to the others based on model performance,
+        """Quantify how similar each dataset is to the others based on model performance,
         then identify the most- and least-representative datasets.
 
         Intuition
@@ -1635,7 +1608,7 @@ class TabArena:
         min_methods : int | None
             If set, require at least this many methods to compute correlations.
 
-        Returns
+        Returns:
         -------
         out : dict with keys
             - "representativeness": pd.DataFrame indexed by dataset with columns:
@@ -1657,7 +1630,7 @@ class TabArena:
         if missing:
             raise ValueError(
                 f"results_per_task is missing required columns: {missing}\n"
-                f"Available columns: {list(results_per_task.columns)}"
+                f"Available columns: {list(results_per_task.columns)}",
             )
 
         df = results_per_task.copy()
@@ -1689,34 +1662,38 @@ class TabArena:
         # 2) Representativeness score per dataset
         if score_mode == "mean_pairwise":
             # Mean similarity to all other datasets (exclude self)
-            score = (dataset_sim.sum(axis=1) - 1.0) / (dataset_sim.shape[0] - 1) if dataset_sim.shape[0] > 1 else \
-            dataset_sim.iloc[:, 0]
+            score = (
+                (dataset_sim.sum(axis=1) - 1.0) / (dataset_sim.shape[0] - 1)
+                if dataset_sim.shape[0] > 1
+                else dataset_sim.iloc[:, 0]
+            )
+        # Similarity to a "population reference vector"
+        # Reference vector is mean performance across datasets (optionally leave-one-out).
+        elif population_mode == "global_mean":
+            ref = M.mean(axis=0)
+            score = M.apply(lambda row: row.corr(ref, method=similarity), axis=1)
         else:
-            # Similarity to a "population reference vector"
-            # Reference vector is mean performance across datasets (optionally leave-one-out).
-            if population_mode == "global_mean":
-                ref = M.mean(axis=0)
-                score = M.apply(lambda row: row.corr(ref, method=similarity), axis=1)
+            # Leave-one-out mean reference: ref_d = mean of all datasets except d
+            # Compute efficiently: total_sum - row, then divide by (n-1)
+            n = M.shape[0]
+            if n <= 1:
+                score = pd.Series(index=M.index, data=np.nan, dtype=float)
             else:
-                # Leave-one-out mean reference: ref_d = mean of all datasets except d
-                # Compute efficiently: total_sum - row, then divide by (n-1)
-                n = M.shape[0]
-                if n <= 1:
-                    score = pd.Series(index=M.index, data=np.nan, dtype=float)
-                else:
-                    total = M.sum(axis=0)
+                total = M.sum(axis=0)
 
-                    def loo_corr(row: pd.Series) -> float:
-                        ref_d = (total - row) / (n - 1)
-                        return row.corr(ref_d, method=similarity)
+                def loo_corr(row: pd.Series) -> float:
+                    ref_d = (total - row) / (n - 1)
+                    return row.corr(ref_d, method=similarity)
 
-                    score = M.apply(loo_corr, axis=1)
+                score = M.apply(loo_corr, axis=1)
 
-        rep = pd.DataFrame({
-            "score": score,
-            "num_methods": num_methods_per_dataset,
-            "num_obs": df.groupby(self.task_col).size().reindex(M.index).astype(int),
-        }).sort_values("score", ascending=False)
+        rep = pd.DataFrame(
+            {
+                "score": score,
+                "num_methods": num_methods_per_dataset,
+                "num_obs": df.groupby(self.task_col).size().reindex(M.index).astype(int),
+            }
+        ).sort_values("score", ascending=False)
 
         most_rep = rep.index[0]
         least_rep = rep.index[-1]
@@ -1740,8 +1717,7 @@ class TabArena:
         min_methods: int | None = None,
         return_pairwise: bool = True,
     ) -> dict:
-        """
-        Quantify how similar a dataset's folds/seeds are, based on how methods perform.
+        """Quantify how similar a dataset's folds/seeds are, based on how methods perform.
 
         Assumes `results_per_task` was produced with `include_seed_col=True`, so that
         each row corresponds to (task, seed, method) with a metric like rank/error.
@@ -1777,7 +1753,7 @@ class TabArena:
         return_pairwise : bool, default True
             If True, also return a tidy dataframe of fold-pair similarities.
 
-        Returns
+        Returns:
         -------
         out : dict
             - "fold_similarity_matrix": pd.DataFrame (fold x fold)
@@ -1793,7 +1769,7 @@ class TabArena:
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
                 f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True)."
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
             )
         if similarity not in {"spearman", "pearson"}:
             raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
@@ -1805,14 +1781,14 @@ class TabArena:
         if missing:
             raise ValueError(
                 f"results_per_task is missing required columns: {missing}\n"
-                f"Available columns: {list(results_per_task.columns)}"
+                f"Available columns: {list(results_per_task.columns)}",
             )
 
         df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
         if df.empty:
             raise ValueError(
                 f"No rows found for {self.task_col} == {dataset!r}.\n"
-                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}"
+                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}",
             )
 
         # If duplicates exist for (task, seed, method), average them.
@@ -1845,10 +1821,12 @@ class TabArena:
             else:
                 scores = off_diag.median(axis=1, skipna=True)
 
-        fold_scores = pd.DataFrame({
-            "score": scores,
-            "num_methods": num_methods_per_fold.reindex(fold_sim.index).astype(int),
-        }).sort_values("score", ascending=False)
+        fold_scores = pd.DataFrame(
+            {
+                "score": scores,
+                "num_methods": num_methods_per_fold.reindex(fold_sim.index).astype(int),
+            }
+        ).sort_values("score", ascending=False)
 
         # Identify most/least similar fold pairs
         most_pair = None
@@ -1896,10 +1874,12 @@ class TabArena:
             # Rename back to desired output names (avoid collisions on rename too)
             col_i = f"{self.seed_column}_i"
             col_j = f"{self.seed_column}_j"
-            pairwise = pairwise.rename(columns={
-                f"__{idx_name}_i": col_i,
-                f"__{col_name}_j": col_j,
-            })
+            pairwise = pairwise.rename(
+                columns={
+                    f"__{idx_name}_i": col_i,
+                    f"__{col_name}_j": col_j,
+                }
+            )
 
             pairwise = pairwise.sort_values("similarity", ascending=False).reset_index(drop=True)
             out["pairwise"] = pairwise
@@ -1921,8 +1901,7 @@ class TabArena:
         stability_conservative: bool = True,
         stability_rho_floor: float = 0.01,
     ) -> dict:
-        """
-        Rank datasets by how consistently their folds/seeds agree with each other,
+        """Rank datasets by how consistently their folds/seeds agree with each other,
         and estimate how many folds are needed to get a stable global ordering.
 
         Assumes `results_per_task` was computed with `include_seed_col=True` so that
@@ -1964,7 +1943,7 @@ class TabArena:
         stability_rho_floor : float, default 0.01
             Minimum rho used when conservative and rho is extremely small/negative.
 
-        Returns
+        Returns:
         -------
         out : dict
             - "dataset_ranking": pd.DataFrame indexed by dataset with columns:
@@ -1985,11 +1964,11 @@ class TabArena:
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
                 f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True)."
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
             )
         if agg_fold_score not in {"mean_pairwise", "median_pairwise"}:
             raise ValueError(
-                f"agg_fold_score must be 'mean_pairwise' or 'median_pairwise', got {agg_fold_score!r}"
+                f"agg_fold_score must be 'mean_pairwise' or 'median_pairwise', got {agg_fold_score!r}",
             )
         if similarity not in {"spearman", "pearson"}:
             raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
@@ -1998,7 +1977,7 @@ class TabArena:
 
         tau = float(target_reliability)
         tau_tag = f"{tau:.2f}".rstrip("0").rstrip(".")  # e.g. "0.9" or "0.95"
-        col_stability_at_k = f"stability_at_num_folds"
+        col_stability_at_k = "stability_at_num_folds"
         col_folds_needed = f"folds_needed_for_stability@{tau_tag}"
 
         def _rel(k: int, rho: float) -> float:
@@ -2031,17 +2010,19 @@ class TabArena:
                     return_pairwise=False,
                 )
             except Exception as e:
-                rows.append({
-                    self.task_col: ds,
-                    "fold_agreement": np.nan,
-                    "num_folds": 0,
-                    "num_methods_min": np.nan,
-                    "num_methods_mean": np.nan,
-                    "rho_used": np.nan,
-                    col_stability_at_k: np.nan,
-                    col_folds_needed: np.nan,
-                    "error": repr(e),
-                })
+                rows.append(
+                    {
+                        self.task_col: ds,
+                        "fold_agreement": np.nan,
+                        "num_folds": 0,
+                        "num_methods_min": np.nan,
+                        "num_methods_mean": np.nan,
+                        "rho_used": np.nan,
+                        col_stability_at_k: np.nan,
+                        col_folds_needed: np.nan,
+                        "error": repr(e),
+                    }
+                )
                 continue
 
             fold_sim = out_ds["fold_similarity_matrix"]
@@ -2053,27 +2034,26 @@ class TabArena:
             num_methods_mean = float(methods_per_fold.mean()) if len(methods_per_fold) else np.nan
 
             if num_folds < min_folds:
-                rows.append({
-                    self.task_col: ds,
-                    "fold_agreement": np.nan,
-                    "num_folds": num_folds,
-                    "num_methods_min": num_methods_min,
-                    "num_methods_mean": num_methods_mean,
-                    "rho_used": np.nan,
-                    col_stability_at_k: np.nan,
-                    col_folds_needed: np.nan,
-                    "error": f"Too few folds (min_folds={min_folds})",
-                })
+                rows.append(
+                    {
+                        self.task_col: ds,
+                        "fold_agreement": np.nan,
+                        "num_folds": num_folds,
+                        "num_methods_min": num_methods_min,
+                        "num_methods_mean": num_methods_mean,
+                        "rho_used": np.nan,
+                        col_stability_at_k: np.nan,
+                        col_folds_needed: np.nan,
+                        "error": f"Too few folds (min_folds={min_folds})",
+                    }
+                )
                 continue
 
             # Aggregate off-diagonal similarities into dataset agreement score (rho estimate)
             sim_vals = fold_sim.to_numpy(copy=True)
             np.fill_diagonal(sim_vals, np.nan)
 
-            if agg_fold_score == "mean_pairwise":
-                rho = float(np.nanmean(sim_vals))
-            else:
-                rho = float(np.nanmedian(sim_vals))
+            rho = float(np.nanmean(sim_vals)) if agg_fold_score == "mean_pairwise" else float(np.nanmedian(sim_vals))
 
             rho_used = rho
             notes = None
@@ -2135,8 +2115,8 @@ class TabArena:
             if notes is not None:
                 per_dataset[ds]["stability_note"] = notes
             if include_pairwise_extremes:
-                per_dataset[ds]["most_similar_pair"] = row.get("most_similar_pair", None)
-                per_dataset[ds]["least_similar_pair"] = row.get("least_similar_pair", None)
+                per_dataset[ds]["most_similar_pair"] = row.get("most_similar_pair")
+                per_dataset[ds]["least_similar_pair"] = row.get("least_similar_pair")
 
         ranking = pd.DataFrame(rows).set_index(self.task_col)
         ranking = ranking.sort_values(by="fold_agreement", ascending=False)
@@ -2165,8 +2145,7 @@ class TabArena:
         sort_by: str = "jitter_mean",
         ascending: bool = True,
     ) -> tuple[pd.DataFrame, dict[str, dict] | None]:
-        """
-        Compute fold jitter metrics for each dataset.
+        """Compute fold jitter metrics for each dataset.
 
         This is a wrapper around `self.dataset_jitter(...)`.
 
@@ -2189,7 +2168,7 @@ class TabArena:
         ascending : bool, default True
             Sort direction.
 
-        Returns
+        Returns:
         -------
         df : pd.DataFrame
             One row per dataset with:
@@ -2206,7 +2185,7 @@ class TabArena:
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
                 f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True)."
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
             )
 
         if datasets is None:
@@ -2225,14 +2204,16 @@ class TabArena:
                     return_per_method=return_per_method,
                 )
                 # ensure consistent row schema
-                rows.append({
-                    "dataset": out["dataset"],
-                    "metric": out["metric"],
-                    "num_folds": out["num_folds"],
-                    "num_methods": out["num_methods"],
-                    "jitter_mean": out["jitter_mean"],
-                    "pairwise_jitter_mean": out["pairwise_jitter_mean"],
-                })
+                rows.append(
+                    {
+                        "dataset": out["dataset"],
+                        "metric": out["metric"],
+                        "num_folds": out["num_folds"],
+                        "num_methods": out["num_methods"],
+                        "jitter_mean": out["jitter_mean"],
+                        "pairwise_jitter_mean": out["pairwise_jitter_mean"],
+                    }
+                )
 
                 if return_per_method:
                     assert per_method is not None
@@ -2243,15 +2224,17 @@ class TabArena:
                     }
 
             except Exception as e:
-                rows.append({
-                    "dataset": ds,
-                    "metric": metric,
-                    "num_folds": np.nan,
-                    "num_methods": np.nan,
-                    "jitter_mean": np.nan,
-                    "pairwise_jitter_mean": np.nan,
-                    "error": repr(e),
-                })
+                rows.append(
+                    {
+                        "dataset": ds,
+                        "metric": metric,
+                        "num_folds": np.nan,
+                        "num_methods": np.nan,
+                        "jitter_mean": np.nan,
+                        "pairwise_jitter_mean": np.nan,
+                        "error": repr(e),
+                    }
+                )
                 if return_per_method:
                     assert per_method is not None
                     per_method[ds] = {"error": repr(e)}
@@ -2272,8 +2255,7 @@ class TabArena:
         metric: str = "winrate",
         return_per_method: bool = False,
     ) -> dict:
-        """
-        Compute fold-instability metrics for a dataset.
+        """Compute fold-instability metrics for a dataset.
 
         ``metric`` selects the per-fold per-method score:
           - ``"winrate"`` (default): per-fold winrate ``1 - (rank - 1) / (M - 1)``,
@@ -2299,7 +2281,7 @@ class TabArena:
         return_per_method : bool
             If True, also return per-method jitter statistics.
 
-        Returns
+        Returns:
         -------
         dict
         """
@@ -2312,13 +2294,10 @@ class TabArena:
             raise ValueError("seed_column must be set to compute fold jitter.")
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
-                "results_per_task must include seed column. "
-                "Call compute_results_per_task(..., include_seed_col=True)"
+                "results_per_task must include seed column. Call compute_results_per_task(..., include_seed_col=True)",
             )
 
-        df = results_per_task.loc[
-            results_per_task[self.task_col] == dataset
-            ].copy()
+        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
 
         if df.empty:
             raise ValueError(f"No rows found for dataset {dataset!r}")
@@ -2382,16 +2361,10 @@ class TabArena:
 
         if return_per_method:
             result["per_method_jitter_mean"] = abs_dev.mean(axis=0)
-            result["per_method_pairwise_jitter_mean"] = (
-                pd.concat(
-                    [
-                        (M.iloc[i] - M.iloc[j]).abs()
-                        for i in range(num_folds)
-                        for j in range(i + 1, num_folds)
-                    ],
-                    axis=1,
-                ).mean(axis=1)
-            )
+            result["per_method_pairwise_jitter_mean"] = pd.concat(
+                [(M.iloc[i] - M.iloc[j]).abs() for i in range(num_folds) for j in range(i + 1, num_folds)],
+                axis=1,
+            ).mean(axis=1)
 
         return result
 
@@ -2407,8 +2380,7 @@ class TabArena:
         seed: int = 0,
         drop_methods_with_any_missing: bool = True,
     ) -> pd.DataFrame:
-        """
-        Bootstrap how the k-fold *mean per-method score* converges to the global mean.
+        """Bootstrap how the k-fold *mean per-method score* converges to the global mean.
 
         For each bootstrap replicate:
           - sample k folds WITH replacement
@@ -2435,7 +2407,7 @@ class TabArena:
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
                 f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True)."
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
             )
 
         df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
@@ -2448,12 +2420,11 @@ class TabArena:
 
         if drop_methods_with_any_missing:
             M_df = M_df.dropna(axis=1)
-        else:
-            if M_df.isna().any().any():
-                raise ValueError(
-                    "Found NaNs in fold×method matrix. Set drop_methods_with_any_missing=True "
-                    "or impute missing values before bootstrapping."
-                )
+        elif M_df.isna().any().any():
+            raise ValueError(
+                "Found NaNs in fold×method matrix. Set drop_methods_with_any_missing=True "
+                "or impute missing values before bootstrapping.",
+            )
 
         M_full = M_df.to_numpy(dtype=float)  # shape (F, M), values are ranks
         F, M = M_full.shape
@@ -2506,18 +2477,20 @@ class TabArena:
                 jit[b] = float(np.abs(mu_hat - mu_global).mean())
 
             s = _summ(jit)
-            rows.append({
-                "dataset": dataset,
-                "metric": metric,
-                "k": k,
-                "n_bootstrap": n_bootstrap,
-                "n_folds_available": F,
-                "n_methods": M,
-                "jitter_mean": s["mean"],
-                "jitter_p50": s["p50"],
-                "jitter_p025": s["p025"],
-                "jitter_p975": s["p975"],
-            })
+            rows.append(
+                {
+                    "dataset": dataset,
+                    "metric": metric,
+                    "k": k,
+                    "n_bootstrap": n_bootstrap,
+                    "n_folds_available": F,
+                    "n_methods": M,
+                    "jitter_mean": s["mean"],
+                    "jitter_p50": s["p50"],
+                    "jitter_p025": s["p025"],
+                    "jitter_p975": s["p975"],
+                }
+            )
 
         return pd.DataFrame(rows).sort_values("k").reset_index(drop=True)
 
@@ -2552,13 +2525,19 @@ class TabArena:
                 )
                 dfs.append(d)
             except Exception as e:
-                dfs.append(pd.DataFrame([{
-                    "dataset": ds,
-                    "metric": metric,
-                    "k": np.nan,
-                    "n_bootstrap": n_bootstrap,
-                    "error": repr(e),
-                }]))
+                dfs.append(
+                    pd.DataFrame(
+                        [
+                            {
+                                "dataset": ds,
+                                "metric": metric,
+                                "k": np.nan,
+                                "n_bootstrap": n_bootstrap,
+                                "error": repr(e),
+                            }
+                        ]
+                    )
+                )
 
         return pd.concat(dfs, axis=0, ignore_index=True)
 
@@ -2572,8 +2551,7 @@ class TabArena:
         conservative: bool = True,
         rho_floor: float = 0.01,
     ) -> dict:
-        """
-        Estimate how many folds are needed to get a stable global ordering on a dataset,
+        """Estimate how many folds are needed to get a stable global ordering on a dataset,
         based on observed inter-fold agreement.
 
         Uses Spearman–Brown style extrapolation:
@@ -2596,7 +2574,7 @@ class TabArena:
         rho_floor : float, default 0.01
             Minimum rho to use when conservative and rho is extremely small/negative.
 
-        Returns
+        Returns:
         -------
         dict with:
             - "rho": used rho
@@ -2625,7 +2603,7 @@ class TabArena:
                 notes.append(
                     "fold_agreement <= 0 suggests folds disagree or are unrelated; "
                     "a stable global ordering may not be achievable by averaging folds alone. "
-                    "Returning cap."
+                    "Returning cap.",
                 )
                 rho = max(rho_floor, 0.0)
 
@@ -2667,7 +2645,9 @@ class TabArena:
         }
 
 
-def get_bootstrap_result_lst(data: list, func_, rng=None, num_round: int = None, func_kwargs=None, seed: int = 0):
+def get_bootstrap_result_lst(
+    data: list, func_, rng=None, num_round: int | None = None, func_kwargs=None, seed: int = 0
+):
     rows = []
     if rng is None:
         rng = np.random.default_rng(seed=seed)
@@ -2677,7 +2657,7 @@ def get_bootstrap_result_lst(data: list, func_, rng=None, num_round: int = None,
         rows.append(func_(data, **func_kwargs))
     else:
         num_data = len(data)
-        for i in range(num_round):
+        for _i in range(num_round):
             data_new = rng.choice(data, size=num_data, replace=True)
             rows.append(func_(data_new, **func_kwargs))
     df = pd.DataFrame(rows)
@@ -2687,22 +2667,21 @@ def get_bootstrap_result_lst(data: list, func_, rng=None, num_round: int = None,
 def _jitter_from_fold_method_matrix(
     M: np.ndarray,  # shape (k_folds, n_methods)
 ) -> tuple[float, float]:
-    """
-    Compute:
+    """Compute:
       - expected_rank_jitter relative to global (mean across folds)
-      - observed_avg_abs_rank_change between folds
+      - observed_avg_abs_rank_change between folds.
 
     Parameters
     ----------
     M : np.ndarray
         Fold x method matrix of ranks (or any scalar performance; ranks recommended).
 
-    Returns
+    Returns:
     -------
     expected_rank_jitter : float
     observed_avg_abs_rank_change : float
     """
-    k, m = M.shape
+    k, _m = M.shape
     global_rank = M.mean(axis=0, keepdims=True)  # (1, m)
     expected_rank_jitter = float(np.abs(M - global_rank).mean())
 

--- a/packages/bencheval/src/bencheval/winrate_utils.py
+++ b/packages/bencheval/src/bencheval/winrate_utils.py
@@ -12,8 +12,7 @@ def compute_winrate_matrix(
     seed_col: str | None = None,
     tie_decimals: int | None = None,
 ) -> pd.DataFrame:
-    """
-    Pairwise win-rate matrix with optional seeding.
+    """Pairwise win-rate matrix with optional seeding.
 
     - If seed_col is provided:
         * Compare methods only within the same (task, seed).
@@ -26,7 +25,7 @@ def compute_winrate_matrix(
           noise in the last few bits) still count as tied. Default None
           preserves the original exact-equality behavior.
 
-    Returns
+    Returns:
     -------
     pd.DataFrame
         Square DataFrame [methods x methods], (i,j) = win-rate of i vs j.
@@ -50,7 +49,7 @@ def compute_winrate_matrix(
     matches_global = np.zeros((n, n), dtype=np.float32)
 
     # Group by task
-    for task, df_task in results_per_task.groupby(task_col, sort=False):
+    for _task, df_task in results_per_task.groupby(task_col, sort=False):
         wins_task = np.zeros((n, n), dtype=np.float32)
         matches_task = np.zeros((n, n), dtype=np.float32)
 
@@ -97,8 +96,7 @@ def compute_winrate_matrix(
     order = np.argsort(-avg_wr)
 
     win_rates_df = pd.DataFrame(win_rates, index=methods, columns=methods)
-    win_rates_df = win_rates_df.iloc[order, order]
-    return win_rates_df
+    return win_rates_df.iloc[order, order]
 
 
 def compute_winrate(
@@ -110,8 +108,7 @@ def compute_winrate(
     sort_desc: bool = True,
     tie_decimals: int | None = None,
 ) -> pd.Series:
-    """
-    Average win-rate per method.
+    """Average win-rate per method.
 
     This calls `compute_winrate_matrix` and then averages across opponents.
     Keeps identical behavior with respect to seeding and task weighting.
@@ -132,7 +129,7 @@ def compute_winrate(
     sort_desc : bool, default=True
         If True, return methods sorted from highest to lowest avg win-rate.
 
-    Returns
+    Returns:
     -------
     pd.Series
         Index = methods, Values = average win-rate.

--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -134,8 +134,10 @@ Homepage = "https://github.com/autogluon/tabarena"
 
 # PEP 735 dependency groups: dev-only tools, not shipped in the wheel.
 # Install with: `uv sync --group dev`  (or `--group lint`, `--group test`).
+# NOTE: keep the ruff pin in sync with .github/workflows/pytest-pytest.yml and
+# .pre-commit-config.yaml so local, pre-commit, and CI all agree.
 [dependency-groups]
-lint = ["ruff>=0.6"]
+lint = ["ruff==0.14.0"]
 test = ["pytest>=7"]
 dev = [{ include-group = "lint" }, { include-group = "test" }]
 

--- a/packages/tabarena/src/tabarena/__init__.py
+++ b/packages/tabarena/src/tabarena/__init__.py
@@ -1,4 +1,6 @@
-from .repository.evaluation_repository import EvaluationRepository
-from .repository.evaluation_repository_collection import EvaluationRepositoryCollection
+from __future__ import annotations
+
 from .evaluation.evaluator import Evaluator
 from .nips2025_utils.tabarena_context import TabArenaContext
+from .repository.evaluation_repository import EvaluationRepository
+from .repository.evaluation_repository_collection import EvaluationRepositoryCollection

--- a/packages/tabarena/src/tabarena/baselines/info.py
+++ b/packages/tabarena/src/tabarena/baselines/info.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from tabarena.models._method_metadata import MethodMetadata
 
-
 _s3_cache_kwargs = dict(
     s3_bucket="tabarena",
     s3_prefix="cache",

--- a/packages/tabarena/src/tabarena/benchmark/batch_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/batch_utils.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import pandas as pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
-def compute_batched_tasks_all(batch_size_groups: list[int], time_per_dataset: pd.DataFrame, methods: list, folds: list) -> list[list[tuple]]:
-    """
-
-    Parameters
+def compute_batched_tasks_all(
+    batch_size_groups: list[int], time_per_dataset: pd.DataFrame, methods: list, folds: list
+) -> list[list[tuple]]:
+    """Parameters
     ----------
     batch_size_groups
     time_per_dataset
     methods
     folds
 
-    Returns
+    Returns:
     -------
 
     """
@@ -23,7 +27,9 @@ def compute_batched_tasks_all(batch_size_groups: list[int], time_per_dataset: pd
     for batch_size in batch_size_groups:
         df_datasets_in_batch_size = time_per_dataset[time_per_dataset["batch_size_group"] == batch_size]
         datasets_in_batch_size = list(df_datasets_in_batch_size.index)
-        tasks_in_ = [(dataset, fold, method) for dataset in datasets_in_batch_size for fold in folds for method in methods]
+        tasks_in_ = [
+            (dataset, fold, method) for dataset in datasets_in_batch_size for fold in folds for method in methods
+        ]
         tasks_in_batched = []
         n_tasks = len(tasks_in_)
         prev_i = 0
@@ -38,14 +44,13 @@ def compute_batched_tasks_all(batch_size_groups: list[int], time_per_dataset: pd
         if len(tasks_in_batched) > 0:
             tasks_all.append(tasks_in_batched)
 
-    tasks_all = [task for tasks_all_batch in tasks_all for task in tasks_all_batch]
-
-    return tasks_all
+    return [task for tasks_all_batch in tasks_all for task in tasks_all_batch]
 
 
-def estimate_benchmark_runtime(n_methods, n_folds, time_per_dataset: pd.DataFrame, target_time: float, time_per_instance_startup: float):
-    """
-    Estimate the total runtime of a benchmark run
+def estimate_benchmark_runtime(
+    n_methods, n_folds, time_per_dataset: pd.DataFrame, target_time: float, time_per_instance_startup: float
+):
+    """Estimate the total runtime of a benchmark run.
 
     TODO: Add max_parallel_instances
 
@@ -57,12 +62,14 @@ def estimate_benchmark_runtime(n_methods, n_folds, time_per_dataset: pd.DataFram
     target_time
     time_per_instance_startup
 
-    Returns
+    Returns:
     -------
 
     """
     n_datasets_per_group = time_per_dataset.value_counts("batch_size_group").to_frame().reset_index(drop=False)
-    n_datasets_per_group["n_instances_group"] = n_methods * n_datasets_per_group["count"] / n_datasets_per_group["batch_size_group"]
+    n_datasets_per_group["n_instances_group"] = (
+        n_methods * n_datasets_per_group["count"] / n_datasets_per_group["batch_size_group"]
+    )
     n_datasets_per_group["n_instances_group"] = np.ceil(n_datasets_per_group["n_instances_group"]).astype(int)
 
     n_datasets = len(time_per_dataset)
@@ -74,19 +81,19 @@ def estimate_benchmark_runtime(n_methods, n_folds, time_per_dataset: pd.DataFram
 
     total_time_s = instance_startup_time_total + target_time
     total_time_hr = total_time_s / 3600
-    print(f"{total_time_hr:.2f} hours to complete {n_runs} runs ({n_datasets} datasets, {n_folds} folds, {n_methods} methods)")
+    print(
+        f"{total_time_hr:.2f} hours to complete {n_runs} runs ({n_datasets} datasets, {n_folds} folds, {n_methods} methods)"
+    )
     return total_time_s
 
 
 def get_time_per_dataset_info(metrics: pd.DataFrame) -> pd.DataFrame:
-    """
-
-    Parameters
+    """Parameters
     ----------
     metrics:
         Output of `Evaluator(repo).compare_metrics(fillna=False).reset_index(drop=False)`
 
-    Returns
+    Returns:
     -------
 
     """
@@ -100,8 +107,10 @@ def get_time_per_dataset_info(metrics: pd.DataFrame) -> pd.DataFrame:
 
     time_per_dataset["time_total_s_mean"] = time_per_dataset["time_total_s"] / dataset_count_ref
 
-    time_per_dataset_q90 = metrics.groupby("dataset")[["time_train_s", "time_infer_s"]].quantile(q=0.9) * metrics.groupby("dataset")[
-        ["time_train_s", "time_infer_s"]].count()
+    time_per_dataset_q90 = (
+        metrics.groupby("dataset")[["time_train_s", "time_infer_s"]].quantile(q=0.9)
+        * metrics.groupby("dataset")[["time_train_s", "time_infer_s"]].count()
+    )
     time_per_dataset_q90["time_total_s"] = time_per_dataset_q90["time_train_s"] + time_per_dataset_q90["time_infer_s"]
     time_per_dataset_q90["time_total_s_q90"] = time_per_dataset_q90["time_total_s"] / dataset_count_ref
 

--- a/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
@@ -332,7 +332,7 @@ class TabArenaExperimentBundle:
                     preprocessing_pipeline=preprocessing_pipeline,
                     time_limit=time_limit,
                     time_limit_with_preprocessing=time_limit_with_preprocessing,
-                )
+                ),
             )
         return experiments
 
@@ -409,7 +409,7 @@ class TabArenaExperimentBundle:
             n_configs = self.n_random_configs
         elif not isinstance(n_configs, int):
             raise ValueError(
-                f"Invalid number of configurations for model {model_name}: {n_configs}. Must be an integer or 'all'."
+                f"Invalid number of configurations for model {model_name}: {n_configs}. Must be an integer or 'all'.",
             )
         if isinstance(model_name, str):
             config_generator = get_configs_generator_from_name(model_name)
@@ -427,6 +427,7 @@ class TabArenaExperimentBundle:
             dynamic_tabarena_validation_protocol=self.dynamic_tabarena_validation_protocol,
         )
 
+
 @dataclass(kw_only=True)
 class TabArenaV0pt1ExperimentBundle(TabArenaExperimentBundle):
     """The original TabArena-v0.1 experiment bundle, for backward compatibility."""
@@ -441,6 +442,7 @@ class TabArenaV0pt1ExperimentBundle(TabArenaExperimentBundle):
     """Use AutoGluon default preprocessing only."""
     adapt_num_folds_to_n_classes: bool = False
     """TabArena-v0.1 did not adapt the number of folds to the number of classes."""
+
 
 @dataclass(kw_only=True)
 class BeyondArenaExperimentBundle(TabArenaExperimentBundle):

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_constructor.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_constructor.py
@@ -3,25 +3,26 @@ from __future__ import annotations
 import copy
 import importlib
 import inspect
-from typing import Any, Type
+from typing import TYPE_CHECKING, Any, Self
 
 import yaml
-from typing_extensions import Self
 
-from autogluon.core.models import AbstractModel
-
-from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel
-from tabarena.benchmark.models.wrapper.AutoGluon_class import AGWrapper, AGSingleWrapper, AGSingleBagWrapper
-from tabarena.benchmark.models.wrapper.ag_model import AGModelWrapper
 from tabarena.benchmark.experiment.experiment_runner import ExperimentRunner, OOFExperimentRunner
 from tabarena.benchmark.models.model_registry import infer_model_cls
+from tabarena.benchmark.models.wrapper.ag_model import AGModelWrapper
+from tabarena.benchmark.models.wrapper.AutoGluon_class import AGSingleBagWrapper, AGSingleWrapper, AGWrapper
 from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionDummy
-from tabarena.benchmark.task.openml import OpenMLTaskWrapper
-from tabarena.benchmark.task.metadata import GroupLabelTypes, SplitTimeHorizonTypes, SplitTimeHorizonUnitTypes
+
+if TYPE_CHECKING:
+    from autogluon.core.models import AbstractModel
+
+    from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel
+    from tabarena.benchmark.task.metadata import GroupLabelTypes, SplitTimeHorizonTypes, SplitTimeHorizonUnitTypes
+    from tabarena.benchmark.task.openml import OpenMLTaskWrapper
+
 
 class Experiment:
-    """
-    Experiment contains a method and the logic to run it on any task.
+    """Experiment contains a method and the logic to run it on any task.
     Experiment is fully generic, and can accept any method_cls so long as it inherits from `AbstractExecModel`.
 
     Parameters
@@ -49,7 +50,7 @@ class Experiment:
         params = sig.parameters
         _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
-        arg_names = [param.name for param in params.values() if param.name != 'self']
+        arg_names = [param.name for param in params.values() if param.name != "self"]
         for i, arg in enumerate(_args):
             arg_name = arg_names[i]
             assert arg_name not in kwargs
@@ -62,18 +63,17 @@ class Experiment:
     def to_yaml_dict(self) -> dict:
         locals = self._locals
         locals_new = self._to_yaml_dict(locals=locals)
-        assert "type" not in locals_new, f"The `type` key is reserved for the class name."
-        locals_new = dict(
+        assert "type" not in locals_new, "The `type` key is reserved for the class name."
+        return dict(
             type=class_to_path(self.__class__),
             **locals_new,
         )
-        return locals_new
 
     def to_yaml(self, path: str):
         assert path.endswith(".yaml")
 
         yaml_out = self.to_yaml_dict()
-        with open(path, 'w') as outfile:
+        with open(path, "w") as outfile:
             yaml.dump(yaml_out, outfile, default_flow_style=False)
 
     def to_yaml_str(self) -> str:
@@ -98,17 +98,16 @@ class Experiment:
         if "experiment_cls" in kwargs:
             kwargs["experiment_cls"] = resolve_class(kwargs["experiment_cls"], context=_context)
 
-        obj = cls(method_cls=method_cls, **kwargs)
-        return obj
+        return cls(method_cls=method_cls, **kwargs)
 
     def __init__(
         self,
         name: str,
-        method_cls: Type[AbstractExecModel],
+        method_cls: type[AbstractExecModel],
         method_kwargs: dict,
         *,
-        experiment_cls: Type[ExperimentRunner] = OOFExperimentRunner,
-        experiment_kwargs: dict = None,
+        experiment_cls: type[ExperimentRunner] = OOFExperimentRunner,
+        experiment_kwargs: dict | None = None,
         preprocessing_pipeline: str | None = None,
         dynamic_tabarena_validation_protocol: bool = False,
     ):
@@ -200,7 +199,7 @@ class Experiment:
             resolved.method_kwargs["fit_kwargs"]["feature_generator_cls"] = TabArenaModelAgnosticPreprocessing
             resolved.method_kwargs["fit_kwargs"]["feature_generator_kwargs"] = {}
             resolved.method_kwargs["model_hyperparameters"] = TabArenaModelSpecificPreprocessing.add_to_hyperparameters(
-                resolved.method_kwargs["model_hyperparameters"]
+                resolved.method_kwargs["model_hyperparameters"],
             )
             return resolved
 
@@ -264,19 +263,19 @@ class Experiment:
         return method_kwargs
 
     def load_validation_split_metadata(
-            self,
-            *,
-            use_task_specific_validation: bool,
-            target_name: str | None = None,
-            stratify_on: str | None = None,
-            group_on: str | list[str] | None = None,
-            time_on: str | None = None,
-            group_time_on: str | None = None,
-            group_labels: GroupLabelTypes | None = None,
-            split_time_horizon: SplitTimeHorizonTypes | None = None,
-            split_time_horizon_unit: SplitTimeHorizonUnitTypes | None = None,
-            overwrite_existing: bool = False,
-        ) -> None:
+        self,
+        *,
+        use_task_specific_validation: bool,
+        target_name: str | None = None,
+        stratify_on: str | None = None,
+        group_on: str | list[str] | None = None,
+        time_on: str | None = None,
+        group_time_on: str | None = None,
+        group_labels: GroupLabelTypes | None = None,
+        split_time_horizon: SplitTimeHorizonTypes | None = None,
+        split_time_horizon_unit: SplitTimeHorizonUnitTypes | None = None,
+        overwrite_existing: bool = False,
+    ) -> None:
         """Load validation split metadata into the experiment's method_kwargs.
 
         Parameter
@@ -304,7 +303,7 @@ class Experiment:
             If True, will overwrite existing validation split metadata in method_kwargs.
         """
         print(
-            "Loading validation split metadata into experiment:"\
+            "Loading validation split metadata into experiment:"
             f"\n\tUse task specific validation: {use_task_specific_validation}"
             f"\n\ttarget_name: {target_name}"
             f"\n\tstratify_on: {stratify_on}"
@@ -313,7 +312,7 @@ class Experiment:
             f"\n\tsplit_time_horizon_unit: {split_time_horizon_unit}"
             f"\n\tgroup_on: {group_on}"
             f"\n\tgroup_time_on: {group_time_on}"
-            f"\n\tgroup_labels: {group_labels}"
+            f"\n\tgroup_labels: {group_labels}",
         )
         params = {
             "use_task_specific_validation": use_task_specific_validation,
@@ -330,29 +329,29 @@ class Experiment:
         for key, value in params.items():
             if (not overwrite_existing) and (key in self.method_kwargs):
                 print(
-                    f"{key} already exists, using existing value: "
-                    f"\n\t{self.method_kwargs[key]}"
+                    f"{key} already exists, using existing value: \n\t{self.method_kwargs[key]}",
                 )
             else:
                 self.method_kwargs[key] = value
 
+
 class AGModelOuterExperiment(Experiment):
-    """
-    Simplified Experiment class
+    """Simplified Experiment class
     for fitting a single model using AutoGluon without doing a train/val split,
     simply passing all data as X, y into `model_cls.fit`.
 
     This can be useful to benchmark methods that don't perform fine-tuning,
     such as TabPFNv2 and TabICL, where they instead want to use all the data for training.
     """
+
     def __init__(
         self,
         name: str,
-        model_cls: Type[AbstractModel],
+        model_cls: type[AbstractModel],
         model_hyperparameters: dict,
         *,
-        method_kwargs: dict = None,
-        experiment_kwargs: dict = None,
+        method_kwargs: dict | None = None,
+        experiment_kwargs: dict | None = None,
     ):
         if method_kwargs is None:
             method_kwargs = {}
@@ -379,16 +378,14 @@ class AGModelOuterExperiment(Experiment):
         )
 
         # Evaluate all values in ag_args_fit
-        if "model_hyperparameters" in kwargs:
-            if "ag_args_fit" in kwargs["model_hyperparameters"]:
-                for key, value in kwargs["model_hyperparameters"]["ag_args_fit"].items():
-                    if isinstance(value, str):
-                        try:
-                            kwargs["model_hyperparameters"]["ag_args_fit"][key] = eval(value, _context)
-                        except NameError:
-                            pass  # If eval fails, keep the original string value
-        obj = cls(model_cls=model_cls, **kwargs)
-        return obj
+        if "model_hyperparameters" in kwargs and "ag_args_fit" in kwargs["model_hyperparameters"]:
+            for key, value in kwargs["model_hyperparameters"]["ag_args_fit"].items():
+                if isinstance(value, str):
+                    try:
+                        kwargs["model_hyperparameters"]["ag_args_fit"][key] = eval(value, _context)  # noqa: S307
+                    except NameError:
+                        pass  # If eval fails, keep the original string value
+        return cls(model_cls=model_cls, **kwargs)
 
 
 class AGExperiment(Experiment):
@@ -430,14 +427,13 @@ class AGExperiment(Experiment):
         locals = copy.deepcopy(locals)
         items = list(locals.items())
         for k, v in items:
-            if k == "fit_kwargs":
-                if "hyperparameters" in v and isinstance(v["hyperparameters"], dict):
-                    hyperparameters = v["hyperparameters"]
-                    keys = list(hyperparameters.keys())
-                    for model in keys:
-                        if inspect.isclass(model):
-                            val = locals["fit_kwargs"]["hyperparameters"].pop(model)
-                            locals["fit_kwargs"]["hyperparameters"][model.ag_key] = val
+            if k == "fit_kwargs" and "hyperparameters" in v and isinstance(v["hyperparameters"], dict):
+                hyperparameters = v["hyperparameters"]
+                keys = list(hyperparameters.keys())
+                for model in keys:
+                    if inspect.isclass(model):
+                        val = locals["fit_kwargs"]["hyperparameters"].pop(model)
+                        locals["fit_kwargs"]["hyperparameters"][model.ag_key] = val
         return locals
 
     @classmethod
@@ -445,30 +441,28 @@ class AGExperiment(Experiment):
         if _context is None:
             _context = globals()
         from tabarena.benchmark.models.model_registry import tabarena_model_registry
+
         tabarena_model_keys = tabarena_model_registry.keys
 
         if "experiment_cls" in kwargs:
-            kwargs["experiment_cls"] = eval(kwargs["experiment_cls"], _context)
-        if "fit_kwargs" in kwargs:
-            if "hyperparameters" in kwargs["fit_kwargs"]:
-                if isinstance(kwargs["fit_kwargs"]["hyperparameters"], dict):
-                    hyperparameters = kwargs["fit_kwargs"]["hyperparameters"]
-                    keys = list(hyperparameters.keys())
-                    for model in keys:
-                        if model in tabarena_model_keys:
-                            val = kwargs["fit_kwargs"]["hyperparameters"].pop(model)
-                            kwargs["fit_kwargs"]["hyperparameters"][tabarena_model_registry.key_to_cls(model)] = val
-        obj = cls(**kwargs)
-        return obj
+            kwargs["experiment_cls"] = eval(kwargs["experiment_cls"], _context)  # noqa: S307
+        if "fit_kwargs" in kwargs and "hyperparameters" in kwargs["fit_kwargs"]:
+            if isinstance(kwargs["fit_kwargs"]["hyperparameters"], dict):
+                hyperparameters = kwargs["fit_kwargs"]["hyperparameters"]
+                keys = list(hyperparameters.keys())
+                for model in keys:
+                    if model in tabarena_model_keys:
+                        val = kwargs["fit_kwargs"]["hyperparameters"].pop(model)
+                        kwargs["fit_kwargs"]["hyperparameters"][tabarena_model_registry.key_to_cls(model)] = val
+        return cls(**kwargs)
 
 
 # convenience wrapper
 class AGModelExperiment(Experiment):
-    """
-    Simplified Experiment class specifically for fitting a single model using AutoGluon.
+    """Simplified Experiment class specifically for fitting a single model using AutoGluon.
     The following arguments are fixed:
         method_cls = AGSingleWrapper
-        experiment_cls = OOFExperimentRunner
+        experiment_cls = OOFExperimentRunner.
 
     Parameters
     ----------
@@ -492,19 +486,20 @@ class AGModelExperiment(Experiment):
     experiment_kwargs: dict, optional
         The kwargs passed to the init of `experiment_cls`.
     """
+
     _method_cls = AGSingleWrapper
     _experiment_cls = OOFExperimentRunner
 
     def __init__(
         self,
         name: str,
-        model_cls: Type[AbstractModel],
+        model_cls: type[AbstractModel],
         model_hyperparameters: dict,
         *,
         time_limit: float | None = None,
         raise_on_model_failure: bool = True,
-        method_kwargs: dict = None,
-        experiment_kwargs: dict = None,
+        method_kwargs: dict | None = None,
+        experiment_kwargs: dict | None = None,
         time_limit_with_preprocessing: bool = False,
         preprocessing_pipeline: str | None = None,
         dynamic_tabarena_validation_protocol: bool = False,
@@ -516,8 +511,9 @@ class AGModelExperiment(Experiment):
             assert isinstance(time_limit, (float, int))
             assert time_limit > 0
         if "fit_kwargs" in method_kwargs:
-            assert "time_limit" not in method_kwargs["fit_kwargs"], \
+            assert "time_limit" not in method_kwargs["fit_kwargs"], (
                 f"Set `time_limit` directly in {self.__class__.__name__} rather than in `fit_kwargs`"
+            )
         assert isinstance(model_hyperparameters, dict)
         if "fit_kwargs" not in method_kwargs:
             method_kwargs["fit_kwargs"] = {}
@@ -525,9 +521,12 @@ class AGModelExperiment(Experiment):
             if time_limit_with_preprocessing:
                 method_kwargs["fit_kwargs"]["time_limit"] = time_limit
             else:
-                model_hyperparameters = self._insert_time_limit(model_hyperparameters=model_hyperparameters, time_limit=time_limit, method_kwargs=method_kwargs)
-        assert "raise_on_model_failure" not in method_kwargs["fit_kwargs"], \
+                model_hyperparameters = self._insert_time_limit(
+                    model_hyperparameters=model_hyperparameters, time_limit=time_limit, method_kwargs=method_kwargs
+                )
+        assert "raise_on_model_failure" not in method_kwargs["fit_kwargs"], (
             f"Set `raise_on_model_failure` directly in {self.__class__.__name__} rather than in `fit_kwargs`"
+        )
         method_kwargs["fit_kwargs"]["raise_on_model_failure"] = raise_on_model_failure
         super().__init__(
             name=name,
@@ -544,8 +543,7 @@ class AGModelExperiment(Experiment):
         )
 
     def _to_yaml_dict(self, locals: dict) -> dict:
-        """
-        Serialize model_cls as an import path so custom/unregistered classes can
+        """Serialize model_cls as an import path so custom/unregistered classes can
         be loaded without requiring TabArena registry registration.
         """
         locals = copy.deepcopy(locals)
@@ -563,16 +561,14 @@ class AGModelExperiment(Experiment):
         )
 
         # Evaluate all values in ag_args_fit
-        if "model_hyperparameters" in kwargs:
-            if "ag_args_fit" in kwargs["model_hyperparameters"]:
-                for key, value in kwargs["model_hyperparameters"]["ag_args_fit"].items():
-                    if isinstance(value, str):
-                        try:
-                            kwargs["model_hyperparameters"]["ag_args_fit"][key] = eval(value, _context)
-                        except NameError:
-                            pass  # If eval fails, keep the original string value
-        obj = cls(model_cls=model_cls, **kwargs)
-        return obj
+        if "model_hyperparameters" in kwargs and "ag_args_fit" in kwargs["model_hyperparameters"]:
+            for key, value in kwargs["model_hyperparameters"]["ag_args_fit"].items():
+                if isinstance(value, str):
+                    try:
+                        kwargs["model_hyperparameters"]["ag_args_fit"][key] = eval(value, _context)  # noqa: S307
+                    except NameError:
+                        pass  # If eval fails, keep the original string value
+        return cls(model_cls=model_cls, **kwargs)
 
     def _insert_time_limit(self, model_hyperparameters: dict, time_limit: float | None, method_kwargs: dict) -> dict:
         is_bag = False
@@ -582,25 +578,26 @@ class AGModelExperiment(Experiment):
         model_hyperparameters = copy.deepcopy(model_hyperparameters)
         if is_bag:
             if "ag_args_ensemble" in model_hyperparameters:
-                assert "ag.max_time_limit" not in model_hyperparameters["ag_args_ensemble"], \
+                assert "ag.max_time_limit" not in model_hyperparameters["ag_args_ensemble"], (
                     f"Set `time_limit` directly in {self.__class__.__name__} rather than in `ag_args_ensemble`"
+                )
             else:
                 model_hyperparameters["ag_args_ensemble"] = {}
             model_hyperparameters["ag_args_ensemble"]["ag.max_time_limit"] = time_limit
         else:
-            assert "ag.max_time_limit" not in model_hyperparameters, \
+            assert "ag.max_time_limit" not in model_hyperparameters, (
                 f"Set `time_limit` directly in {self.__class__.__name__} rather than in `model_hyperparameters`"
+            )
             model_hyperparameters["ag.max_time_limit"] = time_limit
         return model_hyperparameters
 
 
 # convenience wrapper
 class AGModelBagExperiment(AGModelExperiment):
-    """
-    Simplified Experiment class specifically for fitting a single bagged model using AutoGluon.
+    """Simplified Experiment class specifically for fitting a single bagged model using AutoGluon.
     The following arguments are fixed:
         method_cls = AGSingleWrapper
-        experiment_cls = OOFExperimentRunner
+        experiment_cls = OOFExperimentRunner.
 
     All models fit this way will generate out-of-fold predictions on the entire training set,
     and will be compatible with ensemble simulations in TabArena.
@@ -625,22 +622,23 @@ class AGModelBagExperiment(AGModelExperiment):
     time_limit_with_preprocessing: bool, default False
             If True, time limit also captures the time it takes for preprocessing.
     """
+
     _method_cls = AGSingleBagWrapper
 
     def __init__(
         self,
         name: str,
-        model_cls: Type[AbstractModel],
+        model_cls: type[AbstractModel],
         model_hyperparameters: dict,
         *,
         time_limit: float | None = None,
         num_bag_folds: int = 8,
         num_bag_sets: int = 1,
         raise_on_model_failure: bool = True,
-        method_kwargs: dict = None,
-        experiment_kwargs: dict = None,
+        method_kwargs: dict | None = None,
+        experiment_kwargs: dict | None = None,
         time_limit_with_preprocessing: bool = False,
-        extra_model_hyperparameters: dict = None,
+        extra_model_hyperparameters: dict | None = None,
         preprocessing_pipeline: str | None = None,
         dynamic_tabarena_validation_protocol: bool = False,
     ):
@@ -654,22 +652,30 @@ class AGModelBagExperiment(AGModelExperiment):
             else:
                 extra_model_hyperparameters = {}
         else:
-            assert "extra_model_hyperparameters" not in method_kwargs, "Set only one of `extra_model_hyperparameters` and `method_kwargs['extra_model_hyperparameters']`"
+            assert "extra_model_hyperparameters" not in method_kwargs, (
+                "Set only one of `extra_model_hyperparameters` and `method_kwargs['extra_model_hyperparameters']`"
+            )
         assert isinstance(num_bag_folds, int)
         assert isinstance(num_bag_sets, int)
         assert isinstance(method_kwargs, dict)
         assert num_bag_folds >= 2
         assert num_bag_sets >= 1
         if "fit_kwargs" in method_kwargs:
-            assert "num_bag_folds" not in method_kwargs["fit_kwargs"], f"Set `num_bag_folds` directly in {self.__class__.__name__} rather than in `fit_kwargs`"
-            assert "num_bag_sets" not in method_kwargs["fit_kwargs"], f"Set `num_bag_sets` directly in {self.__class__.__name__} rather than in `fit_kwargs`"
+            assert "num_bag_folds" not in method_kwargs["fit_kwargs"], (
+                f"Set `num_bag_folds` directly in {self.__class__.__name__} rather than in `fit_kwargs`"
+            )
+            assert "num_bag_sets" not in method_kwargs["fit_kwargs"], (
+                f"Set `num_bag_sets` directly in {self.__class__.__name__} rather than in `fit_kwargs`"
+            )
             method_kwargs["fit_kwargs"] = copy.deepcopy(method_kwargs["fit_kwargs"])
         else:
             method_kwargs["fit_kwargs"] = {}
         method_kwargs["fit_kwargs"]["num_bag_folds"] = num_bag_folds
         method_kwargs["fit_kwargs"]["num_bag_sets"] = num_bag_sets
         if "model_hyperparameters" in method_kwargs:
-            assert "model_hyperparameters" in method_kwargs["model_hyperparameters"], f"model_hyperparameters should be passed directly to AGModelBagExperiment rather than in method_kwargs"
+            assert "model_hyperparameters" in method_kwargs["model_hyperparameters"], (
+                "model_hyperparameters should be passed directly to AGModelBagExperiment rather than in method_kwargs"
+            )
             model_hyperparameters = copy.deepcopy(model_hyperparameters)
             del method_kwargs["model_hyperparameters"]
         if extra_model_hyperparameters is not None:
@@ -700,8 +706,7 @@ class AGModelBagExperiment(AGModelExperiment):
 class YamlSingleExperimentSerializer:
     @classmethod
     def parse_method(cls, method_config: dict, context=None) -> Experiment:
-        """
-        Parse a method configuration dictionary and return an instance of the method class.
+        """Parse a method configuration dictionary and return an instance of the method class.
         This function evaluates the 'type' field in the method_config to determine the class to instantiate.
         It also evaluates any string values in the configuration that are meant to be Python expressions.
         """
@@ -714,27 +719,24 @@ class YamlSingleExperimentSerializer:
         method_type_raw = method_config.pop("type")
         method_type = resolve_class(method_type_raw, context=context)
 
-        method_obj = method_type.from_yaml(**method_config, _context=context)
-        return method_obj
+        return method_type.from_yaml(**method_config, _context=context)
 
     @classmethod
     def from_yaml(cls, path: str, context=None) -> Experiment:
         yaml_out = cls.load_yaml(path=path)
-        experiment = cls.parse_method(yaml_out, context=context)
-        return experiment
+        return cls.parse_method(yaml_out, context=context)
 
     @classmethod
     def load_yaml(cls, path: str) -> dict:
         assert path.endswith(".yaml")
-        with open(path, 'r') as file:
-            yaml_out = yaml.safe_load(file)
-        return yaml_out
+        with open(path) as file:
+            return yaml.safe_load(file)
 
     @classmethod
     def to_yaml(cls, experiment: Experiment, path: str):
         assert path.endswith(".yaml")
         yaml_out = cls._to_yaml_format(experiment=experiment)
-        with open(path, 'w') as outfile:
+        with open(path, "w") as outfile:
             yaml.dump(yaml_out, outfile, default_flow_style=False)
 
     @classmethod
@@ -764,16 +766,16 @@ class YamlExperimentSerializer:
                 continue
             experiments.append(
                 YamlSingleExperimentSerializer.parse_method(
-                    experiment, context=context
-                )
+                    experiment,
+                    context=context,
+                ),
             )
 
         return experiments
 
     @classmethod
     def from_yaml_str(cls, yaml_str: str, context=None) -> list[Experiment]:
-        """
-        Parse a YAML string containing multiple experiment definitions
+        """Parse a YAML string containing multiple experiment definitions
         and return a list of Experiment instances.
         """
         yaml_out = yaml.safe_load(yaml_str)
@@ -783,8 +785,9 @@ class YamlExperimentSerializer:
         for experiment in methods:
             experiments.append(
                 YamlSingleExperimentSerializer.parse_method(
-                    experiment, context=context
-                )
+                    experiment,
+                    context=context,
+                ),
             )
 
         return experiments
@@ -793,7 +796,7 @@ class YamlExperimentSerializer:
     def load_yaml(cls, path: str) -> list[dict]:
         assert path.endswith(".yaml")
 
-        with open(path, 'r') as file:
+        with open(path) as file:
             yaml_out = yaml.safe_load(file)
         return yaml_out["methods"]
 
@@ -801,7 +804,7 @@ class YamlExperimentSerializer:
     def to_yaml(cls, experiments: list[Experiment], path: str):
         assert path.endswith(".yaml")
         yaml_out = cls._to_yaml_format(experiments=experiments)
-        with open(path, 'w') as outfile:
+        with open(path, "w") as outfile:
             yaml.dump(yaml_out, outfile, default_flow_style=False)
 
     @classmethod
@@ -818,10 +821,9 @@ class YamlExperimentSerializer:
 
 
 def class_to_path(cls: type) -> str:
-    """
-    Serialize a class to a stable import path.
+    """Serialize a class to a stable import path.
 
-    Example
+    Example:
     -------
     autogluon.tabular.models.TabPFNv3preModel
     """
@@ -829,10 +831,9 @@ def class_to_path(cls: type) -> str:
 
 
 def import_class(path: str) -> type:
-    """
-    Import a class from a fully qualified import path.
+    """Import a class from a fully qualified import path.
 
-    Example
+    Example:
     -------
     autogluon.tabular.models.TabPFNv3preModel
     """
@@ -858,12 +859,11 @@ def resolve_class(
     context: dict | None = None,
     registry_resolver=None,
 ) -> type:
-    """
-    Resolve a class from:
+    """Resolve a class from:
     1. an already-materialized class
     2. context/globals
     3. registry resolver, such as infer_model_cls
-    4. fully qualified import path
+    4. fully qualified import path.
     """
     if inspect.isclass(value):
         return value
@@ -879,7 +879,7 @@ def resolve_class(
     if registry_resolver is not None:
         try:
             return registry_resolver(value)
-        except Exception:
+        except Exception:  # noqa: S110
             pass
 
     return import_class(value)

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 import datetime
-from typing import Literal, Type
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
+from autogluon.core.data.label_cleaner import LabelCleaner, LabelCleanerDummy
+from autogluon.core.metrics import Scorer, get_metric
 from pandas.api.types import is_integer_dtype
 
-from autogluon.core.data.label_cleaner import LabelCleaner, LabelCleanerDummy
-from autogluon.core.metrics import get_metric, Scorer
-from tabarena.benchmark.task.openml import OpenMLTaskWrapper
-from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionDummy, CacheFunctionDF
-from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel
+from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionDF, CacheFunctionDummy
+
+if TYPE_CHECKING:
+    from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel
+    from tabarena.benchmark.task.openml import OpenMLTaskWrapper
 
 
 # TODO: make a dataclass so type hinter is happy with subclasses?
@@ -19,7 +21,7 @@ class ExperimentRunner:
     def __init__(
         self,
         *,
-        method_cls: Type[AbstractExecModel],
+        method_cls: type[AbstractExecModel],
         task: OpenMLTaskWrapper,
         fold: int,
         task_name: str,
@@ -33,9 +35,7 @@ class ExperimentRunner:
         debug_mode: bool = True,
         eval_metric_name: str | None = None,
     ):
-        """
-
-        Parameters
+        """Parameters
         ----------
         method_cls
         task
@@ -72,9 +72,9 @@ class ExperimentRunner:
         if eval_metric_name is None:
             # FIXME: Don't hardcode eval metric
             ag_eval_metric_map = {
-                'binary': 'roc_auc',
-                'multiclass': 'log_loss',
-                'regression': 'rmse',
+                "binary": "roc_auc",
+                "multiclass": "log_loss",
+                "regression": "rmse",
             }
             self.eval_metric_name = ag_eval_metric_map[self.task.problem_type]
         else:
@@ -88,7 +88,9 @@ class ExperimentRunner:
             self.X, self.y, self.X_test, self.y_test = None, None, None, None
             _, y, _, _ = self.task.get_train_test_split(fold=self.fold, repeat=self.repeat, sample=self.sample)
         else:
-            self.X, self.y, self.X_test, self.y_test = self.task.get_train_test_split(fold=self.fold, repeat=self.repeat, sample=self.sample)
+            self.X, self.y, self.X_test, self.y_test = self.task.get_train_test_split(
+                fold=self.fold, repeat=self.repeat, sample=self.sample
+            )
             y = self.y
 
         if input_format == "csv":
@@ -101,12 +103,11 @@ class ExperimentRunner:
         self.debug_mode = debug_mode
 
     def init_method(self) -> AbstractExecModel:
-        model = self.method_cls(
+        return self.method_cls(
             problem_type=self.task.problem_type,
             eval_metric=self.eval_metric,
             **self.fit_args,
         )
-        return model
 
     @property
     def split_seed(self):
@@ -117,7 +118,6 @@ class ExperimentRunner:
         X, y, X_test, _ = self.task.get_train_test_split(fold=self.fold, repeat=self.repeat, sample=self.sample)
         return X, y, X_test
 
-
     def run_model_fit(self) -> dict:
         if self.task.lazy_load_data:
             lazy_load_function = self._lazy_load_for_run_model_fit
@@ -125,7 +125,9 @@ class ExperimentRunner:
         else:
             lazy_load_function = None
             X, y, X_test = self.X, self.y, self.X_test
-        return self.model.fit_custom(X=X, y=y, X_test=X_test, split_seed=self.split_seed, lazy_load_function=lazy_load_function)
+        return self.model.fit_custom(
+            X=X, y=y, X_test=X_test, split_seed=self.split_seed, lazy_load_function=lazy_load_function
+        )
 
     def run(self) -> dict:
         out = self._run()
@@ -136,12 +138,12 @@ class ExperimentRunner:
     @classmethod
     def init_and_run(
         cls,
-        method_cls: Type[AbstractExecModel],
+        method_cls: type[AbstractExecModel],
         task: OpenMLTaskWrapper,
         fold: int,
         task_name: str,
         method: str,
-        fit_args: dict = None,
+        fit_args: dict | None = None,
         cleanup: bool = True,
         input_format: Literal["openml", "csv"] = "openml",
         cacher: AbstractCacheFunction | None = None,
@@ -164,8 +166,8 @@ class ExperimentRunner:
         return obj.run()
 
     def _run(self) -> dict:
-        utc_time = datetime.datetime.now(datetime.timezone.utc)
-        time_start_str = utc_time.strftime('%Y-%m-%d %H:%M:%S')
+        utc_time = datetime.datetime.now(datetime.UTC)
+        time_start_str = utc_time.strftime("%Y-%m-%d %H:%M:%S")
         time_start = utc_time.timestamp()
         self.model = self.init_method()
         try:
@@ -191,8 +193,7 @@ class ExperimentRunner:
 
         out = self.post_evaluate(out=out)
         out["experiment_metadata"] = self._experiment_metadata(time_start=time_start, time_start_str=time_start_str)
-        out = self.convert_to_output(out=out)
-        return out
+        return self.convert_to_output(out=out)
 
     def handle_failure(self, exc: Exception):
         # TODO: This is autogluon specific, make a subclass AGExperimentRunner?
@@ -202,7 +203,7 @@ class ExperimentRunner:
         if failures is None:
             try:
                 failures = self.model.get_metadata_failure()
-            except:
+            except Exception:
                 return
         if failures is None:
             return
@@ -239,7 +240,7 @@ class ExperimentRunner:
         metadata = {}
         metadata["experiment_cls"] = self.__class__.__name__
         metadata["method_cls"] = self.method_cls.__name__
-        time_end = datetime.datetime.now(datetime.timezone.utc).timestamp()
+        time_end = datetime.datetime.now(datetime.UTC).timestamp()
         metadata["time_start"] = time_start
         metadata["time_end"] = time_end
         metadata["total_duration"] = time_end - time_start
@@ -291,7 +292,9 @@ class OOFExperimentRunner(ExperimentRunner):
             if self.task.problem_type == "regression":
                 simulation_artifact["pred_proba_dict_test"] = self.label_cleaner.transform(out["predictions"])
             else:
-                simulation_artifact["pred_proba_dict_test"] = self.label_cleaner.transform_proba(out["probabilities"], as_pandas=True)
+                simulation_artifact["pred_proba_dict_test"] = self.label_cleaner.transform_proba(
+                    out["probabilities"], as_pandas=True
+                )
                 if self.task.problem_type == "binary":
                     simulation_artifact["pred_proba_dict_test"] = simulation_artifact["pred_proba_dict_test"].iloc[:, 1]
 
@@ -303,8 +306,12 @@ class OOFExperimentRunner(ExperimentRunner):
 
             if self.optimize_simulation_artifacts_memory:
                 # optimize memory
-                simulation_artifact["y_test"].index = pd.to_numeric(simulation_artifact["y_test"].index, downcast="integer")
-                simulation_artifact["y_val"].index = pd.to_numeric(simulation_artifact["y_val"].index, downcast="integer")
+                simulation_artifact["y_test"].index = pd.to_numeric(
+                    simulation_artifact["y_test"].index, downcast="integer"
+                )
+                simulation_artifact["y_val"].index = pd.to_numeric(
+                    simulation_artifact["y_val"].index, downcast="integer"
+                )
 
                 simulation_artifact["y_test_idx"] = simulation_artifact["y_test"].index.values
                 simulation_artifact["y_val_idx"] = simulation_artifact["y_val"].index.values
@@ -316,8 +323,12 @@ class OOFExperimentRunner(ExperimentRunner):
                 if is_integer_dtype(simulation_artifact["y_val"]):
                     simulation_artifact["y_val"] = pd.to_numeric(simulation_artifact["y_val"], downcast="integer")
 
-                simulation_artifact["pred_proba_dict_test"] = simulation_artifact["pred_proba_dict_test"].astype(np.float32)
-                simulation_artifact["pred_proba_dict_val"] = simulation_artifact["pred_proba_dict_val"].astype(np.float32)
+                simulation_artifact["pred_proba_dict_test"] = simulation_artifact["pred_proba_dict_test"].astype(
+                    np.float32
+                )
+                simulation_artifact["pred_proba_dict_val"] = simulation_artifact["pred_proba_dict_val"].astype(
+                    np.float32
+                )
 
                 simulation_artifact["pred_proba_dict_test"] = simulation_artifact["pred_proba_dict_test"].values
                 simulation_artifact["pred_proba_dict_val"] = simulation_artifact["pred_proba_dict_val"].values
@@ -327,12 +338,13 @@ class OOFExperimentRunner(ExperimentRunner):
 
             if self.compute_bag_info and (self.model.can_get_per_child_oof and self.model.can_get_per_child_val_idx):
                 if self.task.lazy_load_data:
-                    _, _, X_test, _ = self.task.get_train_test_split(fold=self.fold, repeat=self.repeat, sample=self.sample)
+                    _, _, X_test, _ = self.task.get_train_test_split(
+                        fold=self.fold, repeat=self.repeat, sample=self.sample
+                    )
                 else:
                     X_test = self.X_test
 
                 simulation_artifact["bag_info"] = self.model.bag_artifact(X_test=X_test)
-
 
             simulation_artifact["pred_proba_dict_val"] = {self.method: simulation_artifact["pred_proba_dict_val"]}
             simulation_artifact["pred_proba_dict_test"] = {self.method: simulation_artifact["pred_proba_dict_test"]}
@@ -342,7 +354,14 @@ class OOFExperimentRunner(ExperimentRunner):
         return out
 
 
-def evaluate(y_true: pd.Series, y_pred: pd.Series, y_pred_proba: pd.DataFrame, scorer: Scorer, problem_type: str, label_cleaner: LabelCleaner = None) -> float:
+def evaluate(
+    y_true: pd.Series,
+    y_pred: pd.Series,
+    y_pred_proba: pd.DataFrame,
+    scorer: Scorer,
+    problem_type: str,
+    label_cleaner: LabelCleaner = None,
+) -> float:
     if label_cleaner is None:
         label_cleaner = LabelCleanerDummy(problem_type=problem_type)
     y_true = label_cleaner.transform(y_true)

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner_api.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner_api.py
@@ -31,17 +31,17 @@ def _clean_repetitions_mode_args_for_matrix(
     # If one is int and other not, error
     if isinstance(a, int) or isinstance(b, int):
         raise AssertionError(
-            "If `repetitions_mode_args` for 'matrix' is a tuple with integers, both elements must be integers."
+            "If `repetitions_mode_args` for 'matrix' is a tuple with integers, both elements must be integers.",
         )
 
     # Now both must be lists of ints
-    assert isinstance(a, list) and isinstance(b, list), (
+    assert isinstance(a, list) and isinstance(b, list), (  # noqa: PT018
         "If `repetitions_mode_args` for 'matrix' is a tuple with lists, both elements must be a list."
     )
-    assert (len(a) > 0) and all(isinstance(x, int) for x in a), (
+    assert (len(a) > 0) and all(isinstance(x, int) for x in a), (  # noqa: PT018
         "If `repetitions_mode_args` for 'matrix' is a tuple with lists, the first list must contain at least one integer for folds."
     )
-    assert (len(b) > 0) and all(isinstance(x, int) for x in b), (
+    assert (len(b) > 0) and all(isinstance(x, int) for x in b), (  # noqa: PT018
         "If `repetitions_mode_args` for 'matrix' is a tuple with lists, the second list must contain at least one integer for repeats."
     )
 
@@ -151,7 +151,7 @@ def _parse_repetitions_mode_and_args(
                 "In `repetitions_mode_args`, each task's repetition list must contain at least one (fold, repeat) tuple."
             )
             for rep in e:
-                assert isinstance(rep, tuple) and len(rep) == 2, (
+                assert isinstance(rep, tuple) and len(rep) == 2, (  # noqa: PT018
                     "In `repetitions_mode_args`, each repetition entry must be a tuple of (fold_index, repeat_index)."
                 )
                 assert all(isinstance(i, int) for i in rep), (
@@ -206,7 +206,8 @@ def _build_cache_prefix(
     legacy ``run_experiments``/``ExperimentBatchRunner`` remain discoverable.
     """
     subtask_cache_name = ExperimentBatchRunner._subtask_name(
-        fold=fold, repeat=repeat if include_repeat_in_cache_name else None
+        fold=fold,
+        repeat=repeat if include_repeat_in_cache_name else None,
     )
     if cache_path_format == "name_first":
         return f"data/{method_name}/{cache_task_key}/{subtask_cache_name}"
@@ -410,7 +411,7 @@ def run_experiments_new(
             raise ValueError(f"s3_kwargs parameter is required when mode is 'aws', got {s3_kwargs}")
         if s3_kwargs.get("bucket") is None or s3_kwargs.get("bucket") == "":
             raise ValueError(
-                f"bucket parameter in s3_kwargs is required when mode is 'aws', got {s3_kwargs.get('bucket')}"
+                f"bucket parameter in s3_kwargs is required when mode is 'aws', got {s3_kwargs.get('bucket')}",
             )
         base_cache_path = f"s3://{s3_kwargs['bucket']}/{output_dir}"
     elif run_mode == "local":
@@ -442,7 +443,7 @@ def run_experiments_new(
         f"\n\tFitting {len(model_experiments)} methods with {n_splits} fold-repeat pairs for a total of {n_splits * len(model_experiments)} jobs..."
         f"\n\tTIDs    : {tasks}"
         f"\n\tRepeat-Fold-Pairs-Per-Task (first 20): {fold_repeat_pairs_per_task[:20]}"
-        f"\n\tMethods : {[method.name for method in model_experiments]}"
+        f"\n\tMethods : {[method.name for method in model_experiments]}",
     )
 
     result_lst = []
@@ -461,7 +462,7 @@ def run_experiments_new(
 
         for split_index, (fold, repeat) in enumerate(fold_repeat_pairs_per_task[dataset_index], start=1):
             print(
-                f"Starting Split {split_index}/{len(fold_repeat_pairs_per_task[dataset_index])} (Fold {fold}, Repeat {repeat})..."
+                f"Starting Split {split_index}/{len(fold_repeat_pairs_per_task[dataset_index])} (Fold {fold}, Repeat {repeat})...",
             )
 
             for me_index, model_experiment in enumerate(model_experiments, start=1):
@@ -475,7 +476,7 @@ def run_experiments_new(
                     f"{experiment_fail_count} fail | "
                     f"{experiment_cache_exists_count} cache_exists | "
                     f"{experiment_missing_count} missing | "
-                    f"Fitting {cache_task_key} on repeat {repeat}, fold {fold} for method {model_experiment.name}"
+                    f"Fitting {cache_task_key} on repeat {repeat}, fold {fold} for method {model_experiment.name}",
                 )
 
                 # Setup Cache
@@ -550,14 +551,14 @@ def run_experiments_new(
                         if not isinstance(task.task, TabArenaOpenMLSupervisedTask):
                             raise ValueError(
                                 "`dynamic_tabarena_validation_protocol` is only "
-                                "implemented for `TabArenaOpenMLSupervisedTask`!"
+                                "implemented for `TabArenaOpenMLSupervisedTask`!",
                             )
 
                         if not isinstance(model_experiment, AGModelBagExperiment):
                             # TODO: add support
                             raise NotImplementedError(
                                 "Validation split kwargs only implemented for "
-                                f"AGModelBagExperiment for now, got {type(model_experiment)}"
+                                f"AGModelBagExperiment for now, got {type(model_experiment)}",
                             )
 
                         # Add info about group and time for the pipeline to handle
@@ -573,7 +574,9 @@ def run_experiments_new(
                         from tabarena.benchmark.preprocessing.text_cache import use_text_cache_for_task
 
                         text_cache_cm = use_text_cache_for_task(
-                            task_id_or_object, has_text=task._has_text, mode="require"
+                            task_id_or_object,
+                            has_text=task._has_text,
+                            mode="require",
                         )
 
                     try:
@@ -606,7 +609,7 @@ def run_experiments_new(
                         if not np.isfinite(out[metric_error_key]):
                             print(
                                 "Non-finite final metric error detected: "
-                                f"\t{metric_error_key}={out[metric_error_key]}. "
+                                f"\t{metric_error_key}={out[metric_error_key]}. ",
                             )
                             if failure_on_non_finite_metric_error:
                                 print("\tDeleting cache file and counting as failure.")
@@ -615,7 +618,7 @@ def run_experiments_new(
                                 out = None
                                 if raise_on_failure:
                                     raise RuntimeError(
-                                        f"Non-finite metric error detected for key {metric_error_key!r}."
+                                        f"Non-finite metric error detected for key {metric_error_key!r}.",
                                     )
                             break
 

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Type
-
-import pandas as pd
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
 
-from tabarena.benchmark.result import BaselineResult, ExperimentResults
-from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionPickle, CacheFunctionDummy
-from tabarena.repository import EvaluationRepository
 from tabarena.benchmark.experiment.experiment_constructor import Experiment
+from tabarena.benchmark.result import BaselineResult, ExperimentResults
+from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionDummy, CacheFunctionPickle
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from tabarena.repository import EvaluationRepository
 
 
 # TODO: Inspect artifact folder to load all results without needing to specify them explicitly
@@ -18,7 +20,7 @@ class ExperimentBatchRunner:
         self,
         expname: str,
         task_metadata: pd.DataFrame,
-        cache_cls: Type[AbstractCacheFunction] | None = CacheFunctionPickle,
+        cache_cls: type[AbstractCacheFunction] | None = CacheFunctionPickle,
         cache_cls_kwargs: dict | None = None,
         cache_path_format: Literal["name_first", "task_first"] = "name_first",
         only_cache: bool = False,
@@ -27,9 +29,7 @@ class ExperimentBatchRunner:
         debug_mode: bool = True,
         s3_dataset_cache: str | None = None,
     ):
-        """
-
-        Parameters
+        """Parameters
         ----------
         expname
         cache_cls
@@ -63,7 +63,12 @@ class ExperimentBatchRunner:
         self.cache_cls_kwargs = cache_cls_kwargs
         self.cache_path_format = cache_path_format
         self.only_cache = only_cache
-        self._dataset_to_tid_dict = self.task_metadata[['tid', 'dataset']].drop_duplicates(['tid', 'dataset']).set_index('dataset')['tid'].to_dict()
+        self._dataset_to_tid_dict = (
+            self.task_metadata[["tid", "dataset"]]
+            .drop_duplicates(["tid", "dataset"])
+            .set_index("dataset")["tid"]
+            .to_dict()
+        )
         self.mode = mode
         self.s3_bucket = s3_bucket
         self.debug_mode = debug_mode
@@ -80,19 +85,19 @@ class ExperimentBatchRunner:
         ignore_cache: bool = False,
         raise_on_failure: bool = True,
     ) -> list[dict[str, Any]]:
-        """
-        Similar to `run` but with the ability to specify folds and repeats on a per-dataset basis.
+        """Similar to `run` but with the ability to specify folds and repeats on a per-dataset basis.
 
         Parameters
         ----------
-        methods
+
+        Methods:
         dataset_folds_repeats_lst
         ignore_cache: bool, default False
             If True, will run the experiments regardless if the cache exists already, and will overwrite the cache file upon completion.
             If False, will load the cache result if it exists for a given experiment, rather than running the experiment again.
         raise_on_failure
 
-        Returns
+        Returns:
         -------
         results_lst: list[dict[str, Any]]
             A list of experiment run metadata dictionaries.
@@ -102,7 +107,7 @@ class ExperimentBatchRunner:
         results_lst = []
         len_datasets = len(dataset_folds_repeats_lst)
         for i, (dataset, folds, repeats) in enumerate(dataset_folds_repeats_lst):
-            print(f"Fitting dataset {i+1}/{len_datasets}... (dataset={dataset}, folds={folds}, repeats={repeats})")
+            print(f"Fitting dataset {i + 1}/{len_datasets}... (dataset={dataset}, folds={folds}, repeats={repeats})")
             results_lst_cur = self.run(
                 methods=methods,
                 datasets=[dataset],
@@ -123,11 +128,10 @@ class ExperimentBatchRunner:
         ignore_cache: bool = False,
         raise_on_failure: bool = True,
     ) -> list[dict[str, Any]]:
-        """
-
-        Parameters
+        """Parameters
         ----------
-        methods
+
+        Methods:
         datasets
         folds
         repeats
@@ -135,7 +139,7 @@ class ExperimentBatchRunner:
             If True, will run the experiments regardless if the cache exists already, and will overwrite the cache file upon completion.
             If False, will load the cache result if it exists for a given experiment, rather than running the experiment again.
 
-        Returns
+        Returns:
         -------
         results_lst: list[dict[str, Any]]
             A list of experiment run metadata dictionaries.
@@ -206,12 +210,12 @@ class ExperimentBatchRunner:
         repeats: list[int] | None = None,
         require_all: bool = True,
     ) -> list[dict[str, Any]]:
-        """
-        Load results from the cache.
+        """Load results from the cache.
 
         Parameters
         ----------
-        methods
+
+        Methods:
         datasets
         folds
         repeats
@@ -219,7 +223,7 @@ class ExperimentBatchRunner:
             If True, will raise an exception if not all methods x datasets x folds have a cached result to load.
             If False, will return only the list of results with a cached result. This can be an empty list if no cached results exist.
 
-        Returns
+        Returns:
         -------
         results_lst
             The same output format returned by `self.run`
@@ -233,10 +237,7 @@ class ExperimentBatchRunner:
         else:
             repeat_fold_pairs = [(None, f) for f in folds]
         for method in methods:
-            if isinstance(method, Experiment):
-                method_name = method.name
-            else:
-                method_name = method
+            method_name = method.name if isinstance(method, Experiment) else method
             for dataset in datasets:
                 for repeat, fold in repeat_fold_pairs:
                     cache_exists = self._cache_exists(method_name=method_name, dataset=dataset, fold=fold)
@@ -252,7 +253,7 @@ class ExperimentBatchRunner:
                 f"Missing cached results for {len(results_lst_missing)}/{len(results_lst_exists) + len(results_lst_missing)} experiments! "
                 f"\nTo load only the {len(results_lst_exists)} existing experiments, set `require_all=False`, "
                 f"or call `exp_batch_runner.run(methods=methods, datasets=datasets, folds=folds)` to run the missing experiments."
-                f"\nMissing experiments:\n\t{results_lst_missing}"
+                f"\nMissing experiments:\n\t{results_lst_missing}",
             )
         for method_name, dataset, fold, repeat in results_lst_exists:
             results_lst.append(self._load_result(method_name=method_name, dataset=dataset, fold=fold, repeat=repeat))
@@ -265,20 +266,15 @@ class ExperimentBatchRunner:
         include_holdout: bool = False,
     ) -> EvaluationRepository:
         experiment_results = ExperimentResults(task_metadata=self.task_metadata)
-        repo = experiment_results.repo_from_results(
+        return experiment_results.repo_from_results(
             results_lst=results_lst,
             calibrate=calibrate,
             include_holdout=include_holdout,
         )
-        return repo
 
     @classmethod
     def _subtask_name(cls, fold: int, repeat: int | None = None) -> str:
-        if repeat is None:
-            subtask_name = f"{fold}"
-        else:
-            subtask_name = f"{repeat}_{fold}"
-        return subtask_name
+        return f"{fold}" if repeat is None else f"{repeat}_{fold}"
 
     def _cache_name(self, method_name: str, dataset: str, fold: int, repeat: int | None = None) -> str:
         subtask_name = self._subtask_name(fold=fold, repeat=repeat)
@@ -301,10 +297,11 @@ class ExperimentBatchRunner:
         cacher = self._get_cacher(method_name=method_name, dataset=dataset, fold=fold, repeat=repeat)
         return cacher.load_cache()
 
-    def _get_cacher(self, method_name: str, dataset: str, fold: int, repeat: int | None = None) -> AbstractCacheFunction:
+    def _get_cacher(
+        self, method_name: str, dataset: str, fold: int, repeat: int | None = None
+    ) -> AbstractCacheFunction:
         cache_name = self._cache_name(method_name=method_name, dataset=dataset, fold=fold, repeat=repeat)
-        cacher = self.cache_cls(cache_name=cache_name, cache_path=self.expname, **self.cache_cls_kwargs)
-        return cacher
+        return self.cache_cls(cache_name=cache_name, cache_path=self.expname, **self.cache_cls_kwargs)
 
     def _validate_datasets(self, datasets: list[str]):
         unknown_datasets = []
@@ -315,20 +312,21 @@ class ExperimentBatchRunner:
             raise ValueError(
                 f"Dataset must be present in task_metadata!"
                 f"\n\tInvalid Datasets: {unknown_datasets}"
-                f"\n\t  Valid Datasets: {self.datasets}"
+                f"\n\t  Valid Datasets: {self.datasets}",
             )
         if len(datasets) != len(set(datasets)):
-            raise AssertionError(f"Duplicate datasets present! Ensure all datasets are unique.")
+            raise AssertionError("Duplicate datasets present! Ensure all datasets are unique.")
 
     def _validate_folds(self, folds: list[int]):
         if len(folds) != len(set(folds)):
-            raise AssertionError(f"Duplicate folds present! Ensure all folds are unique.")
+            raise AssertionError("Duplicate folds present! Ensure all folds are unique.")
 
     def _validate_repeats(self, repeats: list[int] | None):
         if repeats is None:
             return
         if len(repeats) != len(set(repeats)):
-            raise AssertionError(f"Duplicate repeats present! Ensure all repeats are unique.")
+            raise AssertionError("Duplicate repeats present! Ensure all repeats are unique.")
+
 
 def check_cache_hit(
     *,
@@ -338,7 +336,7 @@ def check_cache_hit(
     fold: int,
     repeat: int | None,
     cache_path_format: Literal["name_first", "task_first"],
-    cache_cls: Type[AbstractCacheFunction] | None,
+    cache_cls: type[AbstractCacheFunction] | None,
     cache_cls_kwargs: dict | None = None,
     mode: Literal["local", "s3"],
     s3_bucket: str | None = None,

--- a/packages/tabarena/src/tabarena/benchmark/models/model_registry.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/model_registry.py
@@ -4,7 +4,6 @@ import copy
 
 from autogluon.tabular.registry import ModelRegistry, ag_model_registry
 
-
 # `tabarena_model_registry` and `_models_to_add` are built lazily on first
 # access so that this module finishes loading before `get_model_registry()`
 # (which transitively triggers `experiment_constructor` → `model_registry`)
@@ -28,10 +27,13 @@ def _build_tabarena_model_registry() -> tuple[ModelRegistry, list[type]]:
     # MODEL_REGISTRY for their MethodMetadata, but the underlying class
     # is the AG one — re-adding it would only trigger a "duplicate key"
     # warning and reinsert the same class.
-    models_to_add: list[type] = list({
-        info.model_cls for info in get_model_registry().values()
-        if info.model_cls.ag_key not in ag_model_registry.keys
-    })
+    models_to_add: list[type] = list(
+        {
+            info.model_cls
+            for info in get_model_registry().values()
+            if info.model_cls.ag_key not in ag_model_registry.keys
+        }
+    )
 
     for model_cls in models_to_add:
         new_key = model_cls.ag_key
@@ -40,7 +42,7 @@ def _build_tabarena_model_registry() -> tuple[ModelRegistry, list[type]]:
             print(
                 f"WARNING: Multiple models exist with the ag_key '{new_key}'..."
                 f"\n\tOnly keeping the TabArena version..."
-                f"\n\tThis can cause subtle bugs and should be resolved ASAP."
+                f"\n\tThis can cause subtle bugs and should be resolved ASAP.",
             )
             registry.remove(model_cls=existing_model_cls)
         registry.add(model_cls)
@@ -60,7 +62,7 @@ def __getattr__(name: str):
 
 def infer_model_cls(model_cls: str, model_register: ModelRegistry = None):
     if model_register is None:
-        model_register = tabarena_model_registry
+        model_register = tabarena_model_registry  # noqa: F821
     if isinstance(model_cls, str):
         if model_cls in model_register.key_to_cls_map():
             model_cls = model_register.key_to_cls(key=model_cls)
@@ -69,10 +71,7 @@ def infer_model_cls(model_cls: str, model_register: ModelRegistry = None):
                 if real_model_cls.ag_name == model_cls:
                     model_cls = real_model_cls
                     break
-        elif model_cls in [
-            str(real_model_cls.__name__)
-            for real_model_cls in model_register.model_cls_list
-        ]:
+        elif model_cls in [str(real_model_cls.__name__) for real_model_cls in model_register.model_cls_list]:
             for real_model_cls in model_register.model_cls_list:
                 if model_cls == str(real_model_cls.__name__):
                     model_cls = real_model_cls

--- a/packages/tabarena/src/tabarena/benchmark/models/simple/__init__.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/simple/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 from .simple_lightgbm import SimpleLightGBM

--- a/packages/tabarena/src/tabarena/benchmark/models/simple/simple_lightgbm.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/simple/simple_lightgbm.py
@@ -14,10 +14,11 @@ class SimpleLightGBM(AbstractExecModel):
 
     def get_model_cls(self):
         from lightgbm import LGBMClassifier, LGBMRegressor
-        is_classification = self.problem_type in ['binary', 'multiclass']
+
+        is_classification = self.problem_type in ["binary", "multiclass"]
         if is_classification:
             model_cls = LGBMClassifier
-        elif self.problem_type == 'regression':
+        elif self.problem_type == "regression":
             model_cls = LGBMRegressor
         else:
             raise AssertionError(f"LightGBM does not recognize the problem_type='{self.problem_type}'")
@@ -28,7 +29,7 @@ class SimpleLightGBM(AbstractExecModel):
         self.model = model_cls(**self.hyperparameters)
         self.model.fit(
             X=X,
-            y=y
+            y=y,
         )
         return self
 

--- a/packages/tabarena/src/tabarena/benchmark/models/wrapper/AutoGluon_class.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/wrapper/AutoGluon_class.py
@@ -4,14 +4,13 @@ import copy
 import gc
 import inspect
 import shutil
-from typing import Type
 
 import numpy as np
 import pandas as pd
+from loguru import logger
 
 from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel, _apply_inv_perm, _make_perm
 
-from loguru import logger
 
 class AGWrapper(AbstractExecModel):
     can_get_error_val = True
@@ -27,7 +26,9 @@ class AGWrapper(AbstractExecModel):
         persist: bool = False,
         **kwargs,
     ):
-        super().__init__(preprocess_data=preprocess_data, preprocess_label=preprocess_label, target_name=target_name, **kwargs)
+        super().__init__(
+            preprocess_data=preprocess_data, preprocess_label=preprocess_label, target_name=target_name, **kwargs
+        )
         if init_kwargs is None:
             init_kwargs = {}
         if fit_kwargs is None:
@@ -58,7 +59,7 @@ class AGWrapper(AbstractExecModel):
             X=X.reset_index(drop=True),
             y=y.reset_index(drop=True),
             num_folds=num_folds,
-            num_repeats=num_repeats
+            num_repeats=num_repeats,
         )
 
         if num_folds is not None:
@@ -104,14 +105,13 @@ class AGWrapper(AbstractExecModel):
 
         return train_data, init_kwargs, fit_kwargs
 
-
     def _fit(
-            self,
-            X: pd.DataFrame,
-            y: pd.Series,
-            X_val: pd.DataFrame = None,
-            y_val: pd.Series = None,
-            **kwargs
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        X_val: pd.DataFrame = None,
+        y_val: pd.Series = None,
+        **kwargs,
     ):
         from autogluon.tabular import TabularPredictor
 
@@ -127,23 +127,21 @@ class AGWrapper(AbstractExecModel):
             label=self.label,
             problem_type=self.problem_type,
             eval_metric=self.eval_metric,
-            **init_kwargs
+            **init_kwargs,
         )
         self.predictor.fit(
             train_data=train_data,
-            **fit_kwargs
+            **fit_kwargs,
         )
 
         # FIXME: persist
         return self
 
     def _predict(self, X: pd.DataFrame) -> pd.Series:
-        y_pred = self.predictor.predict(X)
-        return y_pred
+        return self.predictor.predict(X)
 
     def _predict_proba(self, X: pd.DataFrame) -> pd.DataFrame:
-        y_pred_proba = self.predictor.predict_proba(X)
-        return y_pred_proba
+        return self.predictor.predict_proba(X)
 
     def pre_predict(self):
         if self.persist:
@@ -156,7 +154,9 @@ class AGWrapper(AbstractExecModel):
     def get_oof(self):
         # TODO: Rename method
         simulation_artifact = self.predictor.simulation_artifact()
-        simulation_artifact["pred_proba_dict_val"] = simulation_artifact["pred_proba_dict_val"][self.predictor.model_best]
+        simulation_artifact["pred_proba_dict_val"] = simulation_artifact["pred_proba_dict_val"][
+            self.predictor.model_best
+        ]
         return simulation_artifact
 
     def get_metric_error_val(self) -> float:
@@ -175,14 +175,12 @@ class AGWrapper(AbstractExecModel):
         except ImportError:
             pass
         else:
-            import torch
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
 
 class AGSingleWrapper(AGWrapper):
-    """
-    Wrapper for a single model being fit in AutoGluon
+    """Wrapper for a single model being fit in AutoGluon.
 
     Parameters
     ----------
@@ -198,9 +196,10 @@ class AGSingleWrapper(AGWrapper):
     kwargs
 
     """
+
     def __init__(
         self,
-        model_cls: str | Type["AbstractModel"],
+        model_cls: str | type[AbstractModel],  # noqa: F821
         model_hyperparameters: dict,
         calibrate: bool | str = False,
         init_kwargs: dict | None = None,
@@ -210,7 +209,8 @@ class AGSingleWrapper(AGWrapper):
         **kwargs,
     ):
         from autogluon.tabular.models import AbstractModel
-        assert (isinstance(model_cls, str) or issubclass(model_cls, AbstractModel))
+
+        assert isinstance(model_cls, str) or issubclass(model_cls, AbstractModel)
         assert isinstance(model_hyperparameters, dict)
 
         if fit_kwargs is None:
@@ -218,13 +218,19 @@ class AGSingleWrapper(AGWrapper):
         if init_kwargs is None:
             init_kwargs = {}
 
-        assert "hyperparameters" not in fit_kwargs, f"Must not specify `hyperparameters` in AGSingleWrapper."
-        assert "num_stack_levels" not in fit_kwargs, f"num_stack_levels is not allowed for `AGSingleWrapper"
-        assert "presets" not in fit_kwargs, f"AGSingleWrapper does not support `presets`"
-        assert "fit_weighted_ensemble" not in fit_kwargs, f"Must not specify `fit_weighted_ensemble` in AGSingleWrapper... It is always set to False."
-        assert "calibrate" not in fit_kwargs, f"Specify calibrate directly rather than in `fit_kwargs`"
-        assert "ag_args_fit" not in fit_kwargs, f"ag_args_fit must be specified in `model_hyperparameters`, not in `fit_kwargs` for `AGSingleWrapper"
-        assert "ag_args_ensemble" not in fit_kwargs, f"ag_args_ensemble must be specified in `model_hyperparameters`, not in `fit_kwargs` for `AGSingleWrapper"
+        assert "hyperparameters" not in fit_kwargs, "Must not specify `hyperparameters` in AGSingleWrapper."
+        assert "num_stack_levels" not in fit_kwargs, "num_stack_levels is not allowed for `AGSingleWrapper"
+        assert "presets" not in fit_kwargs, "AGSingleWrapper does not support `presets`"
+        assert "fit_weighted_ensemble" not in fit_kwargs, (
+            "Must not specify `fit_weighted_ensemble` in AGSingleWrapper... It is always set to False."
+        )
+        assert "calibrate" not in fit_kwargs, "Specify calibrate directly rather than in `fit_kwargs`"
+        assert "ag_args_fit" not in fit_kwargs, (
+            "ag_args_fit must be specified in `model_hyperparameters`, not in `fit_kwargs` for `AGSingleWrapper"
+        )
+        assert "ag_args_ensemble" not in fit_kwargs, (
+            "ag_args_ensemble must be specified in `model_hyperparameters`, not in `fit_kwargs` for `AGSingleWrapper"
+        )
 
         self.init_kwargs_extra = init_kwargs
 
@@ -239,22 +245,30 @@ class AGSingleWrapper(AGWrapper):
         self._model_cls = model_cls
         self.model_hyperparameters = model_hyperparameters
 
-        super().__init__(init_kwargs=init_kwargs, fit_kwargs=fit_kwargs, preprocess_data=preprocess_data, preprocess_label=preprocess_label, **kwargs)
+        super().__init__(
+            init_kwargs=init_kwargs,
+            fit_kwargs=fit_kwargs,
+            preprocess_data=preprocess_data,
+            preprocess_label=preprocess_label,
+            **kwargs,
+        )
 
     def post_fit(self, X: pd.DataFrame, y: pd.Series, X_test: pd.DataFrame):
         self.failure_artifact = self.get_metadata_failure()
 
     def get_hyperparameters(self):
-        hyperparameters = self.predictor.model_hyperparameters(model=self.predictor.model_best, output_format="user")
-        return hyperparameters
+        return self.predictor.model_hyperparameters(model=self.predictor.model_best, output_format="user")
 
     @property
-    def model_cls(self) -> Type["AbstractModel"]:
+    def model_cls(self) -> type[AbstractModel]:  # noqa: F821
         if not isinstance(self._model_cls, str):
             model_cls = self._model_cls
         else:
             # TODO: Get it from predictor instead? What if we allow passing custom model registry?
-            from autogluon.tabular.registry import ag_model_registry  # If this raises an exception, you need to update to latest mainline AutoGluon
+            from autogluon.tabular.registry import (
+                ag_model_registry,  # If this raises an exception, you need to update to latest mainline AutoGluon
+            )
+
             model_cls = ag_model_registry.key_to_cls(key=self._model_cls)
         return model_cls
 
@@ -293,10 +307,9 @@ class AGSingleWrapper(AGWrapper):
         return metadata
 
     def get_metadata_failure(self) -> dict:
-        metadata = {
-            "model_failures": self.predictor.model_failures()
+        return {
+            "model_failures": self.predictor.model_failures(),
         }
-        return metadata
 
     def get_metadata(self) -> dict:
         metadata = self.get_metadata_init()
@@ -328,11 +341,11 @@ class AGSingleBagWrapper(AGSingleWrapper):
         else:
             for n_repeat, k in enumerate(model._k_per_n_repeat):
                 kfolds = model._cv_splitters[n_repeat].split(X=X, y=y)
-                cur_kfolds = kfolds[n_repeat * k: (n_repeat + 1) * k]
+                cur_kfolds = kfolds[n_repeat * k : (n_repeat + 1) * k]
                 all_kfolds += cur_kfolds
 
         val_idx_per_child = []
-        for fold_idx, (train_idx, val_idx) in enumerate(all_kfolds):
+        for _fold_idx, (_train_idx, val_idx) in enumerate(all_kfolds):
             val_idx = pd.to_numeric(val_idx, downcast="integer")  # memory opt
             val_idx_per_child.append(val_idx)
 
@@ -361,7 +374,8 @@ class AGSingleBagWrapper(AGSingleWrapper):
 
         if self.shuffle_test:
             # Inverse-permute outputs back to original X_test order
-            per_child_test_preds = [_apply_inv_perm(y_pred, inv_perm, index=original_index) for y_pred in per_child_test_preds]
+            per_child_test_preds = [
+                _apply_inv_perm(y_pred, inv_perm, index=original_index) for y_pred in per_child_test_preds
+            ]
 
-        per_child_test_preds = [preds_child.astype(np.float32) for preds_child in per_child_test_preds]  # memory opt
-        return per_child_test_preds
+        return [preds_child.astype(np.float32) for preds_child in per_child_test_preds]  # memory opt

--- a/packages/tabarena/src/tabarena/benchmark/models/wrapper/__init__.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/wrapper/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 from .AutoGluon_class import AGSingleWrapper, AGWrapper

--- a/packages/tabarena/src/tabarena/benchmark/models/wrapper/abstract_class.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/wrapper/abstract_class.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 from autogluon.core.data.label_cleaner import LabelCleaner, LabelCleanerDummy
-from autogluon.core.metrics import Scorer
 from autogluon.features import AutoMLPipelineFeatureGenerator
 
-from tabarena.utils.time_utils import Timer
 from tabarena.benchmark.models.wrapper.validation_utils import TabArenaValidationProtocolExecMixin
+from tabarena.utils.time_utils import Timer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from autogluon.core.metrics import Scorer
+
 
 class AbstractExecModel(TabArenaValidationProtocolExecMixin):
     can_get_error_val = False
@@ -81,18 +86,17 @@ class AbstractExecModel(TabArenaValidationProtocolExecMixin):
     # TODO: Prateek, Add a toggle here to see if user wants to fit or fit and predict, also add model saving functionality
     # TODO: Nick: Temporary name
     def fit_custom(
-            self,
-            X: pd.DataFrame | None,
-            y: pd.Series | None,
-            X_test: pd.DataFrame | None,
-            *,
-            split_seed: int | None = None,
-            lazy_load_function: Callable | None = None
+        self,
+        X: pd.DataFrame | None,
+        y: pd.Series | None,
+        X_test: pd.DataFrame | None,
+        *,
+        split_seed: int | None = None,
+        lazy_load_function: Callable | None = None,
     ) -> dict:
-        """
-        Calls the fit function of the inheriting class and proceeds to perform predictions based on the problem type
+        """Calls the fit function of the inheriting class and proceeds to perform predictions based on the problem type.
 
-        Arguments
+        Arguments:
         ---------
         split_seed:
             If not None, the seed that is different per split to use for shuffling features.
@@ -100,16 +104,17 @@ class AbstractExecModel(TabArenaValidationProtocolExecMixin):
             If not None, a function that one can call to load X, y, X_test lazily (e.g. to save memory by not
             loading them until needed). If provided, X, y, and X_test arguments must be None.
 
-        Returns
+        Returns:
         -------
         dict
             Returns predictions, probabilities, fit time and inference time
         """
         from tabarena.utils.memory_utils import CpuMemoryTracker, GpuMemoryTracker
+
         self._split_seed = split_seed
 
         if lazy_load_function is not None:
-            assert X is None and y is None and X_test is None, "If lazy_load_function is provided, X and y must be None"
+            assert X is None and y is None and X_test is None, "If lazy_load_function is provided, X and y must be None"  # noqa: PT018
             X, y, _ = lazy_load_function()
             self._can_use_data_in_place = True
 
@@ -163,12 +168,10 @@ class AbstractExecModel(TabArenaValidationProtocolExecMixin):
         out["memory_usage"] = dict(
             peak_mem_cpu=cpu_tracker.peak_rss,
             min_mem_cpu=cpu_tracker.min_rss,
-
             peak_mem_gpu=gpu_tracker.peak_allocated,
             peak_mem_gpu_reserved=gpu_tracker.peak_reserved,
             min_mem_gpu=gpu_tracker.min_allocated,
             min_mem_gpu_reserved=gpu_tracker.min_reserved,
-
             gpu_tracking_enabled=gpu_tracker.enabled,
         )
 
@@ -198,8 +201,7 @@ class AbstractExecModel(TabArenaValidationProtocolExecMixin):
     def predict_from_proba(self, y_pred_proba: pd.DataFrame) -> pd.Series:
         if isinstance(y_pred_proba, pd.DataFrame):
             return y_pred_proba.idxmax(axis=1)
-        else:
-            return np.argmax(y_pred_proba, axis=1)
+        return np.argmax(y_pred_proba, axis=1)
 
     def predict(self, X: pd.DataFrame) -> pd.Series:
         X = self.transform_X(X=X)

--- a/packages/tabarena/src/tabarena/benchmark/models/wrapper/ag_model.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/wrapper/ag_model.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from typing import Type
-
 import pandas as pd
-
-from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.models import AbstractModel
 
+from tabarena.benchmark.models.wrapper.abstract_class import AbstractExecModel
+
 
 class AGModelWrapper(AbstractExecModel):
-    def __init__(self, model_cls: Type[AbstractModel], hyperparameters: dict = None, **kwargs):
+    def __init__(self, model_cls: type[AbstractModel], hyperparameters: dict | None = None, **kwargs):
         super().__init__(**kwargs)
         assert issubclass(model_cls, AbstractModel)
         self.model_cls = model_cls
@@ -40,5 +38,4 @@ class AGModelWrapper(AbstractExecModel):
         y_pred_proba = self.model.predict_proba(X)
         if self.problem_type == "binary":
             y_pred_proba = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_pred_proba)
-        y_pred_proba = pd.DataFrame(y_pred_proba, index=X.index)
-        return y_pred_proba
+        return pd.DataFrame(y_pred_proba, index=X.index)

--- a/packages/tabarena/src/tabarena/benchmark/models/wrapper/validation_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/models/wrapper/validation_utils.py
@@ -108,7 +108,7 @@ class TabArenaValidationProtocolExecMixin:
         if (num_folds is None) or (num_folds <= 1):
             logger.info(
                 "\nnum_folds is None or <= 1, skipping validation splitting logic."
-                "\n\t The model is configured to do not validation at all!"
+                "\n\t The model is configured to do not validation at all!",
             )
             return custom_splits, num_folds, num_repeats
 
@@ -122,7 +122,7 @@ class TabArenaValidationProtocolExecMixin:
             f"\n\tGroup_time_on: {self.group_time_on}"
             f"\n\tGroup_labels: {self.group_labels}"
             f"\n\tSplit_time_horizon: {self.split_time_horizon}"
-            f"\n\tSplit_time_horizon_unit: {self.split_time_horizon_unit}"
+            f"\n\tSplit_time_horizon_unit: {self.split_time_horizon_unit}",
         )
 
         num_folds, num_repeats = self._resolve_number_of_splits(
@@ -146,7 +146,7 @@ class TabArenaValidationProtocolExecMixin:
             groups_data, num_folds_new = self.time_on_to_groups_data(X=X, time_on=self.time_on, num_folds=num_folds)
             num_repeats = 1
             logger.info(
-                f"\n\tFolds time-based grouping: before={num_folds}; after={num_folds_new}\n\tnum_repeats set to 1!"
+                f"\n\tFolds time-based grouping: before={num_folds}; after={num_folds_new}\n\tnum_repeats set to 1!",
             )
             num_folds = num_folds_new
             # Set group labels as needed for time split
@@ -165,7 +165,7 @@ class TabArenaValidationProtocolExecMixin:
                 logger.info(
                     f"Number of unique groups in the data ({n_groups}) is less than the "
                     f"number of folds ({num_folds})! Adjusting the number of folds to be equal to the number of "
-                    f"unique groups, and setting num_repeats to 1."
+                    f"unique groups, and setting num_repeats to 1.",
                 )
                 num_folds = n_groups
                 num_repeats = 1
@@ -176,7 +176,7 @@ class TabArenaValidationProtocolExecMixin:
                     logger.warning(
                         f"Number of samples in minority class for stratification ({n_samples_minority_class}) is less "
                         f"than the number of folds ({num_folds})! We set num_folds to be equal to the number of samples"
-                        " in the minority class, and num_repeats to 1."
+                        " in the minority class, and num_repeats to 1.",
                     )
                     num_folds = n_samples_minority_class
                     num_repeats = 1
@@ -193,7 +193,6 @@ class TabArenaValidationProtocolExecMixin:
         # Sanity checks for custom splits
         if custom_splits is not None:
             for train_idx, test_idx in custom_splits:
-
                 assert len(train_idx) > 0, "Train split is empty!"
                 assert len(test_idx) > 0, "Test split is empty!"
 
@@ -223,7 +222,7 @@ class TabArenaValidationProtocolExecMixin:
                                 "Stratification values in train and test splits do not match!"
                                 f"\n\tOverall stratification values: {stratify_values}"
                                 f"\n\tTrain stratification values: {train_stratify_values}"
-                                f"\n\tTest stratification values: {test_stratify_values}"
+                                f"\n\tTest stratification values: {test_stratify_values}",
                             )
 
                         # For multi-stratify values, we do not allow missing a stratify value in the test split
@@ -233,13 +232,17 @@ class TabArenaValidationProtocolExecMixin:
                             "This means the validation data is likely missing some classes."
                             f"\n\tOverall stratification values: {stratify_values}"
                             f"\n\tTrain stratification values: {train_stratify_values}"
-                            f"\n\tTest stratification values: {test_stratify_values}"
+                            f"\n\tTest stratification values: {test_stratify_values}",
                         )
 
         return custom_splits, num_folds, num_repeats
 
     def _resolve_number_of_splits(
-        self, *, num_folds: int, num_repeats: int | None, num_group_instances: int
+        self,
+        *,
+        num_folds: int,
+        num_repeats: int | None,
+        num_group_instances: int,
     ) -> tuple[int, int | None]:
         """Determine the number of splits we want to use.
 
@@ -266,15 +269,13 @@ class TabArenaValidationProtocolExecMixin:
 
         if new_num_folds is not None:
             logger.info(
-                f"\nUpdating num_bag_folds from {num_folds} to {new_num_folds} "
-                f"because: {new_num_folds_reason}"
+                f"\nUpdating num_bag_folds from {num_folds} to {new_num_folds} because: {new_num_folds_reason}",
             )
             num_folds = new_num_folds
 
         if new_num_repeats is not None:
             logger.info(
-                f"\nUpdating new_num_repeats from {num_repeats} to {new_num_repeats} "
-                f"because: {new_num_repeats_reason}"
+                f"\nUpdating new_num_repeats from {num_repeats} to {new_num_repeats} because: {new_num_repeats_reason}",
             )
             num_repeats = new_num_repeats
 

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/date_feature_generators.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/date_feature_generators.py
@@ -32,12 +32,7 @@ class DateTimeFeatureGenerator(AbstractFeatureGenerator):
         return X_out, type_family_groups_special
 
     def _transform(self, X: pd.DataFrame, *, is_train: bool = False) -> pd.DataFrame:
-        if is_train:
-            X = self._vectorizer.fit_transform(X)
-        else:
-            X = self._vectorizer.transform(X)
-
-        return X
+        return self._vectorizer.fit_transform(X) if is_train else self._vectorizer.transform(X)
 
     @staticmethod
     def get_default_infer_features_in_args() -> dict:
@@ -45,5 +40,5 @@ class DateTimeFeatureGenerator(AbstractFeatureGenerator):
             "required_raw_special_pairs": [
                 (R_DATETIME, None),
                 (None, [S_DATETIME_AS_OBJECT]),
-            ]
+            ],
         }

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/model_agnostic_default_preprocessing.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/model_agnostic_default_preprocessing.py
@@ -80,7 +80,7 @@ class TabArenaModelAgnosticPreprocessing(AutoMLPipelineFeatureGenerator):
                     group_col=group_cols,
                     generate_index_features=group_labels == GroupLabelTypes.PER_GROUP,
                     group_time_on=group_time_on,
-                )
+                ),
             )
 
         if len(custom_feature_generators) == 0:
@@ -113,7 +113,11 @@ class TabArenaModelAgnosticPreprocessing(AutoMLPipelineFeatureGenerator):
         )
 
     def fit_transform(
-        self, X: pd.DataFrame, y: pd.Series | None = None, feature_metadata_in: FeatureMetadata = None, **kwargs
+        self,
+        X: pd.DataFrame,
+        y: pd.Series | None = None,
+        feature_metadata_in: FeatureMetadata = None,
+        **kwargs,
     ) -> pd.DataFrame:
         """Rename columns with '.' before AutoGluon stores feature metadata.
 
@@ -156,7 +160,7 @@ class TabArenaModelAgnosticPreprocessing(AutoMLPipelineFeatureGenerator):
                     S_TEXT,
                     S_TEXT_SPECIAL,
                 ],
-            }
+            },
         )
 
 

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/model_specific_default_preprocessing.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/model_specific_default_preprocessing.py
@@ -64,10 +64,13 @@ class TabArenaModelSpecificPreprocessing:
 
         if hp_key_kwargs not in hyperparameters:
             hyperparameters[hp_key_kwargs] = {}
-        if isinstance(hyperparameters[hp_key_kwargs], dict) and "feature_generators" not in hyperparameters[hp_key_kwargs]:
-            hyperparameters[hp_key_kwargs]["feature_generators"] = [(
-                TabArenaModelSpecificPreprocessing.get_model_specific_generator()
-            )]
+        if (
+            isinstance(hyperparameters[hp_key_kwargs], dict)
+            and "feature_generators" not in hyperparameters[hp_key_kwargs]
+        ):
+            hyperparameters[hp_key_kwargs]["feature_generators"] = [
+                (TabArenaModelSpecificPreprocessing.get_model_specific_generator())
+            ]
         else:
             if isinstance(hyperparameters[hp_key_kwargs], dict):
                 hyperparameters[hp_key_kwargs] = [hyperparameters[hp_key_kwargs]]
@@ -98,7 +101,7 @@ class TabArenaModelSpecificPreprocessing:
             [
                 # The other features are consumed, and thus can be dropped.
                 IdentityFeatureGenerator(
-                    infer_features_in_args=NoCatAsStringCategoryFeatureGenerator.get_infer_features_in_args_to_drop()
+                    infer_features_in_args=NoCatAsStringCategoryFeatureGenerator.get_infer_features_in_args_to_drop(),
                 ),
                 NoCatAsStringCategoryFeatureGenerator(),
             ],
@@ -107,10 +110,10 @@ class TabArenaModelSpecificPreprocessing:
             generators.append(
                 [
                     IdentityFeatureGenerator(
-                        infer_features_in_args=TextEmbeddingDimensionalityReductionFeatureGenerator.get_infer_features_in_args_to_drop()
+                        infer_features_in_args=TextEmbeddingDimensionalityReductionFeatureGenerator.get_infer_features_in_args_to_drop(),
                     ),
                     TextEmbeddingDimensionalityReductionFeatureGenerator(),
-                ]
+                ],
             )
 
         bulk_kwargs = dict(
@@ -123,7 +126,6 @@ class TabArenaModelSpecificPreprocessing:
 
 class NoCatAsStringCategoryFeatureGenerator(CategoryFeatureGenerator):
     """CategoryFeatureGenerator that does not treat each string column as a category.
-
 
     CategoryFeatureGenerator that preserves unseen categories to be handled by
     the downstream model instead of setting them to NaN.

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/text_cache.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/text_cache.py
@@ -222,7 +222,7 @@ def use_text_cache_for_task(task_id_or_object, *, has_text: bool, mode: TextCach
                 raise FileNotFoundError(
                     f"Text cache not found for task {task_key!r} (encoder {embedding_id()!r}). "
                     f"Expected at {text_cache_path(task_key)}. Pre-generate or download it "
-                    f"(text_cache mode='require'); use mode='auto' to compute on the fly instead."
+                    f"(text_cache mode='require'); use mode='auto' to compute on the fly instead.",
                 )
         yield
     finally:

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/text_feature_generators.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/text_feature_generators.py
@@ -4,7 +4,6 @@ import re
 import unicodedata
 import warnings
 from collections import defaultdict
-from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
@@ -22,6 +21,8 @@ from sklearn.decomposition import PCA
 from tqdm import tqdm
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from sentence_transformers import SentenceTransformer
 
 
@@ -160,7 +161,7 @@ class TabArenaDefaultTextEncoder:
             texts=text_to_encode,
             encoder_model=TabArenaDefaultTextEncoder.get_default_encoder(),
         )
-        return dict(zip(text_to_encode, new_embeddings))
+        return dict(zip(text_to_encode, new_embeddings, strict=False))
 
 
 class SemanticTextFeatureGenerator(AbstractFeatureGenerator):
@@ -206,18 +207,17 @@ class SemanticTextFeatureGenerator(AbstractFeatureGenerator):
         # Encode text
         unseen_text = TabArenaDefaultTextEncoder.get_text_to_encode(X=X, seen_texts=set(self._embedding_look_up.keys()))
         if unseen_text:
-
             if self.only_load_from_cache:
                 raise ValueError(
                     "Cache miss for text values during transform with only_load_from_cache=True. "
-                    f"Unseen text values: {unseen_text[:10]} (showing up to 10)."
+                    f"Unseen text values: {unseen_text[:10]} (showing up to 10).",
                 )
 
             embeddings = TabArenaDefaultTextEncoder.encode_texts(
                 texts=list(unseen_text),
                 encoder_model=self._encoder_model,
             )
-            self._embedding_look_up.update(zip(unseen_text, embeddings))
+            self._embedding_look_up.update(zip(unseen_text, embeddings, strict=False))
 
         # Infer embedding dimension
         emb_dim = len(next(iter(self._embedding_look_up.values())))
@@ -229,7 +229,7 @@ class SemanticTextFeatureGenerator(AbstractFeatureGenerator):
             raise ValueError(
                 "Column mismatch between training and transform.\n"
                 f"Expected: {self._expected_columns}\n"
-                f"Got: {list(X.columns)}"
+                f"Got: {list(X.columns)}",
             )
 
         # Pass 2: build matrix (optimized for repeated values)
@@ -282,7 +282,7 @@ class SemanticTextFeatureGenerator(AbstractFeatureGenerator):
     @staticmethod
     def load_embedding_cache(path: str | Path) -> dict[str, np.ndarray]:
         df = pd.read_parquet(path)
-        return dict(zip(df.index, df.to_numpy()))
+        return dict(zip(df.index, df.to_numpy(), strict=False))
 
     @staticmethod
     def get_text_cache_dir(task_id_str: str) -> Path:
@@ -469,7 +469,7 @@ class TextEmbeddingDimensionalityReductionFeatureGenerator(AbstractFeatureGenera
             raise ValueError(
                 "Column mismatch between training and transform.\n"
                 f"Expected: {self.expected_features_}\n"
-                f"Got: {list(X.columns)}"
+                f"Got: {list(X.columns)}",
             )
 
         X_out = self._transform_inference(X)
@@ -558,6 +558,7 @@ class TextEmbeddingDimensionalityReductionFeatureGenerator(AbstractFeatureGenera
             self._batch_pcas_,
             self._batch_input_columns_,
             self._batch_output_columns_,
+            strict=False,
         ):
             X_batch = X_scaled[batch_cols]
             X_pca = pca.transform(X_batch.to_numpy(copy=False))

--- a/packages/tabarena/src/tabarena/benchmark/result/__init__.py
+++ b/packages/tabarena/src/tabarena/benchmark/result/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .ag_bag_result import AGBagResult
 from .baseline_result import BaselineResult
 from .config_result import ConfigResult

--- a/packages/tabarena/src/tabarena/benchmark/result/abstract_result.py
+++ b/packages/tabarena/src/tabarena/benchmark/result/abstract_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 
 

--- a/packages/tabarena/src/tabarena/benchmark/result/ag_bag_result.py
+++ b/packages/tabarena/src/tabarena/benchmark/result/ag_bag_result.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import copy
@@ -56,7 +55,9 @@ class AGBagResult(ConfigResult):
             ordered_class_labels = self.simulation_artifacts["ordered_class_labels"]
             out = pd.DataFrame(data=y_pred_proba_test_child, index=self.y_test_idx, columns=ordered_class_labels)
         elif self.problem_type in ["binary", "regression"]:
-            out = pd.Series(data=y_pred_proba_test_child, index=self.y_test_idx, name=self.simulation_artifacts["label"])
+            out = pd.Series(
+                data=y_pred_proba_test_child, index=self.y_test_idx, name=self.simulation_artifacts["label"]
+            )
         else:
             raise ValueError(f"Unsupported problem_type={self.problem_type}")
         return out
@@ -67,7 +68,7 @@ class AGBagResult(ConfigResult):
         bag_info = self.result["simulation_artifacts"]["bag_info"]
         if "pred_proba_test_per_child" in bag_info:
             bag_info["pred_test_per_child"] = bag_info.pop("pred_proba_test_per_child")
-        num_samples_val = len(self.result["simulation_artifacts"]["y_val_idx"])
+        len(self.result["simulation_artifacts"]["y_val_idx"])
         if "val_idx_per_child" in bag_info and "pred_val_per_child" not in bag_info:
             # TODO: verify nothing break if we dont assert anymore
             # Ensure no repeated bagging
@@ -90,7 +91,9 @@ class AGBagResult(ConfigResult):
         if "pred_val" in self.result["simulation_artifacts"]:
             assert pred_val.shape == self.simulation_artifacts["pred_val"].shape
             if not np.isclose(pred_val, self.simulation_artifacts["pred_val"]).all():
-                print(f"WARNING: Not close  VAL: {self.result['task_metadata']['name']}, {self.result['task_metadata']['split_idx']}, {self.result['framework']}")
+                print(
+                    f"WARNING: Not close  VAL: {self.result['task_metadata']['name']}, {self.result['task_metadata']['split_idx']}, {self.result['framework']}"
+                )
         self.simulation_artifacts["pred_val"] = pred_val
         pred_test = self._pred_test_from_children()
         if "pred_test" in self.result["simulation_artifacts"]:
@@ -99,7 +102,7 @@ class AGBagResult(ConfigResult):
             if not is_close_lst.all():
                 print(
                     f"WARNING: Not close TEST: {self.result['task_metadata']['name']}, {self.result['task_metadata']['split_idx']}, {self.result['framework']}"
-                    f" |\t{((1 - is_close_lst.mean()) * 100):.3f}% of samples were not close!"
+                    f" |\t{((1 - is_close_lst.mean()) * 100):.3f}% of samples were not close!",
                 )
         self.simulation_artifacts["pred_test"] = pred_test
         return self.result
@@ -109,43 +112,43 @@ class AGBagResult(ConfigResult):
         if len(self.bag_info["pred_val_per_child"][0].shape) == 1:
             pred_val = np.zeros(dtype=np.float64, shape=num_samples_val)
         else:
-            pred_val = np.zeros(dtype=np.float64, shape=(num_samples_val, self.bag_info["pred_val_per_child"][0].shape[1]))
+            pred_val = np.zeros(
+                dtype=np.float64, shape=(num_samples_val, self.bag_info["pred_val_per_child"][0].shape[1])
+            )
         val_child_count = np.zeros(dtype=int, shape=num_samples_val)
-        for val_idx_child, pred_val_child in zip(self.bag_info["val_idx_per_child"], self.bag_info["pred_val_per_child"]):
+        for val_idx_child, pred_val_child in zip(
+            self.bag_info["val_idx_per_child"], self.bag_info["pred_val_per_child"], strict=False
+        ):
             val_child_count[val_idx_child] += 1
             pred_val[val_idx_child] += pred_val_child
-        if len(pred_val.shape) == 1:
-            pred_val = pred_val / val_child_count
-        else:
-            pred_val = pred_val / val_child_count[:, None]
-        pred_val = pred_val.astype(np.float32)
-        return pred_val
+        pred_val = pred_val / val_child_count if len(pred_val.shape) == 1 else pred_val / val_child_count[:, None]
+        return pred_val.astype(np.float32)
 
     def _pred_test_from_children(self) -> np.ndarray:
         num_samples_test = len(self.simulation_artifacts["y_test_idx"])
         if len(self.bag_info["pred_val_per_child"][0].shape) == 1:
             pred_test = np.zeros(dtype=np.float64, shape=num_samples_test)
         else:
-            pred_test = np.zeros(dtype=np.float64, shape=(num_samples_test, self.bag_info["pred_test_per_child"][0].shape[1]))
+            pred_test = np.zeros(
+                dtype=np.float64, shape=(num_samples_test, self.bag_info["pred_test_per_child"][0].shape[1])
+            )
         for pred_test_child in self.bag_info["pred_test_per_child"]:
             pred_test += pred_test_child
         pred_test = pred_test / self.num_children
-        pred_test = pred_test.astype(np.float32)
-        return pred_test
+        return pred_test.astype(np.float32)
 
     @property
     def num_children(self) -> int:
         return len(self.bag_info["pred_test_per_child"])
 
     def bag_artifacts(self, as_baseline: bool = True) -> list[BaselineResult]:
-        """
-        Logic that gets the holdout artifact from the bag by only using the first child model.
+        """Logic that gets the holdout artifact from the bag by only using the first child model.
 
         Parameters
         ----------
         as_baseline
 
-        Returns
+        Returns:
         -------
 
         """
@@ -164,7 +167,7 @@ class AGBagResult(ConfigResult):
         # y_test = pd.Series(data=y_test, index=y_test_idx)
 
         if num_children > 1:
-            for i, c in enumerate(pred_proba_test_per_child):
+            for i, _c in enumerate(pred_proba_test_per_child):
                 if i != 0:
                     break
                 # if problem_type == "multiclass":
@@ -196,11 +199,23 @@ class AGBagResult(ConfigResult):
                     sim_artifacts_holdout["pred_val"] = sim_artifacts_holdout["bag_info"]["pred_val_per_child"][i]
                     sim_artifacts_holdout["pred_test"] = sim_artifacts_holdout["bag_info"]["pred_test_per_child"][i]
 
-                    sim_artifacts_holdout["bag_info"]["val_idx_per_child"] = [val_idx_child for i_cur, val_idx_child in enumerate(sim_artifacts_holdout["bag_info"]["val_idx_per_child"]) if i_cur == i]
-                    sim_artifacts_holdout["bag_info"]["pred_val_per_child"] = [pred_val_child for i_cur, pred_val_child in
-                                                                              enumerate(sim_artifacts_holdout["bag_info"]["pred_val_per_child"]) if i_cur == i]
-                    sim_artifacts_holdout["bag_info"]["pred_test_per_child"] = [pred_test_child for i_cur, pred_test_child in
-                                                                              enumerate(sim_artifacts_holdout["bag_info"]["pred_test_per_child"]) if i_cur == i]
+                    sim_artifacts_holdout["bag_info"]["val_idx_per_child"] = [
+                        val_idx_child
+                        for i_cur, val_idx_child in enumerate(sim_artifacts_holdout["bag_info"]["val_idx_per_child"])
+                        if i_cur == i
+                    ]
+                    sim_artifacts_holdout["bag_info"]["pred_val_per_child"] = [
+                        pred_val_child
+                        for i_cur, pred_val_child in enumerate(sim_artifacts_holdout["bag_info"]["pred_val_per_child"])
+                        if i_cur == i
+                    ]
+                    sim_artifacts_holdout["bag_info"]["pred_test_per_child"] = [
+                        pred_test_child
+                        for i_cur, pred_test_child in enumerate(
+                            sim_artifacts_holdout["bag_info"]["pred_test_per_child"]
+                        )
+                        if i_cur == i
+                    ]
 
                     # result_baseline_new["metric_error_val"] = ag_metric.error(y_test, y_pred_proba_test_child)
 
@@ -213,8 +228,9 @@ class AGBagResult(ConfigResult):
                     result_baseline_new["metric_error_val"] = metric_error_val_holdout
                     result_baseline_new["metric_error"] = metric_error_test_holdout
 
-                    result_baseline_new["method_metadata"]["disk_usage"] = result_baseline_new["method_metadata"]["disk_usage"] // num_children
-
+                    result_baseline_new["method_metadata"]["disk_usage"] = (
+                        result_baseline_new["method_metadata"]["disk_usage"] // num_children
+                    )
 
                     # FIXME: support repeat bagging
 

--- a/packages/tabarena/src/tabarena/benchmark/result/baseline_result.py
+++ b/packages/tabarena/src/tabarena/benchmark/result/baseline_result.py
@@ -74,7 +74,8 @@ class BaselineResult(AbstractResult):
                 sim_artifacts = sim_artifacts[dataset][split_idx]
             if "metric_error_val" not in result:
                 metric_error_val = cls._compute_metric_error_val(
-                    result=result, sim_artifacts=sim_artifacts,
+                    result=result,
+                    sim_artifacts=sim_artifacts,
                 )
                 if metric_error_val is not None:
                     result["metric_error_val"] = metric_error_val
@@ -97,15 +98,16 @@ class BaselineResult(AbstractResult):
             return None
         from autogluon.core.metrics import get_metric
         from autogluon.core.utils.utils import get_pred_from_proba
+
         ag_metric = get_metric(metric=result["metric"], problem_type=result["problem_type"])
         if ag_metric.needs_class:
             y_pred_val = get_pred_from_proba(
-                y_pred_proba=pred_proba_val, problem_type=result["problem_type"],
+                y_pred_proba=pred_proba_val,
+                problem_type=result["problem_type"],
             )
             return ag_metric.error(y_val, y_pred_val)
-        if result["problem_type"] == "binary":
-            if len(pred_proba_val.shape) != 1:
-                pred_proba_val = pred_proba_val[:, 1]
+        if result["problem_type"] == "binary" and len(pred_proba_val.shape) != 1:
+            pred_proba_val = pred_proba_val[:, 1]
         return ag_metric.error(y_val, pred_proba_val)
 
     @classmethod
@@ -114,8 +116,9 @@ class BaselineResult(AbstractResult):
         return cls.from_dict(result=result)
 
     def update_name(self, name: str | None = None, name_prefix: str | None = None, name_suffix: str | None = None):
-        assert name is not None or name_prefix is not None or name_suffix is not None, \
+        assert name is not None or name_prefix is not None or name_suffix is not None, (
             "Must specify one of `name`, `name_prefix`, `name_suffix`."
+        )
         assert name is None or name_prefix is None, "Must only specify one of `name`, `name_prefix`."
         assert name is None or name_suffix is None, "Must only specify one of `name`, `name_suffix`."
         if name is not None:
@@ -233,7 +236,6 @@ class BaselineResult(AbstractResult):
                     data.update({col: method_metadata[col]})
 
         return pd.DataFrame([data])
-
 
     def to_dir(self, path: str | Path):
         suffix = Path(f"{self.framework}")

--- a/packages/tabarena/src/tabarena/benchmark/result/config_result.py
+++ b/packages/tabarena/src/tabarena/benchmark/result/config_result.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any
-from typing_extensions import Self
+from typing import Any, Self
 
 import numpy as np
 import pandas as pd
@@ -39,9 +38,16 @@ class ConfigResult(BaselineResult):
     def ag_key(self) -> str:
         return self.result["method_metadata"].get("ag_key", self.model_type)
 
-    def update_name(self, name: str | None = None, name_prefix: str | None = None, name_suffix: str | None = None, keep_suffix: bool = True):
-        assert name is not None or name_prefix is not None or name_suffix is not None, \
+    def update_name(
+        self,
+        name: str | None = None,
+        name_prefix: str | None = None,
+        name_suffix: str | None = None,
+        keep_suffix: bool = True,
+    ):
+        assert name is not None or name_prefix is not None or name_suffix is not None, (
             "Must specify one of `name`, `name_prefix`, `name_suffix`."
+        )
         assert name is None or name_prefix is None, "Must only specify one of `name`, `name_prefix`."
         assert name is None or name_suffix is None, "Must only specify one of `name`, `name_suffix`."
         if name is not None:
@@ -74,9 +80,12 @@ class ConfigResult(BaselineResult):
             self.result["method_metadata"]["name_prefix"] = new_name_prefix
             self.result["framework"] = new_name
 
-    def update_model_type(self, name: str | None = None, name_prefix: str | None = None, name_suffix: str | None = None):
-        assert name is not None or name_prefix is not None or name_suffix is not None, \
+    def update_model_type(
+        self, name: str | None = None, name_prefix: str | None = None, name_suffix: str | None = None
+    ):
+        assert name is not None or name_prefix is not None or name_suffix is not None, (
             "Must specify one of `name`, `name_prefix`, `name_suffix`."
+        )
         assert name is None or name_prefix is None, "Must only specify one of `name`, `name_prefix`."
         assert name is None or name_suffix is None, "Must only specify one of `name`, `name_suffix`."
         if "ag_key" not in self.result["method_metadata"]:
@@ -185,7 +194,9 @@ class ConfigResult(BaselineResult):
 
         if self.problem_type == "binary":
             if len(self.result["simulation_artifacts"]["pred_test"].shape) > 1:
-                self.result["simulation_artifacts"]["pred_test"] = self.result["simulation_artifacts"]["pred_test"][:, 1]
+                self.result["simulation_artifacts"]["pred_test"] = self.result["simulation_artifacts"]["pred_test"][
+                    :, 1
+                ]
             if len(self.result["simulation_artifacts"]["pred_val"].shape) > 1:
                 self.result["simulation_artifacts"]["pred_val"] = self.result["simulation_artifacts"]["pred_val"][:, 1]
 
@@ -243,9 +254,13 @@ class ConfigResult(BaselineResult):
         if len(self.bag_info["pred_val_per_child"][0].shape) == 1:
             pred_val = np.zeros(dtype=np.float64, shape=num_samples_val)
         else:
-            pred_val = np.zeros(dtype=np.float64, shape=(num_samples_val, self.bag_info["pred_val_per_child"][0].shape[1]))
+            pred_val = np.zeros(
+                dtype=np.float64, shape=(num_samples_val, self.bag_info["pred_val_per_child"][0].shape[1])
+            )
         val_child_count = np.zeros(dtype=int, shape=num_samples_val)
-        for val_idx_child, pred_val_child in zip(self.bag_info["val_idx_per_child"], self.bag_info["pred_val_per_child"]):
+        for val_idx_child, pred_val_child in zip(
+            self.bag_info["val_idx_per_child"], self.bag_info["pred_val_per_child"], strict=False
+        ):
             val_child_count[val_idx_child] += 1
             pred_val[val_idx_child] += pred_val_child
         pred_val = pred_val / val_child_count[:, None]
@@ -256,7 +271,9 @@ class ConfigResult(BaselineResult):
         if len(self.bag_info["pred_val_per_child"][0].shape) == 1:
             pred_test = np.zeros(dtype=np.float64, shape=num_samples_test)
         else:
-            pred_test = np.zeros(dtype=np.float64, shape=(num_samples_test, self.bag_info["pred_test_per_child"][0].shape[1]))
+            pred_test = np.zeros(
+                dtype=np.float64, shape=(num_samples_test, self.bag_info["pred_test_per_child"][0].shape[1])
+            )
         num_children = len(self.bag_info["pred_test_per_child"])
         for pred_test_child in self.bag_info["pred_test_per_child"]:
             pred_test += pred_test_child
@@ -274,6 +291,7 @@ class ConfigResult(BaselineResult):
             TemperatureScalingCalibrator,
             TemperatureScalingCalibratorFixed,
         )
+
         if method == "v1":
             calibrator = AutoGluonTemperatureScalingCalibrator(init_val=init_val, max_iter=max_iter, lr=lr)
         elif method == "v2":
@@ -292,6 +310,7 @@ class ConfigResult(BaselineResult):
         sim_artifact = result["simulation_artifacts"]
         metric = result["metric"]
         from autogluon.core.metrics import get_metric
+
         problem_type = result["problem_type"]
         ag_metric = get_metric(metric=metric, problem_type=problem_type)
         y_test = sim_artifact["y_test"]
@@ -337,9 +356,12 @@ class ConfigResult(BaselineResult):
         df_result["aux_metric_error_val"] = aux_metric_error_val
         return df_result
 
-    def compute_metric_test(self, metric, decision_threshold: float | str = 0.5, as_sklearn: bool = False, calibrate: bool = False):
+    def compute_metric_test(
+        self, metric, decision_threshold: float | str = 0.5, as_sklearn: bool = False, calibrate: bool = False
+    ):
         from autogluon.core.metrics import get_metric
         from autogluon.core.utils.utils import get_pred_from_proba
+
         ag_metric = get_metric(metric=metric, problem_type=self.problem_type)
         y_test = self.simulation_artifacts["y_test"]
         y_val = self.simulation_artifacts["y_val"]
@@ -355,6 +377,7 @@ class ConfigResult(BaselineResult):
             if decision_threshold == "auto":
                 if self.problem_type == "binary":
                     from autogluon.core.calibrate import calibrate_decision_threshold
+
                     decision_threshold = calibrate_decision_threshold(
                         y=y_val,
                         y_pred_proba=y_pred_proba_val,
@@ -363,16 +386,25 @@ class ConfigResult(BaselineResult):
                 else:
                     decision_threshold = 0.5
 
-            y_pred_val = get_pred_from_proba(y_pred_proba=y_pred_proba_val, problem_type=self.problem_type, decision_threshold=decision_threshold)
-            y_pred_test = get_pred_from_proba(y_pred_proba=y_pred_proba_test, problem_type=self.problem_type, decision_threshold=decision_threshold)
+            y_pred_val = get_pred_from_proba(
+                y_pred_proba=y_pred_proba_val, problem_type=self.problem_type, decision_threshold=decision_threshold
+            )
+            y_pred_test = get_pred_from_proba(
+                y_pred_proba=y_pred_proba_test, problem_type=self.problem_type, decision_threshold=decision_threshold
+            )
             metric_error_val = ag_metric.error(y_val, y_pred_val)
             metric_error_test = ag_metric.error(y_test, y_pred_test)
         else:
             if calibrate:
                 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
+
                 if self.problem_type == "binary":
-                    y_pred_proba_val = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_pred_proba_val)
-                    y_pred_proba_test = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_pred_proba_test)
+                    y_pred_proba_val = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(
+                        y_pred_proba_val
+                    )
+                    y_pred_proba_test = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(
+                        y_pred_proba_test
+                    )
                 calibrator = self.temp_scale(y_val=y_val, y_pred_proba_val=y_pred_proba_val)
                 y_pred_proba_val = calibrator.predict_proba(y_pred_proba_val)
                 y_pred_proba_test = calibrator.predict_proba(y_pred_proba_test)
@@ -384,8 +416,12 @@ class ConfigResult(BaselineResult):
 
         # print(f"{ag_metric.name}\ttest: {metric_error_test:.4f}\tval: {metric_error_val:.4f}\t{self.problem_type}")
         if as_sklearn:
-            metric_score_test = ag_metric.convert_score_to_original(score=ag_metric.convert_error_to_score(error=metric_error_test))
-            metric_score_val = ag_metric.convert_score_to_original(score=ag_metric.convert_error_to_score(error=metric_error_val))
+            metric_score_test = ag_metric.convert_score_to_original(
+                score=ag_metric.convert_error_to_score(error=metric_error_test)
+            )
+            metric_score_val = ag_metric.convert_score_to_original(
+                score=ag_metric.convert_error_to_score(error=metric_error_val)
+            )
             return metric_score_test, metric_score_val
         return metric_error_test, metric_error_val
 

--- a/packages/tabarena/src/tabarena/benchmark/result/experiment_results.py
+++ b/packages/tabarena/src/tabarena/benchmark/result/experiment_results.py
@@ -39,7 +39,7 @@ class ExperimentResults:
             results_configs_calibrated = []
             for i, result in enumerate(results_configs):
                 if i % 100 == 0:
-                    print(f"Calibrating: {i+1}/{n_configs}\t{result.framework}")
+                    print(f"Calibrating: {i + 1}/{n_configs}\t{result.framework}")
                 results_configs_calibrated.append(self._calibrate(result=result))
             results_configs += results_configs_calibrated
 

--- a/packages/tabarena/src/tabarena/benchmark/task/data_foundry/adapter.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/data_foundry/adapter.py
@@ -169,7 +169,7 @@ class DataFoundryAdapter:
         return metadata_df
 
 
-def convert_curated_container_to_user_task(  # noqa: C901 — linear problem-type validation
+def convert_curated_container_to_user_task(
     *,
     container: CuratedContainer,
     evaluation_metrics: dict[str, list[str]] | None = None,

--- a/packages/tabarena/src/tabarena/benchmark/task/data_foundry/metadata_cache.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/data_foundry/metadata_cache.py
@@ -14,7 +14,6 @@ This module keeps that contract intact while delegating download + conversion to
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import openml
@@ -22,6 +21,8 @@ import openml
 from tabarena.benchmark.task.data_foundry.adapter import DataFoundryAdapter
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pandas as pd
     from data_foundry.collections import DatasetCollection
 

--- a/packages/tabarena/src/tabarena/benchmark/task/data_foundry/text_cache.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/data_foundry/text_cache.py
@@ -99,6 +99,9 @@ def ensure_text_cache_for_task(
     # dataframe), so skip the full `dataset.parquet` read — otherwise every cache-less dataset
     # pays a wasted parquet load on each setup run.
     container = collection.get_dataset(
-        uuid, cache_dir=cache_dir, load_dataset=False, force_download=force_download
+        uuid,
+        cache_dir=cache_dir,
+        load_dataset=False,
+        force_download=force_download,
     )
     return import_text_cache_from_container(container, task_key, verbose=verbose)

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/bundles/base.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/bundles/base.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Literal
-
-import pandas as pd
+from typing import TYPE_CHECKING, Literal
 
 from tabarena.benchmark.task.metadata.schema import SplitMetadata, TabArenaTaskMetadata
 from tabarena.benchmark.task.metadata.sources import TaskMetadataSource, resolve_source
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pandas as pd
 
 
 @dataclass
@@ -42,7 +44,7 @@ class TabArenaMetadataBundle:
             "binary",
             "multiclass",
             "regression",
-        ]
+        ],
     )
     """Problem types to run in the benchmark. Adjust as needed to run only
      specific problem types.
@@ -141,7 +143,7 @@ class TabArenaMetadataBundle:
         if missing:
             raise ValueError(
                 f"Requested dataset names not found in task metadata: {sorted(missing)}. "
-                f"Available dataset names: {sorted(available)}"
+                f"Available dataset names: {sorted(available)}",
             )
         return [ttm for ttm in task_metadata if ttm.dataset_name in requested]
 

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/schema.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/schema.py
@@ -166,7 +166,7 @@ class TabArenaTaskMetadata:
         if self.n_splits != 1:
             raise ValueError(
                 f"Cannot get split index for task with {self.n_splits} splits. "
-                "This is only supported for tasks with exactly one split."
+                "This is only supported for tasks with exactly one split.",
             )
         return self.split_indices[0]
 
@@ -214,7 +214,7 @@ class TabArenaTaskMetadata:
                 {
                     **static_metadata,
                     **split_metadata.to_dict(),
-                }
+                },
             )
 
         df = pd.DataFrame(rows)
@@ -250,7 +250,7 @@ class TabArenaTaskMetadata:
         if not all(name in row_dict for name in required_task_fields):
             raise ValueError(
                 "Metadata row is missing required TabArenaTaskMetadata fields: "
-                f"{required_task_fields - row_dict.keys()}"
+                f"{required_task_fields - row_dict.keys()}",
             )
         task_kwargs = {key: row_dict[key] for key in all_task_fields if key in row_dict}
 
@@ -258,7 +258,7 @@ class TabArenaTaskMetadata:
         split_field_names = {f.name for f in fields(SplitMetadata)}
         if not all(name in row_dict for name in split_field_names):
             raise ValueError(
-                f"Metadata row is missing required SplitMetadata fields: {split_field_names - row_dict.keys()}"
+                f"Metadata row is missing required SplitMetadata fields: {split_field_names - row_dict.keys()}",
             )
         split_kwargs = {key: row_dict[key] for key in split_field_names if key in row_dict}
         # Reconstruct SplitMetadata

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/__init__.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/__init__.py
@@ -9,12 +9,8 @@ that knows about all built-in loaders, so bundles never special-case a suite.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pandas as pd
-
-from tabarena.benchmark.task.metadata.schema import TabArenaTaskMetadata
 from tabarena.benchmark.task.metadata.sources.base import (
     InMemoryTaskMetadataSource,
     TaskMetadataSource,
@@ -26,6 +22,14 @@ from tabarena.benchmark.task.metadata.sources.tabarena_v0pt1 import (
     TabArenaV0pt1TaskMetadataSource,
     load_tabarena_v0_1_task_metadata,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    import pandas as pd
+
+    from tabarena.benchmark.task.metadata.schema import TabArenaTaskMetadata
 
 
 def _beyond_arena_source() -> TaskMetadataSource:

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/data_foundry.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/data_foundry.py
@@ -112,7 +112,7 @@ class DataFoundryTaskMetadataSource(TaskMetadataSource):
 
         print(
             f"Materializing {len(splits_by_uri)} {self.collection.name} dataset(s) "
-            f"across {len(to_materialize)} split(s) (datasets + text caches)..."
+            f"across {len(to_materialize)} split(s) (datasets + text caches)...",
         )
         bar = tqdm(splits_by_uri.items(), desc=f"Materializing {self.collection.name}", unit="dataset")
         try:

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/openml.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/openml.py
@@ -16,10 +16,14 @@ the old pre-download ``--directory`` flag).
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from tabarena.benchmark.task.metadata.schema import TabArenaTaskMetadata
 from tabarena.benchmark.task.metadata.sources.base import TaskMetadataSource
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tabarena.benchmark.task.metadata.schema import TabArenaTaskMetadata
 
 
 class OpenMLTaskMetadataSource(TaskMetadataSource):

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/tabarena_v0pt1.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/tabarena_v0pt1.py
@@ -82,7 +82,7 @@ def load_tabarena_v0_1_task_metadata(curated_metadata: pd.DataFrame) -> list[Tab
                         num_classes_test=num_classes,
                         num_features_train=num_features,
                         num_features_test=num_features,
-                    )
+                    ),
                 }
 
                 task_metadata.append(
@@ -117,7 +117,7 @@ def load_tabarena_v0_1_task_metadata(curated_metadata: pd.DataFrame) -> list[Tab
                         domain=domain,
                         dataset_year=dataset_year,
                         source=data_source,
-                    )
+                    ),
                 )
     return task_metadata
 

--- a/packages/tabarena/src/tabarena/benchmark/task/openml/metadata_mixin.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/openml/metadata_mixin.py
@@ -78,7 +78,11 @@ class TabArenaTaskMetadataMixin:
         return X.groupby(group_on, dropna=False, observed=True).ngroups
 
     def _get_dataset_stats(
-        self, *, oml_dataset: pd.DataFrame, is_classification: bool, target_name: str
+        self,
+        *,
+        oml_dataset: pd.DataFrame,
+        is_classification: bool,
+        target_name: str,
     ) -> tuple[int, int, int, int]:
         num_instance = len(oml_dataset)
         num_features = oml_dataset.shape[1] - 1  # -1 for target
@@ -210,7 +214,7 @@ class TabArenaTaskMetadataMixin:
         # FIXME: make this less strict?
         if len(feature_df.select_dtypes(include=["object"]).columns) > 0:
             raise ValueError(
-                "Object dtype columns are not supported. Please convert them to string dtype or categorical dtype!"
+                "Object dtype columns are not supported. Please convert them to string dtype or categorical dtype!",
             )
 
         # Independent dtype flags
@@ -229,8 +233,7 @@ class TabArenaTaskMetadataMixin:
         non_binary_categorical_cols = [c for c in categorical_cols if c not in binary_cols]
         has_categorical = len(non_binary_categorical_cols) > 0
         has_high_cardinality_categorical = any(
-            feature_df[c].nunique(dropna=True) > 50
-            for c in non_binary_categorical_cols
+            feature_df[c].nunique(dropna=True) > 50 for c in non_binary_categorical_cols
         )
 
         # Warehouse-level counts (consistent with the Data Foundry warehouse computation,
@@ -240,7 +243,7 @@ class TabArenaTaskMetadataMixin:
         num_text_cols = len(text_cols)
         num_datetime_cols = len(datetime_cols)
         num_high_cardinality_cats = int(
-            sum(feature_df[c].nunique(dropna=True) > 50 for c in category_only_cols)
+            sum(feature_df[c].nunique(dropna=True) > 50 for c in category_only_cols),
         )
         num_cols_after_preprocessing = (
             sum(c not in binary_cols for c in numerical_cols)
@@ -249,9 +252,7 @@ class TabArenaTaskMetadataMixin:
             + len(binary_cols)
             + num_datetime_cols * 10
         )
-        missing_value_fraction = (
-            float(feature_df.isna().to_numpy().sum() / feature_df.size) if feature_df.size else 0.0
-        )
+        missing_value_fraction = float(feature_df.isna().to_numpy().sum() / feature_df.size) if feature_df.size else 0.0
 
         self._task_metadata = TabArenaTaskMetadata(
             dataset_name=dataset_name,

--- a/packages/tabarena/src/tabarena/benchmark/task/openml/task_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/openml/task_utils.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import logging
-import openml
-import pandas as pd
 import time
+from typing import TYPE_CHECKING
 
+import openml
 from openml import OpenMLSupervisedTask
 from openml.exceptions import OpenMLServerException
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -21,20 +24,16 @@ def get_task(task_id: int) -> OpenMLSupervisedTask:
     )
     if isinstance(task, OpenMLSupervisedTask):
         return task
-    else:
-        raise AssertionError(f"Invalid task type: {type(task)}")
+    raise AssertionError(f"Invalid task type: {type(task)}")
 
 
 def get_ag_problem_type(task: OpenMLSupervisedTask) -> str:
-    if task.task_type_id.name == 'SUPERVISED_CLASSIFICATION':
-        if len(task.class_labels) > 2:
-            problem_type = 'multiclass'
-        else:
-            problem_type = 'binary'
-    elif task.task_type_id.name == 'SUPERVISED_REGRESSION':
-        problem_type = 'regression'
+    if task.task_type_id.name == "SUPERVISED_CLASSIFICATION":
+        problem_type = "multiclass" if len(task.class_labels) > 2 else "binary"
+    elif task.task_type_id.name == "SUPERVISED_REGRESSION":
+        problem_type = "regression"
     else:
-        raise AssertionError(f'Unsupported task type: {task.task_type_id.name}')
+        raise AssertionError(f"Unsupported task type: {task.task_type_id.name}")
     return problem_type
 
 
@@ -43,16 +42,15 @@ def get_task_with_retry(task_id: int, max_delay_exp: int = 8) -> OpenMLSupervise
     while True:
         try:
             # print(f'Getting task {task_id}')
-            task = get_task(task_id=task_id)
+            return get_task(task_id=task_id)
             # print(f'Got task {task_id}')
-            return task
         except OpenMLServerException as e:
-            delay = 2 ** delay_exp
+            delay = 2**delay_exp
             delay_exp += 1
             if delay_exp > max_delay_exp:
-                raise ValueError("Unable to get task after 10 retries")
+                raise ValueError("Unable to get task after 10 retries") from e
             print(e)
-            print(f'Retry in {delay}s...')
+            print(f"Retry in {delay}s...")
             time.sleep(delay)
             continue
 

--- a/packages/tabarena/src/tabarena/benchmark/task/openml/task_wrapper.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/openml/task_wrapper.py
@@ -2,19 +2,20 @@ from __future__ import annotations
 
 import io
 import logging
-import math
-import numpy as np
+from typing import TYPE_CHECKING, Self
+
 import pandas as pd
-
-from openml.tasks.task import OpenMLSupervisedTask
-from typing_extensions import Self
-
-from autogluon.common.savers import save_pd, save_json
+from autogluon.common.savers import save_json, save_pd
 from autogluon.core.utils import generate_train_test_split
+from openml.tasks.task import OpenMLSupervisedTask
 
-from .task_utils import get_task_data, get_ag_problem_type, get_task_with_retry
-from ..utils import get_split_idx, get_split_vals_from_split_idx
-from ....utils.s3_utils import download_task_from_s3, upload_task_to_s3
+from tabarena.benchmark.task.utils import get_split_idx, get_split_vals_from_split_idx
+from tabarena.utils.s3_utils import download_task_from_s3, upload_task_to_s3
+
+from .task_utils import get_ag_problem_type, get_task_data, get_task_with_retry
+
+if TYPE_CHECKING:
+    import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,7 @@ class OpenMLTaskWrapper:
     def compute_error(self, y_true, y_pred) -> float:
         eval_metric = self.eval_metric
         from autogluon.core.metrics import get_metric
+
         scorer = get_metric(metric=eval_metric, problem_type=self.problem_type)
         return scorer.error(y_true, y_pred)
 
@@ -89,7 +91,7 @@ class OpenMLTaskWrapper:
             X, y = self.X, self.y
         return pd.concat([X, y.to_frame(name=self.label)], axis=1)
 
-    def save_data(self, path: str, file_type='.csv', train_indices=None, test_indices=None):
+    def save_data(self, path: str, file_type=".csv", train_indices=None, test_indices=None):
         data = self.combine_X_y()
         if train_indices is not None and test_indices is not None:
             train_data = data.loc[train_indices]
@@ -143,8 +145,8 @@ class OpenMLTaskWrapper:
         sample: int = 0,
         train_indices: np.ndarray = None,
         test_indices: np.ndarray = None,
-        train_size: int | float = None,
-        test_size: int | float = None,
+        train_size: int | float | None = None,
+        test_size: int | float | None = None,
         random_state: int = 0,
     ) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]:
         if train_indices is None or test_indices is None:
@@ -173,9 +175,7 @@ class OpenMLTaskWrapper:
 
     @classmethod
     def to_csv_format(cls, X: pd.DataFrame) -> pd.DataFrame:
-        """
-        Converts X to the dtypes that it would have if it were saved to a CSV and then loaded.
-        """
+        """Converts X to the dtypes that it would have if it were saved to a CSV and then loaded."""
         s_buf = io.StringIO()
         X_index = X.index
         X.to_csv(s_buf, index=False)
@@ -196,7 +196,11 @@ class OpenMLTaskWrapper:
         if isinstance(size, float) and size >= 1:
             return X, y
         X, _, y, _ = generate_train_test_split(
-            X=X, y=y, problem_type=self.problem_type, train_size=size, random_state=random_state
+            X=X,
+            y=y,
+            problem_type=self.problem_type,
+            train_size=size,
+            random_state=random_state,
         )
         return X, y
 
@@ -207,8 +211,8 @@ class OpenMLTaskWrapper:
         sample: int = 0,
         train_indices: np.ndarray = None,
         test_indices: np.ndarray = None,
-        train_size: int | float = None,
-        test_size: int | float = None,
+        train_size: int | float | None = None,
+        test_size: int | float | None = None,
         random_state: int = 0,
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
         X_train, y_train, X_test, y_test = self.get_train_test_split(
@@ -238,11 +242,9 @@ class OpenMLTaskWrapper:
         """Extra splits kwargs from the TabArenaOpenMLSupervisedTask task,
         or fallback to defaults.
         """
-        from openml.tasks import OpenMLSupervisedTask
-
         from tabarena.benchmark.task.openml.metadata_mixin import TabArenaOpenMLSupervisedTask
 
-        oml_task: TabArenaOpenMLSupervisedTask | OpenMLSupervisedTask  = self.task
+        oml_task: TabArenaOpenMLSupervisedTask | OpenMLSupervisedTask = self.task
 
         if isinstance(oml_task, TabArenaOpenMLSupervisedTask):
             stratify_on = oml_task.stratify_on
@@ -260,12 +262,10 @@ class OpenMLTaskWrapper:
                 group_time_on,
                 group_labels,
                 split_time_horizon,
-                split_time_horizon_unit
-            )= None, None, None, None, None, None, None
+                split_time_horizon_unit,
+            ) = None, None, None, None, None, None, None
 
-
-
-        return dict(  # noqa: C408
+        return dict(
             target_name=oml_task.target_name,
             stratify_on=stratify_on,
             group_on=group_on,
@@ -277,11 +277,9 @@ class OpenMLTaskWrapper:
         )
 
 
-
 class OpenMLS3TaskWrapper(OpenMLTaskWrapper):
-    """
-    Class which uses S3 cache to download task splits.
-    """
+    """Class which uses S3 cache to download task splits."""
+
     @classmethod
     def from_task_id(cls, task_id: int, s3_dataset_cache: str) -> Self:
         assert s3_dataset_cache is not None

--- a/packages/tabarena/src/tabarena/benchmark/task/user_task.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/user_task.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import pickle
 from collections import OrderedDict
-from collections.abc import Iterable
 from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -32,6 +31,8 @@ from tabarena.benchmark.task.openml import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from tabarena.benchmark.task.metadata import (
         GroupLabelTypes,
         SplitTimeHorizonTypes,
@@ -355,11 +356,11 @@ class UserTask:
                     raise ValueError(f"Indices in split {split_id} must be non-negative.")
                 if any(np.array(train_indices + test_indices) >= n_samples):
                     raise ValueError(
-                        f"Indices in split {split_id} must not exceed the dataset size (0 to {n_samples - 1})."
+                        f"Indices in split {split_id} must not exceed the dataset size (0 to {n_samples - 1}).",
                     )
                 if test_indices_per_repeat & set(test_indices):
                     raise ValueError(
-                        f"Test indices in split {split_id} must not overlap with previous splits in repeat {repeat_id}."
+                        f"Test indices in split {split_id} must not overlap with previous splits in repeat {repeat_id}.",
                     )
                 test_indices_per_repeat.update(test_indices)
 
@@ -436,7 +437,7 @@ def openml_create_datasets_without_arff_dump(
     unsupported_cols = data.select_dtypes(include=["datetime64", "timedelta64"]).columns
     # select_dtypes doesn't support "period" or "interval" as strings, so detect manually
     unsupported_cols = unsupported_cols.append(
-        pd.Index(col for col in data.columns if isinstance(data[col].dtype, (pd.PeriodDtype, pd.IntervalDtype)))
+        pd.Index(col for col in data.columns if isinstance(data[col].dtype, (pd.PeriodDtype, pd.IntervalDtype))),
     )
     # Cast categories of categorical columns to string so that
     # attributes_arff_from_df can handle them (e.g. integer categories).
@@ -485,7 +486,8 @@ def openml_create_datasets_without_arff_dump(
 
 
 def from_sklearn_splits_to_user_task_splits(
-    sklearn_splits: Iterable, n_splits: int
+    sklearn_splits: Iterable,
+    n_splits: int,
 ) -> dict[int, dict[int, tuple[list, list]]]:
     """Convert sklearn splits to the OpenML splits format used in TabArena's
     local user tasks.

--- a/packages/tabarena/src/tabarena/benchmark/task/utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/utils.py
@@ -14,8 +14,7 @@ def get_split_idx(
     assert fold < n_folds
     assert repeat < n_repeats
     assert sample < n_samples
-    split_idx = n_folds * n_samples * repeat + n_samples * fold + sample
-    return split_idx
+    return n_folds * n_samples * repeat + n_samples * fold + sample
 
 
 def get_split_vals_from_split_idx(

--- a/packages/tabarena/src/tabarena/contexts/__init__.py
+++ b/packages/tabarena/src/tabarena/contexts/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 from .context import BenchmarkContext

--- a/packages/tabarena/src/tabarena/contexts/context.py
+++ b/packages/tabarena/src/tabarena/contexts/context.py
@@ -1,96 +1,95 @@
-
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from typing import Dict, List, Tuple
 import os
+from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Self
 
 import boto3
-from botocore.errorfactory import ClientError
-import pandas as pd
-from typing_extensions import Self
-
-from autogluon.common.loaders import load_pd, load_json
+from autogluon.common.loaders import load_json, load_pd
 from autogluon.common.savers import save_json
-from autogluon.common.utils.s3_utils import download_s3_files
-from autogluon.common.utils.s3_utils import is_s3_url, s3_path_to_bucket_prefix
+from autogluon.common.utils.s3_utils import download_s3_files, is_s3_url, s3_path_to_bucket_prefix
+from botocore.errorfactory import ClientError
+
+from tabarena.loaders import Paths, load_configs, load_results
+from tabarena.repository.evaluation_repository import EvaluationRepository
+from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
+from tabarena.utils.download import download_files
+from tabarena.utils.huggingfacehub_utils import download_from_huggingface
 
 from .utils import load_zeroshot_input
-from ..loaders import load_configs, load_results, Paths
-from ..simulation.ground_truth import GroundTruth
-from ..simulation.simulation_context import ZeroshotSimulatorContext
-from ..predictions.tabular_predictions import TabularModelPredictions
-from ..repository.evaluation_repository import EvaluationRepository
-from ..utils import catchtime
-from ..utils.huggingfacehub_utils import download_from_huggingface
-from ..utils.download import download_files
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from tabarena.predictions.tabular_predictions import TabularModelPredictions
+    from tabarena.simulation.ground_truth import GroundTruth
 
 
-def download_from_s3(name: str, include_zs: bool, exists: str, dry_run: bool, s3_download_map, benchmark_paths, verbose: bool):
-    print(f'Downloading files for {name} context... '
-          f'(include_zs={include_zs}, exists="{exists}", dry_run={dry_run})')
+def download_from_s3(
+    name: str, include_zs: bool, exists: str, dry_run: bool, s3_download_map, benchmark_paths, verbose: bool
+):
+    print(f'Downloading files for {name} context... (include_zs={include_zs}, exists="{exists}", dry_run={dry_run})')
     if dry_run:
-        print(f'\tNOTE: `dry_run=True`! Files will not be downloaded.')
+        print("\tNOTE: `dry_run=True`! Files will not be downloaded.")
     assert exists in ["raise", "ignore", "overwrite"]
-    assert s3_download_map is not None, \
-        f'self.s3_download_map is None: download functionality is disabled'
+    assert s3_download_map is not None, "self.s3_download_map is None: download functionality is disabled"
     file_paths_expected = benchmark_paths.get_file_paths(include_zs=include_zs)
 
     file_paths_to_download = [f for f in file_paths_expected if f in s3_download_map]
     if len(file_paths_to_download) == 0:
-        print(f'WARNING: Matching file paths to download is 0! '
-              f'`self.s3_download_map` probably has incorrect keys.')
+        print("WARNING: Matching file paths to download is 0! `self.s3_download_map` probably has incorrect keys.")
     file_paths_already_exist = [f for f in file_paths_to_download if benchmark_paths.exists(f)]
     file_paths_missing = [f for f in file_paths_to_download if not benchmark_paths.exists(f)]
 
-    if exists == 'raise':
+    if exists == "raise":
         if file_paths_already_exist:
-            raise AssertionError(f'`exists="{exists}"`, '
-                                 f'and found {len(file_paths_already_exist)} files that already exist locally!\n'
-                                 f'\tExisting Files: {file_paths_already_exist}\n'
-                                 f'\tMissing  Files: {file_paths_missing}\n'
-                                 f'Either manually inspect and delete existing files, '
-                                 f'set `exists="ignore"` to keep your local files and only download missing files, '
-                                 f'or set `exists="overwrite"` to overwrite your existing local files.')
-    elif exists == 'ignore':
+            raise AssertionError(
+                f'`exists="{exists}"`, '
+                f"and found {len(file_paths_already_exist)} files that already exist locally!\n"
+                f"\tExisting Files: {file_paths_already_exist}\n"
+                f"\tMissing  Files: {file_paths_missing}\n"
+                f"Either manually inspect and delete existing files, "
+                f'set `exists="ignore"` to keep your local files and only download missing files, '
+                f'or set `exists="overwrite"` to overwrite your existing local files.'
+            )
+    elif exists == "ignore":
         file_paths_to_download = file_paths_missing
-    elif exists == 'overwrite':
-        file_paths_to_download = file_paths_to_download
+    elif exists == "overwrite":
+        pass  # keep file_paths_to_download as-is (download everything)
     else:
-        raise ValueError(f'Invalid value for exists (`exists="{exists}"`). '
-                         f'Valid values: {["raise", "ignore", "overwrite"]}')
+        raise ValueError(
+            f'Invalid value for exists (`exists="{exists}"`). Valid values: {["raise", "ignore", "overwrite"]}'
+        )
 
-    s3_to_local_tuple_list = [(val, key) for key, val in s3_download_map.items()
-                              if key in file_paths_to_download]
+    s3_to_local_tuple_list = [(val, key) for key, val in s3_download_map.items() if key in file_paths_to_download]
 
-    log_extra = ''
+    log_extra = ""
 
     num_exist = len(file_paths_already_exist)
-    if exists == 'overwrite':
+    if exists == "overwrite":
         if num_exist > 0:
-            log_extra += f'\tWill overwrite {num_exist} files that exist locally:\n' \
-                         f'\t\t{file_paths_already_exist}'
+            log_extra += f"\tWill overwrite {num_exist} files that exist locally:\n\t\t{file_paths_already_exist}"
         else:
-            log_extra = f''
-    if exists == 'ignore':
-        log_extra += f'\tWill skip {num_exist} files that exist locally:\n' \
-                     f'\t\t{file_paths_already_exist}'
+            log_extra = ""
+    if exists == "ignore":
+        log_extra += f"\tWill skip {num_exist} files that exist locally:\n\t\t{file_paths_already_exist}"
     if file_paths_missing:
         if log_extra:
-            log_extra += '\n'
-        log_extra += f'Will download {len(file_paths_missing)} files that are missing locally:\n' \
-                     f'\t\t{file_paths_missing}'
+            log_extra += "\n"
+        log_extra += (
+            f"Will download {len(file_paths_missing)} files that are missing locally:\n\t\t{file_paths_missing}"
+        )
 
     if log_extra:
         print(log_extra)
-    print(f'\tDownloading {len(s3_to_local_tuple_list)} files from s3 to local...')
+    print(f"\tDownloading {len(s3_to_local_tuple_list)} files from s3 to local...")
     for s3_path, local_path in s3_to_local_tuple_list:
         print(f'\t\t"{s3_path}" -> "{local_path}"')
-    s3_required_list = [(s3_path, local_path) for s3_path, local_path in s3_to_local_tuple_list if
-                        s3_path[:2] == "s3"]
-    urllib_required_list = [(s3_path, local_path) for s3_path, local_path in s3_to_local_tuple_list if
-                            s3_path[:2] != "s3"]
+    s3_required_list = [(s3_path, local_path) for s3_path, local_path in s3_to_local_tuple_list if s3_path[:2] == "s3"]
+    urllib_required_list = [
+        (s3_path, local_path) for s3_path, local_path in s3_to_local_tuple_list if s3_path[:2] != "s3"
+    ]
     if urllib_required_list:
         download_files(remote_to_local_tuple_list=urllib_required_list, dry_run=dry_run, verbose=verbose)
     if s3_required_list:
@@ -104,10 +103,10 @@ class BenchmarkPaths:
     task_metadata: str = None
     metadata_join_column: str = "dataset"
     path_pred_proba: str = None
-    datasets: List[str] = None
-    zs_pp: List[str] = None
-    zs_gt: List[str] = None
-    configs_hyperparameters: List[str] = None
+    datasets: list[str] = None
+    zs_pp: list[str] = None
+    zs_gt: list[str] = None
+    configs_hyperparameters: list[str] = None
     relative_path: str = None
 
     def __post_init__(self):
@@ -161,11 +160,11 @@ class BenchmarkPaths:
         return [self._to_full(path) for path in paths]
 
     def print_summary(self):
-        max_str_len = max(len(key) for key in self.__dict__.keys())
-        print(f'BenchmarkPaths Summary:')
-        print("\n".join(f'\t{key + " "*(max_str_len - len(key))} = {value}' for key, value in self.__dict__.items()))
+        max_str_len = max(len(key) for key in self.__dict__)
+        print("BenchmarkPaths Summary:")
+        print("\n".join(f"\t{key + ' ' * (max_str_len - len(key))} = {value}" for key, value in self.__dict__.items()))
 
-    def get_file_paths(self, include_zs: bool = True) -> List[str]:
+    def get_file_paths(self, include_zs: bool = True) -> list[str]:
         file_paths = [
             self.configs_full,
             self.baselines_full,
@@ -174,47 +173,44 @@ class BenchmarkPaths:
         if include_zs:
             file_paths += self.zs_pp_full
             file_paths += self.zs_gt_full
-        file_paths = [f for f in file_paths if f is not None]
-        return file_paths
+        return [f for f in file_paths if f is not None]
 
     def assert_exists_all(self, check_zs=True):
-        self._assert_exists(self.configs_full, 'configs')
+        self._assert_exists(self.configs_full, "configs")
         if self.baselines is not None:
-            self._assert_exists(self.baselines_full, 'baselines')
+            self._assert_exists(self.baselines_full, "baselines")
         if self.task_metadata is not None:
-            self._assert_exists(self.task_metadata_full, 'task_metadata')
+            self._assert_exists(self.task_metadata_full, "task_metadata")
         if check_zs:
             if self.zs_pp is not None:
                 for f in self.zs_pp_full:
-                    self._assert_exists(f, f'zs_pp | {f}')
+                    self._assert_exists(f, f"zs_pp | {f}")
             if self.zs_gt is not None:
                 for f in self.zs_gt_full:
-                    self._assert_exists(f, f'zs_gt | {f}')
+                    self._assert_exists(f, f"zs_gt | {f}")
 
     @staticmethod
-    def _assert_exists(filepath: str, name: str = None):
+    def _assert_exists(filepath: str, name: str | None = None):
         if filepath is None:
-            raise AssertionError(f'Filepath for {name} cannot be None!')
+            raise AssertionError(f"Filepath for {name} cannot be None!")
 
         if is_s3_url(path=filepath):
             s3_bucket, s3_prefix = s3_path_to_bucket_prefix(s3_path=filepath)
-            s3 = boto3.client('s3')
+            s3 = boto3.client("s3")
             try:
                 s3.head_object(Bucket=s3_bucket, Key=s3_prefix)
             except ClientError as e:
-                if e.response['Error']['Code'] == "404":
+                if e.response["Error"]["Code"] == "404":
                     # The key does not exist.
-                    raise ValueError(f'Filepath for {name} does not exist in S3! '
-                                     f'(filepath="{filepath}")')
-                elif e.response['Error']['Code'] == "403":
-                    raise ValueError(f'Filepath for {name} does not exist in S3 or you lack permissions to read! '
-                                     f'(filepath="{filepath}")')
-                else:
-                    raise e
-        else:
-            if not Path(filepath).exists():
-                raise ValueError(f'Filepath for {name} does not exist on local filesystem! '
-                                 f'(filepath="{filepath}")')
+                    raise ValueError(f'Filepath for {name} does not exist in S3! (filepath="{filepath}")') from e
+                if e.response["Error"]["Code"] == "403":
+                    raise ValueError(
+                        f"Filepath for {name} does not exist in S3 or you lack permissions to read! "
+                        f'(filepath="{filepath}")'
+                    ) from e
+                raise e
+        elif not Path(filepath).exists():
+            raise ValueError(f'Filepath for {name} does not exist on local filesystem! (filepath="{filepath}")')
 
     def exists_all(self, check_zs: bool = True) -> bool:
         required_files = self.get_file_paths(include_zs=check_zs)
@@ -231,22 +227,21 @@ class BenchmarkPaths:
     @staticmethod
     def exists(filepath: str) -> bool:
         if filepath is None:
-            raise AssertionError(f'Filepath cannot be None!')
+            raise AssertionError("Filepath cannot be None!")
         filepath = str(filepath)
 
         if is_s3_url(path=filepath):
             s3_bucket, s3_prefix = s3_path_to_bucket_prefix(s3_path=filepath)
-            s3 = boto3.client('s3')
+            s3 = boto3.client("s3")
             try:
                 s3.head_object(Bucket=s3_bucket, Key=s3_prefix)
-            except ClientError as e:
+            except ClientError:
                 return False
-        else:
-            if not Path(filepath).exists():
-                return False
+        elif not Path(filepath).exists():
+            return False
         return True
 
-    def load_results(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    def load_results(self) -> tuple[pd.DataFrame, pd.DataFrame]:
         df_configs, df_metadata = load_results(
             path_configs=self.configs_full,
             path_metadata=self.task_metadata_full,
@@ -258,25 +253,23 @@ class BenchmarkPaths:
     def load_baselines(self) -> pd.DataFrame | None:
         if self.baselines is None:
             return None
-        df_baselines = load_pd.load(self.baselines_full)
-        return df_baselines
+        return load_pd.load(self.baselines_full)
 
     def load_predictions(
         self,
         zsc: ZeroshotSimulatorContext,
         prediction_format: str = "memmap",
         verbose: bool = True,
-    ) -> Tuple[TabularModelPredictions, GroundTruth, ZeroshotSimulatorContext]:
-        """
-        :param prediction_format: Determines the format of the loaded tabular_predictions. Default = "memmap".
-            "memmap": Fast and low memory usage.
-            "memopt": Very fast and high memory usage.
-            "mem": Slow and high memory usage, simplest format to debug.
+    ) -> tuple[TabularModelPredictions, GroundTruth, ZeroshotSimulatorContext]:
+        """:param prediction_format: Determines the format of the loaded tabular_predictions. Default = "memmap".
+        "memmap": Fast and low memory usage.
+        "memopt": Very fast and high memory usage.
+        "mem": Slow and high memory usage, simplest format to debug.
         """
         for f in self.zs_pp_full:
-            self._assert_exists(f, f'zs_pp | {f}')
+            self._assert_exists(f, f"zs_pp | {f}")
         for f in self.zs_gt_full:
-            self._assert_exists(f, name=f'zs_gt | {f}')
+            self._assert_exists(f, name=f"zs_gt | {f}")
         zeroshot_pred_proba, zeroshot_gt, zsc = load_zeroshot_input(
             path_pred_proba=self.path_pred_proba_full,
             paths_gt=self.zs_gt_full,
@@ -295,16 +288,17 @@ class BenchmarkPaths:
 
 
 class BenchmarkContext:
-    def __init__(self,
-                 *,
-                 folds: List[int],
-                 benchmark_paths: BenchmarkPaths,
-                 name: str = None,
-                 description: str = None,
-                 date: str = None,
-                 s3_download_map: Dict[str, str] = None,
-                 config_fallback: str = None,
-                 ):
+    def __init__(
+        self,
+        *,
+        folds: list[int],
+        benchmark_paths: BenchmarkPaths,
+        name: str | None = None,
+        description: str | None = None,
+        date: str | None = None,
+        s3_download_map: dict[str, str] | None = None,
+        config_fallback: str | None = None,
+    ):
         self.folds = folds
         self.benchmark_paths = benchmark_paths
         self.name = name
@@ -314,32 +308,36 @@ class BenchmarkContext:
         self.config_fallback = config_fallback
 
     @classmethod
-    def from_paths(cls,
-                   *,
-                   folds: List[int],
-                   name: str = None,
-                   description: str = None,
-                   date: str = None,
-                   s3_download_map: Dict[str, str] = None,
-                   config_fallback: str = None,
-                   **paths):
-        return cls(folds=folds,
-                   name=name,
-                   description=description,
-                   date=date,
-                   s3_download_map=s3_download_map,
-                   config_fallback=config_fallback,
-                   benchmark_paths=BenchmarkPaths(**paths))
-
-    def download(self,
-                 include_zs: bool = True,
-                 exists: str = 'raise',
-                 verbose: bool = True,
-                 dry_run: bool = False,
-                 use_s3: bool = True,
+    def from_paths(
+        cls,
+        *,
+        folds: list[int],
+        name: str | None = None,
+        description: str | None = None,
+        date: str | None = None,
+        s3_download_map: dict[str, str] | None = None,
+        config_fallback: str | None = None,
+        **paths,
     ):
-        """
-        Downloads all BenchmarkContext required files from s3 to local disk.
+        return cls(
+            folds=folds,
+            name=name,
+            description=description,
+            date=date,
+            s3_download_map=s3_download_map,
+            config_fallback=config_fallback,
+            benchmark_paths=BenchmarkPaths(**paths),
+        )
+
+    def download(
+        self,
+        include_zs: bool = True,
+        exists: str = "raise",
+        verbose: bool = True,
+        dry_run: bool = False,
+        use_s3: bool = True,
+    ):
+        """Downloads all BenchmarkContext required files from s3 to local disk.
 
         :param include_zs: If True, downloads zpp and gt files if they exist.
         :param exists: This determines the behavior of the file download.
@@ -354,28 +352,32 @@ class BenchmarkContext:
         """
         if use_s3:
             download_from_s3(
-                name=self.name, include_zs=include_zs, exists=exists, dry_run=dry_run,
-                s3_download_map=self.s3_download_map, benchmark_paths=self.benchmark_paths, verbose=verbose
+                name=self.name,
+                include_zs=include_zs,
+                exists=exists,
+                dry_run=dry_run,
+                s3_download_map=self.s3_download_map,
+                benchmark_paths=self.benchmark_paths,
+                verbose=verbose,
             )
         else:
             if verbose:
-                print(f'Downloading files for {self.name} context... '
-                      f'(include_zs={include_zs}, exists="{exists}")')
+                print(f'Downloading files for {self.name} context... (include_zs={include_zs}, exists="{exists}")')
             download_from_huggingface(
                 datasets=self.benchmark_paths.datasets,
             )
 
-    def load(self,
-             folds: List[int] = None,
-             load_predictions: bool = True,
-             download_files: bool = True,
-             prediction_format: str = "memmap",
-             exists: str = 'ignore',
-             use_s3: bool = True,
-             verbose: bool = True,
-             ) -> Tuple[ZeroshotSimulatorContext, TabularModelPredictions, GroundTruth]:
-        """
-        :param folds: If None, uses self.folds as default.
+    def load(
+        self,
+        folds: list[int] | None = None,
+        load_predictions: bool = True,
+        download_files: bool = True,
+        prediction_format: str = "memmap",
+        exists: str = "ignore",
+        use_s3: bool = True,
+        verbose: bool = True,
+    ) -> tuple[ZeroshotSimulatorContext, TabularModelPredictions, GroundTruth]:
+        """:param folds: If None, uses self.folds as default.
             If specified, must be a subset of `self.folds`. This will filter the results to only the specified folds.
             Restricting folds can be useful to speed up experiments.
         :param load_predictions: If True, loads zpp and gt files.
@@ -404,17 +406,18 @@ class BenchmarkContext:
         if folds is None:
             folds = self.folds
         for f in folds:
-            assert f in self.folds, f'Fold {f} does not exist in available folds! self.folds={self.folds}'
+            assert f in self.folds, f"Fold {f} does not exist in available folds! self.folds={self.folds}"
 
         if verbose:
-            print(f'Loading BenchmarkContext:\n'
-                  f'\tname: {self.name}\n'
-                  f'\tdescription: {self.description}\n'
-                  f'\tdate: {self.date}\n'
-                  f'\tfolds: {folds}')
-        if download_files and exists == 'ignore':
-            if self.benchmark_paths.exists_all(check_zs=load_predictions):
-                download_files = False
+            print(
+                f"Loading BenchmarkContext:\n"
+                f"\tname: {self.name}\n"
+                f"\tdescription: {self.description}\n"
+                f"\tdate: {self.date}\n"
+                f"\tfolds: {folds}"
+            )
+        if download_files and exists == "ignore" and self.benchmark_paths.exists_all(check_zs=load_predictions):
+            download_files = False
         if download_files:
             if verbose:
                 self.benchmark_paths.print_summary()
@@ -422,9 +425,11 @@ class BenchmarkContext:
                 missing_files = self.benchmark_paths.missing_files()
                 if missing_files:
                     missing_files_str = [f'\n\t"{m}"' for m in missing_files]
-                    raise FileNotFoundError(f'Missing {len(missing_files)} required files: \n[{",".join(missing_files_str)}\n]')
+                    raise FileNotFoundError(
+                        f"Missing {len(missing_files)} required files: \n[{','.join(missing_files_str)}\n]"
+                    )
             if verbose:
-                print(f'Downloading input files from s3...')
+                print("Downloading input files from s3...")
             self.download(include_zs=load_predictions, exists=exists, use_s3=use_s3, verbose=verbose)
         self.benchmark_paths.assert_exists_all(check_zs=load_predictions)
 
@@ -432,7 +437,9 @@ class BenchmarkContext:
         zsc = self._load_zsc(folds=folds, configs_hyperparameters=configs_hyperparameters, verbose=verbose)
 
         if load_predictions:
-            zeroshot_pred_proba, zeroshot_gt, zsc = self._load_predictions(zsc=zsc, prediction_format=prediction_format, verbose=verbose)
+            zeroshot_pred_proba, zeroshot_gt, zsc = self._load_predictions(
+                zsc=zsc, prediction_format=prediction_format, verbose=verbose
+            )
         else:
             zeroshot_pred_proba = None
             zeroshot_gt = None
@@ -441,11 +448,11 @@ class BenchmarkContext:
 
     def load_repo(
         self,
-        folds: List[int] = None,
+        folds: list[int] | None = None,
         load_predictions: bool = True,
         download_files: bool = True,
         prediction_format: str = "memmap",
-        exists: str = 'ignore',
+        exists: str = "ignore",
         use_s3: bool = True,
         verbose: bool = True,
     ) -> EvaluationRepository:
@@ -458,15 +465,14 @@ class BenchmarkContext:
             use_s3=use_s3,
             verbose=verbose,
         )
-        repo = EvaluationRepository(
+        return EvaluationRepository(
             zeroshot_context=zsc,
             tabular_predictions=zeroshot_pred_proba,
             ground_truth=zeroshot_gt,
             config_fallback=self.config_fallback,
         )
-        return repo
 
-    def _load_results(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    def _load_results(self) -> tuple[pd.DataFrame, pd.DataFrame]:
         df_configs, df_metadata = self.benchmark_paths.load_results()
         return df_configs, df_metadata
 
@@ -478,20 +484,22 @@ class BenchmarkContext:
         zsc: ZeroshotSimulatorContext,
         prediction_format: str,
         verbose: bool = True,
-    ) -> Tuple[TabularModelPredictions, GroundTruth, ZeroshotSimulatorContext]:
+    ) -> tuple[TabularModelPredictions, GroundTruth, ZeroshotSimulatorContext]:
         return self.benchmark_paths.load_predictions(zsc=zsc, prediction_format=prediction_format, verbose=verbose)
 
-    def _load_zsc(self, folds: List[int], configs_hyperparameters: dict, verbose: bool = True) -> ZeroshotSimulatorContext:
+    def _load_zsc(
+        self, folds: list[int], configs_hyperparameters: dict, verbose: bool = True
+    ) -> ZeroshotSimulatorContext:
         df_configs, df_metadata = self._load_results()
 
         # Load in real framework results to score against
         if verbose:
-            print(f'Loading baselines: {self.benchmark_paths.baselines}')
+            print(f"Loading baselines: {self.benchmark_paths.baselines}")
         df_baselines = self.benchmark_paths.load_baselines()
 
         score_against_only_baselines = df_baselines is not None
 
-        zsc = ZeroshotSimulatorContext(
+        return ZeroshotSimulatorContext(
             df_configs=df_configs,
             folds=folds,
             df_baselines=df_baselines,
@@ -499,7 +507,6 @@ class BenchmarkContext:
             score_against_only_baselines=score_against_only_baselines,
             configs_hyperparameters=configs_hyperparameters,
         )
-        return zsc
 
     def to_json(self, path: str):
         output = {
@@ -509,7 +516,7 @@ class BenchmarkContext:
             "folds": self.folds,
             "s3_download_map": self.s3_download_map,
             "config_fallback": self.config_fallback,
-            "benchmark_paths": self.benchmark_paths.to_dict()
+            "benchmark_paths": self.benchmark_paths.to_dict(),
         }
         save_json.save(path=path, obj=output)
 
@@ -524,10 +531,10 @@ def construct_s3_download_map(
     s3_prefix: str,
     path_context: str,
     split_key: str,
-    files_pp: List[str],
-    files_gt: List[str],
+    files_pp: list[str],
+    files_gt: list[str],
     task_metadata: str | None = None,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     split_value = f"{s3_prefix}model_predictions/"
     s3_download_map = {
         # FIXME: COMPARISON ROUNDING ERROR
@@ -536,13 +543,12 @@ def construct_s3_download_map(
     }
     if task_metadata is not None:
         s3_download_map[task_metadata] = task_metadata
-    s3_download_map = {f'{path_context}{k}': f'{s3_prefix}{v}' for k, v in s3_download_map.items()}
+    s3_download_map = {f"{path_context}{k}": f"{s3_prefix}{v}" for k, v in s3_download_map.items()}
     _s3_download_map_metadata_pp = {f"{split_key}{f}": f"{split_value}{f}" for f in files_pp}
     _s3_download_map_metadata_gt = {f"{split_key}{f}": f"{split_value}{f}" for f in files_gt}
     s3_download_map.update(_s3_download_map_metadata_pp)
     s3_download_map.update(_s3_download_map_metadata_gt)
-    s3_download_map = {Paths.rel_to_abs(k, relative_to=Paths.data_root): v for k, v in s3_download_map.items()}
-    return s3_download_map
+    return {Paths.rel_to_abs(k, relative_to=Paths.data_root): v for k, v in s3_download_map.items()}
 
 
 def construct_context(
@@ -550,22 +556,20 @@ def construct_context(
     datasets: list[str],
     folds: list[int],
     local_prefix: str,
-    s3_prefix: str = None,
-    description: str = None,
-    date: str = None,
-    task_metadata: str = None,
+    s3_prefix: str | None = None,
+    description: str | None = None,
+    date: str | None = None,
+    task_metadata: str | None = None,
     local_prefix_is_relative: bool = True,
     has_baselines: bool = True,
     metadata_join_column: str = "dataset",
-    configs_hyperparameters: list[str] = None,
+    configs_hyperparameters: list[str] | None = None,
     is_relative: bool = False,
-    config_fallback: str = None,
-    dataset_fold_lst_pp: list[tuple[str, int]] = None,
-    dataset_fold_lst_gt: list[tuple[str, int]] = None,
+    config_fallback: str | None = None,
+    dataset_fold_lst_pp: list[tuple[str, int]] | None = None,
+    dataset_fold_lst_gt: list[tuple[str, int]] | None = None,
 ) -> BenchmarkContext:
-    """
-
-    Parameters
+    """Parameters
     ----------
     name
     description
@@ -580,7 +584,7 @@ def construct_context(
         Example: "s3://s3_bucket/foo/bar/2023_08_21/"
     task_metadata
 
-    Returns
+    Returns:
     -------
     BenchmarkContext object that is able to load the data.
     """
@@ -589,10 +593,7 @@ def construct_context(
     else:
         path_context = str(Path(local_prefix)) + os.sep
 
-    if local_prefix_is_relative:
-        data_root = Paths.data_root_cache
-    else:
-        data_root = Path(path_context).parent
+    data_root = Paths.data_root_cache if local_prefix_is_relative else Path(path_context).parent
 
     split_key = str(Path(path_context) / "model_predictions") + os.sep
 
@@ -652,10 +653,7 @@ def construct_context(
     if is_relative:
         split_key = str(Path("model_predictions")) + os.path.sep
 
-    if is_relative:
-        relative_path = str(Path(path_context))
-    else:
-        relative_path = None
+    relative_path = str(Path(path_context)) if is_relative else None
 
     _bag_zs_path = dict(
         zs_gt=zs_gt,
@@ -683,4 +681,3 @@ def construct_context(
         **_configs_hyperparameters_path,
     )
     return context
-

--- a/packages/tabarena/src/tabarena/contexts/context_artificial.py
+++ b/packages/tabarena/src/tabarena/contexts/context_artificial.py
@@ -1,5 +1,7 @@
-import pandas as pd
+from __future__ import annotations
+
 import numpy as np
+import pandas as pd
 
 from tabarena.predictions import TabularPredictionsInMemory
 from tabarena.repository import EvaluationRepository
@@ -8,7 +10,7 @@ from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
 
 
 def make_random_metric(model):
-    output_cols = ['time_train_s', 'time_infer_s', 'metric_error', 'metric_error_val']
+    output_cols = ["time_train_s", "time_infer_s", "metric_error", "metric_error_val"]
     metric_value_dict = {
         "NeuralNetFastAI_r1": 1.0,
         "NeuralNetFastAI_r2": 2.0,
@@ -56,12 +58,15 @@ def load_context_artificial(
 
     configs_full = {model: {} for model in models}
 
-    df_metadata = pd.DataFrame([{
-        'dataset': dataset,
-        'task_type': "TaskType.SUPERVISED_CLASSIFICATION",
-    }
-        for tid, dataset in zip(tids, datasets)
-    ])
+    df_metadata = pd.DataFrame(
+        [
+            {
+                "dataset": dataset,
+                "task_type": "TaskType.SUPERVISED_CLASSIFICATION",
+            }
+            for tid, dataset in zip(tids, datasets, strict=False)
+        ]
+    )
 
     df_baselines = pd.DataFrame(
         {
@@ -72,7 +77,10 @@ def load_context_artificial(
             "problem_type": problem_type,
             "metric": "root_mean_squared_error",
             **make_random_metric(baseline),
-        } for fold in range(n_folds) for baseline in baselines for (tid, dataset) in zip(tids, datasets)
+        }
+        for fold in range(n_folds)
+        for baseline in baselines
+        for (tid, dataset) in zip(tids, datasets, strict=False)
     )
 
     if add_baselines_extra:
@@ -88,15 +96,21 @@ def load_context_artificial(
                 "problem_type": problem_type,
                 "metric": "root_mean_squared_error",
                 **make_random_metric(baseline),
-            } for fold in [0] for baseline in baselines_extra for (tid, dataset) in zip(tids_extra, datasets_extra)
+            }
+            for fold in [0]
+            for baseline in baselines_extra
+            for (tid, dataset) in zip(tids_extra, datasets_extra, strict=False)
         )
         df_baselines = pd.concat([df_baselines, df_baselines_extra], ignore_index=True)
-        df_metadata_extra = pd.DataFrame([{
-            'dataset': dataset,
-            'task_type': "TaskType.SUPERVISED_CLASSIFICATION",
-        }
-            for tid, dataset in zip(tids_extra, datasets_extra)
-        ])
+        df_metadata_extra = pd.DataFrame(
+            [
+                {
+                    "dataset": dataset,
+                    "task_type": "TaskType.SUPERVISED_CLASSIFICATION",
+                }
+                for tid, dataset in zip(tids_extra, datasets_extra, strict=False)
+            ]
+        )
         df_metadata = pd.concat([df_metadata, df_metadata_extra], ignore_index=True)
 
     df_raw = pd.DataFrame(
@@ -108,7 +122,10 @@ def load_context_artificial(
             "problem_type": problem_type,
             "metric": "root_mean_squared_error",
             **make_random_metric(model),
-        } for fold in range(n_folds) for model in models for (tid, dataset) in zip(tids, datasets)
+        }
+        for fold in range(n_folds)
+        for model in models
+        for (tid, dataset) in zip(tids, datasets, strict=False)
     )
     if not include_configs:
         df_raw = None
@@ -131,7 +148,7 @@ def load_context_artificial(
                 "pred_proba_dict_test": {
                     m: rng.random((13, n_classes), dtype=dtype) if n_classes > 2 else rng.random(13, dtype=dtype)
                     for m in models
-                }
+                },
             }
             for fold in range(n_folds)
         }
@@ -140,10 +157,7 @@ def load_context_artificial(
     zeroshot_pred_proba = TabularPredictionsInMemory.from_dict(pred_dict)
 
     make_dict = lambda size: {
-        dataset: {
-            fold: pd.Series(rng.integers(low=0, high=n_classes, size=size))
-            for fold in range(n_folds)
-        }
+        dataset: {fold: pd.Series(rng.integers(low=0, high=n_classes, size=size)) for fold in range(n_folds)}
         for dataset in datasets
     }
 
@@ -157,7 +171,7 @@ def load_context_artificial(
 
 
 def load_repo_artificial(**kwargs) -> EvaluationRepository:
-    zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_artificial(**kwargs)
+    zsc, _configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_artificial(**kwargs)
     return EvaluationRepository(
         zeroshot_context=zsc,
         tabular_predictions=zeroshot_pred_proba,
@@ -165,5 +179,5 @@ def load_repo_artificial(**kwargs) -> EvaluationRepository:
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     load_context_artificial()

--- a/packages/tabarena/src/tabarena/contexts/utils.py
+++ b/packages/tabarena/src/tabarena/contexts/utils.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import TYPE_CHECKING
 
-from ..simulation.dense_utils import intersect_folds_and_datasets, prune_zeroshot_gt
-from ..simulation.ground_truth import GroundTruth
-from ..simulation.simulation_context import ZeroshotSimulatorContext
-from ..predictions.tabular_predictions import TabularModelPredictions
+from tabarena.simulation.dense_utils import intersect_folds_and_datasets, prune_zeroshot_gt
+
+if TYPE_CHECKING:
+    from tabarena.predictions.tabular_predictions import TabularModelPredictions
+    from tabarena.simulation.ground_truth import GroundTruth
+    from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
 
 
-def load_zeroshot_input(path_pred_proba: str,
-                        paths_gt: List[str],
-                        datasets: List[str],
-                        zsc: ZeroshotSimulatorContext,
-                        prediction_format: str = "memmap",
-                        verbose: bool = True,
-                        ) -> Tuple[TabularModelPredictions, GroundTruth, ZeroshotSimulatorContext]:
+def load_zeroshot_input(
+    path_pred_proba: str,
+    paths_gt: list[str],
+    datasets: list[str],
+    zsc: ZeroshotSimulatorContext,
+    prediction_format: str = "memmap",
+    verbose: bool = True,
+) -> tuple[TabularModelPredictions, GroundTruth, ZeroshotSimulatorContext]:
     if verbose:
         print(
-            f'Loading ZS inputs:\n'
-            f'\tpred_proba:  {path_pred_proba}\n'
+            f"Loading ZS inputs:\n\tpred_proba:  {path_pred_proba}\n",
         )
     zeroshot_gt = zsc.load_groundtruth(paths_gt=paths_gt)
     zeroshot_pred_proba = zsc.load_pred(
@@ -30,6 +32,8 @@ def load_zeroshot_input(path_pred_proba: str,
     # keep only dataset whose folds are all present
     intersect_folds_and_datasets(zsc, zeroshot_pred_proba, zeroshot_gt=zeroshot_gt)
     zeroshot_pred_proba.restrict_models(zsc.get_configs())
-    zeroshot_gt = prune_zeroshot_gt(dataset_to_tid_dict=zsc.dataset_to_tid_dict, zeroshot_pred_proba=zeroshot_pred_proba, zeroshot_gt=zeroshot_gt)
+    zeroshot_gt = prune_zeroshot_gt(
+        dataset_to_tid_dict=zsc.dataset_to_tid_dict, zeroshot_pred_proba=zeroshot_pred_proba, zeroshot_gt=zeroshot_gt
+    )
 
     return zeroshot_pred_proba, zeroshot_gt, zsc

--- a/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
@@ -216,7 +216,9 @@ def evaluate_beyond_subsets(
         method_rename_map = {**method_rename_map, **DEFAULT_METHOD_RENAME_MAP, **(method_rename_map_extra or {})}
 
     df_results = _align_results_to_task_metadata(
-        df_results, task_metadata, require=require_task_metadata_to_match
+        df_results,
+        task_metadata,
+        require=require_task_metadata_to_match,
     )
 
     figure_output_dir = Path(figure_output_dir)
@@ -271,7 +273,10 @@ def evaluate_beyond_subsets(
 
 
 def _align_results_to_task_metadata(
-    df_results: pd.DataFrame, task_metadata: pd.DataFrame, *, require: bool
+    df_results: pd.DataFrame,
+    task_metadata: pd.DataFrame,
+    *,
+    require: bool,
 ) -> pd.DataFrame:
     """Ensure every dataset in ``df_results`` has task metadata; raise or filter on mismatch."""
     import warnings
@@ -292,7 +297,7 @@ def _align_results_to_task_metadata(
         raise AssertionError(
             "Found datasets in df_results that are missing from task_metadata. This likely means "
             "task_metadata is incomplete or df_results contains results for datasets not part of "
-            f"the current evaluation context.\n{detail}"
+            f"the current evaluation context.\n{detail}",
         )
     warnings.warn(
         f"Found datasets in df_results missing from task_metadata; filtering them out.\n{detail}",

--- a/packages/tabarena/src/tabarena/evaluation/beyond_metadata.py
+++ b/packages/tabarena/src/tabarena/evaluation/beyond_metadata.py
@@ -46,9 +46,7 @@ def load_beyond_task_metadata(source: str = "BeyondArena") -> pd.DataFrame:
     n_splits_per_tid = df.groupby("tid").size().rename("n_splits")
     # Reduce to one row per task; keep the row with the largest training fold so that
     # ``n_samples_train_per_fold`` (and ``max_train_rows`` below) reflect the per-task maximum.
-    ta_task_metadata = (
-        df.sort_values("n_samples_train_per_fold", ascending=False).groupby("tid").first().reset_index()
-    )
+    ta_task_metadata = df.sort_values("n_samples_train_per_fold", ascending=False).groupby("tid").first().reset_index()
     ta_task_metadata = ta_task_metadata.merge(n_splits_per_tid, on="tid", how="left")
     # The BeyondArena size predicates read ``max_train_rows`` directly off the metadata frame
     # (``subset_tasks_data_foundry`` does not go through ``compare``'s alias path).

--- a/packages/tabarena/src/tabarena/evaluation/context/beyond_arena.py
+++ b/packages/tabarena/src/tabarena/evaluation/context/beyond_arena.py
@@ -15,11 +15,14 @@ Everything else (method handling, plotting, leaderboard logic) is inherited unch
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 #: Warehouse-level columns BeyondArena predicates/plots rely on. Used by the (idempotent)
 #: back-compat merge below when a caller still supplies a separate warehouse frame.

--- a/packages/tabarena/src/tabarena/evaluation/evaluator.py
+++ b/packages/tabarena/src/tabarena/evaluation/evaluator.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
-from typing import Type
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 
-from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels
 from tabarena.portfolio.greedy_portfolio_generator import zeroshot_results
-from ..repository import EvaluationRepository, EvaluationRepositoryCollection
-from ..repository.repo_utils import convert_time_infer_s_from_sample_to_batch
+from tabarena.repository.repo_utils import convert_time_infer_s_from_sample_to_batch
+from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels
+
+if TYPE_CHECKING:
+    from tabarena.repository import EvaluationRepository, EvaluationRepositoryCollection
 
 
 # TODO: This class is WIP.
 # TODO: Add unit tests
 class Evaluator:
-    """
-    Computes metrics and statistics to compare methods.
-    """
+    """Computes metrics and statistics to compare methods."""
+
     def __init__(
         self,
         repo: EvaluationRepository | EvaluationRepositoryCollection,
@@ -26,10 +27,10 @@ class Evaluator:
     def compare_metrics(
         self,
         results_df: pd.DataFrame = None,
-        datasets: list[str] = None,
-        folds: list[int] = None,
-        configs: list[str] = None,
-        baselines: list[str] = None,
+        datasets: list[str] | None = None,
+        folds: list[int] | None = None,
+        configs: list[str] | None = None,
+        baselines: list[str] | None = None,
         convert_from_sample_to_batch: bool = False,
         keep_extra_columns: bool = False,
         include_metric_error_val: bool = False,
@@ -55,7 +56,7 @@ class Evaluator:
 
         config_columns = columns
         if include_metric_error_val:
-            config_columns = config_columns + ["metric_error_val"]
+            config_columns = [*config_columns, "metric_error_val"]
         df_configs = self.repo._zeroshot_context.df_configs
         config_aux_columns = [c for c in aux_columns if c in df_configs.columns]
         # Dropping task column in df_tr
@@ -75,7 +76,7 @@ class Evaluator:
             df_baselines = self.repo._zeroshot_context.df_baselines.set_index(["dataset", "fold", "framework"])
             baseline_columns = columns
             if include_metric_error_val:
-                baseline_columns = baseline_columns + ["metric_error_val"]
+                baseline_columns = [*baseline_columns, "metric_error_val"]
                 if "metric_error_val" not in df_baselines:
                     df_baselines["metric_error_val"] = np.nan
             df_baselines = df_baselines[baseline_columns]
@@ -126,15 +127,14 @@ class Evaluator:
 
     @classmethod
     def _fillna_metrics(cls, df_metrics: pd.DataFrame, df_fillna: pd.DataFrame) -> pd.DataFrame:
-        """
-        Fills missing (dataset, fold, framework) rows in df_metrics with the (dataset, fold) row in df_fillna.
+        """Fills missing (dataset, fold, framework) rows in df_metrics with the (dataset, fold) row in df_fillna.
 
         Parameters
         ----------
         df_metrics
         df_fillna
 
-        Returns
+        Returns:
         -------
 
         """
@@ -164,27 +164,22 @@ class Evaluator:
         df_filled["imputed"] = False
         df_filled.loc[nan_vals, "imputed"] = True
 
-        df_metrics = df_filled
-
-        return df_metrics
+        return df_filled
 
     # TODO: Prototype, find a better way to do this
     # TODO: Docstring
     def compute_avg_config_prediction_delta(
         self,
         configs: list[str],
-        datasets: list[str] = None,
+        datasets: list[str] | None = None,
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """
-
-
-        Parameters
+        """Parameters
         ----------
         configs
         datasets
         folds
 
-        Returns
+        Returns:
         -------
         delta_avg_abs_mean : pd.DataFrame
             The per-task normalized mean of the absolute delta in cells between two configs' test predictions.
@@ -196,6 +191,7 @@ class Evaluator:
         if datasets is None:
             datasets = self.repo.datasets()
         import numpy as np
+
         delta_comparison = {}
         delta_std_comparison = {}
         for dataset in datasets:
@@ -215,7 +211,7 @@ class Evaluator:
                         y_pred_test2 = self.repo.predict_test(dataset=dataset, fold=fold, config=compare_conf2)
                         delta = y_pred_test2 - y_pred_test1
                         # print(delta)
-                        mean = np.mean(delta)
+                        np.mean(delta)
                         abs_mean = np.mean(np.abs(delta))
                         stddev = np.std(delta)
                         print(f"\t{abs_mean:.3f}\t{stddev:.3f}")
@@ -228,7 +224,7 @@ class Evaluator:
                     max_abs_mean = max(max_abs_mean, v)
                 for k, v in delta_std_comparison[(dataset, fold)].items():
                     max_std = max(max_std, v)
-                for k in delta_comparison[(dataset, fold)].keys():
+                for k in delta_comparison[(dataset, fold)]:
                     if max_abs_mean != 0:
                         delta_comparison[(dataset, fold)][k] /= max_abs_mean
                     if max_std != 0:
@@ -247,11 +243,14 @@ class Evaluator:
 
         # FIXME: Make plotting optional
         from matplotlib import pyplot as plt
-        fig, ax = plt.subplots(figsize=(10, 10))
+
+        _fig, ax = plt.subplots(figsize=(10, 10))
         # config_names = list(delta_avg_abs_mean.index)
         delta_avg_abs_mean_projection = pd.DataFrame(delta_avg_abs_mean_projection, index=delta_avg_abs_mean.index)
         for config in delta_avg_abs_mean_projection.index:
-            ax.scatter(delta_avg_abs_mean_projection.loc[config, 0], delta_avg_abs_mean_projection.loc[config, 1], label=config)
+            ax.scatter(
+                delta_avg_abs_mean_projection.loc[config, 0], delta_avg_abs_mean_projection.loc[config, 1], label=config
+            )
         ax.legend()
         ax.grid(True)
         plt.savefig("pca_projection_test")
@@ -273,8 +272,8 @@ class Evaluator:
         n_ensemble_in_name: bool = True,
         n_max_models_per_type: int | str | None = None,
         n_eval_folds: int | None = None,
-        ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
-        ensemble_kwargs: dict = None,
+        ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+        ensemble_kwargs: dict | None = None,
         patience_callback: list | None = None,
     ) -> pd.DataFrame:
         repo = self.repo
@@ -304,9 +303,11 @@ class Evaluator:
         df_zeroshot_portfolio = pd.DataFrame(a)
 
         if rename_columns:
-            df_zeroshot_portfolio = df_zeroshot_portfolio.rename(columns={
-                "metadata": "method_metadata",
-            })
+            df_zeroshot_portfolio = df_zeroshot_portfolio.rename(
+                columns={
+                    "metadata": "method_metadata",
+                }
+            )
             datasets_info = repo.datasets_info()
 
             df_zeroshot_portfolio["problem_type"] = df_zeroshot_portfolio["dataset"].map(datasets_info["problem_type"])

--- a/packages/tabarena/src/tabarena/export/autogluon.py
+++ b/packages/tabarena/src/tabarena/export/autogluon.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import copy
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
-from tabarena.benchmark.experiment.experiment_constructor import AGModelExperiment
+if TYPE_CHECKING:
+    from tabarena.benchmark.experiment.experiment_constructor import AGModelExperiment
 
 
 class AutoGluonExporter:
@@ -11,14 +13,14 @@ class AutoGluonExporter:
         self.experiments = experiments
 
     def export_hyperparameters(self) -> dict[str, list[dict]]:
-        """
-        Convert TabArena AGModelExperiment objects into an AutoGluon-compatible
+        """Convert TabArena AGModelExperiment objects into an AutoGluon-compatible
         hyperparameters dictionary.
 
-        Returns
+        Returns:
         -------
         dict[str, list[dict]]
-            Example:
+
+        Example:
             {
                 "GBM": [
                     {"extra_trees": True, "ag_args": {"priority": -1}},
@@ -46,10 +48,9 @@ class AutoGluonExporter:
         return dict(hyperparameters)
 
     def export_fit_kwargs(self) -> dict:
-        """
-        Return shared AutoGluon fit kwargs across all experiments.
+        """Return shared AutoGluon fit kwargs across all experiments.
 
-        Raises
+        Raises:
         ------
         AssertionError
             If experiments have non-matching fit_kwargs.
@@ -65,16 +66,15 @@ class AutoGluonExporter:
                     "All experiments must have identical fit_kwargs to export "
                     f"an AutoGluon preset, but experiment 0 and experiment {i} differ.\n"
                     f"experiment 0 fit_kwargs: {fit_kwargs}\n"
-                    f"experiment {i} fit_kwargs: {e.method_kwargs['fit_kwargs']}"
+                    f"experiment {i} fit_kwargs: {e.method_kwargs['fit_kwargs']}",
                 )
 
         return fit_kwargs
 
     def export_preset(self) -> dict:
-        """
-        Export a dict of AutoGluon fit arguments.
+        """Export a dict of AutoGluon fit arguments.
 
-        Returns
+        Returns:
         -------
         dict
             Example:

--- a/packages/tabarena/src/tabarena/loaders/__init__.py
+++ b/packages/tabarena/src/tabarena/loaders/__init__.py
@@ -1,11 +1,12 @@
-from pathlib import Path
+from __future__ import annotations
+
 import os
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 from ._configs import load_configs
-from ._results import load_results
 from ._download import download_zs_metadata
-
+from ._results import load_results
 
 # One-element holder for the runtime TabArena cache-root override. Resolved
 # lazily (see `get_tabarena_cache_root`) so it can be set *after* this module is
@@ -39,15 +40,23 @@ class Paths:
     # ``data_root`` resolves to ``packages/tabarena/data`` as it did before the
     # src/ layout move (``__file__`` is ``.../src/tabarena/loaders/__init__.py``).
     project_root: Path = Path(__file__).resolve().parents[3]
-    data_root: Path = project_root / 'data'
+    data_root: Path = project_root / "data"
 
     # default path is ~/.cache/tabrepo/data, can be overriden by setting the environment variable TABREPO_CACHE
-    data_root_cache: Path = Path.home() / ".cache" / "tabrepo" / "data" if os.getenv("TABREPO_CACHE") is None else Path(os.getenv("TABREPO_CACHE"))
+    data_root_cache: Path = (
+        Path.home() / ".cache" / "tabrepo" / "data"
+        if os.getenv("TABREPO_CACHE") is None
+        else Path(os.getenv("TABREPO_CACHE"))
+    )
     results_root_cache: Path = data_root_cache / "results"
 
     #####
     # TODO: Clean these up and move it to its own class
-    _tabarena_root_cache = Path.home() / ".cache" / "tabarena" if os.getenv("TABARENA_CACHE") is None else Path(os.getenv("TABARENA_CACHE"))
+    _tabarena_root_cache = (
+        Path.home() / ".cache" / "tabarena"
+        if os.getenv("TABARENA_CACHE") is None
+        else Path(os.getenv("TABARENA_CACHE"))
+    )
     _data_root_cache_tabarena = _tabarena_root_cache / "data"
     data_root_cache_raw: Path = _data_root_cache_tabarena / "raw"
     data_root_cache_processed: Path = _data_root_cache_tabarena / "processed"
@@ -61,8 +70,7 @@ class Paths:
         if relative_to_split[-1] != os.sep:
             relative_to_split += os.sep
         assert path.startswith(relative_to_split)
-        path_relative = path.split(relative_to_split, 1)[1]
-        return path_relative
+        return path.split(relative_to_split, 1)[1]
 
     @staticmethod
     def rel_to_abs(path: str, relative_to: Path = project_root) -> str:
@@ -70,7 +78,7 @@ class Paths:
 
     @staticmethod
     def s3_to_local_tuple_list_to_dict(
-            s3_to_local_tuple_list: List[Tuple[str, str]],
-            relative_to: Path = data_root,
-    ) -> Dict[str, str]:
+        s3_to_local_tuple_list: list[tuple[str, str]],
+        relative_to: Path = data_root,
+    ) -> dict[str, str]:
         return {Paths.abs_to_rel(val, relative_to=relative_to): key for key, val in s3_to_local_tuple_list}

--- a/packages/tabarena/src/tabarena/loaders/_configs.py
+++ b/packages/tabarena/src/tabarena/loaders/_configs.py
@@ -1,9 +1,9 @@
-from typing import List
+from __future__ import annotations
 
 from autogluon.common.loaders import load_json
 
 
-def load_configs(config_files: List[str]) -> dict:
+def load_configs(config_files: list[str]) -> dict:
     if config_files is None:
         config_files = []
     configs = {}

--- a/packages/tabarena/src/tabarena/loaders/_download.py
+++ b/packages/tabarena/src/tabarena/loaders/_download.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from autogluon.common.loaders import load_pkl
@@ -5,12 +7,8 @@ from autogluon.common.savers import save_pkl
 
 
 def download_zs_metadata(
-        path_prefix_in,
-        path_prefix_out,
-        name_in_gt,
-        name_in_pred_proba,
-        name_out_gt=None,
-        name_out_pred_proba=None):
+    path_prefix_in, path_prefix_out, name_in_gt, name_in_pred_proba, name_out_gt=None, name_out_pred_proba=None
+):
     if name_out_gt is None:
         name_out_gt = name_in_gt
     if name_out_pred_proba is None:
@@ -21,21 +19,21 @@ def download_zs_metadata(
     save_path_pred_proba = str(path_prefix_out / name_out_pred_proba)
 
     ts = time.time()
-    print(f'Downloading Ground Truth File: {path_gt}')
+    print(f"Downloading Ground Truth File: {path_gt}")
     zeroshot_gt = load_pkl.load(path_gt)
-    print(f'Downloaded Ground Truth File... {round(time.time() - ts, 2)}s')
+    print(f"Downloaded Ground Truth File... {round(time.time() - ts, 2)}s")
 
     ts = time.time()
-    print(f'Saving Ground Truth File: {save_path_gt}')
+    print(f"Saving Ground Truth File: {save_path_gt}")
     save_pkl.save(path=save_path_gt, object=zeroshot_gt)
-    print(f'Saved Ground Truth File... {round(time.time() - ts, 2)}s')
+    print(f"Saved Ground Truth File... {round(time.time() - ts, 2)}s")
 
     ts = time.time()
-    print(f'Downloading Pred Proba File: {path_pred_proba}')
+    print(f"Downloading Pred Proba File: {path_pred_proba}")
     zeroshot_pred_proba = load_pkl.load(path_pred_proba)
-    print(f'Downloaded Pred Proba File... {round(time.time() - ts, 2)}s')
+    print(f"Downloaded Pred Proba File... {round(time.time() - ts, 2)}s")
 
     ts = time.time()
-    print(f'Saving Pred Proba File: {save_path_pred_proba}')
+    print(f"Saving Pred Proba File: {save_path_pred_proba}")
     save_pkl.save(path=save_path_pred_proba, object=zeroshot_pred_proba)
-    print(f'Saved Pred Proba File... {round(time.time() - ts, 2)}s')
+    print(f"Saved Pred Proba File... {round(time.time() - ts, 2)}s")

--- a/packages/tabarena/src/tabarena/loaders/_results.py
+++ b/packages/tabarena/src/tabarena/loaders/_results.py
@@ -1,58 +1,66 @@
-import pandas as pd
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from autogluon.common.loaders import load_pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def load_results(
     path_configs: str,
-    path_metadata: str = None,
+    path_metadata: str | None = None,
     metadata_join_column: str = "dataset",
     require_tid_in_metadata: bool = False,
     fix_tabrepo_dataset_names: bool = True,
 ) -> (pd.DataFrame, pd.DataFrame):
-    print(f'Loading input files...\n'
-          f'\tconfigs :           {path_configs}\n'
-          f'\tmetadata:           {path_metadata}')
-    if path_metadata is not None:
-        df_metadata = load_pd.load(path_metadata)
-    else:
-        df_metadata = None
+    print(f"Loading input files...\n\tconfigs :           {path_configs}\n\tmetadata:           {path_metadata}")
+    df_metadata = load_pd.load(path_metadata) if path_metadata is not None else None
     df_configs = load_pd.load(path_configs)
     df_configs = preprocess_configs(df_configs=df_configs, inplace=True)
 
     if require_tid_in_metadata:
         if df_metadata is None:
-            raise AssertionError('`metadata` must not be None if `require_tid_in_metadata=True`')
+            raise AssertionError("`metadata` must not be None if `require_tid_in_metadata=True`")
         if metadata_join_column not in df_configs:
-            raise AssertionError(f"`metadata` file was specified but `configs` is missing the required `{metadata_join_column}` "
-                                 f"column to join with `metadata`.\n"
-                                 f"\tmetadata_join_column: {metadata_join_column}\n"
-                                 f"\tpath         configs: {path_configs}\n"
-                                 f"\tpath        metadata: {path_metadata}\n"
-                                 f"\tcolumns      configs: {list(df_configs.columns)}\n"
-                                 f"\tcolumns     metadata: {list(df_metadata.columns)}")
+            raise AssertionError(
+                f"`metadata` file was specified but `configs` is missing the required `{metadata_join_column}` "
+                f"column to join with `metadata`.\n"
+                f"\tmetadata_join_column: {metadata_join_column}\n"
+                f"\tpath         configs: {path_configs}\n"
+                f"\tpath        metadata: {path_metadata}\n"
+                f"\tcolumns      configs: {list(df_configs.columns)}\n"
+                f"\tcolumns     metadata: {list(df_metadata.columns)}"
+            )
         if metadata_join_column not in df_metadata:
-            raise AssertionError(f"`metadata` file was specified but `metadata` is missing the required `{metadata_join_column}` "
-                                 f"column to join with `configs`.\n"
-                                 f"\tmetadata_join_column: {metadata_join_column}\n"
-                                 f"\tpath         configs: {path_configs}\n"
-                                 f"\tpath        metadata: {path_metadata}\n"
-                                 f"\tcolumns      configs: {list(df_configs.columns)}\n"
-                                 f"\tcolumns     metadata: {list(df_metadata.columns)}")
-        valid_values = set(list(df_metadata[metadata_join_column].unique()))
+            raise AssertionError(
+                f"`metadata` file was specified but `metadata` is missing the required `{metadata_join_column}` "
+                f"column to join with `configs`.\n"
+                f"\tmetadata_join_column: {metadata_join_column}\n"
+                f"\tpath         configs: {path_configs}\n"
+                f"\tpath        metadata: {path_metadata}\n"
+                f"\tcolumns      configs: {list(df_configs.columns)}\n"
+                f"\tcolumns     metadata: {list(df_metadata.columns)}"
+            )
+        valid_values = set(df_metadata[metadata_join_column].unique())
         init_dataset_count = len(df_configs["dataset"].unique())
         df_configs = df_configs[df_configs[metadata_join_column].isin(valid_values)]
         post_dataset_count = len(df_configs["dataset"].unique())
         if init_dataset_count != post_dataset_count:
-            print(f'Filtered datasets with tids that are missing from metadata. '
-                  f'Filtered from {init_dataset_count} datasets -> {post_dataset_count} datasets.')
+            print(
+                f"Filtered datasets with tids that are missing from metadata. "
+                f"Filtered from {init_dataset_count} datasets -> {post_dataset_count} datasets."
+            )
 
     if df_metadata is not None:
-        if "dataset" != metadata_join_column:
+        if metadata_join_column != "dataset":
             unique_metadata_join_column_vals = df_configs[[metadata_join_column, "dataset"]].drop_duplicates()
-            assert unique_metadata_join_column_vals["dataset"].value_counts().values.max() == 1, (f"Metadata join key `{metadata_join_column}` does not produce a 1:1 mapping with `dataset`.\n"
-                                                                                                  f"Counts post-join (should always be 1):\n"
-                                                                                                  f"{unique_metadata_join_column_vals['dataset'].value_counts()}")
+            assert unique_metadata_join_column_vals["dataset"].value_counts().values.max() == 1, (
+                f"Metadata join key `{metadata_join_column}` does not produce a 1:1 mapping with `dataset`.\n"
+                f"Counts post-join (should always be 1):\n"
+                f"{unique_metadata_join_column_vals['dataset'].value_counts()}"
+            )
             df_metadata = df_metadata.drop(columns=["dataset"], errors="ignore")
         else:
             metadata_column_order = ["dataset"] + [c for c in df_metadata.columns if c != "dataset"]
@@ -61,13 +69,13 @@ def load_results(
     if fix_tabrepo_dataset_names and "name" in df_metadata:
         # Fix for TabRepo v1 datasets
         rename_dict = {
-           'GAMETES_Epistasis_2-Way_1000atts_0.4H_EDM-1_EDM-1_1': 'GAMETES_Epistasis_2-Way_1000atts_0_4H_EDM-1_EDM-1_1',
-           'GAMETES_Epistasis_2-Way_20atts_0.1H_EDM-1_1': 'GAMETES_Epistasis_2-Way_20atts_0_1H_EDM-1_1',
-           'GAMETES_Epistasis_2-Way_20atts_0.4H_EDM-1_1': 'GAMETES_Epistasis_2-Way_20atts_0_4H_EDM-1_1',
-           'GAMETES_Epistasis_3-Way_20atts_0.2H_EDM-1_1': 'GAMETES_Epistasis_3-Way_20atts_0_2H_EDM-1_1',
-           'GAMETES_Heterogeneity_20atts_1600_Het_0.4_0.2_50_EDM-2_001': 'GAMETES_Heterogeneity_20atts_1600_Het_0_4_0_2_50_EDM-2_001',
-           'GAMETES_Heterogeneity_20atts_1600_Het_0.4_0.2_75_EDM-2_001': 'GAMETES_Heterogeneity_20atts_1600_Het_0_4_0_2_75_EDM-2_001',
-           'numerai28.6': 'numerai28_6',
+            "GAMETES_Epistasis_2-Way_1000atts_0.4H_EDM-1_EDM-1_1": "GAMETES_Epistasis_2-Way_1000atts_0_4H_EDM-1_EDM-1_1",
+            "GAMETES_Epistasis_2-Way_20atts_0.1H_EDM-1_1": "GAMETES_Epistasis_2-Way_20atts_0_1H_EDM-1_1",
+            "GAMETES_Epistasis_2-Way_20atts_0.4H_EDM-1_1": "GAMETES_Epistasis_2-Way_20atts_0_4H_EDM-1_1",
+            "GAMETES_Epistasis_3-Way_20atts_0.2H_EDM-1_1": "GAMETES_Epistasis_3-Way_20atts_0_2H_EDM-1_1",
+            "GAMETES_Heterogeneity_20atts_1600_Het_0.4_0.2_50_EDM-2_001": "GAMETES_Heterogeneity_20atts_1600_Het_0_4_0_2_50_EDM-2_001",
+            "GAMETES_Heterogeneity_20atts_1600_Het_0.4_0.2_75_EDM-2_001": "GAMETES_Heterogeneity_20atts_1600_Het_0_4_0_2_75_EDM-2_001",
+            "numerai28.6": "numerai28_6",
         }
         df_metadata["name"] = df_metadata["name"].map(rename_dict).fillna(df_metadata["name"])
 
@@ -85,6 +93,7 @@ def get_metric_name(metric: str) -> str:
 
 def get_metric_error_from_score(score: float, metric: str) -> float:
     from autogluon.core.metrics import get_metric
+
     metric = get_metric_name(metric=metric)
     return get_metric(metric=metric).convert_score_to_error(score=score)
 
@@ -93,14 +102,15 @@ def preprocess_configs(df_configs: pd.DataFrame, inplace=True) -> pd.DataFrame:
     if not inplace:
         df_configs = df_configs.copy(deep=True)
     if "tid" in df_configs:
-        df_configs['tid'] = df_configs['tid'].astype(int)
+        df_configs["tid"] = df_configs["tid"].astype(int)
     df_configs["metric"] = df_configs["metric"].apply(lambda m: get_metric_name(metric=m))
     if "metric_error_val" not in df_configs:
         df_configs["metric_error_val"] = df_configs[["score_val", "metric"]].apply(
-            lambda row: get_metric_error_from_score(score=row["score_val"], metric=row["metric"]), axis=1,
+            lambda row: get_metric_error_from_score(score=row["score_val"], metric=row["metric"]),
+            axis=1,
         )
     if "model" in df_configs:
-        df_configs['framework'] = df_configs['model']
+        df_configs["framework"] = df_configs["model"]
     return df_configs
 
 
@@ -108,6 +118,6 @@ def preprocess_baselines(df_baselines: pd.DataFrame, inplace=True) -> pd.DataFra
     if not inplace:
         df_baselines = df_baselines.copy(deep=True)
     if "tid" in df_baselines:
-        df_baselines['tid'] = df_baselines['tid'].astype(int)
+        df_baselines["tid"] = df_baselines["tid"].astype(int)
     df_baselines["metric"] = df_baselines["metric"].apply(lambda m: get_metric_name(metric=m))
     return df_baselines

--- a/packages/tabarena/src/tabarena/metrics/_fast_log_loss.py
+++ b/packages/tabarena/src/tabarena/metrics/_fast_log_loss.py
@@ -1,26 +1,24 @@
-from typing import Tuple
+from __future__ import annotations
 
 import numpy as np
-
 from autogluon.core.metrics import make_scorer
 
 
 def extract_true_class_prob(y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarray:
-    """
-    Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
+    """Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
     The predictions can then be passed to _fast_log_loss.
     :param y_true: an array with shape (n_samples,) that contains all the classes, values must be in [0, n_classes]
     :param y_pred:
         an array with shape (n_samples, n_classes) whose values are the prediction probability assigned to
         the ground truth classes.
         Can also be in shape (n_samples,), where it is then interpreted as binary classification pred probabilities.
-    :return: an array with shape (n_samples) that contains the predicted probability of the true class for each sample
+    :return: an array with shape (n_samples) that contains the predicted probability of the true class for each sample.
     """
     assert len(y_true) == len(y_pred)
 
     if y_pred.ndim == 1:
         y_true_bool = y_true.astype(np.bool_)
-        true_class_prob = y_true_bool*y_pred + ~y_true_bool*(1-y_pred)
+        true_class_prob = y_true_bool * y_pred + ~y_true_bool * (1 - y_pred)
     else:
         assert y_pred.ndim == 2
         true_class_prob = y_pred[range(len(y_pred)), y_true]
@@ -28,8 +26,7 @@ def extract_true_class_prob(y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarra
 
 
 def extract_true_class_prob_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> np.ndarray:
-    """
-    Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
+    """Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
     The individual config predictions can then be passed to _fast_log_loss.
 
     This function is an optimized way to process a batch of config prob predictions, and is faster than calling
@@ -45,19 +42,19 @@ def extract_true_class_prob_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) ->
     """
     ndim = y_pred_bulk.ndim
     if ndim not in [2, 3]:
-        raise AssertionError(f'y_pred_bulk.ndim must be either 2 or 3 for this function (ndim={ndim})')
-    assert y_pred_bulk.shape[1] == len(y_true), f"y_true and y_pred_bulk have different numbers of samples! " \
-                                                f"({len(y_true)}, {y_pred_bulk.shape[1]})"
+        raise AssertionError(f"y_pred_bulk.ndim must be either 2 or 3 for this function (ndim={ndim})")
+    assert y_pred_bulk.shape[1] == len(y_true), (
+        f"y_true and y_pred_bulk have different numbers of samples! ({len(y_true)}, {y_pred_bulk.shape[1]})"
+    )
     if ndim == 2:
         y_true_bool = y_true.astype(np.bool_)
         true_class_prob_bulk = y_true_bool * y_pred_bulk + ~y_true_bool * (1 - y_pred_bulk)
     else:  # ndim == 3
         true_class_prob_bulk = y_pred_bulk[:, range(y_pred_bulk.shape[1]), y_true]
-    true_class_prob_bulk = _epsilon(true_class_prob_bulk).astype(np.float32)
-    return true_class_prob_bulk
+    return _epsilon(true_class_prob_bulk).astype(np.float32)
 
 
-def _preprocess_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def _preprocess_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     y_pred_bulk = extract_true_class_prob_bulk(y_true=y_true, y_pred_bulk=y_pred_bulk)
     return y_true, y_pred_bulk
 
@@ -67,7 +64,7 @@ def _epsilon(y_pred, eps=1e-15):
 
 
 def _mean_log_loss(true_class_prob: np.ndarray) -> float:
-    return - np.log(true_class_prob).mean()
+    return -np.log(true_class_prob).mean()
 
 
 def _fast_log_loss_end_to_end(y_true: np.ndarray, y_pred: np.ndarray) -> float:
@@ -80,9 +77,9 @@ def _fast_log_loss_end_to_end(y_true: np.ndarray, y_pred: np.ndarray) -> float:
 Heavily optimized log_loss implementation that is valid under a specific context and avoids all sanity checks.
 This can be >100x faster than sklearn.
 
-NOTE: 
+NOTE:
 1. You must first preprocess the input y_pred by calling `extract_true_class_prob` which converts to a 1-dimensional
-  array whose values are the prediction probability assigned to the ground truth class. All other classes that are not 
+  array whose values are the prediction probability assigned to the ground truth class. All other classes that are not
   the ground truth are ignored, as they are not necessary to calculate log_loss.
 2. There is no epsilon / value clipping, ensure y_pred ranges do not include `0` or `1` to avoid infinite loss.
 3. There is no support for sample weights.
@@ -98,11 +95,13 @@ loss
     The negative log-likelihood
 """
 # Score function for probabilistic classification
-fast_log_loss = make_scorer('log_loss',
-                            lambda _, true_class_prob: _mean_log_loss(true_class_prob),
-                            optimum=0,
-                            greater_is_better=False,
-                            needs_proba=True)
+fast_log_loss = make_scorer(
+    "log_loss",
+    lambda _, true_class_prob: _mean_log_loss(true_class_prob),
+    optimum=0,
+    greater_is_better=False,
+    needs_proba=True,
+)
 
 fast_log_loss.preprocess_bulk = _preprocess_bulk
 
@@ -110,8 +109,6 @@ fast_log_loss.preprocess_bulk = _preprocess_bulk
 fast_log_loss.post_problem_type = "binary"
 
 # Score function for probabilistic classification
-fast_log_loss_end_to_end = make_scorer('fast_log_loss_end_to_end',
-                                       _fast_log_loss_end_to_end,
-                                       optimum=0,
-                                       greater_is_better=False,
-                                       needs_proba=True)
+fast_log_loss_end_to_end = make_scorer(
+    "fast_log_loss_end_to_end", _fast_log_loss_end_to_end, optimum=0, greater_is_better=False, needs_proba=True
+)

--- a/packages/tabarena/src/tabarena/metrics/_fast_roc_auc.py
+++ b/packages/tabarena/src/tabarena/metrics/_fast_roc_auc.py
@@ -1,22 +1,17 @@
-from typing import Tuple
+from __future__ import annotations
 
 import numpy as np
-
 from autogluon.core.metrics import make_scorer
 
 from ._roc_auc_cpp import CppAuc
 
-
 # TODO: Consider having `setup.py` automatically compile the C++ code to avoid having to manually do so.
 # Score functions that need decision values
 # Requires compiled C++ code, refer to `_roc_auc_cpp/README.md` for details
-fast_roc_auc_cpp = make_scorer('roc_auc',
-                               CppAuc().roc_auc_score,
-                               greater_is_better=True,
-                               needs_threshold=True)
+fast_roc_auc_cpp = make_scorer("roc_auc", CppAuc().roc_auc_score, greater_is_better=True, needs_threshold=True)
 
 
-def _preprocess_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def _preprocess_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     return y_true.astype(np.bool_), y_pred_bulk.astype(np.float32)
 
 

--- a/packages/tabarena/src/tabarena/metrics/_roc_auc_cpp/__init__.py
+++ b/packages/tabarena/src/tabarena/metrics/_roc_auc_cpp/__init__.py
@@ -16,16 +16,17 @@ class CppAuc:
     """
 
     def __init__(self):
-
         if not self.plugin_path().exists():
             self._compile()
-            assert self.plugin_path().exists(), "Missing cpp_auc.so compiled file... " \
-                                          "You must first compile the C++ code to use this metric. "
+            assert self.plugin_path().exists(), (
+                "Missing cpp_auc.so compiled file... You must first compile the C++ code to use this metric. "
+            )
         self._handle = ctypes.CDLL(self.plugin_path())
-        self._handle.cpp_auc_ext.argtypes = [ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
-                                             ndpointer(ctypes.c_bool, flags="C_CONTIGUOUS"),
-                                             ctypes.c_size_t
-                                             ]
+        self._handle.cpp_auc_ext.argtypes = [
+            ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
+            ndpointer(ctypes.c_bool, flags="C_CONTIGUOUS"),
+            ctypes.c_size_t,
+        ]
         self._handle.cpp_auc_ext.restype = ctypes.c_double
 
     def roc_auc_score(self, y_true: np.array, y_score: np.array) -> float:
@@ -56,7 +57,7 @@ class CppAuc:
         # filesystems (e.g. Singularity containers) with OSError(EROFS). g++ emits its
         # diagnostics on stderr, which we leave attached to the parent so genuine compile
         # errors remain visible.
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # noqa: S603
             compile_command.split(" "),
             shell=False,
             stdout=subprocess.DEVNULL,

--- a/packages/tabarena/src/tabarena/metrics/bench_utils.py
+++ b/packages/tabarena/src/tabarena/metrics/bench_utils.py
@@ -1,5 +1,7 @@
 """Utilities for benchmarking the speed of evaluation metrics."""
-from typing import List, Tuple
+
+from __future__ import annotations
+
 import time
 
 import numpy as np
@@ -17,7 +19,7 @@ def generate_y_true_and_y_pred_proba(num_samples, num_classes, random_seed=0):
     np.random.seed(seed=random_seed)
     y_true = np.random.randint(0, num_classes, num_samples).astype(np.uint16)
     y_pred = np.random.rand(num_samples, num_classes)
-    y_pred = normalize(y_pred, axis=1, norm='l1').astype(np.float32)
+    y_pred = normalize(y_pred, axis=1, norm="l1").astype(np.float32)
     return y_true, y_pred
 
 
@@ -27,16 +29,16 @@ def generate_y_true_and_y_pred_proba_bulk(num_configs, num_samples, num_classes,
     if num_classes == 2:
         y_pred_bulk = np.array([np.random.rand(num_samples) for _ in range(num_configs)])
     else:
-        y_pred_bulk = [normalize(np.random.rand(num_samples, num_classes), axis=1, norm='l1') for _ in range(num_configs)]
+        y_pred_bulk = [
+            normalize(np.random.rand(num_samples, num_classes), axis=1, norm="l1") for _ in range(num_configs)
+        ]
         y_pred_bulk = np.array(y_pred_bulk)
     return y_true, y_pred_bulk
 
 
-def get_eval_speed(*,
-                   eval_metric: callable,
-                   y_true: np.array,
-                   y_pred: np.array,
-                   num_repeats: int) -> Tuple[float, float]:
+def get_eval_speed(
+    *, eval_metric: callable, y_true: np.array, y_pred: np.array, num_repeats: int
+) -> tuple[float, float]:
     score = None
     ts = time.time()
     for _ in range(num_repeats):
@@ -46,24 +48,24 @@ def get_eval_speed(*,
     return time_average_s, score
 
 
-def print_benchmark_result(*,
-                           baseline_speed: float,
-                           time_average_s: float,
-                           score: float,
-                           func_name: str):
+def print_benchmark_result(*, baseline_speed: float, time_average_s: float, score: float, func_name: str):
     relative_speedup = baseline_speed / time_average_s
-    print(f'\tTime = {time_average_s * 1000:.4f} ms\t'
-          f'| Rel Speedup = {relative_speedup:.1f}x\t'
-          f'| Score = {score}\t'
-          f'| {func_name}')
+    print(
+        f"\tTime = {time_average_s * 1000:.4f} ms\t"
+        f"| Rel Speedup = {relative_speedup:.1f}x\t"
+        f"| Score = {score}\t"
+        f"| {func_name}"
+    )
 
 
-def benchmark_metrics_speed(y_true: np.array,
-                            y_pred: np.array,
-                            benchmark_metrics: List[Tuple[callable, str]],
-                            num_repeats: int,
-                            assert_score_isclose: bool = True,
-                            rtol: float = 1e-7) -> Tuple[float, float]:
+def benchmark_metrics_speed(
+    y_true: np.array,
+    y_pred: np.array,
+    benchmark_metrics: list[tuple[callable, str]],
+    num_repeats: int,
+    assert_score_isclose: bool = True,
+    rtol: float = 1e-7,
+) -> tuple[float, float]:
     baseline_speed = None
     baseline_score = None
 
@@ -79,10 +81,9 @@ def benchmark_metrics_speed(y_true: np.array,
         if baseline_score is None:
             baseline_score = score
 
-        print_benchmark_result(baseline_speed=baseline_speed,
-                               time_average_s=time_average_s,
-                               score=score,
-                               func_name=func_name)
+        print_benchmark_result(
+            baseline_speed=baseline_speed, time_average_s=time_average_s, score=score, func_name=func_name
+        )
         if assert_score_isclose:
             np.testing.assert_allclose(baseline_score, score, rtol=rtol)
     return baseline_speed, baseline_score

--- a/packages/tabarena/src/tabarena/metrics/custom_metrics.py
+++ b/packages/tabarena/src/tabarena/metrics/custom_metrics.py
@@ -7,7 +7,8 @@ from autogluon.core.metrics import METRICS, make_scorer
 
 
 def amex_metric(
-    target: np.ndarray | pd.DataFrame | pd.Series, preds: np.ndarray | pd.DataFrame | pd.Series
+    target: np.ndarray | pd.DataFrame | pd.Series,
+    preds: np.ndarray | pd.DataFrame | pd.Series,
 ) -> float:
     """Optimized AMEX Competition Metric.
 

--- a/packages/tabarena/src/tabarena/models/__init__.py
+++ b/packages/tabarena/src/tabarena/models/__init__.py
@@ -82,4 +82,4 @@ _EAGER_EXPORTS = (
 # above still needs static `from … import …` lines so IDEs and static
 # analysers can resolve lazy names — that's the one duplication we can't
 # fold away.
-__all__ = sorted({*_LAZY_CLASSES, *_EAGER_EXPORTS})
+__all__ = sorted({*_LAZY_CLASSES, *_EAGER_EXPORTS})  # noqa: PLE0605  # sorted() returns a valid list for __all__

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_public_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_public_r2.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import shutil
 import tempfile
 import zipfile
-from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote, urljoin
@@ -12,6 +11,8 @@ import requests
 from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from tabarena.models._method_metadata import MethodMetadata
 
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_r2.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import io
 import shutil
 import zipfile
-from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from tabarena.models._method_metadata import MethodMetadata
 
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import io
 import shutil
 import zipfile
-from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from tabarena.models._method_metadata import MethodMetadata
 
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader_r2.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,6 +8,8 @@ from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
 from tabarena.models._artifacts.uploader_utils import zip_in_memory
 
 if TYPE_CHECKING:
+    import io
+
     from tabarena.models._method_metadata import MethodMetadata
 
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader_s3.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader_s3.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,6 +8,8 @@ from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
 from tabarena.models._artifacts.uploader_utils import zip_in_memory
 
 if TYPE_CHECKING:
+    import io
+
     from tabarena.models._method_metadata import MethodMetadata
 
 

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -5,8 +5,7 @@ import json
 import os
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Literal, Self
 
 import pandas as pd
 import yaml
@@ -204,7 +203,6 @@ class MethodMetadata:
             has_results=True,
         )
 
-
     @classmethod
     def compute_method_name(
         cls,
@@ -232,8 +230,7 @@ class MethodMetadata:
         name_suffix = None
         if method_type in ["config", "hpo"]:
             assert method_subtype in subtype_to_suffix_map, (
-                f"Unknown {method_subtype=}. "
-                f"Valid values: {list(subtype_to_suffix_map.keys())}"
+                f"Unknown {method_subtype=}. Valid values: {list(subtype_to_suffix_map.keys())}"
             )
             name_suffix = subtype_to_suffix_map[method_subtype]
         if name_suffix:
@@ -256,13 +253,16 @@ class MethodMetadata:
         assert method_type == "config"
 
         unique_model_types = result_df["model_type"].unique()
-        assert len(unique_model_types) == 1, f"MethodMetadata requires exactly 1 model type, found: {unique_model_types}"
+        assert len(unique_model_types) == 1, (
+            f"MethodMetadata requires exactly 1 model type, found: {unique_model_types}"
+        )
 
         unique_num_gpus = result_df["num_gpus"].unique()
         if len(unique_num_gpus) != 1:
             warnings.warn(
                 f"MethodMetadata found more than one unique num_gpus value, found: {unique_num_gpus}. "
-                "Using max number of groups as official compute value.", stacklevel=2
+                "Using max number of groups as official compute value.",
+                stacklevel=2,
             )
         num_gpus = unique_num_gpus.max()
 
@@ -308,7 +308,6 @@ class MethodMetadata:
             has_processed=True,
             has_results=True,
         )
-
 
     @property
     def has_s3_cache(self) -> bool:
@@ -404,11 +403,12 @@ class MethodMetadata:
                 f"but s3_bucket and/or s3_prefix were not specified!"
                 f"\n\t(method={self.method}, artifact_name={self.artifact_name}, "
                 f"s3_bucket={self.s3_bucket}, s3_prefix={self.s3_prefix})"
-                f"\nEnsure you initialize MethodMetadata with s3_bucket and s3_prefix to enable s3 artifact download."
+                f"\nEnsure you initialize MethodMetadata with s3_bucket and s3_prefix to enable s3 artifact download.",
             )
 
         if cache_type == "r2":
             from tabarena.models._artifacts.downloader_public_r2 import MethodDownloaderPublicR2
+
             return MethodDownloaderPublicR2(
                 method_metadata=self,
                 base_url="https://data.tabarena.ai/",
@@ -418,6 +418,7 @@ class MethodMetadata:
             )
         if cache_type == "s3":
             from tabarena.models._artifacts.downloader_s3 import MethodDownloaderS3
+
             return MethodDownloaderS3(
                 method_metadata=self,
                 s3_bucket=self.s3_bucket,
@@ -436,7 +437,7 @@ class MethodMetadata:
                 f"but s3_bucket and/or s3_prefix were not specified!"
                 f"\n\t(method={self.method}, artifact_name={self.artifact_name}, "
                 f"s3_bucket={self.s3_bucket}, s3_prefix={self.s3_prefix})"
-                f"\nEnsure you initialize MethodMetadata with s3_bucket and s3_prefix to enable s3 artifact upload."
+                f"\nEnsure you initialize MethodMetadata with s3_bucket and s3_prefix to enable s3 artifact upload.",
             )
 
         if cache_type == "r2":
@@ -459,7 +460,7 @@ class MethodMetadata:
                     f"Write) and bucket scope, then submit. Cloudflare displays both the Access "
                     f"Key ID and the Secret Access Key on the success page; the secret is shown "
                     f"only once, so copy it immediately. If you've lost an existing secret, "
-                    f"create a new token (or roll the existing one) from the same page."
+                    f"create a new token (or roll the existing one) from the same page.",
                 )
 
             return MethodUploaderR2(
@@ -472,6 +473,7 @@ class MethodMetadata:
             )
         if cache_type == "s3":
             from tabarena.models._artifacts.uploader_s3 import MethodUploaderS3
+
             return MethodUploaderS3(
                 method_metadata=self,
                 s3_bucket=self.s3_bucket,
@@ -511,7 +513,7 @@ class MethodMetadata:
             except FileNotFoundError:
                 print(
                     f"Cache miss detected for configs_hyperparameters.json "
-                    f"(method={self.method}), attempting download..."
+                    f"(method={self.method}), attempting download...",
                 )
                 out = self.load_configs_hyperparameters(holdout=holdout, download=True)
                 print("\tDownload successful")
@@ -570,6 +572,7 @@ class MethodMetadata:
         if repo is None:
             repo = self.load_processed()
         from tabarena.paper.paper_runner_tabarena import PaperRunTabArena
+
         if self.config_type is None:
             config_types = repo.config_types()
             assert len(config_types) == 1
@@ -650,7 +653,9 @@ class MethodMetadata:
             hpo_results = simulator.run_minimal_single(model_type=model_type, tune=self.can_hpo)
             hpo_results["ta_name"] = self.method
             hpo_results["ta_suite"] = self.artifact_name
-            hpo_results = hpo_results.rename(columns={"framework": "method"})  # FIXME: Don't do this, make it method by default
+            hpo_results = hpo_results.rename(
+                columns={"framework": "method"}
+            )  # FIXME: Don't do this, make it method by default
             if cache:
                 save_pd.save(path=save_file, df=hpo_results)
             config_results = simulator.run_config_family(config_type=model_type)
@@ -666,7 +671,9 @@ class MethodMetadata:
 
         model_results["ta_name"] = self.method
         model_results["ta_suite"] = self.artifact_name
-        model_results = model_results.rename(columns={"framework": "method"})  # FIXME: Don't do this, make it method by default
+        model_results = model_results.rename(
+            columns={"framework": "method"}
+        )  # FIXME: Don't do this, make it method by default
         if cache:
             save_pd.save(path=save_file_model, df=model_results)
 
@@ -704,9 +711,11 @@ class MethodMetadata:
             seed=seed,
             **kwargs,
         )
-        df_results_hpo = df_results_hpo.rename(columns={
-            "framework": "method",
-        })
+        df_results_hpo = df_results_hpo.rename(
+            columns={
+                "framework": "method",
+            }
+        )
         df_results_hpo["method"] = f"HPO-N{n_configs}-{config_type}"
         df_results_hpo["n_configs"] = n_configs
         df_results_hpo["n_iterations"] = n_iterations
@@ -900,7 +909,7 @@ class MethodMetadata:
             print(
                 f"Failed to fetch MethodMetadata yaml file from s3! Maybe it doesn't exist or is not public?"
                 f'\n\t(method="{method}", artifact_name="{artifact_name}", '
-                f's3_bucket="{s3_bucket}", s3_prefix="{s3_prefix}")'
+                f's3_bucket="{s3_bucket}", s3_prefix="{s3_prefix}")',
             )
             raise e
 
@@ -928,6 +937,7 @@ class MethodMetadata:
         model_results = self.load_model_results()
         hpo_results = self.load_hpo_results()
         from tabarena.nips2025_utils.end_to_end_single import EndToEndResultsSingle
+
         return EndToEndResultsSingle(
             method_metadata=self,
             model_results=model_results,
@@ -940,11 +950,11 @@ class MethodMetadata:
     def path_results_files(self, holdout: bool = False) -> list[Path]:
         if self.method_type == "portfolio":
             file_names = [
-                self.path_results_portfolio(holdout=holdout)
+                self.path_results_portfolio(holdout=holdout),
             ]
         else:
             file_names = [
-                self.path_results_model(holdout=holdout)
+                self.path_results_model(holdout=holdout),
             ]
 
         if self.method_type == "config":

--- a/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
@@ -62,8 +62,7 @@ class MethodMetadataCollection:
         if not by_method:
             valid_methods = [m.method for m in self.method_metadata_lst]
             raise LookupError(
-                f"No MethodMetadata entries exist with method='{method}'."
-                f"\nValid methods: {valid_methods}"
+                f"No MethodMetadata entries exist with method='{method}'.\nValid methods: {valid_methods}",
             )
 
         # 2) Apply only the provided (non-None) fields.
@@ -102,7 +101,7 @@ class MethodMetadataCollection:
                 f"Filters used: method={method!r}, artifact_name={artifact_name!r}, "
                 f"s3_bucket={s3_bucket!r}, s3_prefix={s3_prefix!r}\n"
                 "Available candidates for this method:\n"
-                f"{df.to_string(index=False)}"
+                f"{df.to_string(index=False)}",
             )
 
         # More than one remains → ambiguous; show just those indistinguishable candidates.
@@ -112,7 +111,7 @@ class MethodMetadataCollection:
             f"Filters used: method={method!r}, artifact_name={artifact_name!r}, "
             f"s3_bucket={s3_bucket!r}, s3_prefix={s3_prefix!r}\n"
             "Indistinguishable candidates:\n"
-            f"{df.to_string(index=False)}"
+            f"{df.to_string(index=False)}",
         )
 
     def info(self) -> pd.DataFrame:

--- a/packages/tabarena/src/tabarena/models/_model_info.py
+++ b/packages/tabarena/src/tabarena/models/_model_info.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from tabarena.models._method_metadata import MethodMetadata
 
 
@@ -42,6 +43,6 @@ class ModelInfo:
 
     model_cls: type
     search_space: Callable
-    method_metadata: "MethodMetadata"
+    method_metadata: MethodMetadata
     pip_extra: tuple[str, ...] = field(default_factory=tuple)
     prefetch_weights: Callable[[], None] | None = None

--- a/packages/tabarena/src/tabarena/models/_registry.py
+++ b/packages/tabarena/src/tabarena/models/_registry.py
@@ -43,7 +43,9 @@ def discover_models() -> dict[str, ModelInfo]:
                 "Skipping tabarena.models.%s in registry: failed to import its "
                 "info module (%s: %s). The model will not be discoverable until "
                 "the import is fixed.",
-                name, type(exc).__name__, exc,
+                name,
+                type(exc).__name__,
+                exc,
             )
             continue
         for attr_name in dir(info_module):
@@ -56,7 +58,7 @@ def discover_models() -> dict[str, ModelInfo]:
             if key in registry:
                 raise RuntimeError(
                     f"Duplicate ModelInfo key {key!r}: {registry[key]} vs {obj} "
-                    f"(from tabarena.models.{name}.info::{attr_name})"
+                    f"(from tabarena.models.{name}.info::{attr_name})",
                 )
             registry[key] = obj
 
@@ -98,6 +100,6 @@ def register_model_info(info: ModelInfo) -> None:
         raise RuntimeError(
             f"Duplicate ModelInfo composite key {composite_key!r}: "
             f"already registered as {registry[composite_key]}; "
-            f"attempted to re-register with {info}."
+            f"attempted to re-register with {info}.",
         )
     registry[composite_key] = info

--- a/packages/tabarena/src/tabarena/models/automl.py
+++ b/packages/tabarena/src/tabarena/models/automl.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from tabarena.benchmark.experiment.experiment_constructor import AGExperiment
 
 
 def generate_autogluon_experiments():
-    methods = [
+    return [
         AGExperiment(
             name="AutoGluon_v140_bq_4h8c",
             fit_kwargs=dict(
@@ -55,12 +57,10 @@ def generate_autogluon_experiments():
             ),
         ),
     ]
-    return methods
-
 
 
 def generate_autogluon_extreme_experiments():
-    methods = [
+    return [
         AGExperiment(
             name="AutoGluon_v140_eq_4h8c",
             fit_kwargs=dict(
@@ -83,4 +83,3 @@ def generate_autogluon_extreme_experiments():
             ),
         ),
     ]
-    return methods

--- a/packages/tabarena/src/tabarena/models/catboost/hpo.py
+++ b/packages/tabarena/src/tabarena/models/catboost/hpo.py
@@ -15,7 +15,8 @@ def generate_configs_catboost(num_random_configs=200):
         space=[
             Float("learning_rate", (5e-3, 1e-1), log=True),
             Categorical(
-                "bootstrap_type", ["Bernoulli"]
+                "bootstrap_type",
+                ["Bernoulli"],
             ),  # this is a bit faster than 'Bayesian'
             Float("subsample", (0.7, 1.0)),
             Categorical("grow_policy", ["SymmetricTree", "Depthwise"]),

--- a/packages/tabarena/src/tabarena/models/catboost/info.py
+++ b/packages/tabarena/src/tabarena/models/catboost/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import CatBoostModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.catboost.hpo import gen_catboost
-from tabarena.models._method_metadata import MethodMetadata
-
 
 catboost_method_metadata = MethodMetadata(
     method="CatBoost",

--- a/packages/tabarena/src/tabarena/models/ebm/hpo.py
+++ b/packages/tabarena/src/tabarena/models/ebm/hpo.py
@@ -49,6 +49,8 @@ gen_ebm = ConfigGenerator(
 
 def generate_configs_ebm(num_random_configs=200):
     config_generator = ConfigGenerator(
-        name="EBM", manual_configs=[], search_space=search_space
+        name="EBM",
+        manual_configs=[],
+        search_space=search_space,
     )
     return config_generator.generate_all_configs(num_random_configs=num_random_configs)

--- a/packages/tabarena/src/tabarena/models/extra_trees/hpo.py
+++ b/packages/tabarena/src/tabarena/models/extra_trees/hpo.py
@@ -16,10 +16,12 @@ def generate_configs_xt(num_random_configs=200):
             Categorical("max_features", ["sqrt", 0.5, 0.75, 1.0]),
             Integer("min_samples_split", (2, 32), log=True),
             Categorical(
-                "bootstrap", [False]
+                "bootstrap",
+                [False],
             ),  # bootstrap=False doesn't allow OOB scores but seems to help
             Categorical(
-                "n_estimators", [50]
+                "n_estimators",
+                [50],
             ),  # 50 is decent, could go a bit higher for small gains
             Categorical(
                 "min_impurity_decrease",

--- a/packages/tabarena/src/tabarena/models/extra_trees/info.py
+++ b/packages/tabarena/src/tabarena/models/extra_trees/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import XTModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.extra_trees.hpo import gen_extratrees
-from tabarena.models._method_metadata import MethodMetadata
-
 
 extra_trees_method_metadata = MethodMetadata(
     method="ExtraTrees",

--- a/packages/tabarena/src/tabarena/models/fastai/hpo.py
+++ b/packages/tabarena/src/tabarena/models/fastai/hpo.py
@@ -5,11 +5,16 @@ from autogluon.tabular.models import NNFastAiTabularModel
 
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 search_space = {
     # See docs: https://docs.fast.ai/tabular.learner.html
     "layers": Categorical(
-        [200], [400], [200, 100], [400, 200], [800, 400], [200, 100, 50], [400, 200, 100]
+        [200],
+        [400],
+        [200, 100],
+        [400, 200],
+        [800, 400],
+        [200, 100, 50],
+        [400, 200, 100],
     ),
     "emb_drop": Real(0.0, 0.7, default=0.1),
     "ps": Real(0.0, 0.7, default=0.1),
@@ -28,6 +33,8 @@ gen_fastai = ConfigGenerator(
 
 def generate_configs_fastai(num_random_configs=200):
     config_generator = ConfigGenerator(
-        name="NeuralNetFastAI", manual_configs=[{}], search_space=search_space
+        name="NeuralNetFastAI",
+        manual_configs=[{}],
+        search_space=search_space,
     )
     return config_generator.generate_all_configs(num_random_configs=num_random_configs)

--- a/packages/tabarena/src/tabarena/models/fastai/info.py
+++ b/packages/tabarena/src/tabarena/models/fastai/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import NNFastAiTabularModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.fastai.hpo import gen_fastai
-from tabarena.models._method_metadata import MethodMetadata
-
 
 fastai_method_metadata = MethodMetadata(
     method="NeuralNetFastAI",

--- a/packages/tabarena/src/tabarena/models/knn/_internal/knn_preprocessing.py
+++ b/packages/tabarena/src/tabarena/models/knn/_internal/knn_preprocessing.py
@@ -1,26 +1,28 @@
+from __future__ import annotations
+
+from typing import Literal
+
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.preprocessing import (
     OneHotEncoder,
     OrdinalEncoder,
-    StandardScaler,
     QuantileTransformer,
+    StandardScaler,
 )
-from typing import List, Literal, Optional
 
 
 class KNNPreprocessor(BaseEstimator, TransformerMixin):
     def __init__(
         self,
-        categorical_features: List[str],
+        categorical_features: list[str],
         cat_threshold: int = 10,
         handle_unknown: str = "ignore",
         remainder: Literal["passthrough", "drop"] = "passthrough",
-        numeric_strategy: Optional[Literal["standard", "quantile"]] = None,
+        numeric_strategy: Literal["standard", "quantile"] | None = None,
     ):
-        """
-        Parameters
+        """Parameters
         ----------
         categorical_features : list[str]
             Names of categorical columns in the input DataFrame.
@@ -67,9 +69,7 @@ class KNNPreprocessor(BaseEstimator, TransformerMixin):
             raise ValueError("remainder must be 'passthrough' or 'drop'.")
 
         self.feature_names_in_ = list(X.columns)
-        self.non_categorical_features_ = [
-            c for c in self.feature_names_in_ if c not in self.categorical_features
-        ]
+        self.non_categorical_features_ = [c for c in self.feature_names_in_ if c not in self.categorical_features]
 
         if len(self.categorical_features) == len(X.columns) and self.cat_threshold == 0:
             print("Warning: All features are categorical and cat_threshold=0. Fallback to ordinal encoding is used.")

--- a/packages/tabarena/src/tabarena/models/knn/hpo.py
+++ b/packages/tabarena/src/tabarena/models/knn/hpo.py
@@ -5,7 +5,6 @@ from autogluon.common.space import Categorical
 from tabarena.models.knn.model import KNNNewModel
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 search_space = {
     "n_neighbors": Categorical(20, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 30, 40, 50, 100, 200, 300, 400, 500),
     "weights": Categorical("distance", "uniform"),
@@ -24,6 +23,8 @@ gen_knn = ConfigGenerator(
 
 def generate_configs_knn(num_random_configs=200):
     config_generator = ConfigGenerator(
-        name="KNeighbors_new", manual_configs=[{}], search_space=search_space
+        name="KNeighbors_new",
+        manual_configs=[{}],
+        search_space=search_space,
     )
     return config_generator.generate_all_configs(num_random_configs=num_random_configs)

--- a/packages/tabarena/src/tabarena/models/knn/info.py
+++ b/packages/tabarena/src/tabarena/models/knn/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.knn.model import KNNNewModel
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.knn.hpo import gen_knn
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.knn.model import KNNNewModel
 
 knn_method_metadata = MethodMetadata(
     method="KNeighbors",

--- a/packages/tabarena/src/tabarena/models/knn/model.py
+++ b/packages/tabarena/src/tabarena/models/knn/model.py
@@ -4,47 +4,42 @@ import logging
 import time
 
 import numpy as np
-
-from autogluon.common.features.types import R_INT, R_FLOAT, R_CATEGORY
+from autogluon.common.features.types import R_CATEGORY, R_FLOAT, R_INT
 
 logger = logging.getLogger(__name__)
 
-from tabarena.models.knn._internal.knn_preprocessing import KNNPreprocessor
-
 from autogluon.tabular.models.knn.knn_model import KNNModel
 
+from tabarena.models.knn._internal.knn_preprocessing import KNNPreprocessor
+
+
 class KNNNewModel(KNNModel):
-    """
-    KNearestNeighbors model (scikit-learn): https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html
-    """
+    """KNearestNeighbors model (scikit-learn): https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html."""
+
     ag_key = "TA-KNN"
     ag_name = "KNeighbors"
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     def _preprocess(
-        self, X,
+        self,
+        X,
         is_train: bool = False,
         **kwargs,
     ):
-
         X = super(KNNModel, self)._preprocess(X, **kwargs)
-        if is_train:
-            X = self.knn_preprocessor.fit_transform(X)
-        else:
-            X = self.knn_preprocessor.transform(X)
+        X = self.knn_preprocessor.fit_transform(X) if is_train else self.knn_preprocessor.transform(X)
 
-        X = X.fillna(0).to_numpy(dtype=np.float32)
-        return X
+        return X.fillna(0).to_numpy(dtype=np.float32)
 
     def _set_default_params(self):
         default_params = {
             "weights": "distance",
-            'scaler': 'standard',
-            'cat_threshold': 10,
-            'n_neighbors': 20,
-            'p': 2,
+            "scaler": "standard",
+            "cat_threshold": 10,
+            "n_neighbors": 20,
+            "p": 2,
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
@@ -52,7 +47,7 @@ class KNNNewModel(KNNModel):
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()
         extra_auxiliary_params = dict(
-            valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY],  
+            valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY],
             ignored_type_group_special=[],
         )
         default_auxiliary_params.update(extra_auxiliary_params)
@@ -60,7 +55,7 @@ class KNNNewModel(KNNModel):
 
     def _fit(self, X, y, num_cpus=-1, time_limit=None, sample_weight=None, **kwargs):
         time_start = time.time()
-        
+
         params = self._get_model_params()
         if "n_jobs" not in params:
             params["n_jobs"] = num_cpus
@@ -71,21 +66,25 @@ class KNNNewModel(KNNModel):
         scaler = params.pop("scaler")
 
         cat_cols = self._feature_metadata.get_features(valid_raw_types=[R_CATEGORY])
-        self.knn_preprocessor = KNNPreprocessor(cat_threshold=cat_threshold, categorical_features=cat_cols, numeric_strategy=scaler)
+        self.knn_preprocessor = KNNPreprocessor(
+            cat_threshold=cat_threshold, categorical_features=cat_cols, numeric_strategy=scaler
+        )
 
         X = self.preprocess(X, y=y, is_train=True)
 
         num_rows_max = len(X)
 
         # Fix for small datasets
-        if num_rows_max <= params['n_neighbors']:
-            params['n_neighbors'] = num_rows_max - 1
-        
+        if num_rows_max <= params["n_neighbors"]:
+            params["n_neighbors"] = num_rows_max - 1
+
         # FIXME: v0.1 Must store final num rows for refit_full or else will use everything! Worst case refit_full could train far longer than the original model.
         if time_limit is None or num_rows_max <= 10000:
             self.model = self._get_model_type()(**params).fit(X, y)
         else:
-            self.model = self._fit_with_samples(X=X, y=y, model_params=params, time_limit=time_limit - (time.time() - time_start))
+            self.model = self._fit_with_samples(
+                X=X, y=y, model_params=params, time_limit=time_limit - (time.time() - time_start)
+            )
 
     # Higher mem_error_threshold of 0.4 for TabArena.
     def _validate_fit_memory_usage(

--- a/packages/tabarena/src/tabarena/models/lightgbm/hpo.py
+++ b/packages/tabarena/src/tabarena/models/lightgbm/hpo.py
@@ -52,5 +52,6 @@ if __name__ == "__main__":
 
     experiments = gen_lightgbm.generate_all_bag_experiments(num_random_configs=200)
     YamlExperimentSerializer.to_yaml(
-        experiments=experiments, path="configs_lightgbm_alt.yaml"
+        experiments=experiments,
+        path="configs_lightgbm_alt.yaml",
     )

--- a/packages/tabarena/src/tabarena/models/lightgbm/info.py
+++ b/packages/tabarena/src/tabarena/models/lightgbm/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import LGBModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.lightgbm.hpo import gen_lightgbm
-from tabarena.models._method_metadata import MethodMetadata
-
 
 lightgbm_method_metadata = MethodMetadata(
     method="LightGBM",

--- a/packages/tabarena/src/tabarena/models/limix/hpo.py
+++ b/packages/tabarena/src/tabarena/models/limix/hpo.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from tabarena.models.limix.model import LimiXModel
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 gen_limix = ConfigGenerator(
     model_cls=LimiXModel,
     search_space={},

--- a/packages/tabarena/src/tabarena/models/limix/info.py
+++ b/packages/tabarena/src/tabarena/models/limix/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.limix.model import LimiXModel
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.limix.hpo import gen_limix
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.limix.model import LimiXModel
 
 limix_method_metadata = MethodMetadata(
     method="LimiX",

--- a/packages/tabarena/src/tabarena/models/limix/model.py
+++ b/packages/tabarena/src/tabarena/models/limix/model.py
@@ -254,7 +254,7 @@ class LimiXModel(AbstractTorchModel):
             {
                 "fold_fitting_strategy": "sequential_local",
                 "refit_folds": True,
-            }
+            },
         )
         return default_ag_args_ensemble
 
@@ -268,7 +268,7 @@ class LimiXModel(AbstractTorchModel):
             {
                 # "max_rows": 50_000, # Technically from LimiX
                 "max_classes": 10,
-            }
+            },
         )
         return default_auxiliary_params
 

--- a/packages/tabarena/src/tabarena/models/lr/hpo.py
+++ b/packages/tabarena/src/tabarena/models/lr/hpo.py
@@ -5,7 +5,6 @@ from autogluon.tabular.models import LinearModel
 
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 search_space = {
     "C": Real(lower=0.1, upper=1e3, default=1, log=True),  # FIXME: log=True?
     "proc.skew_threshold": Categorical(0.99, 0.9, 0.999, None),
@@ -23,6 +22,8 @@ gen_linear = ConfigGenerator(
 
 def generate_configs_lr(num_random_configs=200):
     config_generator = ConfigGenerator(
-        name="LinearModel", manual_configs=[{}], search_space=search_space
+        name="LinearModel",
+        manual_configs=[{}],
+        search_space=search_space,
     )
     return config_generator.generate_all_configs(num_random_configs=num_random_configs)

--- a/packages/tabarena/src/tabarena/models/lr/info.py
+++ b/packages/tabarena/src/tabarena/models/lr/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import LinearModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.lr.hpo import gen_linear
-from tabarena.models._method_metadata import MethodMetadata
-
 
 lr_method_metadata = MethodMetadata(
     method="LinearModel",

--- a/packages/tabarena/src/tabarena/models/mitra/hpo.py
+++ b/packages/tabarena/src/tabarena/models/mitra/hpo.py
@@ -4,7 +4,6 @@ from autogluon.tabular.models import MitraModel
 
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 gen_mitra = ConfigGenerator(
     model_cls=MitraModel,
     manual_configs=[{}],

--- a/packages/tabarena/src/tabarena/models/mitra/info.py
+++ b/packages/tabarena/src/tabarena/models/mitra/info.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import MitraModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.mitra.hpo import gen_mitra
-from tabarena.models._method_metadata import MethodMetadata
 
 
 # NOTE: Prefetchers normally live in the model's ``model.py``. Mitra is the exception: it is

--- a/packages/tabarena/src/tabarena/models/modernnca/hpo.py
+++ b/packages/tabarena/src/tabarena/models/modernnca/hpo.py
@@ -19,7 +19,7 @@ def generate_single_config_modernnca(rng):
         "sample_rate": rng.uniform(0.05, 0.6),
         "lr": np.exp(rng.uniform(np.log(1e-5), np.log(1e-1))),
         "weight_decay": rng.choice(
-            [0.0, np.exp(rng.uniform(np.log(1e-6), np.log(1e-3)))]
+            [0.0, np.exp(rng.uniform(np.log(1e-6), np.log(1e-3)))],
         ),
         "temperature": 1.0,
         "num_emb_type": "plr",

--- a/packages/tabarena/src/tabarena/models/modernnca/info.py
+++ b/packages/tabarena/src/tabarena/models/modernnca/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.modernnca.model import ModernNCAModel
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.modernnca.hpo import gen_modernnca
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.modernnca.model import ModernNCAModel
 
 modernnca_method_metadata = MethodMetadata(
     method="ModernNCA",

--- a/packages/tabarena/src/tabarena/models/modernnca/model.py
+++ b/packages/tabarena/src/tabarena/models/modernnca/model.py
@@ -352,7 +352,7 @@ class ModernNCAModel(AbstractModel):
         if X_val is not None:
             X_val = self.preprocess(X_val)
 
-        save_path = self.path + "/tmp_model"
+        save_path = self.path + "/tmp_model"  # noqa: S108
         self.model = ModernNCAImplementation(
             n_threads=num_cpus,
             device=device,

--- a/packages/tabarena/src/tabarena/models/nn_torch/hpo.py
+++ b/packages/tabarena/src/tabarena/models/nn_torch/hpo.py
@@ -5,7 +5,6 @@ from autogluon.tabular.models import TabularNeuralNetTorchModel
 
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 search_space = {
     "learning_rate": Real(1e-4, 3e-2, default=3e-4, log=True),
     "weight_decay": Real(1e-12, 0.1, default=1e-6, log=True),

--- a/packages/tabarena/src/tabarena/models/nn_torch/info.py
+++ b/packages/tabarena/src/tabarena/models/nn_torch/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import TabularNeuralNetTorchModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.nn_torch.hpo import gen_nn_torch
-from tabarena.models._method_metadata import MethodMetadata
-
 
 nn_torch_method_metadata = MethodMetadata(
     method="NeuralNetTorch",

--- a/packages/tabarena/src/tabarena/models/orionmsp/hpo.py
+++ b/packages/tabarena/src/tabarena/models/orionmsp/hpo.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from tabarena.models.orionmsp.model import OrionMSPModel
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 gen_orionmsp = ConfigGenerator(
     model_cls=OrionMSPModel,
     manual_configs=[{}],
@@ -17,7 +16,7 @@ if __name__ == "__main__":
     print(
         YamlExperimentSerializer.to_yaml_str(
             experiments=gen_orionmsp.generate_all_bag_experiments(
-                num_random_configs=0
+                num_random_configs=0,
             ),
         ),
     )

--- a/packages/tabarena/src/tabarena/models/orionmsp/info.py
+++ b/packages/tabarena/src/tabarena/models/orionmsp/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.orionmsp.model import OrionMSPModel, prefetch_weights
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.orionmsp.hpo import gen_orionmsp
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.orionmsp.model import OrionMSPModel, prefetch_weights
 
 orionmsp_method_metadata = MethodMetadata(
     method="OrionMSP",

--- a/packages/tabarena/src/tabarena/models/orionmsp/model.py
+++ b/packages/tabarena/src/tabarena/models/orionmsp/model.py
@@ -172,7 +172,7 @@ def _resolve_checkpoint(filename: str, allow_auto_download: bool = True) -> str:
                 f"Checkpoint '{filename}' not cached locally and "
                 f"allow_auto_download=False. Pre-download it via "
                 f"`prefetch_weights(filename='{filename}')` or set "
-                f"allow_auto_download=True."
+                f"allow_auto_download=True.",
             ) from None
         logger.info(
             "Orion-MSP checkpoint '%s' not cached; downloading from %s.",
@@ -204,7 +204,7 @@ def _orionmsp_fixed_pos_emb(self, embeddings, feature_indices=None):
     if self.feature_pos_emb is None or embeddings.dim() != 4:
         return embeddings
 
-    B, HC, T, E = embeddings.shape
+    _B, HC, _T, _E = embeddings.shape
     H = HC - self.reserve_cls_tokens
     if H <= 0:
         return embeddings

--- a/packages/tabarena/src/tabarena/models/perpetual_booster/hpo.py
+++ b/packages/tabarena/src/tabarena/models/perpetual_booster/hpo.py
@@ -7,7 +7,6 @@ from tabarena.models.perpetual_booster.model import (
 )
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 # Suggested search space from:
 # https://github.com/perpetual-ml/perpetual/issues/66#issuecomment-3073175292
 search_space = {"budget": Categorical(0.1, 0.2, 1.0, 1.5, 2.0)}

--- a/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
+++ b/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models._model_info import ModelInfo
+from tabarena.models.perpetual_booster.hpo import gen_perpetual_booster
 from tabarena.models.perpetual_booster.model import (
     PerpetualBoosterModel,
 )
-from tabarena.models._model_info import ModelInfo
-from tabarena.models.perpetual_booster.hpo import gen_perpetual_booster
-from tabarena.models._method_metadata import MethodMetadata
-
 
 perpetual_booster_method_metadata = MethodMetadata(
     method="PerpetualBooster",

--- a/packages/tabarena/src/tabarena/models/perpetual_booster/model.py
+++ b/packages/tabarena/src/tabarena/models/perpetual_booster/model.py
@@ -32,7 +32,7 @@ class PerpetualBoosterModel(AbstractModel):
 
         if self._category_features is None:
             self._category_features = X.select_dtypes(
-                include=["category"]
+                include=["category"],
             ).columns.tolist()
 
         return X

--- a/packages/tabarena/src/tabarena/models/prefetch.py
+++ b/packages/tabarena/src/tabarena/models/prefetch.py
@@ -14,7 +14,10 @@ prefetcher. Models that declare nothing (tree / linear baselines) are skipped.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def prefetch_weights(model_names: Iterable[str], *, raise_on_error: bool = False) -> None:

--- a/packages/tabarena/src/tabarena/models/random_forest/hpo.py
+++ b/packages/tabarena/src/tabarena/models/random_forest/hpo.py
@@ -17,10 +17,12 @@ def generate_configs_rf(num_random_configs=200):
             Float("max_samples", (0.5, 1.0)),
             Integer("min_samples_split", (2, 4), log=True),
             Categorical(
-                "bootstrap", [False, True]
+                "bootstrap",
+                [False, True],
             ),  # bootstrap=False doesn't allow OOB scores but seems to help
             Categorical(
-                "n_estimators", [50]
+                "n_estimators",
+                [50],
             ),  # 50 is decent, could go a bit higher for small gains
             Float("min_impurity_decrease", (1e-5, 1e-3), log=True),
         ],

--- a/packages/tabarena/src/tabarena/models/random_forest/info.py
+++ b/packages/tabarena/src/tabarena/models/random_forest/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import RFModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.random_forest.hpo import gen_randomforest
-from tabarena.models._method_metadata import MethodMetadata
-
 
 random_forest_method_metadata = MethodMetadata(
     method="RandomForest",

--- a/packages/tabarena/src/tabarena/models/realmlp/hpo.py
+++ b/packages/tabarena/src/tabarena/models/realmlp/hpo.py
@@ -26,7 +26,7 @@ def generate_single_config_realmlp(rng):
         "lr": np.exp(rng.uniform(np.log(2e-2), np.log(3e-1))),
         "wd": np.exp(rng.uniform(np.log(1e-3), np.log(5e-2))),
         "use_ls": rng.choice(
-            [False, True]  # changed "auto" to False, to have it equal for all metrics
+            [False, True],  # changed "auto" to False, to have it equal for all metrics
         ),  # use label smoothing (will be ignored for regression)
         "max_one_hot_cat_size": np.floor(np.exp(rng.uniform(np.log(4.0), np.log(33.0)))).item(),
         "embedding_size": rng.choice([4, 8, 16]),
@@ -75,7 +75,9 @@ if __name__ == "__main__":
         name_id_prefix="c",
     )
     experiments_random = generate_bag_experiments(
-        model_cls=RealMLPModel, configs=configs, time_limit=3600
+        model_cls=RealMLPModel,
+        configs=configs,
+        time_limit=3600,
     )
     YamlExperimentSerializer.to_yaml(
         experiments=experiments_default + experiments_random,

--- a/packages/tabarena/src/tabarena/models/realmlp/info.py
+++ b/packages/tabarena/src/tabarena/models/realmlp/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.realmlp.model import RealMLPModel
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.realmlp.hpo import gen_realmlp
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.realmlp.model import RealMLPModel
 
 realmlp_method_metadata = MethodMetadata(
     method="RealMLP_GPU",

--- a/packages/tabarena/src/tabarena/models/realmlp/model.py
+++ b/packages/tabarena/src/tabarena/models/realmlp/model.py
@@ -6,14 +6,12 @@ import time
 from contextlib import contextmanager
 from typing import Literal
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from autogluon.common.utils.resource_utils import ResourceManager
+from autogluon.tabular import __version__
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 from sklearn.impute import SimpleImputer
-
-from autogluon.tabular import __version__
-
 
 logger = logging.getLogger(__name__)
 
@@ -68,10 +66,7 @@ class RealMLPModel(AbstractTorchModel):
 
         assert default_hyperparameters in ["td", "td_s"]
         if self.problem_type in ["binary", "multiclass"]:
-            if default_hyperparameters == "td":
-                model_cls = RealMLP_TD_Classifier
-            else:
-                model_cls = RealMLP_TD_S_Classifier
+            model_cls = RealMLP_TD_Classifier if default_hyperparameters == "td" else RealMLP_TD_S_Classifier
         elif default_hyperparameters == "td":
             model_cls = RealMLP_TD_Regressor
         else:
@@ -99,7 +94,7 @@ class RealMLPModel(AbstractTorchModel):
         start_time = time.time()
 
         try:
-            import pytabkit
+            import pytabkit  # noqa: F401
             import torch
         except ImportError as err:
             logger.log(
@@ -150,11 +145,7 @@ class RealMLPModel(AbstractTorchModel):
             init_kwargs["val_metric_name"] = val_metric_name
 
         # TODO: Make this smarter? Maybe use `eval_metric.needs_pred`
-        if (
-            hyp["use_ls"] is not None
-            and isinstance(hyp["use_ls"], str)
-            and hyp["use_ls"] == "auto"
-        ):
+        if hyp["use_ls"] is not None and isinstance(hyp["use_ls"], str) and hyp["use_ls"] == "auto":
             if val_metric_name is None or val_metric_name in [
                 "cross_entropy",
                 "1-auc_ovr_alt",
@@ -172,7 +163,7 @@ class RealMLPModel(AbstractTorchModel):
         name_categories = hyp.pop("name_categories", True)
 
         hyp = self._set_predict_batch_size(hyp=hyp, n_features=len(X.columns))
-        hpy = self._hp_override_large_features(hyp=hyp, n_features=len(X.columns))
+        self._hp_override_large_features(hyp=hyp, n_features=len(X.columns))
         self.model = model_cls(
             n_threads=num_cpus,
             device=device,
@@ -181,7 +172,11 @@ class RealMLPModel(AbstractTorchModel):
         )
 
         X = self.preprocess(
-            X, y=y, is_train=True, bool_to_cat=bool_to_cat, impute_bool=impute_bool
+            X,
+            y=y,
+            is_train=True,
+            bool_to_cat=bool_to_cat,
+            impute_bool=impute_bool,
         )
 
         # FIXME: In rare cases can cause exceptions if name_categories=False, unknown why
@@ -198,9 +193,7 @@ class RealMLPModel(AbstractTorchModel):
                 y=y,
                 X_val=X_val,
                 y_val=y_val,
-                time_to_fit_in_seconds=time_limit - (time.time() - start_time)
-                if time_limit is not None
-                else None,
+                time_to_fit_in_seconds=time_limit - (time.time() - start_time) if time_limit is not None else None,
                 **extra_fit_kwargs,
             )
 
@@ -251,43 +244,40 @@ class RealMLPModel(AbstractTorchModel):
         if is_train:
             self._bool_to_cat = bool_to_cat
             self._features_bool = self._feature_metadata.get_features(
-                required_special_types=["bool"]
+                required_special_types=["bool"],
             )
             if impute_bool:  # Technically this should do nothing useful because bools will never have NaN
                 self._features_to_impute = self._feature_metadata.get_features(
-                    valid_raw_types=["int", "float"]
+                    valid_raw_types=["int", "float"],
                 )
                 self._features_to_keep = self._feature_metadata.get_features(
-                    invalid_raw_types=["int", "float"]
+                    invalid_raw_types=["int", "float"],
                 )
             else:
                 self._features_to_impute = self._feature_metadata.get_features(
-                    valid_raw_types=["int", "float"], invalid_special_types=["bool"]
+                    valid_raw_types=["int", "float"],
+                    invalid_special_types=["bool"],
                 )
                 self._features_to_keep = [
-                    f
-                    for f in self._feature_metadata.get_features()
-                    if f not in self._features_to_impute
+                    f for f in self._feature_metadata.get_features() if f not in self._features_to_impute
                 ]
             if self._features_to_impute:
                 self._imputer = SimpleImputer(strategy="mean", add_indicator=True)
                 self._imputer.fit(X=X[self._features_to_impute])
                 self._indicator_columns = [
-                    c
-                    for c in self._imputer.get_feature_names_out()
-                    if c not in self._features_to_impute
+                    c for c in self._imputer.get_feature_names_out() if c not in self._features_to_impute
                 ]
         if self._imputer is not None:
             X_impute = self._imputer.transform(X=X[self._features_to_impute])
             X_impute = pd.DataFrame(
-                X_impute, index=X.index, columns=self._imputer.get_feature_names_out()
+                X_impute,
+                index=X.index,
+                columns=self._imputer.get_feature_names_out(),
             )
             if self._indicator_columns:
                 # FIXME: Use CategoryFeatureGenerator? Or tell the model which is category
                 # TODO: Add to features_bool?
-                X_impute[self._indicator_columns] = X_impute[
-                    self._indicator_columns
-                ].astype("category")
+                X_impute[self._indicator_columns] = X_impute[self._indicator_columns].astype("category")
             X = pd.concat([X[self._features_to_keep], X_impute], axis=1)
         if self._bool_to_cat and self._features_bool:
             # FIXME: Use CategoryFeatureGenerator? Or tell the model which is category
@@ -383,9 +373,7 @@ class RealMLPModel(AbstractTorchModel):
         if num_classes is None:
             num_classes = 1
         params = copy.copy(
-            DefaultParams.RealMLP_TD_CLASS
-            if num_classes > 1
-            else DefaultParams.RealMLP_TD_REG
+            DefaultParams.RealMLP_TD_CLASS if num_classes > 1 else DefaultParams.RealMLP_TD_REG,
         )
         params.update(hyperparameters)
         params = RealMLPModel._set_predict_batch_size(hyp=params, n_features=X.shape[1])
@@ -393,13 +381,7 @@ class RealMLPModel(AbstractTorchModel):
 
         n_samples = X.shape[0]
         n_numerical = X.select_dtypes(include=["int", "float"]).shape[1]
-        cat_sizes = (
-            X.select_dtypes(include=["category", "object"])
-            .nunique(dropna=False)
-            .add(1)
-            .astype(int)
-            .tolist()
-        )
+        cat_sizes = X.select_dtypes(include=["category", "object"]).nunique(dropna=False).add(1).astype(int).tolist()
 
         ds = DictDataset(
             tensors=None,
@@ -414,16 +396,21 @@ class RealMLPModel(AbstractTorchModel):
 
         alg_interface = NNAlgInterface(**params)
         res = alg_interface.get_required_resources(
-            ds, n_cv=1, n_refit=0, n_splits=1, split_seeds=[0], n_train=n_samples
+            ds,
+            n_cv=1,
+            n_refit=0,
+            n_splits=1,
+            split_seeds=[0],
+            n_train=n_samples,
         )
 
         est = int(res.gpu_ram_gb * 1e9)
 
         if n_samples > 50_000:
             # Default overhead that somehow exists for large data as it seems
-            est += (12 * 1e9)
+            est += 12 * 1e9
         if X.shape[1] > 5_000:
-            est /= 2.5 # Avoid features are not counted correctly.
+            est /= 2.5  # Avoid features are not counted correctly.
 
         logger.log(
             40,
@@ -433,7 +420,8 @@ class RealMLPModel(AbstractTorchModel):
 
     def _validate_fit_memory_usage(self, mem_error_threshold: float = 1, **kwargs):
         return super()._validate_fit_memory_usage(
-            mem_error_threshold=mem_error_threshold, **kwargs
+            mem_error_threshold=mem_error_threshold,
+            **kwargs,
         )
 
     @classmethod

--- a/packages/tabarena/src/tabarena/models/sap_rpt_oss/hpo.py
+++ b/packages/tabarena/src/tabarena/models/sap_rpt_oss/hpo.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from tabarena.models.sap_rpt_oss.model import SAPRPTOSSModel
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 gen_sap_rpt_oss = ConfigGenerator(
     model_cls=SAPRPTOSSModel,
     manual_configs=[{}],
@@ -17,7 +16,7 @@ if __name__ == "__main__":
     print(
         YamlExperimentSerializer.to_yaml_str(
             experiments=gen_sap_rpt_oss.generate_all_bag_experiments(
-                num_random_configs=0
+                num_random_configs=0,
             ),
         ),
     )

--- a/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
+++ b/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.sap_rpt_oss.model import SAPRPTOSSModel, prefetch_weights
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.sap_rpt_oss.hpo import gen_sap_rpt_oss
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.sap_rpt_oss.model import SAPRPTOSSModel, prefetch_weights
 
 sap_rpt_oss_method_metadata = MethodMetadata(
     method="SAP-RPT-OSS",

--- a/packages/tabarena/src/tabarena/models/sap_rpt_oss/model.py
+++ b/packages/tabarena/src/tabarena/models/sap_rpt_oss/model.py
@@ -92,7 +92,8 @@ class SAPRPTOSSModel(AbstractTorchModel):
         return num_cpus, num_gpus
 
     def get_minimum_resources(
-        self, is_gpu_available: bool = False
+        self,
+        is_gpu_available: bool = False,
     ) -> dict[str, int | float]:
         return {
             "num_cpus": 1,
@@ -137,5 +138,6 @@ def prefetch_weights() -> None:
 
     # Hardcoded to the checkpoint we use in TabArena.
     hf_hub_download(
-        repo_id="SAP/sap-rpt-1-oss", filename="2025-11-04_sap-rpt-one-oss.pt"
+        repo_id="SAP/sap-rpt-1-oss",
+        filename="2025-11-04_sap-rpt-one-oss.pt",
     )

--- a/packages/tabarena/src/tabarena/models/tabdpt/hpo.py
+++ b/packages/tabarena/src/tabarena/models/tabdpt/hpo.py
@@ -5,10 +5,20 @@ from autogluon.common.space import Categorical
 from tabarena.models.tabdpt.model import TabDPTModel
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 search_space = {
     "temperature": Categorical(
-        0.8, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.0, 1.25, 1.5
+        0.8,
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.6,
+        0.7,
+        0.9,
+        1.0,
+        1.25,
+        1.5,
     ),
     "context_size": Categorical(2048, 768, 256),
     "permute_classes": Categorical(True, False),

--- a/packages/tabarena/src/tabarena/models/tabdpt/info.py
+++ b/packages/tabarena/src/tabarena/models/tabdpt/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.tabdpt.model import TabDPTModel, prefetch_weights
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.tabdpt.hpo import gen_tabdpt
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.tabdpt.model import TabDPTModel, prefetch_weights
 
 tabdpt_method_metadata = MethodMetadata(
     method="TabDPT_GPU",

--- a/packages/tabarena/src/tabarena/models/tabdpt/model.py
+++ b/packages/tabarena/src/tabarena/models/tabdpt/model.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
-from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 from autogluon.features.generators import LabelEncoderFeatureGenerator
+from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 if TYPE_CHECKING:
     import numpy as np
@@ -23,7 +23,6 @@ class TabDPTModel(AbstractTorchModel):
         self._feature_generator = None
         self._predict_hps = None
         self._use_flash_og = None
-
 
     def _fit(
         self,
@@ -44,15 +43,9 @@ class TabDPTModel(AbstractTorchModel):
             )
         from tabdpt import TabDPTClassifier, TabDPTRegressor
 
-        model_cls = (
-            TabDPTClassifier
-            if self.problem_type in [BINARY, MULTICLASS]
-            else TabDPTRegressor
-        )
+        model_cls = TabDPTClassifier if self.problem_type in [BINARY, MULTICLASS] else TabDPTRegressor
         supported_predict_hps = (
-            ("context_size", "permute_classes", "temperature")
-            if model_cls is TabDPTClassifier
-            else ("context_size",)
+            ("context_size", "permute_classes", "temperature") if model_cls is TabDPTClassifier else ("context_size",)
         )
 
         hps = self._get_model_params()
@@ -111,7 +104,8 @@ class TabDPTModel(AbstractTorchModel):
         return num_cpus, num_gpus
 
     def get_minimum_resources(
-        self, is_gpu_available: bool = False
+        self,
+        is_gpu_available: bool = False,
     ) -> dict[str, int | float]:
         return {
             "num_cpus": 1,
@@ -136,7 +130,7 @@ class TabDPTModel(AbstractTorchModel):
         if self._feature_generator.features_in:
             X = X.copy()
             X[self._feature_generator.features_in] = self._feature_generator.transform(
-                X=X
+                X=X,
             )
         return X.to_numpy()
 

--- a/packages/tabarena/src/tabarena/models/tabicl/hpo.py
+++ b/packages/tabarena/src/tabarena/models/tabicl/hpo.py
@@ -11,11 +11,14 @@ from tabarena.models.tabicl.model import (
 )
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 # Unofficial search space
 base_search_space = {
     "norm_methods": Categorical(
-        "none", "power", "robust", "quantile_rtdl", ["none", "power"]
+        "none",
+        "power",
+        "robust",
+        "quantile_rtdl",
+        ["none", "power"],
     ),
     # just in case, tuning between TabICL and TabPFN defaults
     "outlier_threshold": Real(4.0, 12.0),
@@ -30,10 +33,12 @@ base_search_space = {
 def get_gen_function(model_cls: TabICLModelBase):
     search_space = deepcopy(base_search_space)
     search_space["checkpoint_version"] = Categorical(
-        *model_cls.checkpoint_search_space()
+        *model_cls.checkpoint_search_space(),
     )
     return ConfigGenerator(
-        model_cls=model_cls, manual_configs=[{}], search_space=search_space
+        model_cls=model_cls,
+        manual_configs=[{}],
+        search_space=search_space,
     )
 
 

--- a/packages/tabarena/src/tabarena/models/tabicl/model.py
+++ b/packages/tabarena/src/tabarena/models/tabicl/model.py
@@ -61,8 +61,7 @@ class TabICLModelBase(AbstractTorchModel):
                 reg_checkpoint = hyperparameter["checkpoint_version"][1]
             else:
                 raise ValueError(
-                    "checkpoint_version hyperparameter must be either "
-                    "a string or a tuple of two strings (clf, reg)."
+                    "checkpoint_version hyperparameter must be either a string or a tuple of two strings (clf, reg).",
                 )
 
         if self.problem_type in ["binary", "multiclass"]:
@@ -84,7 +83,7 @@ class TabICLModelBase(AbstractTorchModel):
     @staticmethod
     def _get_n_estimators_override(n_rows: int) -> int | None:
         # Avoid OOM and time issues
-        if n_rows >=  700_000:
+        if n_rows >= 700_000:
             return 1
         return None
 
@@ -97,7 +96,7 @@ class TabICLModelBase(AbstractTorchModel):
         **kwargs,
     ):
         try:
-            import tabicl
+            import tabicl  # noqa: F401
         except ImportError as err:
             logger.log(
                 40,
@@ -119,7 +118,8 @@ class TabICLModelBase(AbstractTorchModel):
         model_cls = self.get_model_cls()
         hyp = self._get_model_params()
         hyp["batch_size"] = hyp.get(
-            "batch_size", self._get_batch_size(X.shape[0] * X.shape[1])
+            "batch_size",
+            self._get_batch_size(X.shape[0] * X.shape[1]),
         )
         hyp["checkpoint_version"] = self.get_checkpoint_version(hyperparameter=hyp)
 
@@ -138,7 +138,7 @@ class TabICLModelBase(AbstractTorchModel):
             n_jobs=num_cpus,
             disk_offload_dir=disk_offload_dir,
             verbose=X.shape[0] > 250_000,
-            inference_config=dict(COL_CONFIG=dict(cpu_safety_factor=0.75))
+            inference_config=dict(COL_CONFIG=dict(cpu_safety_factor=0.75)),
         )
         X = self.preprocess(X, y=y)
         self.model = self.model.fit(
@@ -154,7 +154,8 @@ class TabICLModelBase(AbstractTorchModel):
         return num_cpus, num_gpus
 
     def get_minimum_resources(
-        self, is_gpu_available: bool = False
+        self,
+        is_gpu_available: bool = False,
     ) -> dict[str, int | float]:
         return {
             "num_cpus": 1,
@@ -186,21 +187,18 @@ class TabICLModelBase(AbstractTorchModel):
         if hyperparameters is None:
             hyperparameters = {}
 
-        dataset_size_mem_est = (
-            3 * get_approximate_df_mem_usage(X).sum()
-        )  # roughly 3x DataFrame memory size
+        dataset_size_mem_est = 3 * get_approximate_df_mem_usage(X).sum()  # roughly 3x DataFrame memory size
         baseline_overhead_mem_est = 1e9  # 1 GB generic overhead
 
         n_rows = X.shape[0]
         n_features = X.shape[1]
         batch_size = hyperparameters.get(
-            "batch_size", cls._get_batch_size(X.shape[0] * X.shape[1])
+            "batch_size",
+            cls._get_batch_size(X.shape[0] * X.shape[1]),
         )
         embedding_dim = 128
         bytes_per_float = 4
-        model_mem_estimate = (
-            2 * batch_size * embedding_dim * bytes_per_float * (4 + n_rows) * n_features
-        )
+        model_mem_estimate = 2 * batch_size * embedding_dim * bytes_per_float * (4 + n_rows) * n_features
 
         model_mem_estimate *= 1.3  # add 30% buffer
 
@@ -259,6 +257,7 @@ class TabICLModelBase(AbstractTorchModel):
         self.model.inference_config_.ROW_CONFIG.device = self.model.device_
         self.model.inference_config_.ICL_CONFIG.device = self.model.device_
 
+
 class TabICLModel(TabICLModelBase):
     """TabICLv1.1 model as used on TabArena."""
 
@@ -280,7 +279,7 @@ class TabICLModel(TabICLModelBase):
 
     def _set_default_params(self):
         default_params = {
-            "n_estimators": 32, # default of TabICLv1
+            "n_estimators": 32,  # default of TabICLv1
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
@@ -306,7 +305,7 @@ class TabICLv2Model(TabICLModelBase):
             (
                 "tabicl-classifier-v2-20260212.ckpt",
                 "tabicl-regressor-v2-20260212.ckpt",
-            )
+            ),
         ]
 
     @classmethod
@@ -322,8 +321,6 @@ class TabICLv2Model(TabICLModelBase):
 
         Problems are: GPU memory est, how to handle off-loading logic, ...
         """
-        dataset_size_mem_est = (
-            3 * get_approximate_df_mem_usage(X).sum()
-        )
+        dataset_size_mem_est = 3 * get_approximate_df_mem_usage(X).sum()
         baseline_overhead_mem_est = 1e9  # 1 GB generic overhead
         return dataset_size_mem_est + baseline_overhead_mem_est

--- a/packages/tabarena/src/tabarena/models/tabm/hpo.py
+++ b/packages/tabarena/src/tabarena/models/tabm/hpo.py
@@ -21,7 +21,7 @@ def generate_single_config_tabm(rng):
         "share_training_batches": False,
         "lr": np.exp(rng.uniform(np.log(1e-4), np.log(3e-3))),
         "weight_decay": rng.choice(
-            [0.0, np.exp(rng.uniform(np.log(1e-4), np.log(1e-1)))]
+            [0.0, np.exp(rng.uniform(np.log(1e-4), np.log(1e-1)))],
         ),
         "n_blocks": rng.choice([2, 3, 4, 5]),
         "d_block": rng.choice([i for i in range(128, 1024 + 1) if i % 16 == 0]),

--- a/packages/tabarena/src/tabarena/models/tabm/info.py
+++ b/packages/tabarena/src/tabarena/models/tabm/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.tabm.model import TabMModel
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.tabm.hpo import gen_tabm
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.tabm.model import TabMModel
 
 tabm_method_metadata = MethodMetadata(
     method="TabM",

--- a/packages/tabarena/src/tabarena/models/tabm/model.py
+++ b/packages/tabarena/src/tabarena/models/tabm/model.py
@@ -10,9 +10,10 @@ import time
 
 import pandas as pd
 from autogluon.common.utils.resource_utils import ResourceManager
-from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
-from ._internal.tabm_utils import get_tabm_auto_batch_size
 from autogluon.tabular import __version__
+from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
+
+from ._internal.tabm_utils import get_tabm_auto_batch_size
 
 logger = logging.getLogger(__name__)
 
@@ -113,9 +114,7 @@ class TabMModel(AbstractTorchModel):
             X_val=X_val,
             y_val=y_val,
             cat_col_names=X.select_dtypes(include="category").columns.tolist(),
-            time_to_fit_in_seconds=time_limit - (time.time() - start_time)
-            if time_limit is not None
-            else None,
+            time_to_fit_in_seconds=time_limit - (time.time() - start_time) if time_limit is not None else None,
         )
 
     # FIXME: bool_to_cat is a hack: Maybe move to abstract model?
@@ -134,7 +133,7 @@ class TabMModel(AbstractTorchModel):
         if is_train:
             self._bool_to_cat = bool_to_cat
             self._features_bool = self._feature_metadata.get_features(
-                required_special_types=["bool"]
+                required_special_types=["bool"],
             )
         if self._bool_to_cat and self._features_bool:
             # FIXME: Use CategoryFeatureGenerator? Or tell the model which is category
@@ -223,7 +222,6 @@ class TabMModel(AbstractTorchModel):
         # Given the good mem estimates with overhead, we set the threshold to 1.
         return super()._validate_fit_memory_usage(mem_error_threshold=mem_error_threshold, **kwargs)
 
-
     @classmethod
     def _estimate_tabm_ram(
         cls,
@@ -266,17 +264,13 @@ class TabMModel(AbstractTorchModel):
         # 2 for pre-act, post-act
         n_floats_forward += n_blocks * 2 * d_block + 2 * max(1, n_classes)
         # 2 for forward and backward, 4 bytes per float
-        mem_forward_backward = (
-            4 * predict_batch_size * n_floats_forward * tabm_k
-        )
+        mem_forward_backward = 4 * predict_batch_size * n_floats_forward * tabm_k
         # * 8 is pessimistic for the long tensors in the forward pass, 4 would probably suffice
 
         mem_ds = n_samples * (4 * n_numerical + 8 * len(cat_sizes))
 
         # some safety constants and offsets (the 5 is probably excessive)
-        res = (
-            4 * mem_ds + 1.2 * mem_forward_backward + 1.2 * mem_params + 0.3 * (1024**3)
-        )
+        res = 4 * mem_ds + 1.2 * mem_forward_backward + 1.2 * mem_params + 0.3 * (1024**3)
         # Safety overhead
         res = res + (5 * 1e9)
 
@@ -285,7 +279,7 @@ class TabMModel(AbstractTorchModel):
 
         logger.log(
             40,
-            f"\tEstimated memory usage {res/1e9:4}.",
+            f"\tEstimated memory usage {res / 1e9:4}.",
         )
         return res
 

--- a/packages/tabarena/src/tabarena/models/tabpfn_3/hpo.py
+++ b/packages/tabarena/src/tabarena/models/tabpfn_3/hpo.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from tabarena.models.tabpfn_3.model import TabPFN3Model
 from tabarena.utils.config_utils import ConfigGenerator
 
-
 gen_tabpfn_3 = ConfigGenerator(
     model_cls=TabPFN3Model,
     search_space={},

--- a/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.tabpfn_3.model import TabPFN3Model, prefetch_weights
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.tabpfn_3.hpo import gen_tabpfn_3
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.tabpfn_3.model import TabPFN3Model, prefetch_weights
 
 tabpfn_3_method_metadata = MethodMetadata(
     method="TabPFN-3",

--- a/packages/tabarena/src/tabarena/models/tabpfn_3/model.py
+++ b/packages/tabarena/src/tabarena/models/tabpfn_3/model.py
@@ -103,7 +103,7 @@ class TabPFN3Model(AbstractTorchModel):
         default_auxiliary_params.update(
             {
                 "max_classes": 160,
-            }
+            },
         )
         return default_auxiliary_params
 

--- a/packages/tabarena/src/tabarena/models/tabpfnv2_5/hpo.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnv2_5/hpo.py
@@ -20,7 +20,7 @@ def _get_model_path_zip(model_cls):
     n_reg_models = len(reg_models)
     for i in range(max(n_clf_models, n_reg_models)):
         zip_model_paths.append(
-            [clf_models[min(i, n_clf_models - 1)], reg_models[min(i, n_reg_models - 1)]]
+            [clf_models[min(i, n_clf_models - 1)], reg_models[min(i, n_reg_models - 1)]],
         )
 
     return zip_model_paths
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     print(
         YamlExperimentSerializer.to_yaml_str(
             experiments=gen_realtabpfnv25.generate_all_bag_experiments(
-                num_random_configs=200
+                num_random_configs=200,
             ),
-        )
+        ),
     )

--- a/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
+from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models._model_info import ModelInfo
+from tabarena.models.tabpfnv2_5.hpo import gen_realtabpfnv25, gen_tabpfnv26
 from tabarena.models.tabpfnv2_5.model import (
     RealTabPFNv25Model,
     TabPFNv26Model,
     prefetch_weights,
 )
-from tabarena.models._model_info import ModelInfo
-from tabarena.models.tabpfnv2_5.hpo import gen_realtabpfnv25, gen_tabpfnv26
-from tabarena.models._method_metadata import MethodMetadata
-
 
 realtabpfnv25_method_metadata = MethodMetadata(
     method="RealTabPFN-v2.5",

--- a/packages/tabarena/src/tabarena/models/tabpfnv2_5/model.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnv2_5/model.py
@@ -5,10 +5,10 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
-from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
+from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.features.generators import LabelEncoderFeatureGenerator
+from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -61,16 +61,14 @@ class TabPFNModel(AbstractTorchModel):
         if self._feature_generator.features_in:
             X = X.copy()
             X[self._feature_generator.features_in] = self._feature_generator.transform(
-                X=X
+                X=X,
             )
 
             if is_train:
                 # Detect/set cat features and indices
                 if self._cat_features is None:
                     self._cat_features = self._feature_generator.features_in[:]
-                self._cat_indices = [
-                    X.columns.get_loc(col) for col in self._cat_features
-                ]
+                self._cat_indices = [X.columns.get_loc(col) for col in self._cat_features]
 
         return X
 
@@ -117,7 +115,8 @@ class TabPFNModel(AbstractTorchModel):
                     "name": scaler,
                     "global_transformer_name": hps.pop("preprocessing/global", None),
                     "categorical_name": hps.pop(
-                        "preprocessing/categoricals", "numeric"
+                        "preprocessing/categoricals",
+                        "numeric",
                     ),
                     "append_original": hps.pop("preprocessing/append_original", True),
                 }
@@ -156,9 +155,7 @@ class TabPFNModel(AbstractTorchModel):
 
         # Resolve inference_config
         inference_config = {
-            _k: v
-            for k, v in hps.items()
-            if k.startswith("inference_config/") and (_k := k.split("/")[-1])
+            _k: v for k, v in hps.items() if k.startswith("inference_config/") and (_k := k.split("/")[-1])
         }
         if inference_config:
             hps["inference_config"] = inference_config
@@ -168,9 +165,7 @@ class TabPFNModel(AbstractTorchModel):
 
         # Resolve finetuning config
         finetuning_config = {
-            _k: v
-            for k, v in hps.items()
-            if k.startswith("finetuning_config/") and (_k := k.split("/")[-1])
+            _k: v for k, v in hps.items() if k.startswith("finetuning_config/") and (_k := k.split("/")[-1])
         }
         for k in list(hps.keys()):
             if k.startswith("finetuning_config/"):
@@ -178,9 +173,7 @@ class TabPFNModel(AbstractTorchModel):
 
         # Resolve many_class config
         many_class_config = {
-            _k: v
-            for k, v in hps.items()
-            if k.startswith("many_class/") and (_k := k.split("/", 1)[1])
+            _k: v for k, v in hps.items() if k.startswith("many_class/") and (_k := k.split("/", 1)[1])
         }
         for k in list(hps.keys()):
             if k.startswith("many_class/"):
@@ -192,7 +185,6 @@ class TabPFNModel(AbstractTorchModel):
 
         if not use_finetuning:
             from tabpfn import TabPFNClassifier, TabPFNRegressor
-
 
             if self.fixed_random_state is not None:
                 hps[self.seed_name] = self.fixed_random_state
@@ -218,7 +210,7 @@ class TabPFNModel(AbstractTorchModel):
             )
         else:
             raise NotImplementedError(
-                "Finetuning is not supported anymore for now due to other changes!."
+                "Finetuning is not supported anymore for now due to other changes!.",
             )
             # TODO:
             #   Future Work for better performance:
@@ -239,19 +231,11 @@ class TabPFNModel(AbstractTorchModel):
                 "rmse": "mse",
             }
             eval_metric = metric_map.get(self.stopping_metric.name, None)
-            model_base = (
-                FinetunedTabPFNClassifier
-                if is_classification
-                else FinetunedTabPFNRegressor
-            )
+            model_base = FinetunedTabPFNClassifier if is_classification else FinetunedTabPFNRegressor
             # Large default number to avoid stopping on it.
             epochs = finetuning_config.pop("epochs", 10_000)
 
-            kwargs_name = (
-                "extra_classifier_kwargs"
-                if is_classification
-                else "extra_regressor_kwargs"
-            )
+            kwargs_name = "extra_classifier_kwargs" if is_classification else "extra_regressor_kwargs"
             finetuning_config[kwargs_name] = hps
 
             if X_val is not None:
@@ -282,7 +266,8 @@ class TabPFNModel(AbstractTorchModel):
         return num_cpus, num_gpus
 
     def get_minimum_resources(
-        self, is_gpu_available: bool = False
+        self,
+        is_gpu_available: bool = False,
     ) -> dict[str, int | float]:
         return {
             "num_cpus": 1,
@@ -367,20 +352,16 @@ class TabPFNModel(AbstractTorchModel):
         model_mem = 14489108  # Based on TabPFNv2 default
 
         n_samples, n_features = X.shape[0], min(X.shape[1], 500)
-        n_feature_groups = (
-            n_features
-        ) / features_per_group + 1  # TODO: Unsure how to calculate this
+        n_feature_groups = (n_features) / features_per_group + 1  # TODO: Unsure how to calculate this
 
         X_mem = n_samples * n_feature_groups * dtype_byte_size
-        activation_mem = (
-            n_samples * n_feature_groups * embedding_size * n_layers * dtype_byte_size
-        )
+        activation_mem = n_samples * n_feature_groups * embedding_size * n_layers * dtype_byte_size
 
         baseline_overhead_mem_est = 1e9  # 1 GB generic overhead
 
         # Add some buffer to each term + 1 GB overhead to be safe
         return int(
-            model_mem + 4 * X_mem + 2 * activation_mem + baseline_overhead_mem_est
+            model_mem + 4 * X_mem + 2 * activation_mem + baseline_overhead_mem_est,
         )
 
     @classmethod
@@ -398,6 +379,7 @@ class TabPFNModel(AbstractTorchModel):
         """By default no adjustments, but can be overridden by subclasses."""
         return hps
 
+
 class RealTabPFNv25Model(TabPFNModel):
     """RealTabPFN-v2.5 version: https://priorlabs.ai/technical-reports/tabpfn-2-5-model-report.
 
@@ -409,9 +391,7 @@ class RealTabPFNv25Model(TabPFNModel):
     ag_key = "TA-REALTABPFN-V2.5"
     ag_name = "TA-RealTabPFN-v2.5"
 
-    default_classification_model: str | None = (
-        "tabpfn-v2.5-classifier-v2.5_default.ckpt"
-    )
+    default_classification_model: str | None = "tabpfn-v2.5-classifier-v2.5_default.ckpt"
     default_regression_model: str | None = "tabpfn-v2.5-regressor-v2.5_default.ckpt"
 
     @staticmethod
@@ -445,9 +425,10 @@ class RealTabPFNv25Model(TabPFNModel):
                 "max_rows": 100_000,
                 "max_features": 2000,
                 "max_classes": 10,
-            }
+            },
         )
         return default_auxiliary_params
+
 
 class TabPFNv26Model(TabPFNModel):
     """TabPFN-2.6 version."""
@@ -468,7 +449,7 @@ class TabPFNv26Model(TabPFNModel):
     def extra_checkpoints_for_tuning(problem_type: str) -> list[str]:
         """The list of checkpoints to use for hyperparameter tuning."""
         raise NotImplementedError(
-            "We did not benchmark more checkpoints or tuning."
+            "We did not benchmark more checkpoints or tuning.",
         )
 
     # We do not put a limit on number of classes or features anymore for
@@ -478,7 +459,7 @@ class TabPFNv26Model(TabPFNModel):
         default_auxiliary_params.update(
             {
                 "max_rows": 100_000,
-            }
+            },
         )
         return default_auxiliary_params
 
@@ -494,9 +475,7 @@ class TabPFNv26Model(TabPFNModel):
         We ignore it for now, moreover as we refit_folds=True, there is no benefit yet.
 
         """
-        dataset_size_mem_est = (
-            3 * get_approximate_df_mem_usage(X).sum()
-        )
+        dataset_size_mem_est = 3 * get_approximate_df_mem_usage(X).sum()
         baseline_overhead_mem_est = 1e9  # 1 GB generic overhead
         return dataset_size_mem_est + baseline_overhead_mem_est
 
@@ -510,19 +489,26 @@ class TabPFNv26Model(TabPFNModel):
             # More extreme heuristic to avoid OOM
             import dataclasses
 
-            from tabpfn.inference_config import _get_v2_6_config, v2_6_classifier_preprocessor_configs, v2_6_regressor_preprocessor_configs
+            from tabpfn.inference_config import (
+                _get_v2_6_config,
+                v2_6_classifier_preprocessor_configs,
+                v2_6_regressor_preprocessor_configs,
+            )
+
             task_type = "multiclass" if is_classification else "regression"
-            preprocessor_configs = v2_6_classifier_preprocessor_configs()  if is_classification else v2_6_regressor_preprocessor_configs()
+            preprocessor_configs = (
+                v2_6_classifier_preprocessor_configs() if is_classification else v2_6_regressor_preprocessor_configs()
+            )
             preprocessor_configs = [
-                dataclasses.replace(cfg, max_features_per_estimator=300)
-                for cfg in preprocessor_configs
+                dataclasses.replace(cfg, max_features_per_estimator=300) for cfg in preprocessor_configs
             ]
             hps["inference_config"] = _get_v2_6_config(
-                    preprocessor_configs=preprocessor_configs,
-                    task_type=task_type,
-                )
+                preprocessor_configs=preprocessor_configs,
+                task_type=task_type,
+            )
 
         return hps
+
 
 def prefetch_weights() -> None:
     """Pre-download all TabPFN checkpoints (shared by the v2.5 / v2.6 wrappers)."""

--- a/packages/tabarena/src/tabarena/models/tabpfnwide/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnwide/info.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.tabpfnwide.model import TabPFNWideModel
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.tabpfnwide.hpo import gen_tabpfnwide
-from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models.tabpfnwide.model import TabPFNWideModel
 
 tabpfnwide_method_metadata = MethodMetadata(
     method="TabPFN-Wide",

--- a/packages/tabarena/src/tabarena/models/tabpfnwide/model.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnwide/model.py
@@ -77,8 +77,7 @@ class TabPFNWideModel(AbstractTorchModel):
 
         if self.problem_type not in ["binary", "multiclass"]:
             raise AssertionError(
-                f"Unsupported problem_type: {self.problem_type}. "
-                "TabPFN-Wide supports only classification."
+                f"Unsupported problem_type: {self.problem_type}. TabPFN-Wide supports only classification.",
             )
 
         hps = self._get_model_params()
@@ -148,6 +147,6 @@ class TabPFNWideModel(AbstractTorchModel):
             {
                 "max_rows": 10_000,
                 "max_classes": 10,
-            }
+            },
         )
         return default_auxiliary_params

--- a/packages/tabarena/src/tabarena/models/tabstar/hpo.py
+++ b/packages/tabarena/src/tabarena/models/tabstar/hpo.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     print(
         YamlExperimentSerializer.to_yaml_str(
             experiments=gen_tabstar.generate_all_bag_experiments(
-                num_random_configs=0
+                num_random_configs=0,
             ),
         ),
     )

--- a/packages/tabarena/src/tabarena/models/tabstar/info.py
+++ b/packages/tabarena/src/tabarena/models/tabstar/info.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.tabstar.model import TabSTARModel, prefetch_weights
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.tabstar.hpo import gen_tabstar
-from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models.tabstar.model import TabSTARModel, prefetch_weights
 
 tabstar_method_metadata = MethodMetadata(
     method="TabSTAR",

--- a/packages/tabarena/src/tabarena/models/tabstar/model.py
+++ b/packages/tabarena/src/tabarena/models/tabstar/model.py
@@ -137,7 +137,8 @@ class TabSTARModel(AbstractModel):
         return num_cpus, num_gpus
 
     def get_minimum_resources(
-        self, is_gpu_available: bool = False
+        self,
+        is_gpu_available: bool = False,
     ) -> dict[str, int | float]:
         return {
             "num_cpus": 1,

--- a/packages/tabarena/src/tabarena/models/utils.py
+++ b/packages/tabarena/src/tabarena/models/utils.py
@@ -39,14 +39,16 @@ def get_model_info_from_name(model_name: str):
         if model_name in (md.display_name, md.method):
             return info
 
-    available = sorted({
-        name
-        for info in registry.values()
-        for name in (info.method_metadata.display_name, info.method_metadata.method)
-        if name
-    })
+    available = sorted(
+        {
+            name
+            for info in registry.values()
+            for name in (info.method_metadata.display_name, info.method_metadata.method)
+            if name
+        }
+    )
     raise ValueError(
-        f"Model name {model_name!r} is not recognized. Options are: {available}"
+        f"Model name {model_name!r} is not recognized. Options are: {available}",
     )
 
 

--- a/packages/tabarena/src/tabarena/models/xgboost/info.py
+++ b/packages/tabarena/src/tabarena/models/xgboost/info.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from autogluon.tabular.models import XGBoostModel
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.xgboost.hpo import gen_xgboost
-from tabarena.models._method_metadata import MethodMetadata
-
 
 xgboost_method_metadata = MethodMetadata(
     method="XGBoost",

--- a/packages/tabarena/src/tabarena/models/xrfm/hpo.py
+++ b/packages/tabarena/src/tabarena/models/xrfm/hpo.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from tabarena.models.xrfm.model import XRFMModel
 from tabarena.models.utils import convert_numpy_dtypes
+from tabarena.models.xrfm.model import XRFMModel
 from tabarena.utils.config_utils import CustomAGConfigGenerator
 
 
@@ -14,15 +14,15 @@ def generate_configs_xrfm(num_random_configs=200) -> list:
         space=[
             Float("bandwidth", (0.5, 200), log=True),
             Categorical("standardize_cats", [False]),
-            Categorical("bandwidth_mode", ['constant']),
+            Categorical("bandwidth_mode", ["constant"]),
             Categorical("diag", [False, True]),
             Categorical("early_stop_multiplier", [1.1]),
             Float("exponent", (0.7, 1.4)),
-            Float("p_interp", (0., 0.8)),
-            Categorical("kernel", ['lpq_kermac', 'l2'], weights=[0.8, 0.2]),
+            Float("p_interp", (0.0, 0.8)),
+            Categorical("kernel", ["lpq_kermac", "l2"], weights=[0.8, 0.2]),
             Float("reg", (1e-6, 1e1), log=True),
-            Categorical("solver", ['solve']),  # [log_reg] possible for binary classification
-            Categorical("classification_mode", ['prevalence']),
+            Categorical("solver", ["solve"]),  # [log_reg] possible for binary classification
+            Categorical("classification_mode", ["prevalence"]),
         ],
         seed=1234,
     )
@@ -46,5 +46,6 @@ if __name__ == "__main__":
 
     experiments = gen_xrfm.generate_all_bag_experiments(num_random_configs=200)
     YamlExperimentSerializer.to_yaml(
-        experiments=experiments, path="configs_xrfm.yaml"
+        experiments=experiments,
+        path="configs_xrfm.yaml",
     )

--- a/packages/tabarena/src/tabarena/models/xrfm/info.py
+++ b/packages/tabarena/src/tabarena/models/xrfm/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tabarena.models.xrfm.model import XRFMModel
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.xrfm.hpo import gen_xrfm
-from tabarena.models._method_metadata import MethodMetadata
-
+from tabarena.models.xrfm.model import XRFMModel
 
 xrfm_method_metadata = MethodMetadata(
     method="xRFM_GPU",

--- a/packages/tabarena/src/tabarena/models/xrfm/model.py
+++ b/packages/tabarena/src/tabarena/models/xrfm/model.py
@@ -39,25 +39,18 @@ class XRFMImplementation:
 
         # preprocessing
         self.cat_cols_ = X.select_dtypes(
-            include=["category", "string", "object"]
+            include=["category", "string", "object"],
         ).columns.tolist()
         self.num_cols_ = X.select_dtypes(
-            exclude=["category", "string", "object"]
+            exclude=["category", "string", "object"],
         ).columns.tolist()
 
         # Initialize encoders
-        self.ohe_ = (
-            OneHotEncoder(handle_unknown="ignore", sparse_output=False)
-            if self.cat_cols_
-            else None
-        )
+        self.ohe_ = OneHotEncoder(handle_unknown="ignore", sparse_output=False) if self.cat_cols_ else None
         self.scaler_ = StandardScaler()
 
         # Encode categorical variables
-        if self.cat_cols_:
-            x_cat_enc = self.ohe_.fit_transform(X.loc[:, self.cat_cols_])
-        else:
-            x_cat_enc = np.empty((len(X), 0))
+        x_cat_enc = self.ohe_.fit_transform(X.loc[:, self.cat_cols_]) if self.cat_cols_ else np.empty((len(X), 0))
 
         x_num_enc = X.loc[:, self.num_cols_].to_numpy().astype(np.float32)
 
@@ -119,13 +112,11 @@ class XRFMImplementation:
                     categorical_indices.append(cat_idxs)
                     if self.kwargs.get("standardize_cats", False):
                         cat_vectors = np.asarray(self.scaler_.scale_)[
-                            None, cat_idxs.numpy()
-                        ] * (
-                            np.eye(cat_len)
-                            - np.asarray(self.scaler_.mean_)[None, cat_idxs.numpy()]
-                        )
+                            None,
+                            cat_idxs.numpy(),
+                        ] * (np.eye(cat_len) - np.asarray(self.scaler_.mean_)[None, cat_idxs.numpy()])
                         categorical_vectors.append(
-                            torch.tensor(cat_vectors, dtype=torch.float32)
+                            torch.tensor(cat_vectors, dtype=torch.float32),
                         )
                     else:
                         categorical_vectors.append(torch.eye(cat_len))
@@ -137,7 +128,7 @@ class XRFMImplementation:
             numerical_block = idx + torch.arange(x_num_enc.shape[1])
             if len(numerical_indices_parts) > 0:
                 numerical_indices = torch.cat(
-                    [*numerical_indices_parts, numerical_block]
+                    [*numerical_indices_parts, numerical_block],
                 )
             else:
                 numerical_indices = numerical_block
@@ -159,10 +150,7 @@ class XRFMImplementation:
     def preprocess_transform(self, X):
         # Encode categorical variables using the same strategy as in fit
 
-        if self.cat_cols_:
-            x_cat_enc = self.ohe_.transform(X.loc[:, self.cat_cols_])
-        else:
-            x_cat_enc = np.empty((len(X), 0))
+        x_cat_enc = self.ohe_.transform(X.loc[:, self.cat_cols_]) if self.cat_cols_ else np.empty((len(X), 0))
 
         x_num_enc = X.loc[:, self.num_cols_].to_numpy().astype(np.float32)
 
@@ -252,7 +240,8 @@ class XRFMModel(AbstractModel):
 
         init_kwargs["standardize_cats"] = init_kwargs.get("standardize_cats", False)
         init_kwargs["classification_mode"] = init_kwargs.get(
-            "classification_mode", "prevalence"
+            "classification_mode",
+            "prevalence",
         )
 
         solver = init_kwargs.get("solver", "solve")
@@ -295,7 +284,11 @@ class XRFMModel(AbstractModel):
         # todo: do we already need to move stuff to the correct device?
 
         X = self.preprocess(
-            X, y=y, is_train=True, bool_to_cat=bool_to_cat, impute_bool=impute_bool
+            X,
+            y=y,
+            is_train=True,
+            bool_to_cat=bool_to_cat,
+            impute_bool=impute_bool,
         )
 
         if X_val is not None:
@@ -305,9 +298,7 @@ class XRFMModel(AbstractModel):
             problem_type=self.problem_type,
             n_threads=num_cpus if num_gpus == 0 else 1,  # avoid VRAM leak
             device=device,
-            time_limit_s=time_limit - (time.time() - start_time)
-            if time_limit is not None
-            else None,
+            time_limit_s=time_limit - (time.time() - start_time) if time_limit is not None else None,
             **init_kwargs,
         )
 
@@ -341,43 +332,40 @@ class XRFMModel(AbstractModel):
         if is_train:
             self._bool_to_cat = bool_to_cat
             self._features_bool = self._feature_metadata.get_features(
-                required_special_types=["bool"]
+                required_special_types=["bool"],
             )
             if impute_bool:  # Technically this should do nothing useful because bools will never have NaN
                 self._features_to_impute = self._feature_metadata.get_features(
-                    valid_raw_types=["int", "float"]
+                    valid_raw_types=["int", "float"],
                 )
                 self._features_to_keep = self._feature_metadata.get_features(
-                    invalid_raw_types=["int", "float"]
+                    invalid_raw_types=["int", "float"],
                 )
             else:
                 self._features_to_impute = self._feature_metadata.get_features(
-                    valid_raw_types=["int", "float"], invalid_special_types=["bool"]
+                    valid_raw_types=["int", "float"],
+                    invalid_special_types=["bool"],
                 )
                 self._features_to_keep = [
-                    f
-                    for f in self._feature_metadata.get_features()
-                    if f not in self._features_to_impute
+                    f for f in self._feature_metadata.get_features() if f not in self._features_to_impute
                 ]
             if self._features_to_impute:
                 self._imputer = SimpleImputer(strategy="mean", add_indicator=True)
                 self._imputer.fit(X=X[self._features_to_impute])
                 self._indicator_columns = [
-                    c
-                    for c in self._imputer.get_feature_names_out()
-                    if c not in self._features_to_impute
+                    c for c in self._imputer.get_feature_names_out() if c not in self._features_to_impute
                 ]
         if self._imputer is not None:
             X_impute = self._imputer.transform(X=X[self._features_to_impute])
             X_impute = pd.DataFrame(
-                X_impute, index=X.index, columns=self._imputer.get_feature_names_out()
+                X_impute,
+                index=X.index,
+                columns=self._imputer.get_feature_names_out(),
             )
             if self._indicator_columns:
                 # FIXME: Use CategoryFeatureGenerator? Or tell the model which is category
                 # TODO: Add to features_bool?
-                X_impute[self._indicator_columns] = X_impute[
-                    self._indicator_columns
-                ].astype("category")
+                X_impute[self._indicator_columns] = X_impute[self._indicator_columns].astype("category")
             X = pd.concat([X[self._features_to_keep], X_impute], axis=1)
         if self._bool_to_cat and self._features_bool:
             # FIXME: Use CategoryFeatureGenerator? Or tell the model which is category
@@ -416,7 +404,8 @@ class XRFMModel(AbstractModel):
         **kwargs,
     ) -> tuple[int | None, int | None]:
         return super()._validate_fit_memory_usage(
-            mem_error_threshold=mem_error_threshold, **kwargs
+            mem_error_threshold=mem_error_threshold,
+            **kwargs,
         )
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:
@@ -449,20 +438,16 @@ class XRFMModel(AbstractModel):
 
         # taken from pytabkit
         columns_mem_est = (
-            6e4 * num_samples
-            + 2e6 * num_features
-            + 30.0 * num_samples**2
-            + 30.0 * num_samples * num_features
+            6e4 * num_samples + 2e6 * num_features + 30.0 * num_samples**2 + 30.0 * num_samples * num_features
         )
 
-        dataset_size_mem_est = (
-            5 * get_approximate_df_mem_usage(X).sum()
-        )  # roughly 5x DataFrame memory size
+        dataset_size_mem_est = 5 * get_approximate_df_mem_usage(X).sum()  # roughly 5x DataFrame memory size
         baseline_overhead_mem_est = 2e8  # 200 MB generic overhead
 
         model_mem_estimate = columns_mem_est + baseline_overhead_mem_est
         model_mem_estimate = min(
-            model_mem_estimate, 3.8e10
+            model_mem_estimate,
+            3.8e10,
         )  # using the tree strategy caps at <40 GB
         return model_mem_estimate + dataset_size_mem_est
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/__init__.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 from ._tabarena_method_metadata import tabarena_method_metadata_collection

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata.py
@@ -133,48 +133,52 @@ removed_cpu_methods = [
     "RealMLP",
 ]
 
-methods_2025_06_12_keep = [m for m in methods_2025_06_12 if m.method not in replaced_methods and m.method not in removed_cpu_methods]
-methods_2025_10_20_camera_ready = [m for m in methods_2025_06_12 if m.method not in updated_methods_camera_ready] + methods_2025_10_20
+methods_2025_06_12_keep = [
+    m for m in methods_2025_06_12 if m.method not in replaced_methods and m.method not in removed_cpu_methods
+]
+methods_2025_10_20_camera_ready = [
+    m for m in methods_2025_06_12 if m.method not in updated_methods_camera_ready
+] + methods_2025_10_20
 
 
 # The latest results for each method
-tabarena_method_metadata_collection = MethodMetadataCollection(method_metadata_lst=
-    methods_2025_06_12_keep +
-    methods_2025_09_03_keep +
-    methods_2025_10_20 +
-    methods_2025_11_01_keep +
-    methods_2025_12_18 +
-    [tabdpt_metadata] +
-    [realtabpfn25_metadata] +
-    [contexttab_metadata] +
-    [tabiclv2_metadata] +
-    [tabstar_metadata] +
-    [perpetualbooster_metadata] +
-    [tabpfn26_metadata] +
-    [tabpfnv3_method_metadata] +
-    [orionmsp_metadata] +
-    [iltm_method_metadata] +
-    methods_misc,
+tabarena_method_metadata_collection = MethodMetadataCollection(
+    method_metadata_lst=methods_2025_06_12_keep
+    + methods_2025_09_03_keep
+    + methods_2025_10_20
+    + methods_2025_11_01_keep
+    + methods_2025_12_18
+    + [tabdpt_metadata]
+    + [realtabpfn25_metadata]
+    + [contexttab_metadata]
+    + [tabiclv2_metadata]
+    + [tabstar_metadata]
+    + [perpetualbooster_metadata]
+    + [tabpfn26_metadata]
+    + [tabpfnv3_method_metadata]
+    + [orionmsp_metadata]
+    + [iltm_method_metadata]
+    + methods_misc,
 )
 
 # All historical results for each method
-tabarena_method_metadata_complete_collection = MethodMetadataCollection(method_metadata_lst=
-    methods_2025_06_12 +
-    methods_2025_09_03 +
-    methods_2025_10_20 +
-    methods_2025_11_01_ag +
-    methods_2025_12_18 +
-    [tabdpt_metadata] +
-    [realtabpfn25_metadata] +
-    [contexttab_metadata] +
-    [tabiclv2_metadata] +
-    [tabstar_metadata] +
-    [perpetualbooster_metadata] +
-    [tabpfn26_metadata] +
-    [tabpfnv3_method_metadata] +
-    [orionmsp_metadata] +
-    [iltm_method_metadata] +
-    methods_misc,
+tabarena_method_metadata_complete_collection = MethodMetadataCollection(
+    method_metadata_lst=methods_2025_06_12
+    + methods_2025_09_03
+    + methods_2025_10_20
+    + methods_2025_11_01_ag
+    + methods_2025_12_18
+    + [tabdpt_metadata]
+    + [realtabpfn25_metadata]
+    + [contexttab_metadata]
+    + [tabiclv2_metadata]
+    + [tabstar_metadata]
+    + [perpetualbooster_metadata]
+    + [tabpfn26_metadata]
+    + [tabpfnv3_method_metadata]
+    + [orionmsp_metadata]
+    + [iltm_method_metadata]
+    + methods_misc,
 )
 
 # All historical results for each method
@@ -183,9 +187,15 @@ tabarena_method_metadata_2025_06_12_collection = MethodMetadataCollection(
 )
 
 tabarena_method_metadata_2025_06_12_collection_main = MethodMetadataCollection(
-    method_metadata_lst=[m for m in tabarena_method_metadata_2025_06_12_collection.method_metadata_lst if m.method in methods_main_paper]
+    method_metadata_lst=[
+        m for m in tabarena_method_metadata_2025_06_12_collection.method_metadata_lst if m.method in methods_main_paper
+    ]
 )
 
 tabarena_method_metadata_2025_06_12_collection_gpu_ablation = MethodMetadataCollection(
-    method_metadata_lst=[m for m in tabarena_method_metadata_2025_06_12_collection.method_metadata_lst if m.method in methods_gpu_ablation]
+    method_metadata_lst=[
+        m
+        for m in tabarena_method_metadata_2025_06_12_collection.method_metadata_lst
+        if m.method in methods_gpu_ablation
+    ]
 )

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_06_12.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_06_12.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models.catboost.info import catboost_method_metadata
 from tabarena.models.extra_trees.info import extra_trees_method_metadata
 from tabarena.models.fastai.info import fastai_method_metadata
@@ -16,7 +17,6 @@ from tabarena.models.realmlp.info import realmlp_cpu_method_metadata
 from tabarena.models.tabicl.info import tabicl_method_metadata
 from tabarena.models.tabm.info import tabm_gpu_method_metadata, tabm_method_metadata
 from tabarena.models.xgboost.info import xgboost_method_metadata
-from tabarena.models._method_metadata import MethodMetadata
 
 # Models that own their MethodMetadata via per-model `info.py` modules. The
 # factory loop below skips these; they are seeded into `methods_2025_06_12` here.
@@ -119,7 +119,6 @@ methods_ag_key_map = {
     "RealMLP": "REALMLP",
     "TabM": "TABM",
     "XGBoost": "XGB",
-
     "ModernNCA_GPU": "MNCA",
     "RealMLP_GPU": "REALMLP",
     "TabDPT_GPU": "TABDPT",
@@ -144,7 +143,6 @@ methods_display_name_map = {
     "RealMLP": "RealMLP (CPU)",
     "TabM": "TabM (CPU)",
     "XGBoost": "XGBoost",
-
     "ModernNCA_GPU": "ModernNCA",
     "RealMLP_GPU": "RealMLP",
     "TabDPT_GPU": "TabDPT",
@@ -169,7 +167,6 @@ methods_config_default_map = {
     "RealMLP": "RealMLP_c1_BAG_L1",
     "TabM": "TabM_c1_BAG_L1",
     "XGBoost": "XGBoost_c1_BAG_L1",
-
     "ModernNCA_GPU": "ModernNCA_GPU_c1_BAG_L1",
     "RealMLP_GPU": "RealMLP_GPU_c1_BAG_L1",
     "TabDPT_GPU": "TabDPT_GPU_c1_BAG_L1",
@@ -194,14 +191,12 @@ methods_compute_map = {
     "RealMLP": "cpu",
     "TabM": "cpu",
     "XGBoost": "cpu",
-
     "ModernNCA_GPU": "gpu",
     "RealMLP_GPU": "gpu",
     "TabDPT_GPU": "gpu",
     "TabICL_GPU": "gpu",
     "TabM_GPU": "gpu",
     "TabPFNv2_GPU": "gpu",
-
 }
 
 methods = [
@@ -219,7 +214,6 @@ methods = [
     "RealMLP",
     "TabM",
     "XGBoost",
-
     "ModernNCA_GPU",
     "RealMLP_GPU",
     "TabDPT_GPU",
@@ -240,13 +234,11 @@ methods_main_paper = [
     "RandomForest",
     "RealMLP",
     "XGBoost",
-
     "ModernNCA_GPU",
     "TabDPT_GPU",
     "TabICL_GPU",
     "TabM_GPU",
     "TabPFNv2_GPU",
-
     "AutoGluon_v130",
     # "Portfolio-N200-4h",
 ]
@@ -304,7 +296,7 @@ for method in methods:
     config_default = methods_config_default_map[method]
     is_bag = method in methods_is_bag
     upload_as_public = method not in methods_upload_as_private
-    display_name = methods_display_name_map.get(method, None)
+    display_name = methods_display_name_map.get(method)
     assert compute_type in ["cpu", "gpu"]
     if compute_type == "cpu":
         method_kwargs = cpu_kwargs
@@ -315,7 +307,7 @@ for method in methods:
     else:
         can_hpo = True
 
-    reference_url = methods_to_url_map.get(method, None)
+    reference_url = methods_to_url_map.get(method)
 
     method_kwargs = copy.deepcopy(method_kwargs)
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2026_01_23_tabprep.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2026_01_23_tabprep.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from tabarena.models._method_metadata import MethodMetadata
 
-
 tabprep_gbm_metadata = MethodMetadata(
     method="PrepLightGBM",
     artifact_name="tabarena-2026-01-23",

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_misc.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_misc.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from tabarena.models._method_metadata import MethodMetadata
 
-
 # LightGBM w/ custom preprocessing pipeline (only first 3 repeats)
 # s3 cache = "cache_aio"
 gbm_aio_0808_metadata = MethodMetadata(

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/download_utils.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/download_utils.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-import requests
-from zipfile import ZipFile
 from io import BytesIO
 from pathlib import Path
+from zipfile import ZipFile
+
+import requests
 
 
 def download_and_extract_zip(url: str, path_local: str | Path):
     path_local = Path(path_local)
 
     # Send a GET request to the URL
-    response = requests.get(url, stream=True)
+    response = requests.get(url, stream=True, timeout=60)
     response.raise_for_status()  # Check for HTTP request errors
 
     path_local.mkdir(parents=True, exist_ok=True)

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/method_artifact_manager.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/method_artifact_manager.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing_extensions import Self
 
-from tabarena.models._artifacts.uploader_s3 import MethodUploaderS3
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.nips2025_utils.artifacts.download_utils import download_and_extract_zip
 from tabarena.nips2025_utils.end_to_end import EndToEndSingle
@@ -13,14 +12,15 @@ from tabarena.nips2025_utils.end_to_end import EndToEndSingle
 @dataclass(slots=True)
 class MethodArtifactManager:
     """Orchestrates download → local cache → upload-to-S3 for a single method."""
-    name: str               # method name, e.g., "xRFM_GPU" <- Method identifier. (name, artifact_name) must be unique.
-    model_key: str          # e.g., "XRFM_GPU" <- Model key to use for differentiating model families.
-    artifact_name: str      # e.g., "tabarena-2025-09-03" <- Differentiates methods with the same name by origin.
-    path_suffix: Path       # e.g., Path("leaderboard_submissions/data_xRFM_11092025.zip")
-    download_prefix: str    # e.g., "https://data.lennart-purucker.com/tabarena/"
-    local_prefix: Path      # e.g., Path("local_data") <- Local dir to download raw files. Can delete after cache.
-    s3_bucket: str | None   # e.g., "my-bucket"
-    s3_prefix: str | None   # e.g., "cache"
+
+    name: str  # method name, e.g., "xRFM_GPU" <- Method identifier. (name, artifact_name) must be unique.
+    model_key: str  # e.g., "XRFM_GPU" <- Model key to use for differentiating model families.
+    artifact_name: str  # e.g., "tabarena-2025-09-03" <- Differentiates methods with the same name by origin.
+    path_suffix: Path  # e.g., Path("leaderboard_submissions/data_xRFM_11092025.zip")
+    download_prefix: str  # e.g., "https://data.lennart-purucker.com/tabarena/"
+    local_prefix: Path  # e.g., Path("local_data") <- Local dir to download raw files. Can delete after cache.
+    s3_bucket: str | None  # e.g., "my-bucket"
+    s3_prefix: str | None  # e.g., "cache"
     upload_as_public: bool = False  # Whether the s3 upload will make files public readable
     method_metadata: MethodMetadata | None = None
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 from tabarena.paper.tabarena_evaluator import TabArenaEvaluator
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def compare_on_tabarena(
@@ -52,10 +55,7 @@ def compare_on_tabarena(
         if "method_subtype" not in new_results.columns:
             new_results["method_subtype"] = np.nan
 
-    if new_results is not None:
-        df_results = pd.concat([ta_results, new_results], ignore_index=True)
-    else:
-        df_results = ta_results
+    df_results = pd.concat([ta_results, new_results], ignore_index=True) if new_results is not None else ta_results
 
     kwargs = kwargs.copy()
     if isinstance(only_valid_tasks, (str, list)):
@@ -139,10 +139,7 @@ def compare(
         error_col = "metric_error"
 
     if calibration_framework == "auto":
-        if isinstance(fillna, pd.DataFrame):
-            calibration_framework = None
-        else:
-            calibration_framework = fillna
+        calibration_framework = None if isinstance(fillna, pd.DataFrame) else fillna
 
     evaluator_kwargs = {}
     if elo_ymin is not None:
@@ -181,12 +178,14 @@ def filter_to_valid_tasks(df_to_filter: pd.DataFrame, df_filter: pd.DataFrame) -
 
     # filter `df_to_filter` to only the dataset, fold pairs that are present in `df_filter`
     is_in_lst = [
-        is_in(dataset, fold) for dataset, fold in zip(
+        is_in(dataset, fold)
+        for dataset, fold in zip(
             df_to_filter["dataset"],
             df_to_filter["fold"],
-        )]
-    df_filtered = df_to_filter[is_in_lst]
-    return df_filtered
+            strict=False,
+        )
+    ]
+    return df_to_filter[is_in_lst]
 
 
 def prepare_data(
@@ -204,10 +203,11 @@ def prepare_data(
             # Filter to tasks present in a specific method
             df_filter = df_results[df_results["method"] == filter_method]
             if "imputed" in df_filter.columns:
-                df_filter = df_filter[df_filter["imputed"] != True]
-            assert len(df_filter) != 0, \
-                (f"No method named '{filter_method}' remains to filter to!\n"
-                 f"Available tasks: {list(df_results['method'].unique())}")
+                df_filter = df_filter[not df_filter["imputed"]]
+            assert len(df_filter) != 0, (
+                f"No method named '{filter_method}' remains to filter to!\n"
+                f"Available tasks: {list(df_results['method'].unique())}"
+            )
             df_results = filter_to_valid_tasks(
                 df_to_filter=df_results,
                 df_filter=df_filter,
@@ -228,7 +228,7 @@ def prepare_data(
             raise ValueError(
                 "Missing fillna method in df_results!"
                 f"\n\tfillna={fillna!r}"
-                f"\n\tvalid_methods={sorted(list(df_results['method'].unique()))}"
+                f"\n\tvalid_methods={sorted(df_results['method'].unique())}",
             )
     if fillna is not None:
         df_results = TabArenaContext.fillna_metrics(
@@ -349,6 +349,7 @@ def subset_tasks(
         so context-specific subset definitions take effect.
     """
     from tabarena.nips2025_utils.fetch_metadata import load_task_metadata
+
     if task_metadata_og is None:
         task_metadata_og = load_task_metadata()
 
@@ -362,9 +363,7 @@ def subset_tasks(
 
     if tasks is not None:
         task_index = pd.MultiIndex.from_tuples(tasks, names=["dataset", "fold"])
-        df_results = df_results[
-            pd.MultiIndex.from_frame(df_results[["dataset", "fold"]]).isin(task_index)
-        ]
+        df_results = df_results[pd.MultiIndex.from_frame(df_results[["dataset", "fold"]]).isin(task_index)]
     if datasets is not None:
         df_results = df_results[df_results["dataset"].isin(datasets)]
     if folds is not None:
@@ -434,6 +433,8 @@ def subset_tasks_data_foundry(
     n_folds_method_dataset = df_results.groupby(["method", "dataset"])["fold"].transform("nunique")
     df_results = df_results[n_folds_method_dataset == n_folds_dataset]
 
-    assert len(df_results) > 0, "No results remain after subsetting! Please check the subset criteria and the data_foundry_metadata."
+    assert len(df_results) > 0, (
+        "No results remain after subsetting! Please check the subset criteria and the data_foundry_metadata."
+    )
 
     return df_results.reset_index(drop=True)

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -1,27 +1,29 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
-from typing import Literal
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Literal, Self
 
 import pandas as pd
 
-from tabarena.benchmark.result import BaselineResult
+from bencheval.tabarena import TabArena
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.nips2025_utils.compare import compare, compare_on_tabarena
 from tabarena.nips2025_utils.end_to_end_single import (
     EndToEndResultsSingle,
     EndToEndSingle,
 )
+from tabarena.nips2025_utils.load_metadata_from_raw import load_from_raw_all_metadata
 from tabarena.nips2025_utils.method_processor import (
     generate_task_metadata,
     load_all_artifacts,
 )
-from tabarena.nips2025_utils.load_metadata_from_raw import load_from_raw_all_metadata
-from bencheval.tabarena import TabArena
 from tabarena.utils.pickle_utils import fetch_all_pickles
 from tabarena.utils.ray_utils import ray_map_list
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tabarena.benchmark.result import BaselineResult
 
 
 class EndToEnd:
@@ -32,9 +34,7 @@ class EndToEnd:
         self.end_to_end_lst = end_to_end_lst
 
     def configs_hyperparameters(self) -> dict[str, dict | None]:
-        configs_hyperparameters_per_method = [
-            e2e.configs_hyperparameters() for e2e in self.end_to_end_lst
-        ]
+        configs_hyperparameters_per_method = [e2e.configs_hyperparameters() for e2e in self.end_to_end_lst]
         configs_hyperparameters = {}
         for d in configs_hyperparameters_per_method:
             for k, v in d.items():
@@ -63,7 +63,7 @@ class EndToEnd:
 
         # raw
         results_lst: list[BaselineResult] = EndToEndSingle.clean_raw(
-            results_lst=results_lst
+            results_lst=results_lst,
         )
 
         if task_metadata is None:
@@ -81,7 +81,7 @@ class EndToEnd:
         unique_types = list(result_types_dict.keys())
 
         log(
-            f"Constructing EndToEnd from raw results... Found {len(unique_types)} unique methods: {unique_types}"
+            f"Constructing EndToEnd from raw results... Found {len(unique_types)} unique methods: {unique_types}",
         )
         end_to_end_lst = []
         for cur_type in unique_types:
@@ -123,12 +123,13 @@ class EndToEnd:
 
         engine = "ray" if backend == "ray" else "sequential"
         file_paths = fetch_all_pickles(
-            dir_path=path_raw, suffix="results.pkl"
+            dir_path=path_raw,
+            suffix="results.pkl",
         )
         results_metadata = load_from_raw_all_metadata(file_paths=file_paths, engine=engine)
         unique_types_dict = dict()
         unique_tids = set()
-        for r, file_path in zip(results_metadata, file_paths):
+        for r, file_path in zip(results_metadata, file_paths, strict=False):
             r_type = r[0].method
             r_tid = r[1]["tid"]
             if r_type not in unique_types_dict:
@@ -141,7 +142,7 @@ class EndToEnd:
             task_metadata = EndToEndSingle.fetch_task_metadata(tids=list(unique_tids), verbose=verbose)
 
         log(
-            f"Constructing EndToEnd from raw results... Found {len(unique_types)} unique methods: {unique_types}"
+            f"Constructing EndToEnd from raw results... Found {len(unique_types)} unique methods: {unique_types}",
         )
         end_to_end_lst = []
         for cur_type in unique_types:
@@ -172,7 +173,8 @@ class EndToEnd:
             else:
                 artifact_name = None
             end_to_end_single = EndToEndSingle.from_cache(
-                method=method, artifact_name=artifact_name
+                method=method,
+                artifact_name=artifact_name,
             )
             end_to_end_lst.append(end_to_end_single)
         return cls(end_to_end_lst=end_to_end_lst)
@@ -190,8 +192,7 @@ class EndToEnd:
         num_cpus: int | None = None,
         verbose: bool = True,
     ) -> EndToEndResults:
-        """
-        Create and cache end-to-end results for all methods in the given directory.
+        """Create and cache end-to-end results for all methods in the given directory.
         Will not cache raw or processed data. To cache all artifacts, call `from_path_raw` instead.
         This is ~10x+ faster than calling `from_path_raw` for large artifacts, but will not cache raw or processed data.
 
@@ -238,7 +239,8 @@ class EndToEnd:
 
         print("Get results paths...")
         file_paths = fetch_all_pickles(
-            dir_path=path_raw, suffix="results.pkl"
+            dir_path=path_raw,
+            suffix="results.pkl",
         )
 
         all_file_paths_method = {}
@@ -288,15 +290,13 @@ class EndToEnd:
         e2e_results = EndToEndResults(end_to_end_results_lst=e2e_single_lst)
 
         if cache:
-            print(f"Caching metadata and results...")
+            print("Caching metadata and results...")
             e2e_results.cache()
         return e2e_results
 
     def to_results(self) -> EndToEndResults:
         return EndToEndResults(
-            end_to_end_results_lst=[
-                end_to_end.to_results() for end_to_end in self.end_to_end_lst
-            ],
+            end_to_end_results_lst=[end_to_end.to_results() for end_to_end in self.end_to_end_lst],
         )
 
 
@@ -310,11 +310,7 @@ class EndToEndResults:
     @property
     def model_results(self) -> pd.DataFrame | None:
         model_results_lst = [e2e.model_results for e2e in self.end_to_end_results_lst]
-        model_results_lst = [
-            model_results
-            for model_results in model_results_lst
-            if model_results is not None
-        ]
+        model_results_lst = [model_results for model_results in model_results_lst if model_results is not None]
         if not model_results_lst:
             return None
 
@@ -323,9 +319,7 @@ class EndToEndResults:
     @property
     def hpo_results(self) -> pd.DataFrame | None:
         hpo_results_lst = [e2e.hpo_results for e2e in self.end_to_end_results_lst]
-        hpo_results_lst = [
-            hpo_results for hpo_results in hpo_results_lst if hpo_results is not None
-        ]
+        hpo_results_lst = [hpo_results for hpo_results in hpo_results_lst if hpo_results is not None]
         if not hpo_results_lst:
             return None
 
@@ -335,7 +329,6 @@ class EndToEndResults:
     def leaderboard(
         self,
     ) -> pd.DataFrame:
-        from bencheval.tabarena import TabArena
         results = self.get_results(
             # new_result_prefix=new_result_prefix,
             # use_artifact_name_in_prefix=use_artifact_name_in_prefix,
@@ -368,11 +361,10 @@ class EndToEndResults:
         # leaderboard_kwargs.setdefault("elo_kwargs", elo_kwargs)
         # leaderboard_kwargs.setdefault("average_seeds", average_seeds)
 
-        leaderboard = tabarena.leaderboard(
+        return tabarena.leaderboard(
             data=results,
             **leaderboard_kwargs,
         )
-        return leaderboard
 
     def compare(
         self,
@@ -474,13 +466,14 @@ class EndToEndResults:
                     use_artifact_name_in_prefix=use_artifact_name_in_prefix,
                     use_model_results=use_model_results,
                     fillna=fillna,
-                )
+                ),
             )
-        df_results = pd.concat(df_results_lst, ignore_index=True)
-        return df_results
+        return pd.concat(df_results_lst, ignore_index=True)
 
     @classmethod
-    def from_cache(cls, methods: list[str | MethodMetadata | tuple[str, str]], *, default_artifact_name: None | str = None) -> Self:
+    def from_cache(
+        cls, methods: list[str | MethodMetadata | tuple[str, str]], *, default_artifact_name: None | str = None
+    ) -> Self:
         end_to_end_results_lst = []
         for method in methods:
             if isinstance(method, tuple):
@@ -488,7 +481,8 @@ class EndToEndResults:
             else:
                 artifact_name = default_artifact_name
             end_to_end_results = EndToEndResultsSingle.from_cache(
-                method=method, artifact_name=artifact_name
+                method=method,
+                artifact_name=artifact_name,
             )
             end_to_end_results_lst.append(end_to_end_results)
         return cls(end_to_end_results_lst=end_to_end_results_lst)
@@ -502,14 +496,16 @@ def _process_result_list(
     *,
     file_paths_method: list[Path],
     task_metadata: pd.DataFrame,
-    name: str = None,
-    name_prefix: str = None,
-    name_suffix: str = None,
-    model_key: str = None,
+    name: str | None = None,
+    name_prefix: str | None = None,
+    name_suffix: str | None = None,
+    model_key: str | None = None,
     artifact_name: str | None = None,
 ) -> EndToEndResults:
     results_lst = load_all_artifacts(
-        file_paths=file_paths_method, engine="sequential", progress_bar=False
+        file_paths=file_paths_method,
+        engine="sequential",
+        progress_bar=False,
     )
 
     e2e = EndToEnd.from_raw(
@@ -525,6 +521,4 @@ def _process_result_list(
         backend="native",
         verbose=False,
     )
-    e2e_results = e2e.to_results()
-
-    return e2e_results
+    return e2e.to_results()

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import copy
 import os
-from pathlib import Path
-from typing import Literal, TYPE_CHECKING
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Literal, Self
 
 import pandas as pd
 from autogluon.common.savers import save_pd
@@ -23,12 +21,13 @@ from tabarena.utils.pickle_utils import fetch_all_pickles
 from tabarena.utils.ray_utils import ray_map_list
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tabarena.repository import EvaluationRepository
 
 
 class EndToEndSingle:
-    """
-    End-to-end pipeline for processing and evaluating a **single** method's results.
+    """End-to-end pipeline for processing and evaluating a **single** method's results.
 
     This class orchestrates:
       1. Inferring method metadata from raw per-task results.
@@ -55,7 +54,7 @@ class EndToEndSingle:
         TabArena HPO simulation results (one row per (task, config, seed)).
         ``None`` if not yet computed.
 
-    Attributes
+    Attributes:
     ----------
     method_metadata : MethodMetadata
         Method identity and on-disk artifact layout (e.g., ``path``, ``path_raw``).
@@ -68,7 +67,7 @@ class EndToEndSingle:
     task_metadata : pd.DataFrame
         (Property) Task-level metadata table provided by the repository.
 
-    Notes
+    Notes:
     -----
     **Caching & Side Effects**
     - The factory constructors (:meth:`from_raw`, :meth:`from_path_raw`) can
@@ -80,7 +79,7 @@ class EndToEndSingle:
       for consistency. If a unique name cannot be assigned (e.g., multiple
       distinct configs while forcing a single ``name``), underlying helpers may raise.
 
-    See Also
+    See Also:
     --------
     EndToEnd
         Multi-method manager that constructs and coordinates multiple
@@ -92,7 +91,7 @@ class EndToEndSingle:
     TabArenaContext
         Simulator used internally for HPO/model selection under TabArena.
 
-    Examples
+    Examples:
     --------
     Basic usage from raw objects::
 
@@ -112,6 +111,7 @@ class EndToEndSingle:
         res = e2e.to_results()
 
     """
+
     def __init__(
         self,
         method_metadata: MethodMetadata,
@@ -154,15 +154,14 @@ class EndToEndSingle:
         backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
-        """
-        Run logic end-to-end and cache all results:
+        """Run logic end-to-end and cache all results:
         1. (only if using `from_path_raw`) load raw artifacts
             path_raw should be a directory containing `results.pkl` files for each run.
             In the current code, we require `path_raw` to contain the results of only 1 type of method.
         2. infer method_metadata
         3. infer task_metadata
         4. generate repo (processed data)
-        5. generate results (per-task metric scores, train time, infer time, etc.)
+        5. generate results (per-task metric scores, train time, infer time, etc.).
 
         Parameters
         ----------
@@ -215,7 +214,7 @@ class EndToEndSingle:
         verbose : bool = True
             If True will log info about the data processing and simulation.
 
-        Returns
+        Returns:
         -------
         EndToEndSingle
             An initialized EndToEndSingle class based on the provided raw results_lst.
@@ -224,9 +223,8 @@ class EndToEndSingle:
 
         # raw
         results_lst: list[BaselineResult] = cls.clean_raw(results_lst=results_lst)
-        if method_metadata is not None:
-            if model_key is None:
-                model_key = method_metadata.model_key
+        if method_metadata is not None and model_key is None:
+            model_key = method_metadata.model_key
         results_lst = cls._rename(
             results_lst=results_lst,
             name=name,
@@ -243,7 +241,7 @@ class EndToEndSingle:
 
         log(
             f"{method_metadata.method}: Creating EndToEndSingle from raw results... "
-            f"(cache={cache}, cache_raw={cache_raw})"
+            f"(cache={cache}, cache_raw={cache_raw})",
         )
 
         if cache or cache_raw:
@@ -259,7 +257,7 @@ class EndToEndSingle:
             tids = list({r.task_metadata["tid"] for r in results_lst})
             task_metadata = cls.fetch_task_metadata(tids=tids, verbose=verbose)
 
-        log(f"\tConverting raw results into an EvaluationRepository...")
+        log("\tConverting raw results into an EvaluationRepository...")
         # processed
         repo: EvaluationRepository = method_metadata.generate_repo(
             results_lst=results_lst,
@@ -271,7 +269,7 @@ class EndToEndSingle:
             # reload into mem-map mode, otherwise can be very slow for large datasets
             repo = method_metadata.load_processed()
 
-        log(f"\tSimulating HPO...")
+        log("\tSimulating HPO...")
         hpo_results, model_results = method_metadata.generate_results(
             repo=repo,
             cache=cache,
@@ -280,7 +278,7 @@ class EndToEndSingle:
         )
 
         if cache_holdout and method_metadata.is_bag:
-            log(f"\tConverting raw (holdout) results into an EvaluationRepository...")
+            log("\tConverting raw (holdout) results into an EvaluationRepository...")
             repo_holdout: EvaluationRepository = method_metadata.generate_repo_holdout(
                 results_lst=results_lst,
                 task_metadata=task_metadata,
@@ -288,8 +286,8 @@ class EndToEndSingle:
             )
             repo_holdout = method_metadata.load_processed(as_holdout=True)
 
-            log(f"\tSimulating HPO (holdout)...")
-            hpo_results_holdout, model_results_holdout = method_metadata.generate_results(
+            log("\tSimulating HPO (holdout)...")
+            _hpo_results_holdout, _model_results_holdout = method_metadata.generate_results(
                 repo=repo_holdout,
                 cache=cache,
                 as_holdout=True,
@@ -298,7 +296,7 @@ class EndToEndSingle:
 
         if cache_hpo_trajectories:
             if method_metadata.method_type == "config":
-                log(f"\tGenerating and caching HPO trajectories...")
+                log("\tGenerating and caching HPO trajectories...")
                 method_metadata.generate_hpo_trajectories(
                     repo=repo,
                     backend=backend,
@@ -306,11 +304,10 @@ class EndToEndSingle:
                 )
             else:
                 log(
-                    f"\tSkipping HPO trajectories (method_type="
-                    f"{method_metadata.method_type!r}, requires 'config')"
+                    f"\tSkipping HPO trajectories (method_type={method_metadata.method_type!r}, requires 'config')",
                 )
 
-        log(f"\tComplete!")
+        log("\tComplete!")
         return cls(
             method_metadata=method_metadata,
             repo=repo,
@@ -339,8 +336,7 @@ class EndToEndSingle:
         num_cpus: int | None = None,
         verbose: bool = True,
     ) -> Self:
-        """
-        Create and cache all artifacts for the method in the given directory.
+        """Create and cache all artifacts for the method in the given directory.
 
         Parameters
         ----------
@@ -359,7 +355,7 @@ class EndToEndSingle:
         backend
         verbose
 
-        Returns
+        Returns:
         -------
 
         """
@@ -395,11 +391,11 @@ class EndToEndSingle:
     def _rename(
         cls,
         results_lst: list[BaselineResult],
-        name: str = None,
-        name_prefix: str = None,
-        name_suffix: str = None,
-        model_key: str = None,
-        inplace: bool = True
+        name: str | None = None,
+        name_prefix: str | None = None,
+        name_suffix: str | None = None,
+        model_key: str | None = None,
+        inplace: bool = True,
     ) -> list[BaselineResult]:
         if not inplace:
             results_lst = copy.deepcopy(results_lst)
@@ -421,7 +417,8 @@ class EndToEndSingle:
             if artifact_name is None:
                 artifact_name = method
             method_metadata = MethodMetadata.from_yaml(
-                method=method, artifact_name=artifact_name,
+                method=method,
+                artifact_name=artifact_name,
             )
         repo = method_metadata.load_processed()
         end_to_end_results_single = EndToEndResultsSingle(method_metadata=method_metadata)
@@ -448,7 +445,7 @@ class EndToEndSingle:
         tids_missing = [tid for tid in tids if tid not in tids_cached]
         if tids_missing:
             log(f"Note: Missing {len(tids_missing)} tasks in the cached task_metadata...")
-            log(f"\tFetching task_metadata from OpenML... (this may take ~1 minute)")
+            log("\tFetching task_metadata from OpenML... (this may take ~1 minute)")
             task_metadata = generate_task_metadata(tids=tids)
         return task_metadata
 
@@ -468,8 +465,7 @@ class EndToEndSingle:
         name_prefix_raw: str | None = None,
         verbose: bool = True,
     ) -> EndToEndResultsSingle:
-        """
-        Create and cache end-to-end results for the method in the given directory.
+        """Create and cache end-to-end results for the method in the given directory.
         Will not cache raw or processed data. To cache all artifacts, call `from_path_raw` instead.
         This is ~10x+ faster than calling `from_path_raw` for large artifacts, but will not cache raw or processed data.
 
@@ -518,7 +514,10 @@ class EndToEndSingle:
 
         print("Get results paths...")
         file_paths = fetch_all_pickles(
-            dir_path=path_raw, suffix="results.pkl", name_pattern=name_prefix_raw, num_workers=num_cpus,
+            dir_path=path_raw,
+            suffix="results.pkl",
+            name_pattern=name_prefix_raw,
+            num_workers=num_cpus,
         )
         if len(file_paths) == 0:
             raise ValueError(f"No results.pkl files found in {path_raw} with name prefix {name_prefix_raw}!")
@@ -539,6 +538,7 @@ class EndToEndSingle:
         all_file_paths_method = _filter_file_paths_by_task_metadata(all_file_paths_method, task_metadata)
 
         import ray
+
         if not ray.is_initialized():
             ray.init(num_cpus=num_cpus)
 
@@ -599,7 +599,8 @@ class EndToEndResultsSingle:
             if artifact_name is None:
                 artifact_name = method
             method_metadata = MethodMetadata.from_yaml(
-                method=method, artifact_name=artifact_name
+                method=method,
+                artifact_name=artifact_name,
             )
         return cls(method_metadata=method_metadata, holdout=holdout)
 
@@ -616,7 +617,7 @@ class EndToEndResultsSingle:
         average_seeds: bool = False,
         leaderboard_kwargs: dict | None = None,
         extra_results: pd.DataFrame = None,
-        tabarena_context_kwargs: dict = None,
+        tabarena_context_kwargs: dict | None = None,
         remove_imputed: bool = False,
     ) -> pd.DataFrame:
         """Compare results on TabArena leaderboard.
@@ -661,19 +662,16 @@ class EndToEndResultsSingle:
         use_model_results: bool = False,
         fillna: bool = False,
     ) -> pd.DataFrame:
-        """
-        Get data to compare results on TabArena leaderboard.
-            Args:
+        """Get data to compare results on TabArena leaderboard.
+
+        Args:
                 new_result_prefix (str | None): If not None, add a prefix to the new
                     results to distinguish new results from the original TabArena results.
                     Use this, for example, if you re-run a model from TabArena.
         """
         use_model_results = self.method_metadata.method_type != "config" or use_model_results
 
-        if use_model_results:
-            df_results = copy.deepcopy(self.model_results)
-        else:
-            df_results = copy.deepcopy(self.hpo_results)
+        df_results = copy.deepcopy(self.model_results) if use_model_results else copy.deepcopy(self.hpo_results)
 
         if use_artifact_name_in_prefix is None:
             use_artifact_name_in_prefix = self.method_metadata.use_artifact_name_in_prefix
@@ -751,13 +749,9 @@ class EndToEndResultsSingle:
                     for k, v in method_metadata.__dict__.items()
                     if v != method_metadata_other.__dict__.get(k)
                 }
-                diff_str = "\n".join(
-                    f"  {k}: {v1!r} != {v2!r}"
-                    for k, (v1, v2) in diffs.items()
-                )
+                diff_str = "\n".join(f"  {k}: {v1!r} != {v2!r}" for k, (v1, v2) in diffs.items())
                 raise ValueError(
-                    "Method metadata mismatch! The following fields differ:\n"
-                    f"{diff_str}"
+                    f"Method metadata mismatch! The following fields differ:\n{diff_str}",
                 )
 
             # merge results
@@ -817,7 +811,9 @@ def _process_result_list(
     artifact_name: str | None = None,
 ) -> EndToEndResultsSingle:
     results_lst = load_all_artifacts(
-        file_paths=file_paths_method, engine="sequential", progress_bar=False
+        file_paths=file_paths_method,
+        engine="sequential",
+        progress_bar=False,
     )
 
     e2e = EndToEndSingle.from_raw(
@@ -835,6 +831,4 @@ def _process_result_list(
         backend="native",
         verbose=False,
     )
-    e2e_results = e2e.to_results()
-
-    return e2e_results
+    return e2e.to_results()

--- a/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
@@ -19,14 +19,17 @@ def get_all_subset_combinations() -> list[tuple[bool, str, bool, str | None, boo
     lite_lst = [False, True]
     average_seeds_lst = [False]
 
-    return list(product(
-        use_imputation_lst,
-        problem_type_lst,
-        with_baselines_lst,
-        dataset_subset_lst,
-        lite_lst,
-        average_seeds_lst,
-    ))
+    return list(
+        product(
+            use_imputation_lst,
+            problem_type_lst,
+            with_baselines_lst,
+            dataset_subset_lst,
+            lite_lst,
+            average_seeds_lst,
+        )
+    )
+
 
 def get_website_folder_name(
     *,
@@ -97,21 +100,25 @@ def evaluate_all(
     for use_imputation, problem_type, with_baselines, dataset_subset, lite, average_seeds in all_combinations:
         custom_folder_name = None
         if use_website_folder_names:
-            custom_folder_name = str(get_website_folder_name(
-                use_imputation=use_imputation,
-                problem_type=problem_type,
-                dataset_subset=dataset_subset,
-                lite=lite,
-            ))
-        inputs.append({
-            "use_imputation": use_imputation,
-            "problem_type": problem_type,
-            "with_baselines": with_baselines,
-            "dataset_subset": dataset_subset,
-            "lite": lite,
-            "average_seeds": average_seeds,
-            "custom_folder_name": custom_folder_name,
-        })
+            custom_folder_name = str(
+                get_website_folder_name(
+                    use_imputation=use_imputation,
+                    problem_type=problem_type,
+                    dataset_subset=dataset_subset,
+                    lite=lite,
+                )
+            )
+        inputs.append(
+            {
+                "use_imputation": use_imputation,
+                "problem_type": problem_type,
+                "with_baselines": with_baselines,
+                "dataset_subset": dataset_subset,
+                "lite": lite,
+                "average_seeds": average_seeds,
+                "custom_folder_name": custom_folder_name,
+            }
+        )
 
     parallel_for(
         f=evaluate_single,
@@ -131,8 +138,6 @@ def evaluate_all(
     )
 
 
-
-
 def evaluate_single(
     tabarena_context,
     df_results,
@@ -150,6 +155,7 @@ def evaluate_single(
     custom_folder_name: str | None = None,
 ):
     from tabarena.nips2025_utils.compare import subset_tasks
+
     df_results = df_results.copy()
 
     method_rename_map = tabarena_context.get_method_rename_map()

--- a/packages/tabarena/src/tabarena/nips2025_utils/fetch_metadata.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/fetch_metadata.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-
-import pandas as pd
+from typing import TYPE_CHECKING
 
 from autogluon.common.loaders import load_pd
+
 import tabarena
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def _get_n_repeats(n_instances: int, tabarena_lite: bool = False) -> int:
@@ -16,7 +19,7 @@ def _get_n_repeats(n_instances: int, tabarena_lite: bool = False) -> int:
     n_instances: int
         Important: these are the number of training samples!
 
-    Returns
+    Returns:
     -------
     n_repeats: int
     """
@@ -35,17 +38,15 @@ def _get_n_repeats(n_instances: int, tabarena_lite: bool = False) -> int:
 def _get_problem_type_from_n_classes(n_classes: int) -> str:
     if n_classes == 0:
         return "regression"
-    elif n_classes == 2:
+    if n_classes == 2:
         return "binary"
-    elif n_classes > 2:
+    if n_classes > 2:
         return "multiclass"
-    else:
-        raise ValueError(f"Invalid n_classes: {n_classes}")
+    raise ValueError(f"Invalid n_classes: {n_classes}")
 
 
-def load_task_metadata(paper: bool = True, subset: str = None, path: str = None) -> pd.DataFrame:
-    """
-    Load the task metadata for all datasets in the TabArena benchmark.
+def load_task_metadata(paper: bool = True, subset: str | None = None, path: str | None = None) -> pd.DataFrame:
+    """Load the task metadata for all datasets in the TabArena benchmark.
 
     Parameters
     ----------
@@ -61,7 +62,7 @@ def load_task_metadata(paper: bool = True, subset: str = None, path: str = None)
             <=100k samples, <=500 features, classification
             36/51 datasets
 
-    Returns
+    Returns:
     -------
     task_metadata: pd.DataFrame
         Metadata about each dataset in the benchmark.
@@ -72,25 +73,24 @@ def load_task_metadata(paper: bool = True, subset: str = None, path: str = None)
         if paper:
             path = f"{tabrepo_root}/tabarena/nips2025_utils/metadata/task_metadata_tabarena51.csv"
         else:
-            raise ValueError(f"paper == True is required")
+            raise ValueError("paper == True is required")
     task_metadata = load_pd.load(path=path)
 
     task_metadata["n_folds"] = 3
     task_metadata["n_repeats"] = task_metadata["NumberOfInstances"].apply(_get_n_repeats)
-    task_metadata["n_samples_test_per_fold"] = (
-        task_metadata["NumberOfInstances"] / task_metadata["n_folds"]
-    ).astype(int)
+    task_metadata["n_samples_test_per_fold"] = (task_metadata["NumberOfInstances"] / task_metadata["n_folds"]).astype(
+        int
+    )
     task_metadata["n_samples_train_per_fold"] = (
         task_metadata["NumberOfInstances"] - task_metadata["n_samples_test_per_fold"]
     ).astype(int)
 
     task_metadata = add_extra_task_metadata_info(task_metadata=task_metadata)
 
-    task_metadata = subset_task_metadata(task_metadata=task_metadata, subset=subset)
-    return task_metadata
+    return subset_task_metadata(task_metadata=task_metadata, subset=subset)
 
 
-def subset_task_metadata(task_metadata, subset: str = None) -> pd.DataFrame:
+def subset_task_metadata(task_metadata, subset: str | None = None) -> pd.DataFrame:
     if subset is None:
         pass
     elif subset == "TabPFNv2":
@@ -143,5 +143,3 @@ def load_curated_task_metadata() -> pd.DataFrame:
     path = str(Path(__file__).parent.resolve() / "metadata" / "curated_tabarena_dataset_metadata.csv")
 
     return load_pd.load(path=path)
-
-

--- a/packages/tabarena/src/tabarena/nips2025_utils/file_path.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/file_path.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 
-def figure_path(prefix: str = None, suffix: str = None, mkdir: bool = True) -> Path:
-    fig_save_path_dir = Path("")
+def figure_path(prefix: str | None = None, suffix: str | None = None, mkdir: bool = True) -> Path:
+    fig_save_path_dir = Path()
     if prefix:
         fig_save_path_dir = fig_save_path_dir / prefix
     fig_save_path_dir = fig_save_path_dir / "figures"

--- a/packages/tabarena/src/tabarena/nips2025_utils/generate_repo.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/generate_repo.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pandas as pd
-
-from tabarena.repository import EvaluationRepository
-from tabarena.utils.pickle_utils import fetch_all_pickles
 from tabarena.benchmark.result import BaselineResult, ConfigResult, ExperimentResults
+from tabarena.utils.pickle_utils import fetch_all_pickles
 
 from .load_artifacts import load_all_artifacts
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def generate_repo(experiment_path: str, task_metadata: pd.DataFrame, name_suffix: str | None = None) -> EvaluationRepository:
+    import pandas as pd
+
+    from tabarena.repository import EvaluationRepository
+
+
+def generate_repo(
+    experiment_path: str, task_metadata: pd.DataFrame, name_suffix: str | None = None
+) -> EvaluationRepository:
     file_paths = fetch_all_pickles(dir_path=experiment_path)
     file_paths = sorted([str(f) for f in file_paths])
     print(len(file_paths))
@@ -40,7 +46,7 @@ def generate_repo_from_results_lst(
     name_suffix: str | None = None,
 ) -> EvaluationRepository:
     results_lst = [r for r in results_lst if r is not None]
-    tids = set(list(task_metadata["tid"].unique()))
+    tids = set(task_metadata["tid"].unique())
     assert all(not isinstance(tid, str) for tid in tids), f"Expected all tids to be numbers, but got str: {tids}"
     results_lst = [r for r in results_lst if r.result["task_metadata"]["tid"] in tids]
 
@@ -54,7 +60,7 @@ def generate_repo_from_results_lst(
         raise ValueError(
             "No results found after filtering by task metadata tids. "
             "Please check that the tids in the results match those in the task metadata. "
-            "Moreover, check that the path you are parsing only contain results for the allowed tids!"
+            "Moreover, check that the path you are parsing only contain results for the allowed tids!",
         )
 
     exp_results = ExperimentResults(task_metadata=task_metadata)

--- a/packages/tabarena/src/tabarena/nips2025_utils/load_artifacts.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/load_artifacts.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import io
-from pathlib import Path
 import pickle
+from typing import TYPE_CHECKING
 
 from tabarena.benchmark.result import AGBagResult, BaselineResult
 from tabarena.utils.parallel_for import parallel_for
 from tabarena.utils.pickle_utils import read_pickle_bytes
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 # TODO: This is a hack to ensure old result artifacts still load properly after renaming tabrepo to tabarena.
@@ -25,7 +28,7 @@ def _rename_load(file_obj):
         raise e from Exception(
             f"Failed to load artifact {file_obj}. This may be due to a corrupted file or"
             " an incompatible format. Please ensure the file is a valid artifact and"
-            " try again."
+            " try again.",
         )
 
 
@@ -51,7 +54,7 @@ def load_all_artifacts(
             {
                 "path": str(file_path),
                 "convert_to_holdout": convert_to_holdout,
-            }
+            },
         )
 
     results_lst: list[BaselineResult] = parallel_for(
@@ -59,7 +62,7 @@ def load_all_artifacts(
         inputs=file_paths_lst,
         engine=engine,
         progress_bar=progress_bar,
-        desc=f"Loading raw artifacts"
+        desc="Loading raw artifacts",
     )
     return results_lst
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/load_metadata_from_raw.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/load_metadata_from_raw.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from typing import Literal
-from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 from tabarena.benchmark.result import BaselineResult
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.utils.parallel_for import parallel_for
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 def load_raw_to_get_metadata(path: str) -> tuple[MethodMetadata, dict]:
-    """
-    Load a raw result pickle file, align it into a `BaselineResult`,
+    """Load a raw result pickle file, align it into a `BaselineResult`,
     and derive the associated `MethodMetadata` and task metadata.
 
     Parameters
@@ -19,14 +20,14 @@ def load_raw_to_get_metadata(path: str) -> tuple[MethodMetadata, dict]:
         Path to the pickle file containing either a raw result
         dictionary or a serialized `BaselineResult`.
 
-    Returns
+    Returns:
     -------
     tuple[MethodMetadata, dict]
         A tuple containing:
         - `MethodMetadata`: Metadata object constructed from the result.
         - dict: The task metadata dictionary extracted from the result.
 
-    Notes
+    Notes:
     -----
     This function ensures that raw results are normalized into
     `BaselineResult` objects before metadata extraction. It should
@@ -44,8 +45,7 @@ def load_from_raw_all_metadata(
     engine: Literal["sequential", "ray", "joblib"] = "sequential",
     progress_bar: bool = True,
 ) -> list[tuple[MethodMetadata, dict]]:
-    """
-    Batch-load multiple raw pickle results and extract their
+    """Batch-load multiple raw pickle results and extract their
     `MethodMetadata` and task metadata in parallel.
 
     Parameters
@@ -57,14 +57,14 @@ def load_from_raw_all_metadata(
     progress_bar : bool, default=True
         Whether to display a progress bar while processing.
 
-    Returns
+    Returns:
     -------
     list[tuple[MethodMetadata, dict]]
         A list of tuples, one per input file, each containing:
         - `MethodMetadata`: Metadata object extracted from the result.
         - dict: Task metadata dictionary.
 
-    Notes
+    Notes:
     -----
     This function leverages `parallel_for` to parallelize calls to
     `load_raw_to_get_metadata`. The parallelization backend can be
@@ -75,7 +75,7 @@ def load_from_raw_all_metadata(
         file_paths_lst.append(
             {
                 "path": str(file_path),
-            }
+            },
         )
 
     results_lst: list[tuple[MethodMetadata, dict]] = parallel_for(

--- a/packages/tabarena/src/tabarena/nips2025_utils/method_processor.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/method_processor.py
@@ -6,14 +6,13 @@ from pathlib import Path
 
 import pandas as pd
 
-from tabarena.benchmark.result import BaselineResult, ConfigResult, AGBagResult
+from tabarena.benchmark.result import AGBagResult, BaselineResult, ConfigResult
 from tabarena.nips2025_utils.load_artifacts import load_all_artifacts
 from tabarena.utils.pickle_utils import fetch_all_pickles
 
 
 def generate_task_metadata(tids: list[int]) -> pd.DataFrame:
-    """
-    Retrieve metadata for a list of OpenML task IDs and return as a clean DataFrame.
+    """Retrieve metadata for a list of OpenML task IDs and return as a clean DataFrame.
 
     This function queries OpenML to obtain task metadata for the specified list of task IDs (`tids`),
     verifies that all requested tasks exist in OpenML, and returns a pandas DataFrame with the metadata.
@@ -25,12 +24,12 @@ def generate_task_metadata(tids: list[int]) -> pd.DataFrame:
     tids : list of int
         List of OpenML task IDs to retrieve metadata for.
 
-    Returns
+    Returns:
     -------
     pd.DataFrame
         DataFrame containing metadata for the requested task IDs.
 
-    Raises
+    Raises:
     ------
     AssertionError
         If one or more of the requested task IDs are not found in OpenML's task list.
@@ -38,7 +37,7 @@ def generate_task_metadata(tids: list[int]) -> pd.DataFrame:
     import openml
 
     tasks = openml.tasks.list_tasks(
-        output_format="dataframe"
+        output_format="dataframe",
     )
 
     tasks_filtered = tasks[tasks["tid"].isin(tids)].reset_index(drop=True)
@@ -47,7 +46,7 @@ def generate_task_metadata(tids: list[int]) -> pd.DataFrame:
     if tids_missing:
         raise AssertionError(
             f"Missing {len(tids_missing)}/{len(tids)} tids in OpenML, for some reason `openml.tasks.list_tasks` "
-            f"does not contain these tids:\n\t{tids_missing}"
+            f"does not contain these tids:\n\t{tids_missing}",
         )
 
     # Convert to simple types to be able to save in parquet without issue
@@ -58,9 +57,7 @@ def generate_task_metadata(tids: list[int]) -> pd.DataFrame:
     csv_buffer.seek(0)
 
     # Load DataFrame back from in-memory CSV
-    tasks_filtered = pd.read_csv(csv_buffer)
-
-    return tasks_filtered
+    return pd.read_csv(csv_buffer)
 
 
 def get_info_from_result(result: BaselineResult) -> dict:
@@ -79,16 +76,15 @@ def get_info_from_result(result: BaselineResult) -> dict:
     method_type = "baseline"
     if isinstance(result, ConfigResult):
         hyperparameters = result.hyperparameters
-        model_cls = hyperparameters["model_cls"]
+        hyperparameters["model_cls"]
         model_type = hyperparameters["model_type"]
         ag_key = hyperparameters["ag_key"]
         name_prefix = hyperparameters["name_prefix"]
         num_gpus = result.result["method_metadata"].get("num_gpus", 0)
         method_type = "config"
 
-        if isinstance(result, AGBagResult):
-            if result.num_children > 1:
-                is_bag = True
+        if isinstance(result, AGBagResult) and result.num_children > 1:
+            is_bag = True
 
     cur_result["is_bag"] = is_bag
     cur_result["ag_key"] = ag_key
@@ -101,14 +97,13 @@ def get_info_from_result(result: BaselineResult) -> dict:
 
 
 def load_raw(
-    path_raw: str | Path | list[str | Path] = None,
+    path_raw: str | Path | list[str | Path] | None = None,
     name_pattern: str | None = None,
     engine: str = "ray",
     as_holdout: bool = False,
     num_workers: int | None = None,
 ) -> list[BaselineResult]:
-    """
-    Loads the raw results artifacts from all `results.pkl` files in the `path_raw` directory
+    """Loads the raw results artifacts from all `results.pkl` files in the `path_raw` directory.
 
     Parameters
     ----------
@@ -116,14 +111,16 @@ def load_raw(
     engine
     as_holdout
 
-    Returns
+    Returns:
     -------
 
     """
-
     suffix = "results.pkl"
     file_paths_method = fetch_all_pickles(
-        dir_path=path_raw, suffix=suffix, name_pattern=name_pattern, num_workers=num_workers,
+        dir_path=path_raw,
+        suffix=suffix,
+        name_pattern=name_pattern,
+        num_workers=num_workers,
     )
     if len(file_paths_method) == 0:
         # Look at every file to provide debugging info
@@ -136,8 +133,6 @@ def load_raw(
         common_str = ", ".join(f"{name} ({count})" for name, count in counter) or "None"
 
         raise AssertionError(
-            f"No valid {suffix!r} files found under path: {path_raw!r}!\n"
-            f"Most common file root names:\n{common_str}"
+            f"No valid {suffix!r} files found under path: {path_raw!r}!\nMost common file root names:\n{common_str}",
         )
-    results_lst = load_all_artifacts(file_paths=file_paths_method, engine=engine, convert_to_holdout=as_holdout)
-    return results_lst
+    return load_all_artifacts(file_paths=file_paths_method, engine=engine, convert_to_holdout=as_holdout)

--- a/packages/tabarena/src/tabarena/nips2025_utils/per_dataset_tables.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/per_dataset_tables.py
@@ -1,9 +1,12 @@
-import os
-from pathlib import Path
-import pandas as pd
-import numpy as np
-import scipy.stats as stats
+from __future__ import annotations
+
 import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
 warnings.filterwarnings("ignore", category=UserWarning, module="scipy")
 
 
@@ -39,21 +42,16 @@ PER_DATASET_PARETO_CAPTION_BODY = (
     r"Reading the plot together with the table makes it possible to compare the cost (compute budget needed to reach a given error) and the achievable error of each method on that dataset, beyond the single endpoint summary in the table."
 )
 
+
 def _max_dot_pos(s: pd.Series) -> int:
-    """
-    Return max position of '.' in stringified values.
+    """Return max position of '.' in stringified values.
     Non-finite values are ignored (so they don't dominate the decision).
     """
     s_num = pd.to_numeric(s, errors="coerce")  # non-numeric -> NaN
     finite = np.isfinite(s_num.to_numpy(dtype="float64", na_value=np.nan))
     if not finite.any():
         return 0
-    return (
-        s_num[finite]
-        .astype(str)
-        .str.find(".")
-        .max()
-    )
+    return s_num[finite].astype(str).str.find(".").max()
 
 
 def _format_fixed(s: pd.Series, decimals: int) -> pd.Series:
@@ -66,8 +64,7 @@ def _format_fixed(s: pd.Series, decimals: int) -> pd.Series:
 
 
 def _format_scaled_int_str(s: pd.Series, scale: float, decimals_after: int = 0) -> pd.Series:
-    """
-    Scale, round to integer, then string.
+    """Scale, round to integer, then string.
     NaN/inf -> NA_STR.
     """
     s_num = pd.to_numeric(s, errors="coerce")
@@ -88,11 +85,10 @@ def get_significance_dataset(df_use, method="wilcoxon", alpha=0.05, verbose=Fals
     ### Get accuracy p-values
     p_values = {}
 
-
     df_use_mean = df_use.groupby(["dataset_name", "model_name"]).mean().unstack()[0].loc[df_use.dataset_name.unique()]
-    
+
     dataset_names = list(df_use_mean.index)
-    
+
     for dataset_name in dataset_names:
         # print(dataset_name)
         p_values[dataset_name] = {}
@@ -101,35 +97,43 @@ def get_significance_dataset(df_use, method="wilcoxon", alpha=0.05, verbose=Fals
             best_model = df_use_mean.columns[df_use_mean.loc[dataset_name].argmin()]
         elif direction == "max":
             best_model = df_use_mean.columns[df_use_mean.loc[dataset_name].argmax()]
-        
+
         for model_name in df_use.model_name.unique():
             if model_name == best_model:
                 # print(dataset_name,model_name)
-                p_values[dataset_name][model_name] = 1.
+                p_values[dataset_name][model_name] = 1.0
             else:
                 # print(dataset_name,model_name)
                 # Example performance metrics over 10 repeats for two models
-                best_results = df_use.loc[np.logical_and(df_use.dataset_name==dataset_name,
-                              df_use.model_name==best_model
-                             ),0].values
-                best_results[best_results<0] = 0
-                
-                curr_model_results = df_use.loc[np.logical_and(df_use.dataset_name==dataset_name,
-                              df_use.model_name==model_name
-                             ),0].values
-                curr_model_results[curr_model_results<0] = 0
-            
-                p_values[dataset_name][model_name] = get_significance(best_results, curr_model_results, direction=direction, method=method, verbose=verbose)
+                best_results = df_use.loc[
+                    np.logical_and(
+                        df_use.dataset_name == dataset_name,
+                        df_use.model_name == best_model,
+                    ),
+                    0,
+                ].values
+                best_results[best_results < 0] = 0
+
+                curr_model_results = df_use.loc[
+                    np.logical_and(
+                        df_use.dataset_name == dataset_name,
+                        df_use.model_name == model_name,
+                    ),
+                    0,
+                ].values
+                curr_model_results[curr_model_results < 0] = 0
+
+                p_values[dataset_name][model_name] = get_significance(
+                    best_results, curr_model_results, direction=direction, method=method, verbose=verbose
+                )
         # except:
         #     p_values[dataset_name] = {model_name: 0. for model_name in df_use.model_name.unique()}
-    
-    significance_df = pd.DataFrame(p_values).transpose()
-    return significance_df
+
+    return pd.DataFrame(p_values).transpose()
 
 
 def holm_bonferroni_correction(p_values):
-    """
-    Apply Holm-Bonferroni correction to a list of p-values.
+    """Apply Holm-Bonferroni correction to a list of p-values.
     :param p_values: List of p-values.
     :return: Adjusted p-values and rejection decisions.
     """
@@ -137,56 +141,54 @@ def holm_bonferroni_correction(p_values):
     sorted_p_values = np.array(p_values)[sorted_indices]
     adjusted_p_values = np.zeros_like(sorted_p_values)
     m = len(p_values)
-    
+
     for i, p in enumerate(sorted_p_values):
         adjusted_p_values[i] = min((m - i) * p, 1.0)
-    
+
     # Reorder to original order
     adjusted_p_values = adjusted_p_values[np.argsort(sorted_indices)]
-    
+
     # Determine rejection
     reject = adjusted_p_values < 0.05
-    
-    return list(zip(p_values, adjusted_p_values, reject))
+
+    return list(zip(p_values, adjusted_p_values, reject, strict=False))
+
 
 def get_significance(best_results, curr_model_results, method="wilcoxon", alpha=0.05, verbose=False, direction="max"):
+    if (
+        (direction == "min" and np.mean(best_results) >= np.mean(curr_model_results))
+        or (direction == "max" and np.mean(best_results) <= np.mean(curr_model_results))
+        or (direction == "max" and np.all(best_results <= curr_model_results))
+    ):
+        p_value = 2
 
-    if direction =="min" and np.mean(best_results)>=np.mean(curr_model_results):
-        p_value = 2
-    elif direction =="max" and np.mean(best_results)<=np.mean(curr_model_results):
-        p_value = 2
-    elif direction =="max" and np.all(best_results<=curr_model_results):
-        p_value = 2
-    
-    else:
-        # Perform the paired t-test
-        if method == "ttest":
-            t_statistic, p_value = stats.ttest_rel(best_results, curr_model_results)
-        elif method == "wilcoxon":
-            t_statistic, p_value = stats.wilcoxon(best_results, curr_model_results) #     w_stat, p_value_w
-        # elif method == "wilcoxon-corrected":
-        #     t_statistic, p_value = stats.wilcoxon(best_results, curr_model_results) #     w_stat, p_value_w
-            # Apply Holm-Bonferroni correction
-            # reject, p_value, _, _ = multipletests(p_value, alpha=0.05, method='holm')
-        elif method == "kruskal-wallis":
-            statistic, p_value = stats.kruskal(best_results, curr_model_results)
-        elif method == "ftest":
-            statistic, p_value = stats.f_oneway(best_results, curr_model_results)
-        elif method == "tabred":
-            sub_series_mean = np.mean(best_results)
-            sub_series_std = np.std(best_results)
-            if direction == "min":
-                thresh = sub_series_mean+sub_series_std
-                p_value = (np.mean(curr_model_results)<thresh)*2
-                
-            elif direction == "max":
-                thresh = sub_series_mean-sub_series_std
-                p_value = (np.mean(curr_model_results)>thresh)*2
-            
+    # Perform the paired t-test
+    elif method == "ttest":
+        t_statistic, p_value = stats.ttest_rel(best_results, curr_model_results)
+    elif method == "wilcoxon":
+        t_statistic, p_value = stats.wilcoxon(best_results, curr_model_results)  #     w_stat, p_value_w
+    # elif method == "wilcoxon-corrected":
+    #     t_statistic, p_value = stats.wilcoxon(best_results, curr_model_results) #     w_stat, p_value_w
+    # Apply Holm-Bonferroni correction
+    # reject, p_value, _, _ = multipletests(p_value, alpha=0.05, method='holm')
+    elif method == "kruskal-wallis":
+        statistic, p_value = stats.kruskal(best_results, curr_model_results)
+    elif method == "ftest":
+        _statistic, p_value = stats.f_oneway(best_results, curr_model_results)
+    elif method == "tabred":
+        sub_series_mean = np.mean(best_results)
+        sub_series_std = np.std(best_results)
+        if direction == "min":
+            thresh = sub_series_mean + sub_series_std
+            p_value = (np.mean(curr_model_results) < thresh) * 2
+
+        elif direction == "max":
+            thresh = sub_series_mean - sub_series_std
+            p_value = (np.mean(curr_model_results) > thresh) * 2
 
     p_value_one_tailed = p_value / 2
     criterion = p_value_one_tailed < alpha
-            
+
     if verbose:
         print(f"T-statistic: {t_statistic}")
         print(f"P-value: {p_value}")
@@ -195,14 +197,14 @@ def get_significance(best_results, curr_model_results, method="wilcoxon", alpha=
     if criterion:
         if verbose:
             print("There is a statistically significant difference between the two models.")
-    else:
-        if verbose:
-            print("There is no statistically significant difference between the two models.")
+    elif verbose:
+        print("There is no statistically significant difference between the two models.")
     if verbose:
         print("----------------------------------------------------------------------------------")
 
     return p_value
- 
+
+
 def _build_dataset_name_map(task_metadata: pd.DataFrame | None) -> dict[str, str]:
     """Map internal ``dataset`` id (e.g. ``Task-7163328506``) to a human-readable
     label drawn from ``task_metadata``.
@@ -226,7 +228,8 @@ _TUNED_ENS_SUFFIX = " (tuned + ensemble)"
 
 def _regime_of(method: str) -> str | None:
     """Classify a method name into one of the three pipeline regimes by its
-    suffix, or ``None`` if it doesn't match any (treated as a baseline)."""
+    suffix, or ``None`` if it doesn't match any (treated as a baseline).
+    """
     if method.endswith(_TUNED_ENS_SUFFIX):
         return "tuned_ensemble"
     if method.endswith(_TUNED_SUFFIX):
@@ -240,7 +243,8 @@ def _default_method_order(df_results: pd.DataFrame) -> list[str]:
     """Derive a default per-dataset ordering from whatever methods are present
     in ``df_results``: every ``(default)`` method, then every ``(tuned)``,
     then every ``(tuned + ensemble)``, then any baselines, with stable
-    alphabetical order within each regime."""
+    alphabetical order within each regime.
+    """
     methods = sorted(df_results["method"].dropna().unique().tolist())
     regime_rank = {"default": 0, "tuned": 1, "tuned_ensemble": 2, None: 3}
     return sorted(methods, key=lambda m: (regime_rank[_regime_of(m)], m))
@@ -249,21 +253,29 @@ def _default_method_order(df_results: pd.DataFrame) -> list[str]:
 def _safe_significance_dataset(for_sig: pd.DataFrame) -> pd.DataFrame:
     """Run ``get_significance_dataset`` only when the slice has at least two
     methods; otherwise return an empty frame so downstream lookups fall back
-    to the ``KeyError`` -> default behavior the caller already handles."""
+    to the ``KeyError`` -> default behavior the caller already handles.
+    """
     if for_sig.empty or for_sig["model_name"].nunique() < 2:
         return pd.DataFrame()
     return get_significance_dataset(
-        for_sig, method="wilcoxon", alpha=0.05, verbose=False, direction="min",
+        for_sig,
+        method="wilcoxon",
+        alpha=0.05,
+        verbose=False,
+        direction="min",
     )
 
 
 def _is_significance_best(
-    significance_df: pd.DataFrame, dataset_name: str, method_name: str,
+    significance_df: pd.DataFrame,
+    dataset_name: str,
+    method_name: str,
 ) -> bool:
     """Return whether ``method_name`` is "not significantly worse than best"
     on ``dataset_name``. Returns ``False`` when significance was not computed
     (empty frame) or the row/column is missing — which matches what the
-    caller wants: no underline/bold when we have no signal."""
+    caller wants: no underline/bold when we have no signal.
+    """
     if significance_df.empty:
         return False
     if dataset_name not in significance_df.index:
@@ -316,20 +328,20 @@ def get_per_dataset_tables(
     baseline_methods = [m for m in use_methods_ordered if _regime_of(m) is None]
 
     df_use = df_results.loc[df_results["method"].isin(use_methods_ordered)]
-    df_use_fold = df_use.loc[df_use["fold"]==0]
+    df_use.loc[df_use["fold"] == 0]
 
     for_sig = df_use[["method", "dataset", "metric_error"]]
-    for_sig.columns=["model_name", "dataset_name", 0]
+    for_sig.columns = ["model_name", "dataset_name", 0]
 
     significance_df = _safe_significance_dataset(for_sig)
     significance_default = _safe_significance_dataset(
-        for_sig.loc[for_sig["model_name"].apply(lambda x: _regime_of(x) == "default")]
+        for_sig.loc[for_sig["model_name"].apply(lambda x: _regime_of(x) == "default")],
     )
     significance_tuned = _safe_significance_dataset(
-        for_sig.loc[for_sig["model_name"].apply(lambda x: _regime_of(x) == "tuned")]
+        for_sig.loc[for_sig["model_name"].apply(lambda x: _regime_of(x) == "tuned")],
     )
     significance_tuned_ensemble = _safe_significance_dataset(
-        for_sig.loc[for_sig["model_name"].apply(lambda x: _regime_of(x) == "tuned_ensemble")]
+        for_sig.loc[for_sig["model_name"].apply(lambda x: _regime_of(x) == "tuned_ensemble")],
     )
 
     # NOTE: the prior implementation loaded TabArena's global task metadata here
@@ -343,28 +355,22 @@ def get_per_dataset_tables(
     datasets_dict = {}
     datasets_human_name: dict[str, str] = {}
     for dataset_name in df_use["dataset"].unique():
-        df_dat = df_use.loc[df_use["dataset"]==dataset_name]
-        imputed_methods = df_dat.loc[df_dat.imputed==True,'method'].unique()
+        df_dat = df_use.loc[df_use["dataset"] == dataset_name]
+        imputed_methods = df_dat.loc[df_dat.imputed, "method"].unique()
 
-        if np.unique(df_dat["metric"])[0]=="roc_auc":
-            df_dat.loc[:, "metric_error"] = 1-df_dat["metric_error"]
+        if np.unique(df_dat["metric"])[0] == "roc_auc":
+            df_dat.loc[:, "metric_error"] = 1 - df_dat["metric_error"]
             metric_dir = "max"
         else:
             metric_dir = "min"
 
         # Reindex to ``use_methods_ordered`` so missing methods (e.g. a baseline
         # with no result for this dataset) become NaN rows rather than raising.
-        df_mean = (
-            df_dat[["method", "metric_error"]]
-            .groupby("method").mean().reindex(use_methods_ordered)
-        )
-        df_std = (
-            df_dat[["method", "metric_error"]]
-            .groupby("method").std().reindex(use_methods_ordered)
-        )
+        df_mean = df_dat[["method", "metric_error"]].groupby("method").mean().reindex(use_methods_ordered)
+        df_std = df_dat[["method", "metric_error"]].groupby("method").std().reindex(use_methods_ordered)
 
         df_mean_raw = df_mean.copy()
-        df_std_raw = df_std.copy()
+        df_std.copy()
 
         df_mean = df_mean["metric_error"]
         df_std = df_std["metric_error"]
@@ -406,9 +412,7 @@ def get_per_dataset_tables(
             return f"{mean_str} $\\pm$ {std_str}"
 
         df_latex = pd.DataFrame(
-            {dataset_name: [
-                _combine_cell(m, s) for m, s in zip(mean_series, std_series)
-            ]},
+            {dataset_name: [_combine_cell(m, s) for m, s in zip(mean_series, std_series, strict=False)]},
             index=mean_series.index,
         )
         # ``reindex`` above introduced NaN rows for methods absent from this
@@ -417,7 +421,7 @@ def get_per_dataset_tables(
         present_methods = set(df_dat["method"].unique())
         missing_methods = [m for m in use_methods_ordered if m not in present_methods]
         for method in list(imputed_methods) + missing_methods:
-            df_latex.loc[method] = '-'
+            df_latex.loc[method] = "-"
 
         placeholder_methods = set(list(imputed_methods) + missing_methods)
 
@@ -429,17 +433,13 @@ def get_per_dataset_tables(
         # altogether. The cell at ``best_idx`` is then guaranteed to render
         # a real number that we can color.
         highlight_candidates = df_mean_raw["metric_error"].drop(
-            labels=list(placeholder_methods), errors="ignore"
+            labels=list(placeholder_methods),
+            errors="ignore",
         )
         if highlight_candidates.notna().any():
-            best_idx = (
-                highlight_candidates.idxmin() if metric_dir == "min"
-                else highlight_candidates.idxmax()
-            )
+            best_idx = highlight_candidates.idxmin() if metric_dir == "min" else highlight_candidates.idxmax()
             df_latex.loc[best_idx, dataset_name] = (
-                r"\textcolor{green!50!black}{"
-                + df_latex.loc[best_idx, dataset_name]
-                + "}"
+                r"\textcolor{green!50!black}{" + df_latex.loc[best_idx, dataset_name] + "}"
             )
 
         # With only one split (one fold of data per method) the Wilcoxon
@@ -457,17 +457,17 @@ def get_per_dataset_tables(
         # ``-`` (and any literal ``NA`` that slipped through formatting) gets
         # left alone so we don't end up with ``\textbf{-}`` decorations.
         def _stylize(score: str, name: str, sig_df: pd.DataFrame, prefix: str) -> str:
-            if single_split:
+            if single_split:  # noqa: B023
                 return score
-            if name in placeholder_methods or score == "-" or NA_STR in score:
+            if name in placeholder_methods or score == "-" or NA_STR in score:  # noqa: B023
                 return score
-            if not _is_significance_best(sig_df, dataset_name, name):
+            if not _is_significance_best(sig_df, dataset_name, name):  # noqa: B023
                 return score
             return prefix + score + "}"
 
         df_latex.loc[:, dataset_name] = [
             _stylize(score, name, significance_df, r"\textbf{")
-            for name, score in zip(df_latex.index, df_latex[dataset_name])
+            for name, score in zip(df_latex.index, df_latex[dataset_name], strict=False)
         ]
 
         df_latex_def = df_latex.loc[[_regime_of(i) == "default" for i in df_latex.index]]
@@ -476,23 +476,29 @@ def get_per_dataset_tables(
 
         df_latex_def.loc[:, dataset_name] = [
             _stylize(score, name, significance_default, r"\underline{")
-            for name, score in zip(df_latex_def.index, df_latex_def[dataset_name])
+            for name, score in zip(df_latex_def.index, df_latex_def[dataset_name], strict=False)
         ]
         df_latex_tuned.loc[:, dataset_name] = [
             _stylize(score, name, significance_tuned, r"\underline{")
-            for name, score in zip(df_latex_tuned.index, df_latex_tuned[dataset_name])
+            for name, score in zip(df_latex_tuned.index, df_latex_tuned[dataset_name], strict=False)
         ]
         df_latex_tuned_ensemble.loc[:, dataset_name] = [
             _stylize(score, name, significance_tuned_ensemble, r"\underline{")
-            for name, score in zip(df_latex_tuned_ensemble.index, df_latex_tuned_ensemble[dataset_name])
+            for name, score in zip(df_latex_tuned_ensemble.index, df_latex_tuned_ensemble[dataset_name], strict=False)
         ]
 
-        df_latex_final = pd.merge(df_latex_def.rename(index=lambda s: s.split(" (")[0]),
-                                    df_latex_tuned.rename(index=lambda s: s.split(" (")[0]),
-                                    left_index=True, right_index=True, how="left"
-                                    ).merge(df_latex_tuned_ensemble.rename(index=lambda s: s.split(" (")[0])
-                                    , left_index=True, right_index=True, how="left"
-                                    )
+        df_latex_final = pd.merge(
+            df_latex_def.rename(index=lambda s: s.split(" (")[0]),
+            df_latex_tuned.rename(index=lambda s: s.split(" (")[0]),
+            left_index=True,
+            right_index=True,
+            how="left",
+        ).merge(
+            df_latex_tuned_ensemble.rename(index=lambda s: s.split(" (")[0]),
+            left_index=True,
+            right_index=True,
+            how="left",
+        )
         # Each baseline (a method with no regime suffix) gets its own row in
         # the ``Tuned + Ens.`` column with placeholders for the other two —
         # this generalizes the previous AutoGluon-specific hard-coded line.
@@ -503,10 +509,10 @@ def get_per_dataset_tables(
         df_latex_final.columns = ["Default", "Tuned", "Tuned + Ens."]
 
         # if not can_run_tabpfnv2[dataset_name]:
-        #     df_latex_final.loc["TabPFNv2"] = ["-", "-", "-"]    
+        #     df_latex_final.loc["TabPFNv2"] = ["-", "-", "-"]
         # if not can_run_tabicl[dataset_name]:
-        #     df_latex_final.loc["TabICL"] = ["-", "-", "-"]    
-        
+        #     df_latex_final.loc["TabICL"] = ["-", "-", "-"]
+
         df_latex_final.index.name = None
         latex_safe_id = dataset_name.replace("_", r"\_")
         datasets_dict[latex_safe_id] = df_latex_final.copy()
@@ -516,13 +522,16 @@ def get_per_dataset_tables(
         datasets_human_name[latex_safe_id] = human_label.replace("_", r"\_")
 
     output_file = save_path / "per_dataset_tables.tex"
-    per_col    = 2                  # 2 columns per row
-    per_page   = 6                  # 3 rows × 2 columns = 6 subtables per figure
-    sub_width  = 0.48               # width for each subtable (2 across)
+    per_col = 2  # 2 columns per row
+    per_page = 6  # 3 rows × 2 columns = 6 subtables per figure
+    sub_width = 0.48  # width for each subtable (2 across)
     sub_height = ""  # fixed height for each subtable
 
     metrics_used = dict(df_use[["dataset", "metric"]].drop_duplicates().values)
-    metrics_used = {key.replace("_", r"\_"): "AUC" if value=="roc_auc" else ("logloss" if value=="log_loss" else "rmse") for key, value in metrics_used.items()}
+    metrics_used = {
+        key.replace("_", r"\_"): "AUC" if value == "roc_auc" else ("logloss" if value == "log_loss" else "rmse")
+        for key, value in metrics_used.items()
+    }
 
     items = list(datasets_dict.items())
 
@@ -530,22 +539,21 @@ def get_per_dataset_tables(
 
     with open(output_file, "w") as f:
         for page_start in range(0, len(items), per_page):
-            page_items = items[page_start:page_start + per_page]
+            page_items = items[page_start : page_start + per_page]
 
             f.write(r"\begin{table}[htb]" + "\n")
             f.write(r"  \centering" + "\n")
             if page_start == 0:
                 f.write("\\caption{" + PER_DATASET_TABLE_CAPTION_BODY + "}\n\n")
 
-
             # Build 3 rows of 2 columns each
             for row_start in range(0, len(page_items), per_col):
-                row = page_items[row_start:row_start + per_col]
+                row = page_items[row_start : row_start + per_col]
                 for idx, (name, df) in enumerate(row):
                     print_name = datasets_human_name.get(name, name)
                     # Long-name special case from the original tabarena tables.
-                    if print_name == 'HR\\_Analytics\\_Job\\_Change\\_of\\_Data\\_Scientists':
-                        print_name = 'HR\\_Analytics\\_Job\\_Change'
+                    if print_name == "HR\\_Analytics\\_Job\\_Change\\_of\\_Data\\_Scientists":
+                        print_name = "HR\\_Analytics\\_Job\\_Change"
                     # compute column format: index, quad gap, then one 'r' per data column
                     n_data = df.shape[1]
                     col_fmt = "l@{\\quad}" + "l" * n_data
@@ -555,10 +563,7 @@ def get_per_dataset_tables(
                     f.write(r"    \scriptsize" + "\n")
 
                     # caption at the top
-                    if metrics_used[name]=="AUC":
-                        arrow = r"$\uparrow$"
-                    else:
-                        arrow = r"$\downarrow$"
+                    arrow = r"$\uparrow$" if metrics_used[name] == "AUC" else r"$\downarrow$"
                     f.write(f"    \\caption*{{{print_name} ({metrics_used[name]} {arrow})}}" + "\n")
                     f.write(r"    \vspace{-1ex}")
                     f.write(f"    \\label{{tab:{page_start + row_start + idx + 1}}}\n")
@@ -571,7 +576,7 @@ def get_per_dataset_tables(
                     latex_table = df.to_latex(
                         index=True,
                         escape=False,
-                        column_format=col_fmt
+                        column_format=col_fmt,
                     )
                     for line in latex_table.splitlines():
                         f.write("      " + line + "\n")
@@ -585,7 +590,7 @@ def get_per_dataset_tables(
 
                 # small vertical gap between rows
                 f.write(r"  \medskip" + "\n\n")
-            
+
             # overall caption & label for this figure
             # f.write(
             #     rf"  \caption{{Datasets {page_start+1}–{page_start+len(page_items)}}}" + "\n"
@@ -614,7 +619,7 @@ def get_per_dataset_tables(
             tex_path = per_dataset_dir / f"{raw_id}.tex"
             with open(tex_path, "w") as f:
                 f.write(f"% Per-dataset performance table for {human_label} ({metric} {arrow}).\n")
-                f.write(f"% Auto-generated; designed to be \\input{{}} into a minipage / subfigure.\n")
+                f.write("% Auto-generated; designed to be \\input{} into a minipage / subfigure.\n")
                 f.write(r"\scriptsize" + "\n")
                 f.write(tabular)
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/scripts/run_amlb2025.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/scripts/run_amlb2025.py
@@ -1,23 +1,20 @@
 from __future__ import annotations
 
 import pandas as pd
-
 from autogluon.tabular import TabularDataset
+
 from bencheval.tabarena import TabArena
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     amlb2025_prefix = "s3://neerick-autogluon/tabarena/benchmarks/amlb2025/"
 
     results_files = [
-        "amlb_all.csv"
+        "amlb_all.csv",
     ]
 
     results_files = [f"{amlb2025_prefix}{result_file}" for result_file in results_files]
 
-    results_dfs = [
-        TabularDataset(result_file) for result_file in results_files
-    ]
+    results_dfs = [TabularDataset(result_file) for result_file in results_files]
 
     df_results = pd.concat(results_dfs, ignore_index=True)
     df_results["tid"] = df_results["id"].str.split("/").str[-1].astype(float)
@@ -25,21 +22,25 @@ if __name__ == '__main__':
     df_results = df_results[~df_results["result"].isnull()]
     df_results["fold"] = df_results["fold"].astype(int)
     df_results["metric_error"] = -df_results["result"]
-    optimum_result = df_results["metric"].map({
-        "auc": 1.0,
-        "neg_rmse": 0.0,
-        "neg_logloss": 0.0,
-    })
+    optimum_result = df_results["metric"].map(
+        {
+            "auc": 1.0,
+            "neg_rmse": 0.0,
+            "neg_logloss": 0.0,
+        }
+    )
     df_results["metric_error"] = optimum_result - df_results["result"]
-    df_results["metric"] = df_results["metric"].map({
-        "auc": "roc_auc",
-        "neg_rmse": "rmse",
-        "neg_logloss": "logloss",
-    })
+    df_results["metric"] = df_results["metric"].map(
+        {
+            "auc": "roc_auc",
+            "neg_rmse": "rmse",
+            "neg_logloss": "logloss",
+        }
+    )
     df_results["training_duration"] = df_results["training_duration"].fillna(df_results["duration"])
     df_results = df_results[~df_results["predict_duration"].isnull()]
 
-    fillna_method = f"constantpredictor_60min"
+    fillna_method = "constantpredictor_60min"
     baseline_method = "RandomForest_60min"
 
     default_methods = [
@@ -56,15 +57,19 @@ if __name__ == '__main__':
         f"autosklearn2{method_suffix}",
     ]
 
-    df_results = df_results[(df_results["framework"].str.contains(method_suffix)) | (df_results["framework"].isin(default_methods))]
+    df_results = df_results[
+        (df_results["framework"].str.contains(method_suffix)) | (df_results["framework"].isin(default_methods))
+    ]
     df_results = df_results[~df_results["framework"].isin(banned_methods)]
     df_results = df_results[df_results["framework"] != fillna_method]
 
-    df_results = df_results.rename(columns={
-        "framework": "method",
-        "training_duration": "time_train_s",
-        "predict_duration": "time_infer_s",
-    })
+    df_results = df_results.rename(
+        columns={
+            "framework": "method",
+            "training_duration": "time_train_s",
+            "predict_duration": "time_infer_s",
+        }
+    )
 
     arena = TabArena(
         method_col="method",

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -22,6 +21,8 @@ from tabarena.utils.pickle_utils import fetch_all_pickles
 from tabarena.website.website_format import format_leaderboard
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from tabarena.benchmark.result import BaselineResult
     from tabarena.repository.abstract_repository import AbstractRepository
 
@@ -30,7 +31,6 @@ _methods_paper = [
     # "AutoGluon_v140_eq_4h8c",
     "AutoGluon_v150_eq_4h8c",
     # "Portfolio-N200-4h",
-
     "CatBoost",
     # "Dummy",
     "ExplainableBM",
@@ -45,7 +45,6 @@ _methods_paper = [
     # "RealMLP",
     # "TabM",
     "XGBoost",
-
     "Mitra_GPU",
     "ModernNCA_GPU",
     "RealMLP_GPU",
@@ -53,7 +52,6 @@ _methods_paper = [
     "TabICL_GPU",
     "TabM_GPU",
     "TabPFNv2_GPU",
-
     "xRFM_GPU",
     "BetaTabPFN_GPU",
     "TabFlex_GPU",
@@ -62,7 +60,6 @@ _methods_paper = [
     "TabICLv2",
     "TabSTAR",
     "PerpetualBooster",
-
     "TabPFN-v2.6",
     "LimiX",
     "OrionMSP",
@@ -123,7 +120,7 @@ class TabArenaContext:
                 raise ValueError(f"Unknown methods preset '{methods}'.")
             methods = copy.deepcopy(_methods_paper)
             method_metadata_lst: list[MethodMetadata] = copy.deepcopy(
-                tabarena_method_metadata_collection.method_metadata_lst
+                tabarena_method_metadata_collection.method_metadata_lst,
             )
 
             method_metadata_lst = [m for m in method_metadata_lst if m.method in methods]
@@ -168,9 +165,9 @@ class TabArenaContext:
         self,
         output_dir,
         subsets: list[list[str] | tuple[str, list[str]]] | str = "auto",
-        new_results = None,
-        compare_kwargs = None,
-        tuning_trajectory_kwargs = None,
+        new_results=None,
+        compare_kwargs=None,
+        tuning_trajectory_kwargs=None,
         plot_compare: bool = True,
         plot_runtime_per_method: bool = False,
         plot_tuning_trajectories: bool = False,
@@ -338,7 +335,7 @@ class TabArenaContext:
                         print(
                             f"WARNING: Multiple display_name values detected for the same config_type={m.config_type!r}"
                             f"\n\tdisplay_name 1: {method_rename_map[m.config_type]!r}"
-                            f"\n\tdisplay_name 2: {display_name!r}"
+                            f"\n\tdisplay_name 2: {display_name!r}",
                         )
                     method_rename_map[m.config_type] = display_name
         return method_rename_map
@@ -347,7 +344,9 @@ class TabArenaContext:
         metadata: MethodMetadata = self.method_metadata(method=method)
         return metadata.load_raw(engine=self.engine, as_holdout=as_holdout)
 
-    def load_repo(self, methods: list[str | MethodMetadata] | None = None, config_fallback: str | None = None) -> EvaluationRepositoryCollection:
+    def load_repo(
+        self, methods: list[str | MethodMetadata] | None = None, config_fallback: str | None = None
+    ) -> EvaluationRepositoryCollection:
         if methods is None:
             methods = self.methods
         repos = []
@@ -596,12 +595,14 @@ class TabArenaContext:
         tuned_ens["config_type"] = new_config_type
         tuned_ens["method"] = f"{new_config_type} (tuned + ensemble)"
 
-        return pd.concat([
-            default,
-            tuned,
-            tuned_ens,
-        ], ignore_index=True)
-
+        return pd.concat(
+            [
+                default,
+                tuned,
+                tuned_ens,
+            ],
+            ignore_index=True,
+        )
 
     def run_hpo(
         self,
@@ -640,9 +641,11 @@ class TabArenaContext:
             seed=seed,
             **kwargs,
         )
-        df_results_family_hpo = df_results_family_hpo.rename(columns={
-            "framework": "method",
-        })
+        df_results_family_hpo = df_results_family_hpo.rename(
+            columns={
+                "framework": "method",
+            }
+        )
         name = "HPO"
         if n_configs is not None:
             name += f"-N{n_configs}"
@@ -756,7 +759,9 @@ class TabArenaContext:
             time_limit=time_limit,
         )
 
-    def simulate_portfolio(self, methods: list[str], config_fallback: str, repo: EvaluationRepositoryCollection = None, **kwargs):
+    def simulate_portfolio(
+        self, methods: list[str], config_fallback: str, repo: EvaluationRepositoryCollection = None, **kwargs
+    ):
         if repo is None:
             repo = self.load_repo(methods=methods, config_fallback=config_fallback)
         simulator = PaperRunTabArena(repo=repo, backend=self.backend)
@@ -765,7 +770,8 @@ class TabArenaContext:
         n_portfolios = [200] if "n_portfolios" not in kwargs else kwargs.pop("n_portfolios")
         for n_portfolio in n_portfolios:
             df_results_n_portfolio.append(
-                simulator.run_zs(n_portfolios=n_portfolio, n_ensemble=None, n_ensemble_in_name=False, **kwargs))
+                simulator.run_zs(n_portfolios=n_portfolio, n_ensemble=None, n_ensemble_in_name=False, **kwargs)
+            )
         return pd.concat(df_results_n_portfolio, ignore_index=True)
 
     def run_portfolio_from_config_types(
@@ -815,8 +821,7 @@ class TabArenaContext:
             for method in methods_drop:
                 if method not in methods:
                     raise AssertionError(
-                        f"Specified '{method}' in `methods_drop`, "
-                        f"but '{method}' is not present in methods: {methods}"
+                        f"Specified '{method}' in `methods_drop`, but '{method}' is not present in methods: {methods}",
                     )
             methods = [method for method in methods if method not in methods_drop]
 
@@ -834,7 +839,7 @@ class TabArenaContext:
                     print(
                         f"Missing local results files for method! "
                         f"Attempting to download from s3 and retry... "
-                        f'(download_results={download_results}, method="{method_metadata.method}")'
+                        f'(download_results={download_results}, method="{method_metadata.method}")',
                     )
                     method_downloader = method_metadata.method_downloader()
                     method_downloader.download_results(holdout=holdout)
@@ -842,7 +847,7 @@ class TabArenaContext:
                 else:
                     print(
                         f"Missing local results files for method {method_metadata.method}! "
-                        f"Try setting `download_results=True` to get the required files."
+                        f"Try setting `download_results=True` to get the required files.",
                     )
                     raise err
             df_results_lst.append(df_results)
@@ -859,6 +864,7 @@ class TabArenaContext:
         folds: list[int] | None = None,
     ) -> pd.DataFrame:
         from tabarena.nips2025_utils.compare import subset_tasks
+
         if subset is not None or datasets is not None or folds is not None or tasks is not None:
             df_results = subset_tasks(
                 df_results=df_results,
@@ -897,7 +903,7 @@ class TabArenaContext:
                         raise KeyError(
                             f"Duplicate key found in configs_hyperparameters: {key}\n"
                             f"This should never happen and may mean that a given config name "
-                            f"belongs to multiple different hyperparameters!"
+                            f"belongs to multiple different hyperparameters!",
                         )
                 merged.update(d)
             return merged
@@ -952,6 +958,7 @@ class TabArenaContext:
         **kwargs,
     ):
         from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories
+
         plot_tuning_trajectories(
             tabarena_context=self,
             fig_save_dir=save_path,
@@ -969,6 +976,7 @@ class TabArenaContext:
         if to_grid:
             assert file_ext == ".png", f"to_grid=True only works with file_ext={'.png'!r}"
         from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories_per_dataset
+
         plot_tuning_trajectories_per_dataset(
             tabarena_context=self,
             fig_save_dir=save_path,
@@ -990,6 +998,7 @@ class TabArenaContext:
         datasets: list[str] | None = None,
     ):
         from tabarena.plot.png_to_grid import make_png_grid
+
         if not datasets:
             task_metadata = self.task_metadata
             datasets = sorted(task_metadata["dataset"].unique())
@@ -1040,9 +1049,7 @@ class TabArenaContext:
             if m.method_type == "config"
         }
         df_results_configs["config_type"] = (
-            df_results_configs["ta_name"]
-            .map(method_to_display_name)
-            .fillna(df_results_configs["ta_name"])
+            df_results_configs["ta_name"].map(method_to_display_name).fillna(df_results_configs["ta_name"])
         )
 
         deep_dive_kwargs = dict(kwargs.pop("deep_dive_kwargs", None) or {})
@@ -1119,7 +1126,7 @@ class TabArenaContext:
             columns={
                 "method": "ta_name",
                 "artifact_name": "ta_suite",
-            }
+            },
         )
         return format_leaderboard(
             df_leaderboard=leaderboard,
@@ -1170,7 +1177,7 @@ class TabArenaContext:
 
             for dataset, fold in tasks_missing:
                 runs_missing_lst.append(
-                    (dataset, fold, config)
+                    (dataset, fold, config),
                 )
 
             print(f"{n_tasks_missing}\t{config}\t{i + 1}/{n_configs}")
@@ -1222,7 +1229,7 @@ class TabArenaContext:
             if not invalid.empty:
                 raise AssertionError(
                     f"Found a method with multiple values for column {c} (must be unique):\n"
-                    f"{groupby_method_invalid.value_counts(dropna=False)}"
+                    f"{groupby_method_invalid.value_counts(dropna=False)}",
                 )
 
             # Using .first() is safe because nunique == 1 for every method

--- a/packages/tabarena/src/tabarena/paper/paper_runner.py
+++ b/packages/tabarena/src/tabarena/paper/paper_runner.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
 
 from tabarena.evaluation.evaluator import Evaluator
-from tabarena.repository import EvaluationRepository
+
+if TYPE_CHECKING:
+    from tabarena.repository import EvaluationRepository
 
 
 class PaperRun:
-    def __init__(self, repo: EvaluationRepository, output_dir: str = None, backend: Literal["ray", "native"] = "ray"):
+    def __init__(
+        self, repo: EvaluationRepository, output_dir: str | None = None, backend: Literal["ray", "native"] = "ray"
+    ):
         self.repo = repo
         self.evaluator = Evaluator(repo=self.repo)
         self.output_dir = output_dir
@@ -34,12 +38,20 @@ class PaperRun:
 
     def run_hpo(self, model_type: str) -> tuple[pd.DataFrame, pd.DataFrame]:
         df_results_family_hpo_ens = self.run_ensemble_config_type(
-            config_type=model_type, fit_order="original", seed=0, n_iterations=40, time_limit=None,
+            config_type=model_type,
+            fit_order="original",
+            seed=0,
+            n_iterations=40,
+            time_limit=None,
         )
         df_results_family_hpo_ens["framework"] = f"{model_type} (tuned + ensemble)"
 
         df_results_family_hpo = self.run_ensemble_config_type(
-            config_type=model_type, fit_order="original", seed=0, n_iterations=1, time_limit=None,
+            config_type=model_type,
+            fit_order="original",
+            seed=0,
+            n_iterations=1,
+            time_limit=None,
         )
         df_results_family_hpo["framework"] = f"{model_type} (tuned)"
         return df_results_family_hpo, df_results_family_hpo_ens
@@ -52,20 +64,21 @@ class PaperRun:
         if model_types is None:
             model_types = list(config_type_groups.keys())
         for family in model_types:
-            assert family in config_type_groups, f"Model family {family} missing from available families: {list(config_type_groups.keys())}"
+            assert family in config_type_groups, (
+                f"Model family {family} missing from available families: {list(config_type_groups.keys())}"
+            )
 
         for family in model_types:
             df_results_family_hpo, df_results_family_hpo_ens = self.run_hpo(model_type=family)
             hpo_results_lst += [df_results_family_hpo, df_results_family_hpo_ens]
 
-        df_results_hpo_all = pd.concat(hpo_results_lst, ignore_index=True)
-        return df_results_hpo_all
+        return pd.concat(hpo_results_lst, ignore_index=True)
 
     def run_ensemble_config_type(
         self,
         config_type: str | list[str],
         n_iterations: int,
-        n_configs: int = None,
+        n_configs: int | None = None,
         fixed_configs: list[str] | None = None,
         time_limit: float | None = None,
         fit_order: Literal["original", "random"] = "original",
@@ -107,10 +120,7 @@ class PaperRun:
         df_results_family_hpo = df_results_family_hpo.reset_index()
         df_results_family_hpo["method_type"] = "hpo"
 
-        if n_iterations == 1:
-            method_subtype = "tuned"
-        else:
-            method_subtype = "tuned_ensemble"
+        method_subtype = "tuned" if n_iterations == 1 else "tuned_ensemble"
         df_results_family_hpo["method_subtype"] = method_subtype
         df_results_family_hpo["config_type"] = str(config_type)
 
@@ -151,10 +161,7 @@ class PaperRun:
         df_results = df_results.reset_index()
         df_results["method_type"] = "portfolio"
 
-        if n_iterations == 1:
-            method_subtype = "tuned"
-        else:
-            method_subtype = "tuned_ensemble"
+        method_subtype = "tuned" if n_iterations == 1 else "tuned_ensemble"
         df_results["method_subtype"] = method_subtype
 
         method_metadata = dict(
@@ -188,10 +195,7 @@ class PaperRun:
         df_results = df_results.reset_index()
         df_results["method_type"] = "portfolio"
 
-        if n_iterations == 1:
-            method_subtype = "tuned"
-        else:
-            method_subtype = "tuned_ensemble"
+        method_subtype = "tuned" if n_iterations == 1 else "tuned_ensemble"
         df_results["method_subtype"] = method_subtype
 
         method_metadata = dict(
@@ -207,7 +211,7 @@ class PaperRun:
     def run_zs(
         self,
         n_portfolios: int = 200,
-        n_ensemble: int = None,
+        n_ensemble: int | None = None,
         n_ensemble_in_name: bool = True,
         n_max_models_per_type: int | str | None = None,
         time_limit: float | None = 14400,
@@ -239,7 +243,9 @@ class PaperRun:
 
     def run_config_family(self, config_type: str) -> pd.DataFrame:
         configs = self.repo.configs(config_types=[config_type])
-        df_results_configs = self.evaluator.compare_metrics(configs=configs, baselines=[], include_metric_error_val=True).reset_index()
+        df_results_configs = self.evaluator.compare_metrics(
+            configs=configs, baselines=[], include_metric_error_val=True
+        ).reset_index()
         df_results_configs["method_type"] = "config"
         configs_types = self.repo.configs_type()
         df_results_configs["config_type"] = df_results_configs["framework"].map(configs_types)

--- a/packages/tabarena/src/tabarena/paper/paper_runner_tabarena.py
+++ b/packages/tabarena/src/tabarena/paper/paper_runner_tabarena.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import pandas as pd
 
-from .paper_runner import PaperRun
 from bencheval.tabarena import TabArena
+
+from .paper_runner import PaperRun
 
 
 class PaperRunTabArena(PaperRun):
@@ -11,8 +12,8 @@ class PaperRunTabArena(PaperRun):
     def run_portfolio_search(
         self,
         result_baselines: pd.DataFrame,
-        model_types: list[str] = None,
-        selected_types: list[str] = None,
+        model_types: list[str] | None = None,
+        selected_types: list[str] | None = None,
         n_portfolio: int = 25,
         n_ensemble: int = 40,
         time_limit: float | None = 14400,
@@ -27,11 +28,11 @@ class PaperRunTabArena(PaperRun):
 
         if selected_types is None:
             selected_types = []
-        for i in range(n_types):
+        for _i in range(n_types):
             model_types_avail = [model_type for model_type in model_types if model_type not in selected_types]
             results_dict_cur_round = {}
             for model_type in model_types_avail:
-                candidate_selected_types = selected_types + [model_type]
+                candidate_selected_types = [*selected_types, model_type]
                 print(candidate_selected_types)
                 candidate_configs = self.repo.configs(config_types=candidate_selected_types)
                 cur_result = self.run_zs(
@@ -44,7 +45,7 @@ class PaperRunTabArena(PaperRun):
                 cur_result["method"] = model_type
                 results_dict_cur_round[model_type] = cur_result
 
-            combined_data_cur_round = pd.concat([v for v in results_dict_cur_round.values()], ignore_index=True)
+            combined_data_cur_round = pd.concat(list(results_dict_cur_round.values()), ignore_index=True)
             combined_data = pd.concat([result_baselines, combined_data_cur_round], ignore_index=True)
 
             arena = TabArena(
@@ -60,7 +61,7 @@ class PaperRunTabArena(PaperRun):
                     calibration_framework=calibration_framework,
                     calibration_elo=1000,
                     BOOTSTRAP_ROUNDS=elo_bootstrap_rounds,
-                )
+                ),
             ).reset_index(drop=False)
             leaderboard_cur_round = leaderboard[leaderboard["method"].isin(results_dict_cur_round.keys())]
             print(leaderboard[["method", "elo", "improvability"]].to_markdown(index=False))
@@ -77,7 +78,7 @@ class PaperRunTabArena(PaperRun):
         configs_default = [c for c in configs if "_c1_" in c or c.endswith("_c1")]
         if len(configs_default) == 1:
             return configs_default[0]
-        elif len(configs_default) == 0:
+        if len(configs_default) == 0:
             configs_default = [c for c in configs if "_r1_" in c or c.endswith("_r1")]
             if len(configs_default) == 0:
                 if (len(configs) > 0) and use_first_if_missing:
@@ -85,39 +86,36 @@ class PaperRunTabArena(PaperRun):
                 if return_none_if_missing:
                     return None
                 raise ValueError(
-                    f"Could not find any default config for config_type='{config_type}'"
-                    f"\n\tconfigs={configs}"
-                )
-            else:
-                return configs_default[0]
-        else:  # >1
-            remaining = [c for c in configs_default if c.endswith("_c1")]
-            if len(remaining) == 1:
-                return remaining[0]
-            elif len(remaining) > 1:
-                configs_default = remaining
-            else:
-                len_suffix = [len(c.rsplit("_c1_", maxsplit=1)[-1]) for c in configs_default]
-                min_suffix = min(len_suffix)
-                configs_default = [c for i, c in enumerate(configs_default) if len_suffix[i] == min_suffix]
-            configs_default = sorted(configs_default)
-            if len(configs_default) > 1:
-                print(
-                    f"Found {len(configs_default)} potential default configs for config_type='{config_type}', but only one should exist."
-                    f"\n\tpotential defaults: {configs_default}"
-                    f"\n\tconfigs={configs}"
-                    f"\nSelecting {configs_default[0]} as default via string sort."
+                    f"Could not find any default config for config_type='{config_type}'\n\tconfigs={configs}",
                 )
             return configs_default[0]
+        # >1
+        remaining = [c for c in configs_default if c.endswith("_c1")]
+        if len(remaining) == 1:
+            return remaining[0]
+        if len(remaining) > 1:
+            configs_default = remaining
+        else:
+            len_suffix = [len(c.rsplit("_c1_", maxsplit=1)[-1]) for c in configs_default]
+            min_suffix = min(len_suffix)
+            configs_default = [c for i, c in enumerate(configs_default) if len_suffix[i] == min_suffix]
+        configs_default = sorted(configs_default)
+        if len(configs_default) > 1:
+            print(
+                f"Found {len(configs_default)} potential default configs for config_type='{config_type}', but only one should exist."
+                f"\n\tpotential defaults: {configs_default}"
+                f"\n\tconfigs={configs}"
+                f"\nSelecting {configs_default[0]} as default via string sort.",
+            )
+        return configs_default[0]
 
     def run_config(self, config: str) -> pd.DataFrame:
         configs = [config]
-        df_results_config = self.evaluator.compare_metrics(
+        return self.evaluator.compare_metrics(
             configs=configs,
             baselines=[],
             include_metric_error_val=True,
         ).reset_index()
-        return df_results_config
 
     def run_config_default(self, model_type: str) -> pd.DataFrame:
         config_default = self._config_default(config_type=model_type, use_first_if_missing=True)
@@ -130,10 +128,9 @@ class PaperRunTabArena(PaperRun):
         return df_results_config
 
     def run_minimal_single(self, model_type: str, tune: bool = True) -> pd.DataFrame:
-        """
-        Run logic that isn't impacted by other methods or other datasets
+        """Run logic that isn't impacted by other methods or other datasets.
 
-        Returns
+        Returns:
         -------
 
         """
@@ -144,12 +141,7 @@ class PaperRunTabArena(PaperRun):
         else:
             df_results_config_default = None
 
-        if tune:
-            df_results_hpo = self.run_hpo_by_family(
-                model_types=[model_type],
-            )
-        else:
-            df_results_hpo = None
+        df_results_hpo = self.run_hpo_by_family(model_types=[model_type]) if tune else None
 
         to_concat_lst = [
             df_results_config_default,
@@ -157,9 +149,7 @@ class PaperRunTabArena(PaperRun):
         ]
         to_concat_lst = [df for df in to_concat_lst if df is not None]
 
-        df_results_all = pd.concat(to_concat_lst, ignore_index=True)
-
-        return df_results_all
+        return pd.concat(to_concat_lst, ignore_index=True)
 
     @classmethod
     def compute_normalized_error_dynamic(cls, df_results: pd.DataFrame) -> pd.DataFrame:
@@ -170,8 +160,9 @@ class PaperRunTabArena(PaperRun):
 
         method_col = "framework"
 
-        df_results_per_dataset = df_results.groupby([method_col, "dataset"])["metric_error"].mean().reset_index(
-            drop=False)
+        df_results_per_dataset = (
+            df_results.groupby([method_col, "dataset"])["metric_error"].mean().reset_index(drop=False)
+        )
 
         from tabarena.utils.normalized_scorer import NormalizedScorer
 
@@ -196,18 +187,23 @@ class PaperRunTabArena(PaperRun):
             framework_col=method_col,
         )
 
-        df_results["normalized-error-task"] = [normalized_scorer_task.rank(task=(dataset, fold), error=error) for
-                                               (dataset, fold, error) in
-                                               zip(df_results["dataset"], df_results["fold"],
-                                                   df_results["metric_error"])]
+        df_results["normalized-error-task"] = [
+            normalized_scorer_task.rank(task=(dataset, fold), error=error)
+            for (dataset, fold, error) in zip(
+                df_results["dataset"], df_results["fold"], df_results["metric_error"], strict=False
+            )
+        ]
 
         df_results_per_dataset["normalized-error-dataset"] = [
-            normalized_scorer_dataset.rank(task=dataset, error=error) for (dataset, error) in
-            zip(df_results_per_dataset["dataset"], df_results_per_dataset["metric_error"])
+            normalized_scorer_dataset.rank(task=dataset, error=error)
+            for (dataset, error) in zip(
+                df_results_per_dataset["dataset"], df_results_per_dataset["metric_error"], strict=False
+            )
         ]
 
         df_results_per_dataset = df_results_per_dataset.set_index(["dataset", method_col], drop=True)[
-            "normalized-error-dataset"]
+            "normalized-error-dataset"
+        ]
         df_results = df_results.merge(df_results_per_dataset, left_on=["dataset", method_col], right_index=True)
 
         df_results_og["normalized-error-dataset"] = df_results["normalized-error-dataset"]

--- a/packages/tabarena/src/tabarena/paper/paper_utils.py
+++ b/packages/tabarena/src/tabarena/paper/paper_utils.py
@@ -9,15 +9,13 @@ def get_method_rename_map() -> dict:
 
 def get_framework_type_method_names(
     framework_types,
-    max_runtimes: list[tuple[int, str]] = None,
+    max_runtimes: list[tuple[int, str]] | None = None,
     include_default: bool = True,
     include_best: bool = True,
     include_holdout: bool = True,
     f_map_type_name: dict | None = None,
 ):
-    """
-
-    Parameters
+    """Parameters
     ----------
     framework_types
     max_runtimes: list[tuple[int, str]], default None
@@ -27,7 +25,7 @@ def get_framework_type_method_names(
     include_default
     include_best
 
-    Returns
+    Returns:
     -------
     f_map, f_map_type, f_map_inverse
 
@@ -45,7 +43,9 @@ def get_framework_type_method_names(
         for max_runtime, suffix in max_runtimes:
             if suffix is None:
                 suffix = ""
-            f_map_cur[f"tuned{suffix}"] = framework_name(framework_type, max_runtime=max_runtime, ensemble_size=1, tuned=True)
+            f_map_cur[f"tuned{suffix}"] = framework_name(
+                framework_type, max_runtime=max_runtime, ensemble_size=1, tuned=True
+            )
             f_map_cur[f"tuned_ensembled{suffix}"] = framework_name(framework_type, max_runtime=max_runtime, tuned=True)
 
         if include_default:
@@ -55,7 +55,9 @@ def get_framework_type_method_names(
         if include_holdout:
             f_map_cur["holdout"] = framework_name(framework_type, tuned=False, suffix=" (holdout)")
             f_map_cur["holdout_tuned"] = framework_name(framework_type, tuned=False, suffix=" (tuned, holdout)")
-            f_map_cur["holdout_tuned_ensembled"] = framework_name(framework_type, tuned=False, suffix=" (tuned + ensemble, holdout)")
+            f_map_cur["holdout_tuned_ensembled"] = framework_name(
+                framework_type, tuned=False, suffix=" (tuned + ensemble, holdout)"
+            )
 
         f_map_inverse_cur = {v: k for k, v in f_map_cur.items()}
         # f_map_type_cur = {v: f_map_type_name[framework_type] for k, v in f_map_cur.items()}
@@ -68,7 +70,7 @@ def get_framework_type_method_names(
 
 
 def get_f_map_suffix_plots() -> dict:
-    f_map_suffix_plots = dict(
+    return dict(
         default="-D",
         tuned="-T",
         tuned_ensembled="-TE",
@@ -77,24 +79,27 @@ def get_f_map_suffix_plots() -> dict:
         holdout_tuned="-T (H)",
         holdout_tuned_ensembled="-TE (H)",
     )
-    return f_map_suffix_plots
 
 
-def framework_name(framework_type, max_runtime=None, ensemble_size=default_ensemble_size, tuned: bool=True, all: bool = False, prefix: str = None, suffix: str = None) -> str:
+def framework_name(
+    framework_type,
+    max_runtime=None,
+    ensemble_size=default_ensemble_size,
+    tuned: bool = True,
+    all: bool = False,
+    prefix: str | None = None,
+    suffix: str | None = None,
+) -> str:
     method = framework_type if framework_type else "All"
     if prefix is None:
         prefix = ""
     if all:
         method = "All"
     if suffix is None:
-        if not tuned:
-            suffix = " (default)"
-        else:
-            suffix = " (tuned + ensemble)" if ensemble_size > 1 else " (tuned)"
+        suffix = " (default)" if not tuned else " (tuned + ensemble)" if ensemble_size > 1 else " (tuned)"
     if max_runtime:
         suffix += time_suffix(max_runtime=max_runtime)
-    method = f"{method}{prefix}{suffix}"
-    return method
+    return f"{method}{prefix}{suffix}"
 
 
 def time_suffix(max_runtime: float) -> str:
@@ -102,8 +107,6 @@ def time_suffix(max_runtime: float) -> str:
         if max_runtime >= 3600:
             str_num_hours = f"{int(max_runtime / 3600)}" if max_runtime % 3600 == 0 else f"{max_runtime / 3600:0.2f}"
             return f" ({str_num_hours}h)"
-        else:
-            str_num_mins = f"{int(max_runtime / 60)}" if max_runtime % 60 == 0 else f"{max_runtime / 60:0.2f}"
-            return f" ({str_num_mins}m)"
-    else:
-        return ""
+        str_num_mins = f"{int(max_runtime / 60)}" if max_runtime % 60 == 0 else f"{max_runtime / 60:0.2f}"
+        return f" ({str_num_mins}m)"
+    return ""

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -4,31 +4,32 @@ import copy
 import itertools
 import json
 import math
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-import re
-from typing import Mapping
 
 import matplotlib
+import matplotlib.colors as mcolors
 import matplotlib.patheffects as PathEffects
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from matplotlib import ticker
-from tueplots import bundles, fonts, fontsizes
-import matplotlib.pyplot as plt
 import seaborn as sns
-from matplotlib.patches import Patch
-import matplotlib.colors as mcolors
-
 from autogluon.common.savers import save_pd
+from matplotlib import ticker
+from matplotlib.patches import Patch
+from tueplots import bundles, fonts, fontsizes
 
-from tabarena.utils.normalized_scorer import NormalizedScorer
-from tabarena.nips2025_utils.fetch_metadata import load_task_metadata
 from bencheval.tabarena import TabArena
-from tabarena.paper.paper_utils import get_framework_type_method_names, get_method_rename_map, get_f_map_suffix_plots
+from tabarena.nips2025_utils.fetch_metadata import load_task_metadata
+from tabarena.paper.paper_utils import get_f_map_suffix_plots, get_framework_type_method_names, get_method_rename_map
 from tabarena.plot.dataset_analysis import plot_train_time_deep_dive
 from tabarena.plot.plot_ens_weights import create_heatmap
-from tabarena.plot.plot_pareto_frontier import plot_pareto as _plot_pareto, plot_pareto_aggregated
+from tabarena.plot.plot_pareto_frontier import (
+    plot_pareto as _plot_pareto,
+)
+from tabarena.utils.normalized_scorer import NormalizedScorer
 
 MethodLabelStyle = str | Mapping[str, object]
 
@@ -46,28 +47,31 @@ class TuneMethodOverride:
     Multiple overrides can coexist in the same plot; each contributes one bar
     dict and one entry to the elo err-color loop.
     """
-    tune_method: str                          # value written to df["tune_method"]; must be unique per plot
-    methods: list[str]                        # method names (in `method_col`) to retag
-    bar_label: str                            # legend label for this bar
-    bar_color: str                            # bar fill color
+
+    tune_method: str  # value written to df["tune_method"]; must be unique per plot
+    methods: list[str]  # method names (in `method_col`) to retag
+    bar_label: str  # legend label for this bar
+    bar_color: str  # bar fill color
     bar_width: float = 0.4
-    err_color: str | None = None              # whisker color; defaults to errcolors[0] (default-blue)
+    err_color: str | None = None  # whisker color; defaults to errcolors[0] (default-blue)
     err_linewidth_key: str = "tuned_ensembled"  # which entry of err_linewidths to use
     rename_map: dict[str, str] = field(default_factory=dict)  # applied to method_col before f_map_inverse
-    promote_from_baselines: bool = False      # move `methods` out of `baselines` into `framework_types`
+    promote_from_baselines: bool = False  # move `methods` out of `baselines` into `framework_types`
+
 
 matplotlib.rcParams.update(fontsizes.neurips2024())
-matplotlib.rcParams.update({
-    'text.latex.preamble': r'\usepackage{times} \usepackage{amsmath} \usepackage{amsfonts} \usepackage{amssymb} \usepackage{xcolor}'
-})
+matplotlib.rcParams.update(
+    {
+        "text.latex.preamble": r"\usepackage{times} \usepackage{amsmath} \usepackage{amsfonts} \usepackage{amssymb} \usepackage{xcolor}",
+    }
+)
 
 
 def darken_color(color_str, amount=0.5):
     # Convert color string to RGB tuple (values between 0 and 1)
     rgb = mcolors.to_rgb(color_str)
     # Interpolate with black (0, 0, 0)
-    darker_rgb = tuple((1 - amount) * c for c in rgb)
-    return darker_rgb
+    return tuple((1 - amount) * c for c in rgb)
 
 
 # FIXME: ensemble weights can get if including `config_hyperparameters` as input
@@ -77,7 +81,7 @@ class TabArenaEvaluator:
         *,
         output_dir: str | Path,
         task_metadata: pd.DataFrame | None = None,
-        config_types: dict[str, str] = None,
+        config_types: dict[str, str] | None = None,
         method_col: str = "method",
         error_col: str = "metric_error",
         methods: list[str] | None = None,
@@ -94,11 +98,10 @@ class TabArenaEvaluator:
         use_latex: bool = False,
         tabarena_context=None,  # FIXME: Remove this and refactor after leaderboard v0.2 upload, this is purely to get things working fast
     ):
-        """
-
-        Parameters
+        """Parameters
         ----------
-        methods
+
+        Methods:
             filter methods
         folds
             filter folds
@@ -140,9 +143,9 @@ class TabArenaEvaluator:
             matplotlib.rcParams.update(bundles.neurips2024())
             matplotlib.rcParams.update(fonts.neurips2024_tex())
             self.rc_context_params = {
-                                         'font.family': 'serif',
-                                         "text.usetex": True,
-                                     } | fontsizes.neurips2024(default_smaller=0)
+                "font.family": "serif",
+                "text.usetex": True,
+            } | fontsizes.neurips2024(default_smaller=0)
         else:
             self.rc_context_params = {}
 
@@ -170,10 +173,12 @@ class TabArenaEvaluator:
 
         if tabarena_context is not None:
             self.method_metadata_info = tabarena_context.method_metadata_collection.info()
-            self.method_metadata_info = self.method_metadata_info.rename(columns={
-                "method": "ta_name",
-                "artifact_name": "ta_suite",
-            })
+            self.method_metadata_info = self.method_metadata_info.rename(
+                columns={
+                    "method": "ta_name",
+                    "artifact_name": "ta_suite",
+                }
+            )
             self.method_metadata_info = self.method_metadata_info.drop(columns=["method_type"])
         else:
             self.method_metadata_info = None
@@ -186,8 +191,9 @@ class TabArenaEvaluator:
 
         method_col = self.method_col
 
-        df_results_per_dataset = df_results.groupby([method_col, "dataset"])[self.error_col].mean().reset_index(
-            drop=False)
+        df_results_per_dataset = (
+            df_results.groupby([method_col, "dataset"])[self.error_col].mean().reset_index(drop=False)
+        )
 
         # Alternative, this also incorporates Portfolios and HPO into the normalized scoring. This makes normalized-error dependent on what simulations we run.
         # This is unbiased against very strong simulation results because the best method defines what is `0.0` on a dataset.
@@ -211,18 +217,23 @@ class TabArenaEvaluator:
             framework_col=method_col,
         )
 
-        df_results["normalized-error-task"] = [normalized_scorer_task.rank(task=(dataset, fold), error=error) for
-                                               (dataset, fold, error) in
-                                               zip(df_results["dataset"], df_results["fold"],
-                                                   df_results[self.error_col])]
+        df_results["normalized-error-task"] = [
+            normalized_scorer_task.rank(task=(dataset, fold), error=error)
+            for (dataset, fold, error) in zip(
+                df_results["dataset"], df_results["fold"], df_results[self.error_col], strict=False
+            )
+        ]
 
         df_results_per_dataset["normalized-error-dataset"] = [
-            normalized_scorer_dataset.rank(task=dataset, error=error) for (dataset, error) in
-            zip(df_results_per_dataset["dataset"], df_results_per_dataset[self.error_col])
+            normalized_scorer_dataset.rank(task=dataset, error=error)
+            for (dataset, error) in zip(
+                df_results_per_dataset["dataset"], df_results_per_dataset[self.error_col], strict=False
+            )
         ]
 
         df_results_per_dataset = df_results_per_dataset.set_index(["dataset", method_col], drop=True)[
-            "normalized-error-dataset"]
+            "normalized-error-dataset"
+        ]
         df_results = df_results.merge(df_results_per_dataset, left_on=["dataset", method_col], right_index=True)
 
         df_results_og["normalized-error-dataset"] = df_results["normalized-error-dataset"]
@@ -231,11 +242,13 @@ class TabArenaEvaluator:
 
     @classmethod
     def _get_config_types(cls, df_results: pd.DataFrame) -> list[str]:
-        config_types = sorted([
-            config_type for config_type in df_results["config_type"].unique()
-            if config_type is not None and isinstance(config_type, str)
-        ])
-        return config_types
+        return sorted(
+            [
+                config_type
+                for config_type in df_results["config_type"].unique()
+                if config_type is not None and isinstance(config_type, str)
+            ]
+        )
 
     # TODO: Remove the need for this, have the original results have the correct name to begin with
     @classmethod
@@ -255,8 +268,7 @@ class TabArenaEvaluator:
         require_paired_splits: bool = True,
         zscore_ddof: int = 1,  # 1 = sample std (recommended), 0 = population std
     ) -> pd.DataFrame:
-        """
-        Compare two methods on metric_error (lower is better; 0 is perfect), per dataset.
+        """Compare two methods on metric_error (lower is better; 0 is perfect), per dataset.
 
         Adds a per-dataset z-score of the paired mean difference across splits:
             z = mean(diff) / (std(diff) / sqrt(n))
@@ -271,20 +283,15 @@ class TabArenaEvaluator:
         if missing:
             raise ValueError(f"df missing columns: {sorted(missing)}")
 
-        sub = df[df[method_col].isin([method_a, method_b])][
-            [dataset_col, split_col, method_col, error_col]
-        ].copy()
+        sub = df[df[method_col].isin([method_a, method_b])][[dataset_col, split_col, method_col, error_col]].copy()
 
         # Align A/B on the same (dataset, split)
-        wide = (
-            sub.pivot_table(
-                index=[dataset_col, split_col],
-                columns=method_col,
-                values=error_col,
-                aggfunc="mean",  # handle duplicates
-            )
-            .rename(columns={method_a: "A", method_b: "B"})
-        )
+        wide = sub.pivot_table(
+            index=[dataset_col, split_col],
+            columns=method_col,
+            values=error_col,
+            aggfunc="mean",  # handle duplicates
+        ).rename(columns={method_a: "A", method_b: "B"})
 
         if require_paired_splits:
             wide = wide.dropna(subset=["A", "B"])
@@ -311,7 +318,7 @@ class TabArenaEvaluator:
             diffs = paired["diff_A_minus_B"]
 
             out = {
-                "n_splits": int(len(paired)),
+                "n_splits": len(paired),
                 "mean_error_A": paired["A"].mean(),
                 "mean_error_B": paired["B"].mean(),
                 "median_error_A": paired["A"].median(),
@@ -333,7 +340,8 @@ class TabArenaEvaluator:
         stats = wide.groupby(level=0, sort=True).apply(_agg)
 
         stats["winner_by_mean"] = np.where(
-            stats["mean_error_A"] < stats["mean_error_B"], method_a,
+            stats["mean_error_A"] < stats["mean_error_B"],
+            method_a,
             np.where(stats["mean_error_A"] > stats["mean_error_B"], method_b, "tie"),
         )
 
@@ -350,8 +358,7 @@ class TabArenaEvaluator:
         min_splits: int = 2,
         tie_decimals: int | None = None,
     ) -> dict[str, float]:
-        """
-        Compute average split agreement across all method pairs within ONE dataset.
+        """Compute average split agreement across all method pairs within ONE dataset.
 
         Agreement for pair (i,j):
           p_ij = fraction of splits where error_i < error_j
@@ -369,7 +376,10 @@ class TabArenaEvaluator:
         """
         # Pivot to a dense matrix: rows=splits, cols=methods, values=error
         wide = df_dataset.pivot_table(
-            index=split_col, columns=method_col, values=error_col, aggfunc="mean"
+            index=split_col,
+            columns=method_col,
+            values=error_col,
+            aggfunc="mean",
         )
         # Keep only methods that appear on >=1 split (already true) and splits with >=2 methods
         if wide.shape[0] < min_splits or wide.shape[1] < 2:
@@ -392,8 +402,8 @@ class TabArenaEvaluator:
         # Broadcast comparisons: for each split s, compare all method pairs (i,j)
         # win[s,i,j] = 1 if X[s,i] < X[s,j]
         # tie[s,i,j] = 1 if X[s,i] == X[s,j]
-        win = (X_cmp[:, :, None] < X_cmp[:, None, :])
-        tie = (X_cmp[:, :, None] == X_cmp[:, None, :])
+        win = X_cmp[:, :, None] < X_cmp[:, None, :]
+        tie = X_cmp[:, :, None] == X_cmp[:, None, :]
 
         # Handle missing values: comparisons where either side is NaN should not count
         valid = np.isfinite(X)
@@ -419,8 +429,11 @@ class TabArenaEvaluator:
 
             avg = float(np.nanmean(agree_pairs))
             # weighted by how many non-tie split comparisons each pair had
-            wavg = float(np.nansum(agree_pairs * denom_pairs) / np.nansum(denom_pairs)) if np.nansum(
-                denom_pairs) > 0 else np.nan
+            wavg = (
+                float(np.nansum(agree_pairs * denom_pairs) / np.nansum(denom_pairs))
+                if np.nansum(denom_pairs) > 0
+                else np.nan
+            )
 
         elif tie_policy == "half":
             # treat ties as half-win for both sides
@@ -432,8 +445,11 @@ class TabArenaEvaluator:
             denom_pairs = denom[iu]
 
             avg = float(np.nanmean(agree_pairs))
-            wavg = float(np.nansum(agree_pairs * denom_pairs) / np.nansum(denom_pairs)) if np.nansum(
-                denom_pairs) > 0 else np.nan
+            wavg = (
+                float(np.nansum(agree_pairs * denom_pairs) / np.nansum(denom_pairs))
+                if np.nansum(denom_pairs) > 0
+                else np.nan
+            )
 
         elif tie_policy == "count_as_disagree":
             # ties count in denom but not in wins => they push p toward 0 and agreement downward
@@ -445,8 +461,11 @@ class TabArenaEvaluator:
             denom_pairs = denom[iu]
 
             avg = float(np.nanmean(agree_pairs))
-            wavg = float(np.nansum(agree_pairs * denom_pairs) / np.nansum(denom_pairs)) if np.nansum(
-                denom_pairs) > 0 else np.nan
+            wavg = (
+                float(np.nansum(agree_pairs * denom_pairs) / np.nansum(denom_pairs))
+                if np.nansum(denom_pairs) > 0
+                else np.nan
+            )
 
         else:
             raise ValueError("tie_policy must be one of: {'ignore','half','count_as_disagree'}")
@@ -487,22 +506,14 @@ class TabArenaEvaluator:
 
     def plot_imp(self, results_per_task: pd.DataFrame):
         # 1. Find the index of the lowest-rank row per dataset
-        best_idx = (
-            results_per_task
-            .groupby("dataset", sort=False)["rank"]
-            .idxmin()
-        )
+        best_idx = results_per_task.groupby("dataset", sort=False)["rank"].idxmin()
 
         # 2. Extract method name and metric_error for those rows
-        best_per_dataset = (
-            results_per_task
-            .loc[best_idx, ["dataset", "method", "metric_error"]]
-            .rename(
-                columns={
-                    "method": "best_method",
-                    "metric_error": "best_metric_error",
-                }
-            )
+        best_per_dataset = results_per_task.loc[best_idx, ["dataset", "method", "metric_error"]].rename(
+            columns={
+                "method": "best_method",
+                "metric_error": "best_metric_error",
+            },
         )
 
         # 3. Join back to the original DataFrame
@@ -515,17 +526,10 @@ class TabArenaEvaluator:
         import matplotlib.pyplot as plt
 
         # --- dataset order (same as you already do) ---
-        order = (
-            results_per_task
-            .groupby("dataset")["improvability"]
-            .median()
-            .sort_values()
-            .index
-        )
+        order = results_per_task.groupby("dataset")["improvability"].median().sort_values().index
 
         results_per_task = (
-            results_per_task
-            .assign(dataset=pd.Categorical(results_per_task["dataset"], categories=order, ordered=True))
+            results_per_task.assign(dataset=pd.Categorical(results_per_task["dataset"], categories=order, ordered=True))
             .sort_values("dataset")
             .reset_index(drop=True)
         )
@@ -565,7 +569,7 @@ class TabArenaEvaluator:
 
             # overlay in red (skip NaNs automatically by masking)
             mask = pd.notna(y)
-            ax.scatter([xi for xi, ok in zip(x, mask) if ok], y[mask], color="red", s=30, zorder=3)
+            ax.scatter([xi for xi, ok in zip(x, mask, strict=False) if ok], y[mask], color="red", s=30, zorder=3)
 
             ax.set_title(f"Improvability per Dataset — highlight: {method}")
             fig.suptitle("")  # remove pandas default subtitle
@@ -637,7 +641,7 @@ class TabArenaEvaluator:
         df_results = df_results.copy(deep=True)
         if "method_metadata" in df_results.columns:
             # currently no need to use this column
-            df_results.drop(columns=["method_metadata"], inplace=True)
+            df_results = df_results.drop(columns=["method_metadata"])
         if "imputed" not in df_results.columns:
             df_results["imputed"] = False
         df_results["imputed"] = df_results["imputed"].astype(int).fillna(0).astype(bool)
@@ -668,34 +672,50 @@ class TabArenaEvaluator:
 
         df_results_rank_compare = copy.deepcopy(df_results)
 
-        f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
+        _f_map, f_map_type, _f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
             framework_types=framework_types,
         )
 
-        df_results_rank_compare = df_results_rank_compare[(~df_results_rank_compare[self.method_col].map(f_map_type).isna()) | (df_results_rank_compare[self.method_col].isin(baselines))]
+        df_results_rank_compare = df_results_rank_compare[
+            (~df_results_rank_compare[self.method_col].map(f_map_type).isna())
+            | (df_results_rank_compare[self.method_col].isin(baselines))
+        ]
 
         # ----- end removing unused methods -----
 
         method_info: pd.DataFrame = self.get_method_info(df=df_results_rank_compare)
         if self.method_metadata_info is not None:
-            method_info_full = pd.merge(left=method_info.reset_index(), right=self.method_metadata_info, on=["ta_name", "ta_suite"])
+            method_info_full = pd.merge(
+                left=method_info.reset_index(), right=self.method_metadata_info, on=["ta_name", "ta_suite"]
+            )
             save_pd.save(path=self.output_dir / "method_info.csv", df=method_info_full)
         save_pd.save(path=self.output_dir / "results_per_split.csv", df=df_results_rank_compare)
 
         # ----- add times per 1K samples -----
         # FIXME: Hack to work in cases where this is not available
-        if "n_samples_train_per_fold" not in self.task_metadata.columns or "n_samples_test_per_fold" not in self.task_metadata.columns:
-            print(f"WARNING: Missing n_samples_train_per_fold and/or n_samples_test_per_fold in task_metadata. Using dummy values...")
+        if (
+            "n_samples_train_per_fold" not in self.task_metadata.columns
+            or "n_samples_test_per_fold" not in self.task_metadata.columns
+        ):
+            print(
+                "WARNING: Missing n_samples_train_per_fold and/or n_samples_test_per_fold in task_metadata. Using dummy values..."
+            )
             dataset_to_n_samples_train = self.task_metadata.set_index("name")["NumberOfInstances"].to_dict()
             dataset_to_n_samples_test = self.task_metadata.set_index("name")["NumberOfInstances"].to_dict()
         else:
             dataset_to_n_samples_train = self.task_metadata.set_index("name")["n_samples_train_per_fold"].to_dict()
             dataset_to_n_samples_test = self.task_metadata.set_index("name")["n_samples_test_per_fold"].to_dict()
 
-        df_results_rank_compare['time_train_s_per_1K'] = df_results_rank_compare['time_train_s'] * 1000 / df_results_rank_compare["dataset"].map(
-            dataset_to_n_samples_train)
-        df_results_rank_compare['time_infer_s_per_1K'] = df_results_rank_compare['time_infer_s'] * 1000 / df_results_rank_compare["dataset"].map(
-            dataset_to_n_samples_test)
+        df_results_rank_compare["time_train_s_per_1K"] = (
+            df_results_rank_compare["time_train_s"]
+            * 1000
+            / df_results_rank_compare["dataset"].map(dataset_to_n_samples_train)
+        )
+        df_results_rank_compare["time_infer_s_per_1K"] = (
+            df_results_rank_compare["time_infer_s"]
+            * 1000
+            / df_results_rank_compare["dataset"].map(dataset_to_n_samples_test)
+        )
 
         if plot_times:
             self.plot_tabarena_times(df=df_results_rank_compare, output_dir=self.output_dir, show=False)
@@ -703,7 +723,9 @@ class TabArenaEvaluator:
         # TODO: Move this into the `.leaderboard` call
         if "normalized-error-dataset" not in df_results_rank_compare.columns:
             df_results_rank_compare = self.compute_normalized_error_dynamic(df_results=df_results_rank_compare)
-        assert "normalized-error-dataset" in df_results_rank_compare.columns, f"Run `self.compute_normalized_error_dynamic(df_results)` first to get normalized-error."
+        assert "normalized-error-dataset" in df_results_rank_compare.columns, (
+            "Run `self.compute_normalized_error_dynamic(df_results)` first to get normalized-error."
+        )
         df_results_rank_compare["normalized-error"] = df_results_rank_compare["normalized-error-dataset"]
 
         if include_norm_score:
@@ -762,7 +784,9 @@ class TabArenaEvaluator:
         )
 
         if tmp_treat_tasks_independently:
-            df_results_rank_compare["dataset"] = df_results_rank_compare["dataset"] + "_" + df_results_rank_compare["fold"].astype(str)
+            df_results_rank_compare["dataset"] = (
+                df_results_rank_compare["dataset"] + "_" + df_results_rank_compare["fold"].astype(str)
+            )
             df_results_rank_compare["fold"] = 0
 
         tabarena = TabArena(
@@ -798,7 +822,7 @@ class TabArenaEvaluator:
             **leaderboard_kwargs,
         )
         leaderboard = leaderboard.join(method_info, on="method")
-        elo_map = leaderboard["elo"]
+        leaderboard["elo"]
         leaderboard = leaderboard.reset_index(drop=False)
         save_pd.save(path=f"{self.output_dir}/tabarena_leaderboard.csv", df=leaderboard)
 
@@ -813,7 +837,8 @@ class TabArenaEvaluator:
 
         if verbose:
             print(
-                f"Evaluating with {len(df_results_rank_compare[tabarena.task_col].unique())} datasets... ({n_tasks} tasks)| problem_types={self.problem_types}, folds={self.folds}")
+                f"Evaluating with {len(df_results_rank_compare[tabarena.task_col].unique())} datasets... ({n_tasks} tasks)| problem_types={self.problem_types}, folds={self.folds}"
+            )
             with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
                 print(leaderboard)
 
@@ -856,7 +881,6 @@ class TabArenaEvaluator:
         results_per_task = results_per_task.join(method_info, on="method")
         results_per_split = results_per_split.join(method_info, on="method")
 
-
         if compute_fold_stability_curves:
             fold_stability_curves = tabarena.jitter_bootstrap_curve_all_datasets(
                 results_per_split,
@@ -882,24 +906,37 @@ class TabArenaEvaluator:
 
         # FIXME: Is critical diagram incorrect?
         if plot_cdd:
+
             def rename_model(name: str):
                 parts = name.split(" ")
                 if parts[0] in f_map_type_name:
                     parts[0] = f_map_type_name[parts[0]]
                 name = " ".join(parts)
-                return name.replace('(tuned + ensemble)', '(T+E)')
+                return name.replace("(tuned + ensemble)", "(T+E)")
 
             # use tuned+ensembled version if available, and default otherwise
             tune_methods = results_per_task[self.method_col].map(method_info["method_subtype"])
-            method_types = results_per_task[self.method_col].map(method_info["config_type"]).fillna(results_per_task[self.method_col])
+            method_types = (
+                results_per_task[self.method_col]
+                .map(method_info["config_type"])
+                .fillna(results_per_task[self.method_col])
+            )
 
-            tuned_ens_types = method_types[tune_methods == 'tuned_ensemble']
-            per_task_filter = (tune_methods == 'tuned_ensemble') | ((tune_methods == 'default') & ~method_types.isin(tuned_ens_types))
+            tuned_ens_types = method_types[tune_methods == "tuned_ensemble"]
+            per_task_filter = (tune_methods == "tuned_ensemble") | (
+                (tune_methods == "default") & ~method_types.isin(tuned_ens_types)
+            )
 
             tune_methods_split = results_per_split[self.method_col].map(method_info["method_subtype"])
-            method_types_split = results_per_split[self.method_col].map(method_info["config_type"]).fillna(results_per_split[self.method_col])
-            tuned_ens_types_split = method_types_split[tune_methods_split == 'tuned_ensemble']
-            per_split_filter = (tune_methods_split == 'tuned_ensemble') | ((tune_methods_split == 'default') & ~method_types_split.isin(tuned_ens_types_split))
+            method_types_split = (
+                results_per_split[self.method_col]
+                .map(method_info["config_type"])
+                .fillna(results_per_split[self.method_col])
+            )
+            tuned_ens_types_split = method_types_split[tune_methods_split == "tuned_ensemble"]
+            per_split_filter = (tune_methods_split == "tuned_ensemble") | (
+                (tune_methods_split == "default") & ~method_types_split.isin(tuned_ens_types_split)
+            )
 
             if plot_with_baselines:
                 per_task_filter = per_task_filter | results_per_task[self.method_col].isin(baselines)
@@ -933,7 +970,7 @@ class TabArenaEvaluator:
             hidden_methods_winrate = plot_tuning_kwargs.get("hidden_methods") or []
             if hidden_methods_winrate:
                 hidden_mask = _results_to_use_winrate_matrix[self.method_col].isin(
-                    hidden_methods_winrate
+                    hidden_methods_winrate,
                 )
                 if "config_type" in _results_to_use_winrate_matrix.columns:
                     mapped_names = (
@@ -942,9 +979,7 @@ class TabArenaEvaluator:
                         .fillna(_results_to_use_winrate_matrix["config_type"])
                     )
                     hidden_mask = hidden_mask | mapped_names.isin(hidden_methods_winrate)
-                _results_to_use_winrate_matrix = _results_to_use_winrate_matrix.loc[
-                    ~hidden_mask
-                ]
+                _results_to_use_winrate_matrix = _results_to_use_winrate_matrix.loc[~hidden_mask]
 
             if len(_results_to_use_winrate_matrix) != 0:
                 winrate_matrix = tabarena.compute_winrate_matrix(results_per_task=_results_to_use_winrate_matrix)
@@ -977,7 +1012,7 @@ class TabArenaEvaluator:
                 except (RuntimeError, ValueError) as e:
                     print(
                         f"Warning: Error encountered during winrate matrix plotting. {e}"
-                        "This likely means the CLI does not have access to the correct Chromium version..."
+                        "This likely means the CLI does not have access to the correct Chromium version...",
                     )
 
             if len(results_te_per_task) != 0:
@@ -987,10 +1022,10 @@ class TabArenaEvaluator:
                         save_path=f"{self.output_dir}/figures/critical-diagram.{self.figure_file_type}",
                         show=False,
                     )
-                except ValueError as e:
+                except ValueError:
                     print(
-                        f"Warning: ValueError encountered during critical diagram plotting. "
-                        f"This likely means there is too little data to compute critical diagrams. Skipping ..."
+                        "Warning: ValueError encountered during critical diagram plotting. "
+                        "This likely means there is too little data to compute critical diagrams. Skipping ...",
                     )
 
         if plot_runtimes:
@@ -1008,10 +1043,12 @@ class TabArenaEvaluator:
 
     def assert_no_duplicates(self, df_results: pd.DataFrame):
         # don't allow duplicate results
-        dupes = df_results[df_results.duplicated(
-            subset=["dataset", "fold", self.method_col],
-            keep=False,
-        )]
+        dupes = df_results[
+            df_results.duplicated(
+                subset=["dataset", "fold", self.method_col],
+                keep=False,
+            )
+        ]
         if not dupes.empty:
             dupes = dupes.sort_values(by=[self.method_col, "dataset", "fold"])
             duplicated_methods = dupes["method"].value_counts()
@@ -1021,7 +1058,7 @@ class TabArenaEvaluator:
                 f"The following {len(duplicated_methods)} methods were duplicated (w/ counts):\n"
                 f"{duplicated_methods.to_string()}\n"
                 f"The following {len(dupes)} rows are duplicates:\n"
-                f"{dupes.to_string(index=False)}"
+                f"{dupes.to_string(index=False)}",
             )
 
     def assert_no_nan_methods(self, df_results: pd.DataFrame):
@@ -1030,7 +1067,7 @@ class TabArenaEvaluator:
             missing_percent = missing_count / len(df_results)
             raise AssertionError(
                 f"Found NaN values in '{self.method_col}' column: "
-                f"{missing_count}/{len(df_results)} ({missing_percent * 100:.1f}%) were NaN."
+                f"{missing_count}/{len(df_results)} ({missing_percent * 100:.1f}%) were NaN.",
             )
 
     def filter_results(self, df_results: pd.DataFrame):
@@ -1049,22 +1086,20 @@ class TabArenaEvaluator:
         return df_results
 
     def get_method_info(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Verify that each method has exactly one unique value for method_type,
+        """Verify that each method has exactly one unique value for method_type,
         method_subtype, config_type, ta_name, and ta_suite. Return a mapping dataframe.
 
-        Raises
+        Raises:
         ------
         ValueError
             If any method has non-unique values in any of the checked columns.
 
-        Returns
+        Returns:
         -------
         pd.DataFrame
             A dataframe indexed by "method" with
             the unique values for each of method_type, method_subtype, config_type, ta_name, ta_suite.
         """
-
         group_cols = self.method_col
         value_cols = ["method_type", "method_subtype", "config_type", "ta_name", "ta_suite"]
 
@@ -1085,9 +1120,7 @@ class TabArenaEvaluator:
             raise ValueError(msg)
 
         # Safe: each value is unique → extract the scalar values
-        mapping = grouped.first()  # identical to .agg("first") but faster
-
-        return mapping
+        return grouped.first()  # identical to .agg("first") but faster
 
     def plot_pareto(
         self,
@@ -1096,32 +1129,38 @@ class TabArenaEvaluator:
         with_baselines: bool = True,
         plot_tuning_kwargs: dict | None = None,
     ):
-        f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
+        _f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
             framework_types=framework_types,
         )
         leaderboard_pareto = leaderboard.copy()
-        leaderboard_pareto["Method"] = leaderboard_pareto[self.method_col].map(f_map_type).fillna(
-            leaderboard_pareto[self.method_col])
+        leaderboard_pareto["Method"] = (
+            leaderboard_pareto[self.method_col].map(f_map_type).fillna(leaderboard_pareto[self.method_col])
+        )
 
         if self.banned_pareto_methods:
             leaderboard_pareto = leaderboard_pareto[~leaderboard_pareto["Method"].isin(self.banned_pareto_methods)]
 
         leaderboard_pareto["Type"] = leaderboard_pareto[self.method_col].map(f_map_inverse).fillna("baseline")
-        leaderboard_pareto["Method"] = leaderboard_pareto["Method"].map(f_map_type_name).fillna(
-            leaderboard_pareto["Method"])
+        leaderboard_pareto["Method"] = (
+            leaderboard_pareto["Method"].map(f_map_type_name).fillna(leaderboard_pareto["Method"])
+        )
         f_map_suffix = get_f_map_suffix_plots()
         leaderboard_pareto["suffix"] = leaderboard_pareto["Type"].map(f_map_suffix).fillna("")
         method_order = None
         plot_pareto_kwargs = {}
         if plot_tuning_kwargs is not None:
             if "hidden_methods" in plot_tuning_kwargs:
-                leaderboard_pareto = leaderboard_pareto[~leaderboard_pareto["Method"].isin(plot_tuning_kwargs["hidden_methods"])]
+                leaderboard_pareto = leaderboard_pareto[
+                    ~leaderboard_pareto["Method"].isin(plot_tuning_kwargs["hidden_methods"])
+                ]
             if "pareto_order" in plot_tuning_kwargs:
                 method_order = plot_tuning_kwargs["pareto_order"]
             if "method_style_map" in plot_tuning_kwargs:
                 method_style_map = plot_tuning_kwargs["method_style_map"]
                 display_name_map = {m: v["display_name"] for m, v in method_style_map.items() if "display_name" in v}
-                leaderboard_pareto["Method"] = leaderboard_pareto["Method"].map(display_name_map).fillna(leaderboard_pareto["Method"])
+                leaderboard_pareto["Method"] = (
+                    leaderboard_pareto["Method"].map(display_name_map).fillna(leaderboard_pareto["Method"])
+                )
                 if method_order is not None:
                     method_order = [display_name_map.get(m, m) for m in method_order]
             if "title" in plot_tuning_kwargs:
@@ -1138,17 +1177,29 @@ class TabArenaEvaluator:
             "holdout_tuned": "Tuned, Holdout",
             "holdout_tuned_ensembled": "Tuned + Ens., Holdout",
         }
-        leaderboard_pareto["Type"] = leaderboard_pareto["Type"].map(fig_rename_dict).fillna(
+        leaderboard_pareto["Type"] = (
             leaderboard_pareto["Type"]
+            .map(fig_rename_dict)
+            .fillna(
+                leaderboard_pareto["Type"],
+            )
         )
 
         if not with_baselines:
             leaderboard_pareto = leaderboard_pareto[leaderboard_pareto["Type"] != "Baseline"]
 
-        self.plot_pareto_elo_vs_time_infer(leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs)
-        self.plot_pareto_elo_vs_time_train(leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs)
-        self.plot_pareto_improvability_vs_time_infer(leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs)
-        self.plot_pareto_improvability_vs_time_train(leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs)
+        self.plot_pareto_elo_vs_time_infer(
+            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
+        )
+        self.plot_pareto_elo_vs_time_train(
+            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
+        )
+        self.plot_pareto_improvability_vs_time_infer(
+            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
+        )
+        self.plot_pareto_improvability_vs_time_train(
+            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
+        )
 
     def plot_pareto_elo_vs_time_train(
         self,
@@ -1197,7 +1248,7 @@ class TabArenaEvaluator:
         y_name = "Elo"
         x_name = "Inference time per 1K samples (s) (median)"
         if title == "auto":
-            title = f"Elo vs Inference Time"
+            title = "Elo vs Inference Time"
 
         data = leaderboard.copy()
         data[x_name] = data["median_time_infer_s_per_1K"]
@@ -1317,15 +1368,18 @@ class TabArenaEvaluator:
         return imputed_names
 
     def plot_portfolio_ensemble_weights_barplot(self, df_ensemble_weights: pd.DataFrame):
-        import seaborn as sns
-        import matplotlib.pyplot as plt
         from pathlib import Path
-        import matplotlib.colors as mcolors
-        import numpy as np
 
-        fig, ax = plt.subplots(1, 1,
-                               figsize=(3.5, 3)
-                               )
+        import matplotlib.colors as mcolors
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import seaborn as sns
+
+        _fig, ax = plt.subplots(
+            1,
+            1,
+            figsize=(3.5, 3),
+        )
 
         df_ensemble_weights = df_ensemble_weights.copy(deep=True)
         _method_rename_map = self.get_method_rename_map()
@@ -1366,7 +1420,7 @@ class TabArenaEvaluator:
         )
 
         # Apply alpha to bar colors
-        for patch, alpha in zip(barplot.patches, alphas):
+        for patch, alpha in zip(barplot.patches, alphas, strict=False):
             r, g, b = patch.get_facecolor()[:3]
             patch.set_facecolor((r, g, b, alpha))
 
@@ -1397,7 +1451,7 @@ class TabArenaEvaluator:
         hidden_methods: list[str] | None = None,
     ):
         df = df.copy(deep=True)
-        f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
+        _f_map, _f_map_type, _f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
             framework_types=framework_types,
         )
 
@@ -1416,10 +1470,9 @@ class TabArenaEvaluator:
             if parts[0] in f_map_type_name:
                 parts[0] = f_map_type_name[parts[0]]
             name = " ".join(parts)
-            name = name.replace('(default)', '(D)')
-            name = name.replace('(tuned)', '(T)')
-            name = name.replace('(tuned + ensemble)', '(T+E)')
-            return name
+            name = name.replace("(default)", "(D)")
+            name = name.replace("(tuned)", "(T)")
+            return name.replace("(tuned + ensemble)", "(T+E)")
 
         df = df.sort_values(by="elo", ascending=False)
 
@@ -1427,22 +1480,23 @@ class TabArenaEvaluator:
 
         df_new[r"Model"] = df[self.method_col].map(rename_model)
         # do the more annoying way {}_{...} so that \textbf{} affects the main number
-        df_new[r"Elo ($\uparrow$)"] = [f'{round(elo)}' + r'${}_{' + f'-{math.ceil(elom)},+{math.ceil(elop)}' + r'}$'
-                                       for elo, elom, elop in zip(df["elo"], df["elo-"], df["elo+"])]
-        df_new[r"\#wins ($\uparrow$)"] = [f'{cnt:.1f}' for cnt in df["rank=1_count"]]
-        df_new[f"Improva-\n" + r"bility ($\downarrow$)"] = [f'{100*val:.1f}\\%' for val in df["improvability"]]
-        df_new[r"Train time" + "\n" + r"per 1K [s]"] = [f'{t:.2f}' for t in df["median_time_train_s_per_1K"]]
-        df_new[r"Predict time" + "\n" + r"per 1K [s]"] = [f'{t:.2f}' for t in df["median_time_infer_s_per_1K"]]
+        df_new[r"Elo ($\uparrow$)"] = [
+            f"{round(elo)}" + r"${}_{" + f"-{math.ceil(elom)},+{math.ceil(elop)}" + r"}$"
+            for elo, elom, elop in zip(df["elo"], df["elo-"], df["elo+"], strict=False)
+        ]
+        df_new[r"\#wins ($\uparrow$)"] = [f"{cnt:.1f}" for cnt in df["rank=1_count"]]
+        df_new["Improva-\n" + r"bility ($\downarrow$)"] = [f"{100 * val:.1f}\\%" for val in df["improvability"]]
+        df_new[r"Train time" + "\n" + r"per 1K [s]"] = [f"{t:.2f}" for t in df["median_time_train_s_per_1K"]]
+        df_new[r"Predict time" + "\n" + r"per 1K [s]"] = [f"{t:.2f}" for t in df["median_time_infer_s_per_1K"]]
 
         # ----- highlight best and second-best numbers per column -----
 
         # first, convert the strings back to floats
         def extract_first_float(s):
-            """
-            Extracts the first sequence of digits (including decimal point) from the input string
+            """Extracts the first sequence of digits (including decimal point) from the input string
             and returns it as a float. Returns None if no valid number is found.
             """
-            match = re.search(r'\d+(\.\d+)?', s)
+            match = re.search(r"\d+(\.\d+)?", s)
             if match:
                 return float(match.group())
             return None
@@ -1466,14 +1520,14 @@ class TabArenaEvaluator:
             return min_indices, second_min_indices
 
         # then, add textbf or underline to the correct rows
-        for col_idx, col in enumerate(df_new.columns):
-            if r'\uparrow' in col or r'\downarrow' in col:
+        for _col_idx, col in enumerate(df_new.columns):
+            if r"\uparrow" in col or r"\downarrow" in col:
                 # factor = 1 if r'\downarrow' in col else -1
                 # numbers = [factor * extract_first_float(s) for s in df_new[col]]
-                ranks = df_new[col].map(extract_first_float).rank(method="min", ascending=r'\downarrow' in col)
-                for rank, color in [(1, 'gold'), (2, 'silver'), (3, 'bronze')]:
+                ranks = df_new[col].map(extract_first_float).rank(method="min", ascending=r"\downarrow" in col)
+                for rank, color in [(1, "gold"), (2, "silver"), (3, "bronze")]:
                     df_new.loc[ranks == rank, col] = df_new.loc[ranks == rank, col].apply(
-                        lambda x: f"\\textcolor{{{color}}}{{\\textbf{{{x}}}}}"
+                        lambda x: f"\\textcolor{{{color}}}{{\\textbf{{{x}}}}}",  # noqa: B023
                     )
 
                 # min_indices, second_min_indices = find_smallest_and_second_smallest_indices(numbers)
@@ -1482,30 +1536,31 @@ class TabArenaEvaluator:
                 # for idx in second_min_indices:
                 #     df_new.iloc[idx, col_idx] = r'\underline{' + df_new.iloc[idx, col_idx] + r'}'
 
-
         # ----- create latex table -----
 
         rows = []
-        rows.append(r'\begin{tabular}{' + 'llccrr' + r'}')
-        rows.append(r'\toprule')
+        rows.append(r"\begin{tabular}{" + "llccrr" + r"}")
+        rows.append(r"\toprule")
         # rows.append(' & '.join(df_new.columns) + r' \\')
 
-        col_names_split = [col.split('\n') for col in df_new.columns]
+        col_names_split = [col.split("\n") for col in df_new.columns]
         n_rows_header = max([len(rows) for rows in col_names_split])
         for row_idx in range(n_rows_header):
-            rows.append(' & '.join([r'\textbf{' + lst[row_idx] + r'}' if row_idx < len(lst) else ''
-                                    for lst in col_names_split]) + r' \\')
-        rows.append(r'\midrule')
+            rows.append(
+                " & ".join([r"\textbf{" + lst[row_idx] + r"}" if row_idx < len(lst) else "" for lst in col_names_split])
+                + r" \\"
+            )
+        rows.append(r"\midrule")
 
-        for row_index, row in df_new.iterrows():
-            rows.append(' & '.join([row[col_name] for col_name in df_new.columns]) + r' \\')
+        for _row_index, row in df_new.iterrows():
+            rows.append(" & ".join([row[col_name] for col_name in df_new.columns]) + r" \\")
 
-        rows.append(r'\bottomrule')
-        rows.append(r'\end{tabular}')
+        rows.append(r"\bottomrule")
+        rows.append(r"\end{tabular}")
 
-        table = '\n'.join(rows)
+        table = "\n".join(rows)
 
-        with open(Path(save_dir) / 'leaderboard.tex', 'w') as f:
+        with open(Path(save_dir) / "leaderboard.tex", "w") as f:
             f.write(table)
 
     # FIXME: Avoid hardcoding
@@ -1514,8 +1569,8 @@ class TabArenaEvaluator:
         df: pd.DataFrame,
         framework_types: list,
         save_prefix: str,
-        baselines: list[str] = None,
-        baseline_colors: list[str] = None,
+        baselines: list[str] | None = None,
+        baseline_colors: list[str] | None = None,
         show: bool = True,
         use_gmean=False,
         use_score: bool = True,
@@ -1570,7 +1625,7 @@ class TabArenaEvaluator:
             df["normalized-score"] = 1 - df[metric]
             metric = "normalized-score"
         else:
-            metric = metric
+            pass  # keep the caller-provided metric
 
         if tune_method_overrides is None:
             tune_method_overrides = []
@@ -1579,9 +1634,7 @@ class TabArenaEvaluator:
         # so f_map_inverse sees the post-rename method names.
         for ov in tune_method_overrides:
             if ov.rename_map:
-                df[self.method_col] = (
-                    df[self.method_col].map(ov.rename_map).fillna(df[self.method_col])
-                )
+                df[self.method_col] = df[self.method_col].map(ov.rename_map).fillna(df[self.method_col])
                 framework_types = [ov.rename_map.get(f, f) for f in framework_types]
 
         if baselines is None:
@@ -1597,13 +1650,13 @@ class TabArenaEvaluator:
             for m in ov.methods:
                 if m in baselines:
                     idx = baselines.index(m)
-                    baselines = baselines[:idx] + baselines[idx + 1:]
+                    baselines = baselines[:idx] + baselines[idx + 1 :]
                     if baseline_colors is not None:
-                        baseline_colors = baseline_colors[:idx] + baseline_colors[idx + 1:]
+                        baseline_colors = baseline_colors[:idx] + baseline_colors[idx + 1 :]
                     if m not in framework_types:
                         framework_types.append(m)
 
-        f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
+        _f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
             framework_types=framework_types,
         )
 
@@ -1624,7 +1677,7 @@ class TabArenaEvaluator:
 
         df["framework_type"] = df["framework_type"].map(f_map_type_name).fillna(df["framework_type"])
 
-        baselines =  [f_map_type_name.get(m, m) for m in baselines]
+        baselines = [f_map_type_name.get(m, m) for m in baselines]
         tick_methods = [f_map_type_name.get(m, m) for m in tick_methods]
         if hidden_methods:
             hidden_methods = [f_map_type_name.get(m, m) for m in hidden_methods]
@@ -1637,20 +1690,26 @@ class TabArenaEvaluator:
 
         df_plot = df[df["framework_type"].isin(framework_types)]
 
-        df_plot_w_mean_per_dataset = df_plot.groupby(["framework_type", "tune_method", *groupby_columns_extra])[
-            metric].mean().reset_index()
+        df_plot_w_mean_per_dataset = (
+            df_plot.groupby(["framework_type", "tune_method", *groupby_columns_extra])[metric].mean().reset_index()
+        )
 
         if use_gmean:
             # FIXME: Doesn't plot correctly, need to figure out error bars for geometric mean
             df_plot_eps = df_plot.copy(deep=True)
             df_plot_eps[metric] += 0.01
             from scipy.stats import gmean
-            df_plot_w_gmean_per_dataset = df_plot.groupby(["framework_type", "tune_method", *groupby_columns_extra])[
-                metric].apply(gmean).reset_index()
+
+            df_plot_w_gmean_per_dataset = (
+                df_plot.groupby(["framework_type", "tune_method", *groupby_columns_extra])[metric]
+                .apply(gmean)
+                .reset_index()
+            )
             df_plot_w_mean_per_dataset = df_plot_w_gmean_per_dataset
 
-        df_plot_w_mean_2 = df_plot_w_mean_per_dataset.groupby(["framework_type", "tune_method"])[
-            metric].mean().reset_index()
+        df_plot_w_mean_2 = (
+            df_plot_w_mean_per_dataset.groupby(["framework_type", "tune_method"])[metric].mean().reset_index()
+        )
 
         df_plot_w_mean_2 = df_plot_w_mean_2.sort_values(by=metric, ascending=lower_is_better)
         baseline_means = {}
@@ -1678,7 +1737,9 @@ class TabArenaEvaluator:
             df_plot_w_mean_per_dataset = df_plot_w_mean_per_dataset.copy()
             df_plot["framework_type"] = df_plot["framework_type"].replace(display_name_map)
             df_plot_mean_dedupe["framework_type"] = df_plot_mean_dedupe["framework_type"].replace(display_name_map)
-            df_plot_w_mean_per_dataset["framework_type"] = df_plot_w_mean_per_dataset["framework_type"].replace(display_name_map)
+            df_plot_w_mean_per_dataset["framework_type"] = df_plot_w_mean_per_dataset["framework_type"].replace(
+                display_name_map
+            )
 
         if display_name_map:
             framework_type_order = [display_name_map.get(m, m) for m in framework_type_order_orig]
@@ -1705,23 +1766,20 @@ class TabArenaEvaluator:
                     y = metric
                     ylim = lim
                     if figsize is None:
-                        figsize = (0.5*len(framework_types), figheight if figheight is not None else 2.7)
+                        figsize = (0.5 * len(framework_types), figheight if figheight is not None else 2.7)
                     # figsize = None
 
                 fig, ax = plt.subplots(1, 1, figsize=figsize, constrained_layout=True)
 
-                if use_y:
-                    baseline_func = ax.axvline
-                else:
-                    baseline_func = ax.axhline
+                baseline_func = ax.axvline if use_y else ax.axhline
 
                 linewidth = 0.0 if use_y else 0.3
                 err_linewidth = 1.6
                 err_linewidths = {
-                    'tuned_ensembled': err_linewidth,
-                    'tuned': err_linewidth * 0.8,
-                    'default': err_linewidth * 0.6,
-                    'holdout_tuned_ensembled': err_linewidth * 0.6,
+                    "tuned_ensembled": err_linewidth,
+                    "tuned": err_linewidth * 0.8,
+                    "default": err_linewidth * 0.6,
+                    "holdout_tuned_ensembled": err_linewidth * 0.6,
                 }
                 # Ensure every override has an entry in err_linewidths so the
                 # elo err-bar loop below can look it up.
@@ -1742,29 +1800,43 @@ class TabArenaEvaluator:
                     if ov.tune_method in seen_tune_methods:
                         continue
                     seen_tune_methods.add(ov.tune_method)
-                    override_bars.append(dict(
-                        x=pos, y=y,
-                        label=ov.bar_label,
-                        data=df_plot_w_mean_per_dataset[df_plot_w_mean_per_dataset["tune_method"] == ov.tune_method],
-                        ax=ax,
-                        order=framework_type_order, color=ov.bar_color,
-                        width=ov.bar_width, linewidth=linewidth,
-                        err_kws={
-                            "color": ov.err_color if ov.err_color is not None else errcolors[0],
-                            "linewidth": err_linewidths[ov.tune_method],
-                            "alpha": err_alpha,
-                        },
-                    ))
+                    override_bars.append(
+                        dict(
+                            x=pos,
+                            y=y,
+                            label=ov.bar_label,
+                            data=df_plot_w_mean_per_dataset[
+                                df_plot_w_mean_per_dataset["tune_method"] == ov.tune_method
+                            ],
+                            ax=ax,
+                            order=framework_type_order,
+                            color=ov.bar_color,
+                            width=ov.bar_width,
+                            linewidth=linewidth,
+                            err_kws={
+                                "color": ov.err_color if ov.err_color is not None else errcolors[0],
+                                "linewidth": err_linewidths[ov.tune_method],
+                                "alpha": err_alpha,
+                            },
+                        )
+                    )
                 to_plot = [
                     *override_bars,
                     dict(
-                        x=pos, y=y,
+                        x=pos,
+                        y=y,
                         label="Tuned + Ensembled",
                         data=df_plot_w_mean_per_dataset[df_plot_w_mean_per_dataset["tune_method"] == "tuned_ensembled"],
                         ax=ax,
-                        order=framework_type_order, color=colors[2],
-                        width=0.6, linewidth=linewidth,
-                        err_kws={"color": errcolors[2], "linewidth": err_linewidths['tuned_ensembled'], 'alpha': err_alpha},
+                        order=framework_type_order,
+                        color=colors[2],
+                        width=0.6,
+                        linewidth=linewidth,
+                        err_kws={
+                            "color": errcolors[2],
+                            "linewidth": err_linewidths["tuned_ensembled"],
+                            "alpha": err_alpha,
+                        },
                     ),
                     # dict(
                     #     x=x, y=y,
@@ -1785,33 +1857,47 @@ class TabArenaEvaluator:
                     #     err_kws={"color": errcolors[5]},
                     # ),
                     dict(
-                        x=pos, y=y,
+                        x=pos,
+                        y=y,
                         label="Tuned",
-                        data=df_plot_w_mean_per_dataset[df_plot_w_mean_per_dataset["tune_method"] == "tuned"], ax=ax,
+                        data=df_plot_w_mean_per_dataset[df_plot_w_mean_per_dataset["tune_method"] == "tuned"],
+                        ax=ax,
                         order=framework_type_order,
                         color=colors[1],
-                        width=0.5, linewidth=linewidth,
-                        err_kws={"color": errcolors[1], "linewidth": err_linewidths['tuned'], 'alpha': err_alpha},
+                        width=0.5,
+                        linewidth=linewidth,
+                        err_kws={"color": errcolors[1], "linewidth": err_linewidths["tuned"], "alpha": err_alpha},
                     ),
                     dict(
-                        x=pos, y=y,
+                        x=pos,
+                        y=y,
                         label="Default",
-                        data=df_plot_w_mean_per_dataset[df_plot_w_mean_per_dataset["tune_method"] == "default"], ax=ax,
-                        order=framework_type_order, color=colors[0],
-                        width=0.4, linewidth=linewidth,
-                        err_kws={"color": errcolors[0], "linewidth": err_linewidths['default'], 'alpha': err_alpha},
+                        data=df_plot_w_mean_per_dataset[df_plot_w_mean_per_dataset["tune_method"] == "default"],
+                        ax=ax,
+                        order=framework_type_order,
+                        color=colors[0],
+                        width=0.4,
+                        linewidth=linewidth,
+                        err_kws={"color": errcolors[0], "linewidth": err_linewidths["default"], "alpha": err_alpha},
                         alpha=1.0,
                     ),
                     dict(
-                        x=pos, y=y,
+                        x=pos,
+                        y=y,
                         label="Tuned + Ensembled (Holdout)",
                         data=df_plot_w_mean_per_dataset[
-                            df_plot_w_mean_per_dataset["tune_method"] == "holdout_tuned_ensembled"], ax=ax,
+                            df_plot_w_mean_per_dataset["tune_method"] == "holdout_tuned_ensembled"
+                        ],
+                        ax=ax,
                         order=framework_type_order,
                         color=colors[3],
-                        width=0.3, linewidth=linewidth,
-                        err_kws={"color": errcolors[3], "linewidth": err_linewidths['holdout_tuned_ensembled'],
-                                 'alpha': err_alpha},
+                        width=0.3,
+                        linewidth=linewidth,
+                        err_kws={
+                            "color": errcolors[3],
+                            "linewidth": err_linewidths["holdout_tuned_ensembled"],
+                            "alpha": err_alpha,
+                        },
                     ),
                     # dict(
                     #     x=x, y=y,
@@ -1831,7 +1917,7 @@ class TabArenaEvaluator:
 
                     # to_plot.reverse()
                     same_width_value = bar_width if bar_width is not None else 0.6 * 1.3
-                    for plot_line, width, color, err_kws in zip(to_plot, widths, colors, err_kws_lst):
+                    for plot_line, width, color, _err_kws in zip(to_plot, widths, colors, err_kws_lst, strict=False):
                         if same_width:
                             plot_line["width"] = same_width_value
                         else:
@@ -1841,9 +1927,11 @@ class TabArenaEvaluator:
                     boxplot = sns.barplot(**plot_line)
 
                 if use_y:
-                    boxplot.set(xlabel='Elo' if metric=='elo' else 'Normalized score', ylabel=None)
+                    boxplot.set(xlabel="Elo" if metric == "elo" else "Normalized score", ylabel=None)
                 else:
-                    boxplot.set(xlabel=None, ylabel='Elo' if metric=='elo' else 'Normalized score')  # remove method in the x-axis
+                    boxplot.set(
+                        xlabel=None, ylabel="Elo" if metric == "elo" else "Normalized score"
+                    )  # remove method in the x-axis
                 if title is not None:
                     # ``set_title`` places text just above the axes spine,
                     # which is where the legend sits (`bbox_to_anchor=[..., 1.01]`,
@@ -1853,10 +1941,10 @@ class TabArenaEvaluator:
                     fig.suptitle(title)
 
                 # do this before setting x/y limits
-                for baseline_idx, (baseline, color) in enumerate(zip(baselines, baseline_colors)):
+                for baseline_idx, (baseline, color) in enumerate(zip(baselines, baseline_colors, strict=False)):
                     baseline_mean = baseline_means[baseline]
 
-                    style_raw = method_style_map.get(baseline, None)
+                    style_raw = method_style_map.get(baseline)
                     style = _normalize_style(style_raw)
                     baseline_label = style.get("display_name", baseline)
 
@@ -1907,7 +1995,8 @@ class TabArenaEvaluator:
 
                     if use_y:
                         txt = ax.text(
-                            y=(1 - 0.035 * (1 + 2 * baseline_text_y_gap * (len(baselines) - 1 - baseline_idx))) * ax.get_ylim()[0],
+                            y=(1 - 0.035 * (1 + 2 * baseline_text_y_gap * (len(baselines) - 1 - baseline_idx)))
+                            * ax.get_ylim()[0],
                             x=baseline_mean * 0.99,
                             s=baseline_label,
                             ha="right",
@@ -1921,8 +2010,13 @@ class TabArenaEvaluator:
                         # below the line.  Add a small fixed 3-point offset (≈ 3 px at
                         # 72 DPI, visually consistent regardless of elo / output DPI).
                         from matplotlib.transforms import offset_copy
+
                         text_transform = offset_copy(
-                            ax.transData, fig=fig, x=-8, y=-3, units="points"
+                            ax.transData,
+                            fig=fig,
+                            x=-8,
+                            y=-3,
+                            units="points",
                         )
                         txt = ax.text(
                             x=0.5,
@@ -1932,11 +2026,15 @@ class TabArenaEvaluator:
                             transform=text_transform,
                             **text_kwargs,
                         )
-                    txt.set_path_effects([PathEffects.withStroke(
-                        linewidth=2,
-                        foreground='white',
-                        alpha=0.5,
-                    )])
+                    txt.set_path_effects(
+                        [
+                            PathEffects.withStroke(
+                                linewidth=2,
+                                foreground="white",
+                                alpha=0.5,
+                            )
+                        ]
+                    )
 
                 if ylim is not None:
                     ax.set_ylim(ylim)
@@ -1944,13 +2042,13 @@ class TabArenaEvaluator:
                     ax.set_xlim(xlim)
 
                 ticks = boxplot.get_yticks() if use_y else boxplot.get_xticks()
-                ticklabels = [tick.get_text() for tick in
-                              (boxplot.get_yticklabels() if use_y else boxplot.get_xticklabels())]
+                ticklabels = [
+                    tick.get_text() for tick in (boxplot.get_yticklabels() if use_y else boxplot.get_xticklabels())
+                ]
 
                 if use_elo:
                     # ----- add elo error bars -----
                     # Get the bar positions
-
 
                     # Add asymmetric error bars manually
                     # Pair each tune_method with the same errcolor used by its
@@ -1968,40 +2066,53 @@ class TabArenaEvaluator:
                         if ov.tune_method in _seen_tune_methods:
                             continue
                         _seen_tune_methods.add(ov.tune_method)
-                        tune_method_errcolors.append((
-                            ov.tune_method,
-                            ov.err_color if ov.err_color is not None else errcolors[0],
-                        ))
-                    for pos, framework_type in zip(ticks, ticklabels):
+                        tune_method_errcolors.append(
+                            (
+                                ov.tune_method,
+                                ov.err_color if ov.err_color is not None else errcolors[0],
+                            )
+                        )
+                    for pos, framework_type in zip(ticks, ticklabels, strict=False):
                         for tune_method, errcolor in tune_method_errcolors:
-                            row = df_plot.loc[(df_plot["framework_type"] == framework_type) & (df_plot["tune_method"] == tune_method)]
+                            row = df_plot.loc[
+                                (df_plot["framework_type"] == framework_type) & (df_plot["tune_method"] == tune_method)
+                            ]
                             if len(row) == 1:
                                 # not all methods have tuned or tuned_ensembled
-                                y = row['elo'].values
-                                yerr_low = row['elo-'].values
-                                yerr_high = row['elo+'].values
+                                y = row["elo"].values
+                                yerr_low = row["elo-"].values
+                                yerr_high = row["elo+"].values
                                 if use_y:
-                                    plotline, caps, barlinecols = plt.errorbar(y, pos, xerr=[yerr_low, yerr_high],
-                                                                               fmt='none', color=errcolor,
-                                                                               alpha=err_alpha,
-                                                                               linewidth=err_linewidths[tune_method])
+                                    plotline, caps, barlinecols = plt.errorbar(
+                                        y,
+                                        pos,
+                                        xerr=[yerr_low, yerr_high],
+                                        fmt="none",
+                                        color=errcolor,
+                                        alpha=err_alpha,
+                                        linewidth=err_linewidths[tune_method],
+                                    )
                                 else:
-                                    plotline, caps, barlinecols = plt.errorbar(pos, y, yerr=[yerr_low, yerr_high],
-                                                                               fmt='none', color=errcolor,
-                                                                               alpha=err_alpha,
-                                                                               linewidth=err_linewidths[tune_method])
+                                    _plotline, _caps, _barlinecols = plt.errorbar(
+                                        pos,
+                                        y,
+                                        yerr=[yerr_low, yerr_high],
+                                        fmt="none",
+                                        color=errcolor,
+                                        alpha=err_alpha,
+                                        linewidth=err_linewidths[tune_method],
+                                    )
                                 # don't round because it will make the lines longer
                                 # plt.setp(barlinecols[0], capstyle="round")
-
 
                 # ----- highlight bars that contain imputed results -----
 
                 # Map x-tick positions to category labels
-                label_lookup = dict(zip(ticks, ticklabels))
+                label_lookup = dict(zip(ticks, ticklabels, strict=False))
 
                 has_imputed = False
 
-                for i, bar in enumerate(boxplot.patches):
+                for _i, bar in enumerate(boxplot.patches):
                     # Get position and convert to category label
                     pos = bar.get_y() + bar.get_height() / 2 if use_y else bar.get_x() + bar.get_width() / 2
                     category_index = round(pos)  # x-ticks are usually 0, 1, 2, ...
@@ -2009,7 +2120,7 @@ class TabArenaEvaluator:
 
                     if category in imputed_names:
                         has_imputed = True
-                        bar.set_hatch('xx')
+                        bar.set_hatch("xx")
 
                 if not use_y:
                     # ----- alternate rows of x tick labels -----
@@ -2017,7 +2128,9 @@ class TabArenaEvaluator:
                     labels = [label.get_text() for label in boxplot.get_xticklabels()]
 
                     # Add newline to every second label
-                    new_labels = [label if i % 2 == 0 else r'$\uparrow$' + '\n' + label for i, label in enumerate(labels)]
+                    new_labels = [
+                        label if i % 2 == 0 else r"$\uparrow$" + "\n" + label for i, label in enumerate(labels)
+                    ]
 
                     if has_non_baselines:
                         # Apply modified labels
@@ -2038,7 +2151,7 @@ class TabArenaEvaluator:
 
                 if has_imputed:
                     # Create a custom legend patch for "imputed"
-                    imputed_patch = Patch(facecolor='gray', edgecolor='white', hatch='xx', label='Partially imputed')
+                    imputed_patch = Patch(facecolor="gray", edgecolor="white", hatch="xx", label="Partially imputed")
 
                     # Add to existing legend
                     handles.append(imputed_patch)
@@ -2115,98 +2228,104 @@ class TabArenaEvaluator:
 
         framework_types = self._get_config_types(df_results=df)
 
-        f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
+        _f_map, f_map_type, f_map_inverse, f_map_type_name = self.get_framework_type_method_names(
             framework_types=framework_types,
         )
 
         df["framework_type"] = df[self.method_col].map(f_map_type).fillna(df[self.method_col])
         df["tune_method"] = df[self.method_col].map(f_map_inverse).fillna("default")
         df = df[df["tune_method"].isin(["default", "tuned_ensembled"])]
-        df = df[df['framework_type'].isin(framework_types)]
+        df = df[df["framework_type"].isin(framework_types)]
         df.loc[:, "framework_type"] = df["framework_type"].map(f_map_type_name).fillna(df["framework_type"])
 
-        gpu_methods = ['TabICL', 'TabDPT', 'TabPFNv2', "ModernNCA", "TabM"]
+        gpu_methods = ["TabICL", "TabDPT", "TabPFNv2", "ModernNCA", "TabM"]
 
         # add device name
         framework_types = df["framework_type"].unique()
         device_map = {
-            ft: f'{ft} ' + r'(GPU)' if ft in gpu_methods else f'{ft} (CPU)' if not ft.endswith("(CPU)") else ft for ft in framework_types
+            ft: f"{ft} " + r"(GPU)" if ft in gpu_methods else f"{ft} (CPU)" if not ft.endswith("(CPU)") else ft
+            for ft in framework_types
         }
         device_map = {}
         for ft in framework_types:
             if ft in gpu_methods:
-                ft_new = f'{ft} (GPU)'
-            elif ft.endswith("(CPU)"):
-                ft_new = ft
-            elif ft.endswith("(GPU)"):
+                ft_new = f"{ft} (GPU)"
+            elif ft.endswith(("(CPU)", "(GPU)")):
                 ft_new = ft
             else:
-                ft_new = f'{ft} (CPU)'
+                ft_new = f"{ft} (CPU)"
             device_map[ft] = ft_new
 
         df["framework_type"] = df["framework_type"].map(device_map).fillna(df["framework_type"])
 
         # take mean times
-        df = df.groupby(['dataset', 'framework_type', 'tune_method'])[['time_train_s_per_1K', 'time_infer_s_per_1K']].mean().reset_index()
-        df = df.groupby(['framework_type', 'tune_method'])[['time_train_s_per_1K', 'time_infer_s_per_1K']].median().reset_index()
+        df = (
+            df.groupby(["dataset", "framework_type", "tune_method"])[["time_train_s_per_1K", "time_infer_s_per_1K"]]
+            .mean()
+            .reset_index()
+        )
+        df = (
+            df.groupby(["framework_type", "tune_method"])[["time_train_s_per_1K", "time_infer_s_per_1K"]]
+            .median()
+            .reset_index()
+        )
 
         # ----- ChatGPT plotting code -----
 
         # Unique values for mapping
         # Sort frameworks by max train time
         sorted_frameworks = (
-            df.groupby('framework_type')['time_train_s_per_1K']
-            .min()
-            .sort_values(ascending=False)
-            .index
-            .tolist()
+            df.groupby("framework_type")["time_train_s_per_1K"].min().sort_values(ascending=False).index.tolist()
         )
         frameworks = sorted_frameworks
         y_positions = np.arange(len(frameworks))
 
         # Maps for tuning method to color and marker
-        tune_methods = df['tune_method'].unique()
+        tune_methods = df["tune_method"].unique()
         # color_map = {tm: c for tm, c in zip(tune_methods, plt.cm.tab10.colors)}
         sns_colors = sns.color_palette("muted").as_hex()
         # sns_colors = sns.color_palette("pastel").as_hex()
-        color_map = {'default': sns_colors[0], 'tuned': sns_colors[1], 'tuned_ensembled': sns_colors[2]}
-        marker_list = ['o', 's', '^', 'D', 'P', '*', 'X', 'v']
-        marker_map = {tm: m for tm, m in zip(tune_methods, marker_list)}
+        color_map = {"default": sns_colors[0], "tuned": sns_colors[1], "tuned_ensembled": sns_colors[2]}
+        marker_list = ["o", "s", "^", "D", "P", "*", "X", "v"]
+        marker_map = dict(zip(tune_methods, marker_list, strict=False))
 
         # Create side-by-side subplots with shared y-axis
         fig, (ax_train, ax_infer) = plt.subplots(
-            1, 2, sharey=True, figsize=(5, 4)
+            1,
+            2,
+            sharey=True,
+            figsize=(5, 4),
         )
 
         # Alternate row background on both axes
         for i in range(0, len(frameworks), 2):
             for ax in [ax_train, ax_infer]:
-                ax.axhspan(i - 0.5, i + 0.5, facecolor='lightgray', alpha=0.3, zorder=0)
+                ax.axhspan(i - 0.5, i + 0.5, facecolor="lightgray", alpha=0.3, zorder=0)
 
         # Plot training and inference times
         for i, fw in enumerate(frameworks):
-            df_fw = df[df['framework_type'] == fw]
+            df_fw = df[df["framework_type"] == fw]
             for _, row in df_fw.iterrows():
-                color = color_map[row['tune_method']]
-                marker = marker_map[row['tune_method']]
-                ax_train.plot(row['time_train_s_per_1K'], i, marker=marker, color=color, linestyle='None')
-                ax_infer.plot(row['time_infer_s_per_1K'], i, marker=marker, color=color, linestyle='None')
+                color = color_map[row["tune_method"]]
+                marker = marker_map[row["tune_method"]]
+                ax_train.plot(row["time_train_s_per_1K"], i, marker=marker, color=color, linestyle="None")
+                ax_infer.plot(row["time_infer_s_per_1K"], i, marker=marker, color=color, linestyle="None")
 
         # Train time axis
-        ax_train.set_xscale('log')
+        ax_train.set_xscale("log")
         ax_train.set_xlabel("Median time per 1K samples [s]")
-        ax_train.set_title(r"\textbf{Train+val time}", fontweight='bold')
+        ax_train.set_title(r"\textbf{Train+val time}", fontweight="bold")
         ax_train.set_yticks(y_positions)
         ax_train.set_yticklabels(frameworks, fontsize=10)
-        ax_train.grid(True, axis='x', alpha=0.5)
+        ax_train.grid(True, axis="x", alpha=0.5)
 
         # Inference time axis
-        ax_infer.set_xscale('log')
+        ax_infer.set_xscale("log")
         ax_infer.set_xlabel("Median time per 1K samples [s]")
-        ax_infer.set_title(r"\textbf{Inference time}", fontweight='bold')
+        ax_infer.set_title(r"\textbf{Inference time}", fontweight="bold")
         ax_infer.set_yticks(y_positions)
         ax_infer.tick_params(labelleft=False)  # Explicitly hide y-tick labels
-        ax_infer.grid(True, axis='x', alpha=0.5)
+        ax_infer.grid(True, axis="x", alpha=0.5)
 
         for ax in [ax_train, ax_infer]:
             ax.xaxis.set_major_locator(ticker.LogLocator(base=10.0))
@@ -2217,19 +2336,32 @@ class TabArenaEvaluator:
             # ax.yaxis.set_minor_formatter(ticker.NullFormatter())
 
         tune_method_display_names = {
-            'default': 'Default',
-            'tuned': 'Tuned',
-            'tuned_ensembled': 'Tuned + Ensembled'
+            "default": "Default",
+            "tuned": "Tuned",
+            "tuned_ensembled": "Tuned + Ensembled",
         }
 
         # Add legend above both plots
         legend_elements = [
-            plt.Line2D([0], [0], marker=marker_map[tm], color=color_map[tm],
-                       linestyle='None', label=tune_method_display_names[tm], markersize=8)
+            plt.Line2D(
+                [0],
+                [0],
+                marker=marker_map[tm],
+                color=color_map[tm],
+                linestyle="None",
+                label=tune_method_display_names[tm],
+                markersize=8,
+            )
             for tm in tune_methods
         ]
-        fig.legend(handles=legend_elements,  # title='Tuning Method',
-                   loc='upper center', bbox_to_anchor=(0.65, 1.01), ncol=3, fontsize=10, title_fontsize=11)
+        fig.legend(
+            handles=legend_elements,  # title='Tuning Method',
+            loc="upper center",
+            bbox_to_anchor=(0.65, 1.01),
+            ncol=3,
+            fontsize=10,
+            title_fontsize=11,
+        )
 
         # Layout adjustment (no clipping)
         plt.tight_layout(rect=[0, 0, 1, 0.94])
@@ -2237,7 +2369,7 @@ class TabArenaEvaluator:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        plt.savefig(output_dir / f'time_plot.{self.figure_file_type}')
+        plt.savefig(output_dir / f"time_plot.{self.figure_file_type}")
         if show:
             plt.show()
         plt.close(fig)
@@ -2246,7 +2378,7 @@ class TabArenaEvaluator:
         self,
         df_results: pd.DataFrame,
         method: str,
-        excluded_families: list[str] = None,
+        excluded_families: list[str] | None = None,
         aggregate_folds: bool = False,
     ) -> pd.DataFrame:
         if self.datasets is not None:
@@ -2269,7 +2401,12 @@ class TabArenaEvaluator:
         #
         # df_ensemble_weights_2 = pd.DataFrame()
 
-        for d, f, ensemble_weights in zip(df_ensemble_weights["dataset"], df_ensemble_weights["fold"], df_ensemble_weights["ensemble_weight"]):
+        for d, f, ensemble_weights in zip(
+            df_ensemble_weights["dataset"],
+            df_ensemble_weights["fold"],
+            df_ensemble_weights["ensemble_weight"],
+            strict=False,
+        ):
             if isinstance(ensemble_weights, str):
                 ensemble_weights = json.loads(ensemble_weights)
             assert isinstance(ensemble_weights, dict)
@@ -2278,12 +2415,11 @@ class TabArenaEvaluator:
             ens_weights_w_dataset_fold["fold"] = f
             ens_weights_w_dataset_fold.update(ensemble_weights)
             full_dict.append(ens_weights_w_dataset_fold)
-            pass
 
         model_to_families = self.config_types
 
         model_families = set()
-        for m, f in model_to_families.items():
+        for _m, f in model_to_families.items():
             if f not in model_families:
                 model_families.add(f)
 
@@ -2304,6 +2440,7 @@ class TabArenaEvaluator:
             weight_per_family_dict.append(new_dict)
 
         import pandas as pd
+
         df = pd.DataFrame(weight_per_family_dict)
         df = df.set_index(["dataset", "fold"])
         df = df.fillna(0)
@@ -2318,17 +2455,16 @@ class TabArenaEvaluator:
         if excluded_families:
             df = df.drop(columns=excluded_families)
 
-        df = self._get_ensemble_weights(
+        return self._get_ensemble_weights(
             df_ensemble_weights=df,
             aggregate_folds=aggregate_folds,
             sort_by_mean=True,
         )
 
-        return df
-
     def _process_baselines(
         self,
-        df_results: pd.DataFrame, baselines: list[str] | None | str,
+        df_results: pd.DataFrame,
+        baselines: list[str] | None | str,
         baseline_colors: list[str] | None,
     ) -> tuple[list[str], list[str]]:
         methods = df_results[self.method_col].unique()
@@ -2338,9 +2474,9 @@ class TabArenaEvaluator:
         elif baselines == "auto":
             baselines = list(
                 df_results[
-                    df_results["method_type"].isin(["baseline", "portfolio"]) |
-                    ((df_results["method_type"] == "config") & df_results["method_subtype"].isna())
-                ][self.method_col].unique()
+                    df_results["method_type"].isin(["baseline", "portfolio"])
+                    | ((df_results["method_type"] == "config") & df_results["method_subtype"].isna())
+                ][self.method_col].unique(),
             )
         else:
             missing_baselines = [b for b in baselines if b not in methods]
@@ -2359,7 +2495,7 @@ class TabArenaEvaluator:
         assert len(baselines) == len(baseline_colors)
         assert len(baselines) == len(list(set(baselines))), f"Duplicates keys found in baselines: {baselines}"
         # Filter both baselines and baseline_colors using the same mask
-        filtered = [(b, c) for b, c in zip(baselines, baseline_colors) if b in methods]
+        filtered = [(b, c) for b, c in zip(baselines, baseline_colors, strict=False) if b in methods]
 
         baselines = [b for b, _ in filtered]
         baseline_colors = [c for _, c in filtered]
@@ -2374,7 +2510,7 @@ class TabArenaEvaluator:
     ) -> pd.DataFrame:
         df_ensemble_weights = copy.deepcopy(df_ensemble_weights)
         if aggregate_folds:
-            df_ensemble_weights = df_ensemble_weights.groupby(level='dataset').mean()
+            df_ensemble_weights = df_ensemble_weights.groupby(level="dataset").mean()
         else:
             index_new = list(df_ensemble_weights.index.to_flat_index())
             index_new = [str(t[0]) + "_" + str(t[1]) for t in index_new]
@@ -2405,9 +2541,7 @@ class TabArenaEvaluator:
         include_mean: bool = True,
         **kwargs,
     ):
-        """
-
-        Parameters
+        """Parameters
         ----------
         df_ensemble_weights : pd.DataFrame
             The 2nd output object of `repo.evaluate_ensembles(...)
@@ -2423,7 +2557,7 @@ class TabArenaEvaluator:
         **kwargs
             Passed to the `create_heatmap` function
 
-        Returns
+        Returns:
         -------
         plt
 
@@ -2434,8 +2568,7 @@ class TabArenaEvaluator:
         #     sort_by_mean=sort_by_mean,
         # )
 
-        p = create_heatmap(df=df_ensemble_weights, include_mean=include_mean, **kwargs)
-        return p
+        return create_heatmap(df=df_ensemble_weights, include_mean=include_mean, **kwargs)
 
     def plot_ensemble_weights_heatmap(self, df_ensemble_weights: pd.DataFrame, **kwargs):
         # FIXME: if family never present, then this won't work
@@ -2448,7 +2581,7 @@ class TabArenaEvaluator:
     def generate_runtime_plot(
         self,
         df_results: pd.DataFrame,
-        deep_dive_kwargs: dict | None = None
+        deep_dive_kwargs: dict | None = None,
     ):
         if deep_dive_kwargs is None:
             deep_dive_kwargs = {}
@@ -2459,7 +2592,9 @@ class TabArenaEvaluator:
         df_results_configs = df_results_configs[df_results_configs["config_type"].isin(framework_types)]
 
         method_rename_map = self.get_method_rename_map()
-        df_results_configs["config_type"] = df_results_configs["config_type"].map(method_rename_map).fillna(df_results_configs["config_type"])
+        df_results_configs["config_type"] = (
+            df_results_configs["config_type"].map(method_rename_map).fillna(df_results_configs["config_type"])
+        )
 
         plot_train_time_deep_dive(
             df=df_results_configs,
@@ -2487,8 +2622,7 @@ def _apply_ticklabel_styles(
     display_name_inverse_map: dict[str, str] | None = None,
     tick_method_keys: list[str] | None = None,
 ):
-    """
-    Apply per-method ticklabel styling.
+    """Apply per-method ticklabel styling.
 
     Key feature: if `tick_method_keys` is provided, styles are resolved using the
     original method key for each tick (in axis order). This prevents collisions
@@ -2521,19 +2655,14 @@ def _apply_ticklabel_styles(
 
     if tick_method_keys is not None and len(tick_method_keys) != len(tick_texts):
         raise ValueError(
-            f"tick_method_keys length ({len(tick_method_keys)}) must match number of tick labels ({len(tick_texts)})."
+            f"tick_method_keys length ({len(tick_method_keys)}) must match number of tick labels ({len(tick_texts)}).",
         )
 
     for i, t in enumerate(tick_texts):
         raw_name = t.get_text()
 
         # Normalize label text if you added arrows / newlines earlier
-        base_name = (
-            raw_name
-            .replace("\n", "")
-            .replace(r"$\uparrow$", "")
-            .strip()
-        )
+        base_name = raw_name.replace("\n", "").replace(r"$\uparrow$", "").strip()
 
         # --- Resolve the style lookup key ---
         # 1) If provided, use underlying original method key by position (robust to display_name collisions)
@@ -2590,9 +2719,7 @@ def _resolve_method_style(
 
 
 def _normalize_label_style(style: MethodLabelStyle) -> dict[str, object]:
-    """
-    Normalize label style spec into a dict usable by matplotlib Text.set_* APIs.
-    """
+    """Normalize label style spec into a dict usable by matplotlib Text.set_* APIs."""
     if isinstance(style, str):
         return {"color": style}
     return dict(style)

--- a/packages/tabarena/src/tabarena/plot/dataset_analysis.py
+++ b/packages/tabarena/src/tabarena/plot/dataset_analysis.py
@@ -1,14 +1,19 @@
-import math
-from pathlib import Path
-import warnings
+from __future__ import annotations
 
-import pandas as pd
+import math
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import matplotlib
 import matplotlib.pyplot as plt
+import pandas as pd
 import seaborn as sns
 
-from tabarena.repository import EvaluationRepository
 from tabarena.plot.plot_utils import figure_path, save_latex_table
+
+if TYPE_CHECKING:
+    from tabarena.repository import EvaluationRepository
 
 
 def order_clustermap(df, allow_nan=True):
@@ -26,8 +31,7 @@ def index(name):
     config_number = name.split("-")[-1]
     if "c" in config_number:
         return None
-    else:
-        return int(config_number)
+    return int(config_number)
 
 
 def generate_dataset_info_latex(repo: EvaluationRepository, expname_outdir: str):
@@ -35,65 +39,70 @@ def generate_dataset_info_latex(repo: EvaluationRepository, expname_outdir: str)
     assert len(metadata) == len(repo.datasets())
 
     with warnings.catch_warnings():
-        warnings.filterwarnings('ignore')
-        metadata['problem_type'] = ''
-        metadata['problem_type'][metadata['NumberOfClasses'] == 2] = 'binary'
-        metadata['problem_type'][metadata['NumberOfClasses'] > 2] = 'multiclass'
-        metadata['problem_type'][metadata['NumberOfClasses'] == 0] = 'regression'
+        warnings.filterwarnings("ignore")
+        metadata["problem_type"] = ""
+        metadata["problem_type"][metadata["NumberOfClasses"] == 2] = "binary"
+        metadata["problem_type"][metadata["NumberOfClasses"] > 2] = "multiclass"
+        metadata["problem_type"][metadata["NumberOfClasses"] == 0] = "regression"
 
-    metadata_min = metadata[["tid", "name", "NumberOfInstances", "NumberOfFeatures", "NumberOfClasses", 'problem_type']]
+    metadata_min = metadata[["tid", "name", "NumberOfInstances", "NumberOfFeatures", "NumberOfClasses", "problem_type"]]
     metadata_min_sorted = metadata_min.sort_values(by=["name"])
     metadata_latex = metadata_min_sorted.copy()
 
     max_name_length = 20
 
-    metadata_latex.columns = ['Task ID', 'name', 'n', 'f', 'C', 'Problem Type']
-    metadata_latex['Task ID'] = metadata_latex['Task ID'].astype(str)
-    metadata_latex['n'] = metadata_latex['n'].astype(int)
-    metadata_latex['f'] = metadata_latex['f'].astype(int)
-    metadata_latex['f'] = metadata_latex['f'] - 1  # Original counts the label column, remove to get the feature count
-    metadata_latex['C'] = metadata_latex['C'].astype(int)
+    metadata_latex.columns = ["Task ID", "name", "n", "f", "C", "Problem Type"]
+    metadata_latex["Task ID"] = metadata_latex["Task ID"].astype(str)
+    metadata_latex["n"] = metadata_latex["n"].astype(int)
+    metadata_latex["f"] = metadata_latex["f"].astype(int)
+    metadata_latex["f"] = metadata_latex["f"] - 1  # Original counts the label column, remove to get the feature count
+    metadata_latex["C"] = metadata_latex["C"].astype(int)
 
-    datasets_statistics = metadata_latex.describe(percentiles=[.05, .1, .25, .5, .75, .9, .95])
-    datasets_statistics = datasets_statistics.drop(columns='C')
-    datasets_statistics = datasets_statistics.drop(index='count')
+    datasets_statistics = metadata_latex.describe(percentiles=[0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95])
+    datasets_statistics = datasets_statistics.drop(columns="C")
+    datasets_statistics = datasets_statistics.drop(index="count")
     datasets_statistics = datasets_statistics.round()
     datasets_statistics = datasets_statistics.astype(int)
 
-    save_latex_table(df=datasets_statistics, title=f"datasets_statistics", show_table=True, save_prefix=expname_outdir)
+    save_latex_table(df=datasets_statistics, title="datasets_statistics", show_table=True, save_prefix=expname_outdir)
 
-    metadata_latex['name'] = metadata_latex['name'].apply(lambda x: x[:max_name_length])
+    metadata_latex["name"] = metadata_latex["name"].apply(lambda x: x[:max_name_length])
 
-    problem_types = ['binary', 'multiclass', 'regression']
+    problem_types = ["binary", "multiclass", "regression"]
     latex_kwargs = dict(
         index=False,
     )
 
     # Separate by problem types and into batches to ensure each table fits on one page
     for p in problem_types:
-        metadata_latex_p = metadata_latex[metadata_latex['Problem Type'] == p]
+        metadata_latex_p = metadata_latex[metadata_latex["Problem Type"] == p]
         num_datasets = len(metadata_latex_p)
 
-        metadata_latex_v2 = metadata_latex_p.drop(columns='Problem Type')
+        metadata_latex_v2 = metadata_latex_p.drop(columns="Problem Type")
 
         vertical = math.ceil(num_datasets / 2)
         metadata_left = metadata_latex_v2.iloc[:vertical].reset_index(drop=True)
         metadata_right = metadata_latex_v2.iloc[vertical:].reset_index(drop=True)
-        metadata_left['n'] = metadata_left['n'].astype(str)
-        metadata_left['f'] = metadata_left['f'].astype(str)
-        metadata_left['C'] = metadata_left['C'].astype(str)
+        metadata_left["n"] = metadata_left["n"].astype(str)
+        metadata_left["f"] = metadata_left["f"].astype(str)
+        metadata_left["C"] = metadata_left["C"].astype(str)
 
-        metadata_right['n'] = metadata_right['n'].astype(str)
-        metadata_right['f'] = metadata_right['f'].astype(str)
-        metadata_right['C'] = metadata_right['C'].astype(str)
-        if p == 'regression':
-            metadata_left = metadata_left.drop(columns='C')
-            metadata_right = metadata_right.drop(columns='C')
+        metadata_right["n"] = metadata_right["n"].astype(str)
+        metadata_right["f"] = metadata_right["f"].astype(str)
+        metadata_right["C"] = metadata_right["C"].astype(str)
+        if p == "regression":
+            metadata_left = metadata_left.drop(columns="C")
+            metadata_right = metadata_right.drop(columns="C")
 
         metadata_combined = pd.concat([metadata_left, metadata_right], axis=1)
-        metadata_combined = metadata_combined.fillna('')
-        save_latex_table(df=metadata_combined, title=f"datasets_{p}", show_table=True,
-                         latex_kwargs=latex_kwargs, save_prefix=expname_outdir)
+        metadata_combined = metadata_combined.fillna("")
+        save_latex_table(
+            df=metadata_combined,
+            title=f"datasets_{p}",
+            show_table=True,
+            latex_kwargs=latex_kwargs,
+            save_prefix=expname_outdir,
+        )
 
 
 def generate_dataset_analysis(repo, expname_outdir: str):
@@ -113,7 +122,9 @@ def generate_dataset_analysis(repo, expname_outdir: str):
 
     metric = "metric_error"
     df_pivot = df.pivot_table(
-        index="framework", columns="tid", values=metric
+        index="framework",
+        columns="tid",
+        values=metric,
     )
     df_rank = df_pivot.rank() / len(df_pivot)
     df_rank.index = [x.replace("_BAG_L1", "").replace("_r", "_").replace("_", "-") for x in df_rank.index]
@@ -126,57 +137,65 @@ def generate_dataset_analysis(repo, expname_outdir: str):
     df_rank.columns.name = "dataset"
 
     # task-model rank
-    fig, axes = plt.subplots(1, 3, figsize=figsize, dpi=300)
+    _fig, axes = plt.subplots(1, 3, figsize=figsize, dpi=300)
     ax = axes[0]
-    cmap = matplotlib.colormaps.get_cmap('RdYlGn_r')
+    cmap = matplotlib.colormaps.get_cmap("RdYlGn_r")
     cmap.set_bad("black")
     sns.heatmap(
-        df_rank, cmap=cmap, vmin=0, vmax=1, ax=ax,
+        df_rank,
+        cmap=cmap,
+        vmin=0,
+        vmax=1,
+        ax=ax,
     )
     ax.set_xticks([])
-    ax.set_xlabel("Datasets", fontdict={'size': title_size})
-    ax.set_title("Ranks of models per dataset", fontdict={'size': title_size})
+    ax.set_xlabel("Datasets", fontdict={"size": title_size})
+    ax.set_title("Ranks of models per dataset", fontdict={"size": title_size})
 
     # model-model correlation
     ax = axes[1]
     sns.heatmap(
-        df_rank.T.corr(), cmap="vlag", vmin=-1, vmax=1, ax=ax,
+        df_rank.T.corr(),
+        cmap="vlag",
+        vmin=-1,
+        vmax=1,
+        ax=ax,
     )
-    ax.set_title("Model rank correlation", fontdict={'size': title_size})
+    ax.set_title("Model rank correlation", fontdict={"size": title_size})
 
     # runtime figure
     df = zsc.df_configs_ranked
     ax = axes[2]
-    df['method'] = df.apply(lambda x: x["framework"].split("_")[0], axis=1)
-    df['method'] = df['method'].map({"NeuralNetTorch": "MLP"}).fillna(df["method"])
+    df["method"] = df.apply(lambda x: x["framework"].split("_")[0], axis=1)
+    df["method"] = df["method"].map({"NeuralNetTorch": "MLP"}).fillna(df["method"])
     df_grouped = df[["method", "tid", "time_train_s"]].groupby(["method", "tid"]).max()["time_train_s"].sort_values()
     df_grouped = df_grouped.reset_index(drop=False)
     df_grouped["group_index"] = df_grouped.groupby("method")["time_train_s"].cumcount()
     df_grouped["group_index"] += 1
 
     palette = [
-        '#1f77b4',  # blue
-        '#ff7f0e',  # orange
-        '#2ca02c',  # green
-        '#d62728',  # red
-        '#9467bd',  # purple
-        '#8c564b',  # brown
-        '#e377c2',  # pink
-        '#7f7f7f',  # gray
-        '#bcbd22',  # yellow-green
-        '#17becf',  # cyan
-        '#aec7e8',  # light blue
-        '#ffbb78',  # light orange
-        '#98df8a',  # light green
-        '#ff9896',  # light red
-        '#c5b0d5',  # light purple
-        '#c49c94',  # light brown
-        '#f7b6d2',  # light pink
-        '#c7c7c7',  # light gray
-        '#dbdb8d',  # light yellow-green
-        '#9edae5',  # light cyan
+        "#1f77b4",  # blue
+        "#ff7f0e",  # orange
+        "#2ca02c",  # green
+        "#d62728",  # red
+        "#9467bd",  # purple
+        "#8c564b",  # brown
+        "#e377c2",  # pink
+        "#7f7f7f",  # gray
+        "#bcbd22",  # yellow-green
+        "#17becf",  # cyan
+        "#aec7e8",  # light blue
+        "#ffbb78",  # light orange
+        "#98df8a",  # light green
+        "#ff9896",  # light red
+        "#c5b0d5",  # light purple
+        "#c49c94",  # light brown
+        "#f7b6d2",  # light pink
+        "#c7c7c7",  # light gray
+        "#dbdb8d",  # light yellow-green
+        "#9edae5",  # light cyan
     ]
-    hue_order = sorted(list(df_grouped["method"].unique()))
+    hue_order = sorted(df_grouped["method"].unique())
     n_colors = len(hue_order)
 
     sns.lineplot(
@@ -189,15 +208,15 @@ def generate_dataset_analysis(repo, expname_outdir: str):
         palette=palette[:n_colors],
         ax=ax,
     )
-    ax.set_yscale('log')
+    ax.set_yscale("log")
     ax.grid()
     ax.legend()
-    ax.set_xlabel("Datasets", fontdict={'size': title_size})
-    ax.set_ylabel("Training runtime (s)", fontdict={'size': title_size})
-    ax.set_title("Training runtime distribution", fontdict={'size': title_size})
+    ax.set_xlabel("Datasets", fontdict={"size": title_size})
+    ax.set_ylabel("Training runtime (s)", fontdict={"size": title_size})
+    ax.set_title("Training runtime distribution", fontdict={"size": title_size})
 
     plt.tight_layout()
-    fig_save_path = figure_path(path=expname_outdir) / f"data-analysis.pdf"
+    fig_save_path = figure_path(path=expname_outdir) / "data-analysis.pdf"
     plt.savefig(fig_save_path)
     plt.show()
 
@@ -221,18 +240,18 @@ def plot_train_time_deep_dive(
         fig, axes = plt.subplots(1, 2, figsize=figsize, dpi=300)
     else:
         figsize = (26, 7)
-        fig, axes = plt.subplots(1, 4, figsize=figsize, dpi=300)
+        _fig, axes = plt.subplots(1, 4, figsize=figsize, dpi=300)
 
     # runtime max stats
     index_above_time_limit = df["time_train_s"] >= time_limit_soft
     proportion_of_models_reaching_time_limit = index_above_time_limit.mean()
     num_models_reaching_time_limit = index_above_time_limit.sum()
     models_by_family_reaching_time_limit = df.loc[index_above_time_limit].value_counts(family_col)
-    models_by_config_reaching_time_limit = df.loc[index_above_time_limit].value_counts(method_col)
+    df.loc[index_above_time_limit].value_counts(method_col)
     datasets_reaching_time_limit = df.loc[index_above_time_limit].value_counts("dataset")
     datasets_type_reaching_time_limit = df.loc[index_above_time_limit].value_counts(["dataset", family_col])
 
-    latex_kwargs = dict(
+    dict(
         index=False,
     )
 
@@ -276,7 +295,9 @@ def plot_train_time_deep_dive(
     # Span each family across [0, 1]: divide cumcount (0..n-1) by (n-1) so the
     # final config lands at 1.0 instead of (n-1)/n. Clip avoids div-by-zero for
     # single-config families (their lone point sits at 0).
-    df_sorted_by_time["group_index"] = df_sorted_by_time["group_index"] / (df_sorted_by_time["group_index_max"] - 1).clip(lower=1)
+    df_sorted_by_time["group_index"] = df_sorted_by_time["group_index"] / (
+        df_sorted_by_time["group_index_max"] - 1
+    ).clip(lower=1)
 
     cur_idx = 0
     if not only_per_method:
@@ -289,13 +310,20 @@ def plot_train_time_deep_dive(
             linewidth=3,
             ax=ax,
         )
-        ax.set_yscale('log')
+        ax.set_yscale("log")
         ax.grid()
-        ax.hlines(time_limit_hard, xmin=0, xmax=df_sorted_by_time["index"].max(), color="black", label=f"{int(time_limit_hard)} Seconds", ls="--")
+        ax.hlines(
+            time_limit_hard,
+            xmin=0,
+            xmax=df_sorted_by_time["index"].max(),
+            color="black",
+            label=f"{int(time_limit_hard)} Seconds",
+            ls="--",
+        )
         ax.legend()
-        ax.set_xlabel("Configs (Proportion)", fontdict={'size': title_size})
-        ax.set_ylabel("Training runtime (s)", fontdict={'size': title_size})
-        ax.set_title("Config runtime distribution", fontdict={'size': title_size})
+        ax.set_xlabel("Configs (Proportion)", fontdict={"size": title_size})
+        ax.set_ylabel("Training runtime (s)", fontdict={"size": title_size})
+        ax.set_title("Config runtime distribution", fontdict={"size": title_size})
         plt.tight_layout()
 
     ax = axes[cur_idx]
@@ -321,13 +349,20 @@ def plot_train_time_deep_dive(
         palette=palette[:n_colors],
         ax=ax,
     )
-    ax.set_yscale('log')
+    ax.set_yscale("log")
     ax.grid()
-    ax.hlines(time_limit_hard, xmin=0, xmax=df_sorted_by_time["group_index"].max(), color="black", label=f"{int(time_limit_hard)} Seconds", ls="--")
+    ax.hlines(
+        time_limit_hard,
+        xmin=0,
+        xmax=df_sorted_by_time["group_index"].max(),
+        color="black",
+        label=f"{int(time_limit_hard)} Seconds",
+        ls="--",
+    )
     ax.legend(loc="upper left")
-    ax.set_xlabel("Proportion of Model Configurations", fontdict={'size': title_size})
-    ax.set_ylabel("Training runtime (s)", fontdict={'size': title_size})
-    ax.set_title("Model runtime distribution", fontdict={'size': title_size})
+    ax.set_xlabel("Proportion of Model Configurations", fontdict={"size": title_size})
+    ax.set_ylabel("Training runtime (s)", fontdict={"size": title_size})
+    ax.set_title("Model runtime distribution", fontdict={"size": title_size})
     plt.tight_layout()
 
     if not only_per_method:
@@ -340,18 +375,18 @@ def plot_train_time_deep_dive(
             linewidth=3,
             ax=ax,
         )
-        ax.set_yscale('log')
+        ax.set_yscale("log")
         ax.grid()
-        ax.set_xlabel("Configs (Proportion)", fontdict={'size': title_size})
-        ax.set_ylabel("Cumulative training runtime (s)", fontdict={'size': title_size})
-        ax.set_title("Cumulative config runtime distribution", fontdict={'size': title_size})
+        ax.set_xlabel("Configs (Proportion)", fontdict={"size": title_size})
+        ax.set_ylabel("Cumulative training runtime (s)", fontdict={"size": title_size})
+        ax.set_title("Cumulative config runtime distribution", fontdict={"size": title_size})
         plt.tight_layout()
 
     ax = axes[cur_idx]
     cur_idx += 1
 
     n_colors = len(hue_order)
-    
+
     sns.lineplot(
         data=df_sorted_by_time,
         x="group_index",
@@ -363,11 +398,11 @@ def plot_train_time_deep_dive(
         ax=ax,
         legend=False,
     )
-    ax.set_yscale('log')
+    ax.set_yscale("log")
     ax.grid()
-    ax.set_xlabel("Proportion of Model Configurations", fontdict={'size': title_size})
-    ax.set_ylabel("Cumulative training runtime (s)", fontdict={'size': title_size})
-    ax.set_title("Cumulative model runtime distribution", fontdict={'size': title_size})
+    ax.set_xlabel("Proportion of Model Configurations", fontdict={"size": title_size})
+    ax.set_ylabel("Cumulative training runtime (s)", fontdict={"size": title_size})
+    ax.set_title("Cumulative model runtime distribution", fontdict={"size": title_size})
     plt.tight_layout()
 
     fig_name = "data-analysis-runtime"

--- a/packages/tabarena/src/tabarena/plot/plot_ens_weights.py
+++ b/packages/tabarena/src/tabarena/plot/plot_ens_weights.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import pandas as pd
 import matplotlib.pyplot as plt
+import pandas as pd
 import seaborn as sns
 
 
@@ -9,9 +9,14 @@ import seaborn as sns
 # TODO: Title?
 # TODO: return type, don't return `plt`
 # TODO: Auto calculate required figsize based on # of rows and # of cols
-def create_heatmap(df: pd.DataFrame, xlabel: str = "Config", ylabel: str = "Task", figsize: tuple[float, float] = (12, 10), include_mean: bool = False):
-    """
-    Creates a heatmap visualizing the ensemble weights across a suite of tasks and configs.
+def create_heatmap(
+    df: pd.DataFrame,
+    xlabel: str = "Config",
+    ylabel: str = "Task",
+    figsize: tuple[float, float] = (12, 10),
+    include_mean: bool = False,
+):
+    """Creates a heatmap visualizing the ensemble weights across a suite of tasks and configs.
 
     Parameters
     ----------
@@ -27,7 +32,7 @@ def create_heatmap(df: pd.DataFrame, xlabel: str = "Config", ylabel: str = "Task
         If True, will add a row at the bottom with label "mean" representing the mean of the config weights across all tasks.
         NaN values are considered 0 for the purposes of calculating the mean.
 
-    Returns
+    Returns:
     -------
     plt
 
@@ -49,20 +54,20 @@ def create_heatmap(df: pd.DataFrame, xlabel: str = "Config", ylabel: str = "Task
         vmax=1,
         center=0.5,
         annot=True,
-        annot_kws={'size': 20},
-        fmt='.2f',
+        annot_kws={"size": 20},
+        fmt=".2f",
     )
 
     # Hide text for zero values (but still colored, otherwise fully white)
     for text in heatmap.texts:
         x, y = text.get_position()
         if mask.iloc[int(y), int(x)]:
-            text.set_text('')
+            text.set_text("")
 
             # Customize the colorbar
     cbar = heatmap.collections[0].colorbar
-    cbar.set_ticks([0, 0.5, 1, ])
-    cbar.set_ticklabels(['0', '0.5', '1'])
+    cbar.set_ticks([0, 0.5, 1])
+    cbar.set_ticklabels(["0", "0.5", "1"])
 
     # Set labels with specific font sizes
     plt.xlabel(xlabel, fontsize=20)

--- a/packages/tabarena/src/tabarena/plot/plot_family_proportion.py
+++ b/packages/tabarena/src/tabarena/plot/plot_family_proportion.py
@@ -8,7 +8,13 @@ import pandas as pd
 import seaborn as sns
 
 
-def plot_family_proportion(df, method="Portfolio-N200 (ensemble) (4h)", save_prefix: str = None, show: bool = True, hue_order: list = None):
+def plot_family_proportion(
+    df,
+    method="Portfolio-N200 (ensemble) (4h)",
+    save_prefix: str | None = None,
+    show: bool = True,
+    hue_order: list | None = None,
+):
     df_family = df[df["method"] == method].copy()
     df_family = df_family[df_family["fold"] == 0]
     portfolios = list(df_family["config_selected"].values)
@@ -18,6 +24,7 @@ def plot_family_proportion(df, method="Portfolio-N200 (ensemble) (4h)", save_pre
         portfolios_lst = portfolios
 
     from collections import defaultdict
+
     type_count = defaultdict(int)
     type_count_family = defaultdict(int)
     type_count_per_iter = dict()
@@ -31,25 +38,26 @@ def plot_family_proportion(df, method="Portfolio-N200 (ensemble) (4h)", save_pre
             if len(portfolio) <= i:
                 continue
             name = portfolio[i]
-            family = name.split('_', 1)[0]
+            family = name.split("_", 1)[0]
             type_count[name] += 1
             type_count_family[family] += 1
             type_count_per_iter[i][name] += 1
             type_count_family_per_iter[i][family] += 1
 
-    families = sorted(list(type_count_family.keys()))
+    families = sorted(type_count_family.keys())
 
     import copy
+
     type_count_cumulative = dict()
     type_count_family_cumulative = dict()
     type_count_cumulative[0] = copy.deepcopy(type_count_per_iter[0])
     type_count_family_cumulative[0] = copy.deepcopy(type_count_family_per_iter[0])
     for i in range(1, n_iters):
-        type_count_cumulative[i] = copy.deepcopy(type_count_cumulative[i-1])
-        for k in type_count_per_iter[i].keys():
+        type_count_cumulative[i] = copy.deepcopy(type_count_cumulative[i - 1])
+        for k in type_count_per_iter[i]:
             type_count_cumulative[i][k] += type_count_per_iter[i][k]
-        type_count_family_cumulative[i] = copy.deepcopy(type_count_family_cumulative[i-1])
-        for k in type_count_family_per_iter[i].keys():
+        type_count_family_cumulative[i] = copy.deepcopy(type_count_family_cumulative[i - 1])
+        for k in type_count_family_per_iter[i]:
             type_count_family_cumulative[i][k] += type_count_family_per_iter[i][k]
 
     data = []
@@ -59,22 +67,26 @@ def plot_family_proportion(df, method="Portfolio-N200 (ensemble) (4h)", save_pre
     for i in range(n_iters):
         data_cumulative.append([type_count_family_cumulative[i][f] for f in families])
 
-
     data_df = pd.DataFrame(data=data, columns=families)
     data_df = data_df.div(data_df.sum(axis=1), axis=0) * 100
-    data_df2 = data_df.stack().reset_index(name='Model Frequency (%) at Position').rename(columns={'level_1': 'Model', 'level_0': 'Portfolio Position'})
+    data_df2 = (
+        data_df.stack()
+        .reset_index(name="Model Frequency (%) at Position")
+        .rename(columns={"level_1": "Model", "level_0": "Portfolio Position"})
+    )
     data_df2["Portfolio Position"] += 1
 
     data_cumulative_df = pd.DataFrame(data=data_cumulative, columns=families)
     data_cumulative_df = data_cumulative_df.div(data_cumulative_df.sum(axis=1), axis=0) * 100
-    data_cumulative_df2 = data_cumulative_df.stack().reset_index(name='Cumulative Model Frequency (%)').rename(columns={'level_1': 'Model', 'level_0': 'Portfolio Position'})
+    data_cumulative_df2 = (
+        data_cumulative_df.stack()
+        .reset_index(name="Cumulative Model Frequency (%)")
+        .rename(columns={"level_1": "Model", "level_0": "Portfolio Position"})
+    )
     data_cumulative_df2["Portfolio Position"] += 1
 
     plot_per_position = False
-    if plot_per_position:
-        nrows = 2
-    else:
-        nrows = 1
+    nrows = 2 if plot_per_position else 1
 
     fig, axes = plt.subplots(nrows, 1, sharey=False, sharex=True, figsize=(3.5, 3), dpi=300, layout="constrained")
 
@@ -91,13 +103,13 @@ def plot_family_proportion(df, method="Portfolio-N200 (ensemble) (4h)", save_pre
             # palette="light:m_r",
             palette="pastel",
             edgecolor=".3",
-            linewidth=.5,
+            linewidth=0.5,
             discrete=True,
             ax=axes[0],
             # legend=False,
         )
         axes[0].set(ylabel="Model Frequency (%) at Position")
-        axes[0].set_xlim([0, n_iters+1])
+        axes[0].set_xlim([0, n_iters + 1])
         axes[0].set_ylim([0, 100])
         sns.move_legend(axes[0], "upper left")
     else:
@@ -116,26 +128,26 @@ def plot_family_proportion(df, method="Portfolio-N200 (ensemble) (4h)", save_pre
         # palette="light:m_r",
         palette="pastel",
         edgecolor=".3",
-        linewidth=.5,
+        linewidth=0.5,
         discrete=True,
         ax=axes[1],
         legend=legend,
     )
     axes[1].set(ylabel="Cumulative Model Frequency (%)")
-    axes[1].set_xlim([0, n_iters+1])
+    axes[1].set_xlim([0, n_iters + 1])
     axes[1].set_ylim([0, 100])
 
     if not plot_per_position:
         sns.move_legend(axes[1], "upper right")
 
-    fig.suptitle(f"Model Family Presence in Portfolio by Training Order")
+    fig.suptitle("Model Family Presence in Portfolio by Training Order")
 
     if save_prefix:
         fig_path = Path(save_prefix)
         fig_path.mkdir(parents=True, exist_ok=True)
-        fig_save_path = fig_path / f"portfolio-model-presence.png"
+        fig_save_path = fig_path / "portfolio-model-presence.png"
         plt.savefig(fig_save_path)
-        fig_save_path = fig_path / f"portfolio-model-presence.pdf"
+        fig_save_path = fig_path / "portfolio-model-presence.pdf"
         plt.savefig(fig_save_path)
     if show:
         plt.show()

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_frontier.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_frontier.py
@@ -4,14 +4,13 @@ import io
 import os
 from contextlib import redirect_stdout
 
+import matplotlib.patheffects as PathEffects
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
-import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
-import matplotlib.patheffects as PathEffects
-import matplotlib.patches as mpatches
 import seaborn as sns
+from matplotlib.lines import Line2D
+from pandas.api.types import is_numeric_dtype
 
 try:
     from adjustText import adjust_text
@@ -21,7 +20,9 @@ except ImportError:
     HAS_ADJUST_TEXT = False
 
 
-def aggregate_stats(df, on: str, groupby="method", method=["mean", "median", "std"]):
+def aggregate_stats(df, on: str, groupby="method", method=None):
+    if method is None:
+        method = ["mean", "median", "std"]
     return df[[groupby, on]].groupby(groupby).agg(method)[on]
 
 
@@ -34,8 +35,7 @@ def get_pareto_frontier(
     max_Y=True,
     include_boundary_edges=True,
 ):
-    """
-    Compute the (piece‑wise constant) Pareto frontier and, in parallel,
+    """Compute the (piece‑wise constant) Pareto frontier and, in parallel,
     return the label associated with each frontier vertex.
 
     Parameters
@@ -51,7 +51,7 @@ def get_pareto_frontier(
     include_boundary_edges : bool, default True
         If True, will include pareto front edges to the worst x and y values observed.
 
-    Returns
+    Returns:
     -------
     pareto_front : list[tuple[float, float]]
         The vertices that define the frontier, including the vertical
@@ -68,7 +68,7 @@ def get_pareto_frontier(
 
     # Sort primarily by X (descending if we maximise), secondarily by Y.
     pts = sorted(
-        zip(Xs, Ys, names),
+        zip(Xs, Ys, names, strict=False),
         key=lambda t: (t[0], t[1]),
         reverse=max_X,
     )
@@ -178,8 +178,7 @@ def plot_pareto(
         if place_first_at_end:
             first_in.reverse()
             return rest + first_in
-        else:
-            return first_in + rest
+        return first_in + rest
 
     # Build stable color mapping per hue category (here: method_type)
     hue_levels = list(pd.unique(plot_df[hue]))
@@ -202,11 +201,11 @@ def plot_pareto(
         extended_palette = (
             sns.color_palette("tab20", 20) + sns.color_palette("tab20b", 20) + sns.color_palette("tab20c", 20)
         )
-        colors = extended_palette[:len(hue_levels)]
+        colors = extended_palette[: len(hue_levels)]
     else:
-        colors = base_palette[:len(hue_levels)]
+        colors = base_palette[: len(hue_levels)]
     colors = [colors[i % len(colors)] for i in range(len(hue_levels))]
-    palette_map = dict(zip(hue_levels, colors))
+    palette_map = dict(zip(hue_levels, colors, strict=False))
 
     label_to_hue_dict = data.set_index(label_col)[hue].to_dict()
     label_to_color_dict = {l: palette_map[h] for l, h in label_to_hue_dict.items()}
@@ -217,7 +216,7 @@ def plot_pareto(
 
     # Create a mapping of labels to highlight colors
     label_to_highlight = {}
-    for label in label_to_color_dict.keys():
+    for label in label_to_color_dict:
         for prefix, color in highlight_prefixes.items():
             if label.startswith(prefix):
                 label_to_highlight[label] = color
@@ -353,8 +352,8 @@ def plot_pareto(
     pf_Y_first = y_min if max_Y else y_max
     pf_Y_last = pf_Y[-1]
 
-    pf_X = [pf_X_first] + pf_X + [pf_X_last]
-    pf_Y = [pf_Y_first] + pf_Y + [pf_Y_last]
+    pf_X = [pf_X_first, *pf_X, pf_X_last]
+    pf_Y = [pf_Y_first, *pf_Y, pf_Y_last]
 
     if add_optimal_arrow:
         plot_optimal_arrow(ax=ax, max_X=max_X, max_Y=max_Y, size=fig_size_ratio, scale=1.2)
@@ -385,11 +384,13 @@ def plot_pareto(
     y_offset = y_range * 0.025  # 2.5% vertical offset for "above" placement
 
     # Get all real Pareto points (with labels) for analysis
-    real_pareto_points = [(x, y, lbl) for (x, y), lbl in zip(pareto_front, pareto_names) if lbl is not None]
+    real_pareto_points = [
+        (x, y, lbl) for (x, y), lbl in zip(pareto_front, pareto_names, strict=False) if lbl is not None
+    ]
     pareto_labels_set = {lbl for _, _, lbl in real_pareto_points}
 
     # Build the list of points to label: Pareto frontier + force_labels (if not already on frontier)
-    points_to_label = list(zip(pareto_front, pareto_names))
+    points_to_label = list(zip(pareto_front, pareto_names, strict=False))
     if force_labels is not None:
         # Add forced labels that are not on the Pareto frontier
         for force_label in force_labels:
@@ -402,7 +403,7 @@ def plot_pareto(
                     points_to_label.append(((x_val, y_val), force_label))
 
     # Sort by Y to find top points
-    sorted_by_y = sorted(real_pareto_points, key=lambda p: p[1], reverse=True)
+    sorted(real_pareto_points, key=lambda p: p[1], reverse=True)
     top_y_threshold = y_max - y_range * 0.25  # Top 25% of Y range
 
     for (x, y), label in points_to_label:
@@ -431,7 +432,7 @@ def plot_pareto(
         x_log = np.log10(x)
         x_log_min, x_log_max = np.log10(x_min), np.log10(x_max)
         x_frac = (x_log - x_log_min) / (x_log_max - x_log_min) if x_log_max != x_log_min else 0.5
-        y_frac = (y - y_min) / y_range if y_range != 0 else 0.5
+        (y - y_min) / y_range if y_range != 0 else 0.5
 
         # Calculate offsets
         x_offset_log = (x_log_max - x_log_min) * 0.015  # 1.5% of x-axis range
@@ -520,7 +521,7 @@ def plot_pareto(
                         alpha=0.5,
                     ),
                     PathEffects.withStroke(linewidth=2, foreground="white"),
-                ]
+                ],
             )
         else:
             # Non-highlighted labels: white stroke for readability
@@ -691,10 +692,10 @@ def plot_pareto(
         # Need to draw to get legend bbox
         g.fig.canvas.draw()
         bbox1 = legend1.get_window_extent()
-        bbox1_axes = bbox1.transformed(ax.transAxes.inverted())
+        bbox1.transformed(ax.transAxes.inverted())
 
         # Second legend: markers (Default, Tuned, etc.) - INSIDE plot at lower right
-        legend2 = ax.legend(
+        ax.legend(
             marker_handles,
             marker_labels,
             loc="best",
@@ -839,8 +840,8 @@ def plot_pareto_aggregated(
     max_Y: bool = True,
     ylim=(None, 1),
     hue: str = "Method",
-    title: str = None,
-    save_path: str = None,
+    title: str | None = None,
+    save_path: str | None = None,
     show: bool = True,
     include_method_in_axis_name: bool = True,
     sort_y: bool = False,
@@ -849,15 +850,15 @@ def plot_pareto_aggregated(
         data_x = data
     if x_name not in data_x:
         raise AssertionError(f"Missing x_name='{x_name}' column in data_x")
-    elif not is_numeric_dtype(data_x[x_name]):
+    if not is_numeric_dtype(data_x[x_name]):
         raise AssertionError(f"x_name='{x_name}' must be a numeric dtype")
-    elif data_x[x_name].isnull().values.any():
+    if data_x[x_name].isnull().values.any():
         raise AssertionError(f"x_name='{x_name}' cannot contain NaN values")
     if y_name not in data:
         raise AssertionError(f"Missing y_name='{y_name}' column in data")
-    elif not is_numeric_dtype(data[y_name]):
+    if not is_numeric_dtype(data[y_name]):
         raise AssertionError(f"y_name='{y_name}' must be a numeric dtype")
-    elif data[y_name].isnull().values.any():
+    if data[y_name].isnull().values.any():
         raise AssertionError(f"y_name='{y_name}' cannot contain NaN values")
     y_vals = aggregate_stats(df=data, on=y_name, method=[y_method])[y_method]
     x_vals = aggregate_stats(df=data_x, on=x_name, method=[x_method])[x_method]

--- a/packages/tabarena/src/tabarena/plot/plot_utils.py
+++ b/packages/tabarena/src/tabarena/plot/plot_utils.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pandas as pd
+if TYPE_CHECKING:
+    import pandas as pd
 
 
-def figure_path(path: str | Path, prefix: str = None, suffix: str = None):
+def figure_path(path: str | Path, prefix: str | None = None, suffix: str | None = None):
     fig_save_path_dir = Path(path)
     if prefix:
         fig_save_path_dir = fig_save_path_dir / prefix
@@ -16,7 +18,7 @@ def figure_path(path: str | Path, prefix: str = None, suffix: str = None):
     return fig_save_path_dir
 
 
-def table_path(path: str | Path, prefix: str = None, suffix: str = None):
+def table_path(path: str | Path, prefix: str | None = None, suffix: str | None = None):
     table_save_path_dir = Path(path)
     if prefix:
         table_save_path_dir = table_save_path_dir / prefix
@@ -27,13 +29,20 @@ def table_path(path: str | Path, prefix: str = None, suffix: str = None):
     return table_save_path_dir
 
 
-def save_latex_table(df: pd.DataFrame, title: str, show_table: bool = False, latex_kwargs: dict | None = None, n_digits = None, save_prefix: str = None):
+def save_latex_table(
+    df: pd.DataFrame,
+    title: str,
+    show_table: bool = False,
+    latex_kwargs: dict | None = None,
+    n_digits=None,
+    save_prefix: str | None = None,
+):
     if n_digits:
         for col in df.columns:
-            if (not df[col].dtype == "object") and (not df[col].dtype == "int64"):
+            if (df[col].dtype != "object") and (df[col].dtype != "int64"):
                 n_digit = n_digits.get(col, 2)
                 df[col] = df[col].astype("object")
-                df.loc[:, col] = df.loc[:, col].apply(lambda s: f'{s:.{n_digit}f}')
+                df.loc[:, col] = df.loc[:, col].apply(lambda s: f"{s:.{n_digit}f}")  # noqa: B023
 
     if latex_kwargs is None:
         latex_kwargs = dict()

--- a/packages/tabarena/src/tabarena/plot/png_to_grid.py
+++ b/packages/tabarena/src/tabarena/plot/png_to_grid.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-import math
 from pathlib import Path
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 from PIL import Image
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def make_png_grid(
@@ -20,8 +22,7 @@ def make_png_grid(
     scale: float | None = None,
     resample: Image.Resampling = Image.Resampling.LANCZOS,
 ) -> None:
-    """
-    Combine PNG images into an n_rows x n_cols composite PNG.
+    """Combine PNG images into an n_rows x n_cols composite PNG.
 
     Parameters
     ----------
@@ -53,7 +54,7 @@ def make_png_grid(
     resample
         PIL resampling filter used for resizing.
 
-    Notes
+    Notes:
     -----
     - If fewer images than grid cells are provided, remaining cells are left blank.
     - If more images than grid cells are provided, raises ValueError.
@@ -64,19 +65,16 @@ def make_png_grid(
 
     if len(image_paths) > n_rows * n_cols:
         raise ValueError(
-            f"Too many images ({len(image_paths)}) for grid {n_rows}x{n_cols} "
-            f"({n_rows * n_cols} cells)."
+            f"Too many images ({len(image_paths)}) for grid {n_rows}x{n_cols} ({n_rows * n_cols} cells).",
         )
 
     if not image_paths:
         raise ValueError("image_paths must contain at least one image.")
 
-    resize_args_provided = sum(
-        x is not None for x in (output_size, max_output_size, scale)
-    )
+    resize_args_provided = sum(x is not None for x in (output_size, max_output_size, scale))
     if resize_args_provided > 1:
         raise ValueError(
-            "Specify at most one of output_size, max_output_size, or scale."
+            "Specify at most one of output_size, max_output_size, or scale.",
         )
 
     if scale is not None and scale <= 0:
@@ -119,7 +117,7 @@ def make_png_grid(
             out_w, out_h = output_size
             if out_w <= 0 or out_h <= 0:
                 raise ValueError(
-                    f"output_size dimensions must be > 0, but got {output_size}."
+                    f"output_size dimensions must be > 0, but got {output_size}.",
                 )
             canvas = canvas.resize((out_w, out_h), resample)
 
@@ -127,7 +125,7 @@ def make_png_grid(
             max_w, max_h = max_output_size
             if max_w <= 0 or max_h <= 0:
                 raise ValueError(
-                    f"max_output_size dimensions must be > 0, but got {max_output_size}."
+                    f"max_output_size dimensions must be > 0, but got {max_output_size}.",
                 )
 
             scale_factor = min(max_w / canvas.width, max_h / canvas.height)
@@ -150,7 +148,6 @@ def make_png_grid(
             img.close()
 
 
-
 def make_png_grid_old(
     image_paths: Sequence[str | Path],
     output_path: str | Path,
@@ -160,8 +157,7 @@ def make_png_grid_old(
     bg_color: tuple[int, int, int, int] = (255, 255, 255, 255),
     resize_mode: str = "fit",
 ) -> None:
-    """
-    Combine PNG images into an n_rows x n_cols composite PNG.
+    """Combine PNG images into an n_rows x n_cols composite PNG.
 
     Parameters
     ----------
@@ -182,7 +178,7 @@ def make_png_grid_old(
         - "fit": preserve aspect ratio, fit inside cell
         - "stretch": resize exactly to cell size
 
-    Notes
+    Notes:
     -----
     - If fewer images than grid cells are provided, remaining cells are left blank.
     - If more images than grid cells are provided, raises ValueError.
@@ -192,8 +188,7 @@ def make_png_grid_old(
 
     if len(image_paths) > n_rows * n_cols:
         raise ValueError(
-            f"Too many images ({len(image_paths)}) for grid {n_rows}x{n_cols} "
-            f"({n_rows * n_cols} cells)."
+            f"Too many images ({len(image_paths)}) for grid {n_rows}x{n_cols} ({n_rows * n_cols} cells).",
         )
 
     if not image_paths:

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -10,8 +10,8 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from autogluon.common.loaders import load_pd
-from bencheval.tabarena import TabArena
 
+from bencheval.tabarena import TabArena
 from tabarena.nips2025_utils.compare import subset_tasks
 from tabarena.nips2025_utils.eval_all import (
     get_all_subset_combinations,
@@ -180,10 +180,10 @@ def plot_hpo(
         color = color_map[method_name]
 
         # 1) Draw the connecting line (no markers)
-        _h, = ax.plot(
+        (_h,) = ax.plot(
             times,
             scores,
-            "-",                # no point markers
+            "-",  # no point markers
             label=method_name,
             color=color,
             alpha=0.9,
@@ -199,7 +199,7 @@ def plot_hpo(
                     times[mask],
                     scores[mask],
                     marker="o",
-                    s=64,          # ~markersize=16 equivalent
+                    s=64,  # ~markersize=16 equivalent
                     color=color,
                     alpha=0.9,
                     zorder=4,
@@ -301,7 +301,7 @@ def plot_hpo(
                 **_annotation_placement(lbl),
             )
             txt.set_path_effects(
-                [PathEffects.withStroke(linewidth=3, foreground="white")]
+                [PathEffects.withStroke(linewidth=3, foreground="white")],
             )
 
     if show_pareto_frontier:
@@ -391,7 +391,7 @@ def plot_hpo(
             # ``seen_labels`` is shared with the ``link_points`` block —
             # a method labeled there is skipped here so it doesn't get
             # annotated twice.
-            for (x, y), lbl in zip(pareto_front, pareto_names):
+            for (x, y), lbl in zip(pareto_front, pareto_names, strict=False):
                 if lbl is None or lbl in seen_labels:
                     continue
                 seen_labels.add(lbl)
@@ -407,7 +407,7 @@ def plot_hpo(
                     **_annotation_placement(lbl),
                 )
                 txt.set_path_effects(
-                    [PathEffects.withStroke(linewidth=3, foreground="white")]
+                    [PathEffects.withStroke(linewidth=3, foreground="white")],
                 )
 
             # Plotting the extended frontier + label annotations triggers
@@ -453,10 +453,7 @@ def plot_hpo(
     # names continue to drive color lookups, frontier annotations, etc.
     if hidden_legend_methods:
         hidden_set = set(hidden_legend_methods)
-        kept = [
-            (h, lbl) for h, lbl in zip(handles_legend, labels_legend)
-            if lbl not in hidden_set
-        ]
+        kept = [(h, lbl) for h, lbl in zip(handles_legend, labels_legend, strict=False) if lbl not in hidden_set]
         handles_legend = [h for h, _ in kept]
         labels_legend = [lbl for _, lbl in kept]
     if legend_display_names:
@@ -513,10 +510,7 @@ def plot_hpo(
         # first then values in matching order.
         keys_list = list(dataset_metadata.keys())
         values_list = [str(v) for v in dataset_metadata.values()]
-        meta_handles = [
-            Line2D([], [], linestyle="none", marker="", color="none")
-            for _ in range(2 * len(keys_list))
-        ]
+        meta_handles = [Line2D([], [], linestyle="none", marker="", color="none") for _ in range(2 * len(keys_list))]
         meta_labels = keys_list + values_list
 
         # Preserve the model legend so adding the metadata one doesn't drop it.
@@ -606,7 +600,7 @@ def compute_tuning_trajectories_leaderboard(
     elo_bootstrap_rounds: int = 1,
     average_seeds: bool = False,
     subset: str | list[str] | None = None,
-    name_col = "config_type",
+    name_col="config_type",
     folds: list[int] | None = None,
 ):
     combined_data = combined_data.copy()
@@ -690,7 +684,7 @@ def compute_tuning_trajectories_leaderboard(
     if val_nan_methods:
         print(
             f"Dropping {len(val_nan_methods)} method(s) from validation-score "
-            f"leaderboard due to NaN metric_error_val: {val_nan_methods}"
+            f"leaderboard due to NaN metric_error_val: {val_nan_methods}",
         )
     combined_data_val = combined_data[~combined_data["method"].isin(val_nan_methods)]
 
@@ -732,13 +726,16 @@ def compute_tuning_trajectories_leaderboard(
     leaderboard["Improvability (%)"] = leaderboard["improvability"] * 100
     leaderboard["Improvability (%) (Test)"] = leaderboard["Improvability (%)"]
     leaderboard["Improvability (%) (Val)"] = leaderboard["improvability_val"] * 100
-    leaderboard["Improvability (%) (Test) - Improvability (%) (Val)"] = leaderboard["Improvability (%) (Test)"] - leaderboard["Improvability (%) (Val)"]
+    leaderboard["Improvability (%) (Test) - Improvability (%) (Val)"] = (
+        leaderboard["Improvability (%) (Test)"] - leaderboard["Improvability (%) (Val)"]
+    )
 
     leaderboard["Baseline Advantage (%)"] = leaderboard["baseline_advantage"] * 100
     leaderboard["Baseline Advantage (%) (Test)"] = leaderboard["Baseline Advantage (%)"]
     leaderboard["Baseline Advantage (%) (Val)"] = leaderboard["baseline_advantage_val"] * 100
-    leaderboard["Baseline Advantage (%) (Test - Val)"] = (leaderboard["baseline_advantage"] - leaderboard[
-        "baseline_advantage_val"]) * 100
+    leaderboard["Baseline Advantage (%) (Test - Val)"] = (
+        leaderboard["baseline_advantage"] - leaderboard["baseline_advantage_val"]
+    ) * 100
 
     leaderboard["Train time per 1K samples (s) (median)"] = leaderboard["median_time_train_s_per_1K"]
     leaderboard["Inference time per 1K samples (s) (median)"] = leaderboard["median_time_infer_s_per_1K"]
@@ -757,8 +754,8 @@ def plot_tuning_trajectories_all(
     fig_save_dir: str | Path = Path("plots") / "n_configs",
     ban_bad_methods: bool = True,
     file_ext: str = ".pdf",
-    extra_results = None,
-    calibration_framework = "auto",
+    extra_results=None,
+    calibration_framework="auto",
     folds: list[int] | None = None,
     methods_to_display: list[str] | None = None,
     plot_kwargs: dict | None = None,
@@ -804,12 +801,14 @@ def plot_tuning_trajectories_all(
             subset_list.append("lite")
         (fig_save_dir / custom_folder_name).mkdir(parents=True, exist_ok=True)
 
-        inputs.append({
-            "subset_map": {"placeholder_name": subset_list},
-            "average_seeds": average_seeds,
-            "exclude_imputed": not use_imputation,
-            "fig_save_dir": fig_save_dir / custom_folder_name / "tuning_trajectories",
-        })
+        inputs.append(
+            {
+                "subset_map": {"placeholder_name": subset_list},
+                "average_seeds": average_seeds,
+                "exclude_imputed": not use_imputation,
+                "fig_save_dir": fig_save_dir / custom_folder_name / "tuning_trajectories",
+            }
+        )
 
     parallel_for(
         f=plot_tuning_trajectories,
@@ -933,7 +932,7 @@ def plot_tuning_trajectories_per_dataset(
     fig_save_dir: str | Path = Path("plots") / "n_configs_per_dataset",
     ban_bad_methods: bool = True,
     file_ext: str = ".pdf",
-    extra_results = None,
+    extra_results=None,
     calibration_framework: str | None = "auto",
     fillna_method: str | None = "auto",
     folds: list[int] | None = None,
@@ -1021,14 +1020,16 @@ def plot_tuning_trajectories_per_dataset(
             plot_kwargs_cur = {}
         plot_kwargs_cur["title"] = f"Dataset: {_name_map.get(dataset, dataset)}"
 
-        inputs.append({
-            "datasets": [dataset],
-            "fig_save_dir": fig_save_dir / dataset / "tuning_trajectories",
-            "subset_map": list(subset_list),
-            "plot_kwargs": plot_kwargs_cur,
-            "error_ylabel_metric": _metric_map.get(dataset),
-            "dataset_metadata": _metadata_map.get(dataset),
-        })
+        inputs.append(
+            {
+                "datasets": [dataset],
+                "fig_save_dir": fig_save_dir / dataset / "tuning_trajectories",
+                "subset_map": list(subset_list),
+                "plot_kwargs": plot_kwargs_cur,
+                "error_ylabel_metric": _metric_map.get(dataset),
+                "dataset_metadata": _metadata_map.get(dataset),
+            }
+        )
 
     parallel_for(
         f=_plot_tuning_trajectories_from_prepared,
@@ -1094,9 +1095,15 @@ def _prepare_tuning_trajectories_data(
 
     result_baselines = tabarena_context.load_results_paper()
 
-    results_hpo_mean = results_hpo.copy().groupby(["method", "dataset", "fold", "problem_type", "metric", "config_type", "display_name"]).mean(
-        numeric_only=True
-    ).drop(columns=["seed"]).reset_index()
+    results_hpo_mean = (
+        results_hpo.copy()
+        .groupby(["method", "dataset", "fold", "problem_type", "metric", "config_type", "display_name"])
+        .mean(
+            numeric_only=True,
+        )
+        .drop(columns=["seed"])
+        .reset_index()
+    )
     results_hpo_mean["imputed"] = 0
     results_hpo_mean["imputed"] = results_hpo_mean["imputed"].astype(bool)
 
@@ -1122,18 +1129,27 @@ def _prepare_tuning_trajectories_data(
     if include_hpo_seeds:
         results_hpo_seeds = results_hpo.copy()
         results_hpo_seeds["method"] = results_hpo_seeds["method"] + "-" + results_hpo_seeds["seed"].astype(str)
-        results_hpo_seeds["config_type"] = results_hpo_seeds["config_type"] + "-" + results_hpo_seeds["seed"].astype(str)
-        results_hpo_seeds = results_hpo_seeds.groupby(["method", "dataset", "fold", "problem_type", "metric", "config_type", "display_name"]).mean(
-            numeric_only=True).reset_index()
+        results_hpo_seeds["config_type"] = (
+            results_hpo_seeds["config_type"] + "-" + results_hpo_seeds["seed"].astype(str)
+        )
+        results_hpo_seeds = (
+            results_hpo_seeds.groupby(
+                ["method", "dataset", "fold", "problem_type", "metric", "config_type", "display_name"]
+            )
+            .mean(numeric_only=True)
+            .reset_index()
+        )
         results_lst.append(results_hpo_seeds)
 
     if include_portfolio:  # TODO: This only works if you have legacy files, add general support for portfolio
         results_portfolio = load_pd.load(path="../tabarena/advanced/rebuttal/rebuttal_portfolio_n_configs.parquet")
         results_portfolio["config_type"] = results_portfolio["method"]
-        results_portfolio = results_portfolio.rename(columns={
-            "n_portfolio": "n_configs",
-            "n_ensembles": "n_iterations",
-        })
+        results_portfolio = results_portfolio.rename(
+            columns={
+                "n_portfolio": "n_configs",
+                "n_ensembles": "n_iterations",
+            }
+        )
         results_portfolio["method"] = results_portfolio["method"] + "-" + results_portfolio["n_configs"].astype(str)
         results_portfolio["imputed"] = 0
         results_portfolio["imputed"] = results_portfolio["imputed"].astype(bool)
@@ -1150,10 +1166,12 @@ def _prepare_tuning_trajectories_data(
     dataset_to_n_samples_train = tabarena_context.task_metadata.set_index("name")["n_samples_train_per_fold"].to_dict()
     dataset_to_n_samples_test = tabarena_context.task_metadata.set_index("name")["n_samples_test_per_fold"].to_dict()
 
-    combined_data["time_train_s_per_1K"] = combined_data["time_train_s"] * 1000 / combined_data["dataset"].map(
-        dataset_to_n_samples_train)
-    combined_data["time_infer_s_per_1K"] = combined_data["time_infer_s"] * 1000 / combined_data["dataset"].map(
-        dataset_to_n_samples_test)
+    combined_data["time_train_s_per_1K"] = (
+        combined_data["time_train_s"] * 1000 / combined_data["dataset"].map(dataset_to_n_samples_train)
+    )
+    combined_data["time_infer_s_per_1K"] = (
+        combined_data["time_infer_s"] * 1000 / combined_data["dataset"].map(dataset_to_n_samples_test)
+    )
 
     # Combined train + inference runtime, both raw and per-1K-samples.
     # Computed at the row level (not as the sum of medians) so the
@@ -1162,7 +1180,11 @@ def _prepare_tuning_trajectories_data(
     combined_data["time_total_s"] = combined_data["time_train_s"] + combined_data["time_infer_s"]
     combined_data["time_total_s_per_1K"] = combined_data["time_train_s_per_1K"] + combined_data["time_infer_s_per_1K"]
 
-    methods_map = results_hpo[["method", "n_configs", "n_iterations", "config_type"]].drop_duplicates(subset=["method"]).set_index("method")
+    methods_map = (
+        results_hpo[["method", "n_configs", "n_iterations", "config_type"]]
+        .drop_duplicates(subset=["method"])
+        .set_index("method")
+    )
 
     return combined_data, methods_map
 
@@ -1294,8 +1316,8 @@ def plot_tuning_trajectories(
     file_ext: str = ".pdf",
     extra_results: pd.DataFrame | None = None,
     datasets: list[str] | None = None,
-    calibration_framework = "auto",
-    fillna_method = "auto",
+    calibration_framework="auto",
+    fillna_method="auto",
     folds: list[int] | None = None,
     methods_to_display: list[str] | None = None,
     hidden_methods: list[str] | None = None,
@@ -1424,9 +1446,7 @@ def plot_tuning_trajectories_from_leaderboard(
         method_col = plot_kwargs.get("method_col", "name")
         if "Elo" in leaderboard.columns and method_col in leaderboard.columns:
             plot_kwargs["method_order"] = (
-                leaderboard.groupby(method_col)["Elo"].max()
-                .sort_values(ascending=False)
-                .index.tolist()
+                leaderboard.groupby(method_col)["Elo"].max().sort_values(ascending=False).index.tolist()
             )
 
     ylim_imp = plot_kwargs.pop("ylim_imp")

--- a/packages/tabarena/src/tabarena/portfolio/__init__.py
+++ b/packages/tabarena/src/tabarena/portfolio/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 from ._portfolio_cv import Portfolio, PortfolioCV

--- a/packages/tabarena/src/tabarena/portfolio/_portfolio_cv.py
+++ b/packages/tabarena/src/tabarena/portfolio/_portfolio_cv.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import Dict, List, Optional
 
 import numpy as np
 from scipy import stats as st
@@ -7,19 +8,21 @@ from scipy import stats as st
 
 # TODO: Consider including more, such as metric, metric_error, so that we don't need to calculate that later
 class Portfolio:
-    def __init__(self,
-                 configs: List[str],
-                 train_score: float = None,
-                 test_score: float = None,
-                 train_datasets: List[str] = None,
-                 test_datasets: List[str] = None,
-                 train_datasets_fold: List[str] = None,
-                 test_datasets_fold: List[str] = None,
-                 fold: int = None,
-                 split: int = None,
-                 repeat: int = None,
-                 step: int = None,
-                 n_configs_avail: int = None):
+    def __init__(
+        self,
+        configs: list[str],
+        train_score: float | None = None,
+        test_score: float | None = None,
+        train_datasets: list[str] | None = None,
+        test_datasets: list[str] | None = None,
+        train_datasets_fold: list[str] | None = None,
+        test_datasets_fold: list[str] | None = None,
+        fold: int | None = None,
+        split: int | None = None,
+        repeat: int | None = None,
+        step: int | None = None,
+        n_configs_avail: int | None = None,
+    ):
         self.configs = configs
         self.train_score = train_score
         self.test_score = test_score
@@ -39,16 +42,13 @@ class Portfolio:
 
 
 class PortfolioCV:
-    """
-    Contains a list of Portfolios generated during cross-validation.
-    """
-    def __init__(self, portfolios: List[Portfolio]):
+    """Contains a list of Portfolios generated during cross-validation."""
+
+    def __init__(self, portfolios: list[Portfolio]):
         self.portfolios = portfolios
 
     def is_dense(self) -> bool:
-        """
-        Return True if for each repeat all test datasets appear in exactly one split
-        """
+        """Return True if for each repeat all test datasets appear in exactly one split."""
         portfolios_by_repeat = self.get_portfolios_by_repeat()
         for r in portfolios_by_repeat:
             is_dense_repeat = self.are_test_folds_unique(portfolios=portfolios_by_repeat[r])
@@ -72,55 +72,53 @@ class PortfolioCV:
         is_dense = self.is_dense()
         num_repeats = self.num_repeats()
         num_portfolios = len(self.portfolios)
-        print(f'Summarizing PortfolioCV:\n'
-              f'\tis_dense={is_dense}, num_portfolios={num_portfolios}, num_repeats={num_repeats}, '
-              f'split_max={self.split_max()}, num_configs_max={self.num_configs_max()}, '
-              f'num_configs_avail_max={self.num_configs_avail_max()}, step_max={self.step_max()}'
-              f'\n'
-              f'\ttrain_error   = {self.get_train_score_overall():.5f}'
-              f'\ttrain_stddev  = {self.get_train_score_stddev():.5f}'
-              f'\ttrain_95_conf = {self.get_train_score_conf_from_repeats():.5f}\n'
-              f'\t test_error   = {self.get_test_score_overall():.5f}'
-              f'\t test_stddev  = {self.get_test_score_stddev():.5f}'
-              f'\t test_95_conf = {self.get_test_score_conf_from_repeats():.5f}'
-              f'')
+        print(
+            f"Summarizing PortfolioCV:\n"
+            f"\tis_dense={is_dense}, num_portfolios={num_portfolios}, num_repeats={num_repeats}, "
+            f"split_max={self.split_max()}, num_configs_max={self.num_configs_max()}, "
+            f"num_configs_avail_max={self.num_configs_avail_max()}, step_max={self.step_max()}"
+            f"\n"
+            f"\ttrain_error   = {self.get_train_score_overall():.5f}"
+            f"\ttrain_stddev  = {self.get_train_score_stddev():.5f}"
+            f"\ttrain_95_conf = {self.get_train_score_conf_from_repeats():.5f}\n"
+            f"\t test_error   = {self.get_test_score_overall():.5f}"
+            f"\t test_stddev  = {self.get_test_score_stddev():.5f}"
+            f"\t test_95_conf = {self.get_test_score_conf_from_repeats():.5f}"
+            f""
+        )
 
-    def get_portfolios_by_repeat(self) -> Dict[int, List[Portfolio]]:
+    def get_portfolios_by_repeat(self) -> dict[int, list[Portfolio]]:
         portfolio_by_repeat_dict = defaultdict(list)
         for portfolio in self.portfolios:
             portfolio_by_repeat_dict[portfolio.repeat].append(portfolio)
         return dict(portfolio_by_repeat_dict)
 
-    def repeats(self) -> List[int]:
+    def repeats(self) -> list[int]:
         repeats = set()
         for p in self.portfolios:
             repeats.add(p.repeat)
-        repeats = sorted(list(repeats))
-        return repeats
+        return sorted(repeats)
 
     def num_repeats(self):
         return len(self.repeats())
 
     def has_test_score(self) -> bool:
-        for portfolio in self.portfolios:
-            if portfolio.test_score is None:
-                return False
-        return True
+        return all(portfolio.test_score is not None for portfolio in self.portfolios)
 
-    def get_test_scores(self) -> List[float]:
+    def get_test_scores(self) -> list[float]:
         return [portfolio.test_score for portfolio in self.portfolios]
 
-    def get_train_scores(self) -> List[float]:
+    def get_train_scores(self) -> list[float]:
         return [portfolio.train_score for portfolio in self.portfolios]
 
-    def get_test_scores_per_repeat(self) -> List[float]:
+    def get_test_scores_per_repeat(self) -> list[float]:
         repeats = self.repeats()
         repeat_error_dict = defaultdict(list)
         for portfolio in self.portfolios:
             repeat_error_dict[portfolio.repeat].append(portfolio.test_score)
         return [np.mean(repeat_error_dict[repeat]) for repeat in repeats]
 
-    def get_train_scores_per_repeat(self) -> List[float]:
+    def get_train_scores_per_repeat(self) -> list[float]:
         repeats = self.repeats()
         repeat_error_dict = defaultdict(list)
         for portfolio in self.portfolios:
@@ -142,23 +140,19 @@ class PortfolioCV:
         return self._error_to_t_interval(errors=train_errors, confidence=confidence)
 
     def get_test_score_conf_from_repeats(self, confidence=0.95):
-        """Most accurate way to compute conf bound, but requires multiple repeats"""
+        """Most accurate way to compute conf bound, but requires multiple repeats."""
         test_errors = self.get_test_scores_per_repeat()
         return self._error_to_t_interval(errors=test_errors, confidence=confidence)
 
     def get_train_score_conf_from_repeats(self, confidence=0.95):
-        """Most accurate way to compute conf bound, but requires multiple repeats"""
+        """Most accurate way to compute conf bound, but requires multiple repeats."""
         train_errors = self.get_train_scores_per_repeat()
         return self._error_to_t_interval(errors=train_errors, confidence=confidence)
 
-    def _error_to_t_interval(self, errors: List[float], confidence: float = 0.95) -> float:
-        t_interval = st.t.interval(confidence=confidence,
-                                   df=len(errors)-1,
-                                   loc=np.mean(errors),
-                                   scale=st.sem(errors))
+    def _error_to_t_interval(self, errors: list[float], confidence: float = 0.95) -> float:
+        t_interval = st.t.interval(confidence=confidence, df=len(errors) - 1, loc=np.mean(errors), scale=st.sem(errors))
         t_interval_mean = np.mean(t_interval)
-        t_interval_deviation = t_interval_mean - t_interval[0]
-        return t_interval_deviation
+        return t_interval_mean - t_interval[0]
 
     def get_test_score_overall(self) -> float:
         total_num_datasets = 0
@@ -167,9 +161,8 @@ class PortfolioCV:
             test_score = portfolio.test_score
             num_datasets = len(portfolio.test_datasets_fold)
             total_num_datasets += num_datasets
-            total_test_score += test_score*num_datasets
-        test_score = total_test_score / total_num_datasets
-        return test_score
+            total_test_score += test_score * num_datasets
+        return total_test_score / total_num_datasets
 
     def get_train_score_overall(self):
         total_num_datasets = 0
@@ -178,13 +171,11 @@ class PortfolioCV:
             train_score = portfolio.train_score
             num_datasets = len(portfolio.train_datasets_fold)
             total_num_datasets += num_datasets
-            total_train_score += train_score*num_datasets
-        train_score = total_train_score / total_num_datasets
-        return train_score
+            total_train_score += train_score * num_datasets
+        return total_train_score / total_num_datasets
 
-    def are_test_folds_unique(self, portfolios: Optional[List[Portfolio]] = None) -> bool:
-        """
-        Return True if each test dataset is only present in one fold.
+    def are_test_folds_unique(self, portfolios: list[Portfolio] | None = None) -> bool:
+        """Return True if each test dataset is only present in one fold.
         An example of when this would return False is repeated k-fold.
         """
         if portfolios is None:
@@ -200,18 +191,15 @@ class PortfolioCV:
 
     @classmethod
     def combine(cls, portfolio_cv_list: list):
-        """
-        Combine a list of PortfolioCV objects into one
-        """
+        """Combine a list of PortfolioCV objects into one."""
         portfolios = []
         for p in portfolio_cv_list:
             portfolios += p.portfolios
         return PortfolioCV(portfolios=portfolios)
 
     def get_test_train_rank_diff(self) -> float:
-        """
-        Returns the amount of overfitting that has occurred.
+        """Returns the amount of overfitting that has occurred.
         AKA: How overoptimistic the portfolio is on training compared to test
-        Lower = Better
+        Lower = Better.
         """
         return self.get_test_score_overall() - self.get_train_score_overall()

--- a/packages/tabarena/src/tabarena/portfolio/greedy_portfolio_generator.py
+++ b/packages/tabarena/src/tabarena/portfolio/greedy_portfolio_generator.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import itertools
-from typing import List, Type
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
-from dataclasses import dataclass
 
-from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels
 from tabarena.portfolio.zeroshot_selection import zeroshot_configs
-from tabarena.repository import EvaluationRepository
+from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels
 from tabarena.utils.parallel_for import parallel_for
+
+if TYPE_CHECKING:
+    from tabarena.repository import EvaluationRepository
 
 default_ensemble_size = 40
 n_portfolios_default = 200
@@ -32,22 +34,20 @@ class ResultRow:
 
 
 def evaluate_configs(
-        repo: EvaluationRepository,
-        configs: List[str],
-        tid: int,
-        folds: List[int],
-        method: str,
-        ensemble_size: int = default_ensemble_size,
-        ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
-        ensemble_kwargs=None,
-        patience_callback: list | None = None,
-        time_limit: float | None = None,
-        fit_order="original",
-        seed: int = 0,
-) -> List[ResultRow]:
-    """
-
-    :param repo:
+    repo: EvaluationRepository,
+    configs: list[str],
+    tid: int,
+    folds: list[int],
+    method: str,
+    ensemble_size: int = default_ensemble_size,
+    ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+    ensemble_kwargs=None,
+    patience_callback: list | None = None,
+    time_limit: float | None = None,
+    fit_order="original",
+    seed: int = 0,
+) -> list[ResultRow]:
+    """:param repo:
     :param configs:
     :param tid:
     :param method:
@@ -82,29 +82,31 @@ def evaluate_configs(
         ensemble_weights_dict = ensemble_weights.iloc[0].to_dict()
         ensemble_weights_dict = {k: v for k, v in ensemble_weights_dict.items() if v != 0}
 
-        task = repo.task_name(dataset=dataset, fold=fold)
+        repo.task_name(dataset=dataset, fold=fold)
 
         metric_error = metrics["metric_error"]
         metric_error_val = metrics["metric_error_val"]
         time_train_s = metrics["time_train_s"]
         time_infer_s = metrics["time_infer_s"]
 
-        rows.append(ResultRow(
-            dataset=dataset,
-            fold=fold,
-            method=method,
-            metric_error=metric_error,
-            time_train_s=time_train_s,
-            time_infer_s=time_infer_s,
-            metric_error_val=metric_error_val,
-            config_selected=configs_selected,
-            seed=seed,
-            metadata=dict(
-                n_iterations=ensemble_size,
-                time_limit=time_limit,
-            ),
-            ensemble_weight=ensemble_weights_dict,
-        ))
+        rows.append(
+            ResultRow(
+                dataset=dataset,
+                fold=fold,
+                method=method,
+                metric_error=metric_error,
+                time_train_s=time_train_s,
+                time_infer_s=time_infer_s,
+                metric_error_val=metric_error_val,
+                config_selected=configs_selected,
+                seed=seed,
+                metadata=dict(
+                    n_iterations=ensemble_size,
+                    time_limit=time_limit,
+                ),
+                ensemble_weight=ensemble_weights_dict,
+            )
+        )
     return rows
 
 
@@ -113,21 +115,24 @@ def time_suffix(max_runtime: float) -> str:
         if max_runtime >= 3600:
             str_num_hours = f"{int(max_runtime / 3600)}" if max_runtime % 3600 == 0 else f"{max_runtime / 3600:0.2f}"
             return f" ({str_num_hours}h)"
-        else:
-            str_num_mins = f"{int(max_runtime / 60)}" if max_runtime % 60 == 0 else f"{max_runtime / 60:0.2f}"
-            return f" ({str_num_mins}m)"
-    else:
-        return ""
+        str_num_mins = f"{int(max_runtime / 60)}" if max_runtime % 60 == 0 else f"{max_runtime / 60:0.2f}"
+        return f" ({str_num_mins}m)"
+    return ""
 
 
 def zeroshot_name(
-        n_portfolio: int = n_portfolios_default, n_ensemble: int = None, n_training_dataset: int = None,
-        n_training_fold: int = None, n_training_config: int = None,
-        max_runtime: float = default_runtime, prefix: str = None, n_ensemble_in_name: bool = False,
-        max_models: int = None, max_models_per_type: int = None,
+    n_portfolio: int = n_portfolios_default,
+    n_ensemble: int | None = None,
+    n_training_dataset: int | None = None,
+    n_training_fold: int | None = None,
+    n_training_config: int | None = None,
+    max_runtime: float = default_runtime,
+    prefix: str | None = None,
+    n_ensemble_in_name: bool = False,
+    max_models: int | None = None,
+    max_models_per_type: int | None = None,
 ):
-    """
-    :return: name of the zeroshot method such as Zeroshot-N20-C40 if n_training_dataset or n_training_folds are not
+    """:return: name of the zeroshot method such as Zeroshot-N20-C40 if n_training_dataset or n_training_folds are not
     None, suffixes "-D{n_training_dataset}" and "-S{n_training_folds}" are added, for instance "Zeroshot-N20-C40-D30-S5"
     would be the name if n_training_dataset=30 and n_training_fold=5
     """
@@ -137,8 +142,14 @@ def zeroshot_name(
         prefix = ""
     suffix = [
         f"-{letter}{x}" if x is not None else ""
-        for letter, x in
-        [("N", n_portfolio), ("D", n_training_dataset), ("S", n_training_fold), ("M", n_training_config), ("X", max_models), ("Z", max_models_per_type)]
+        for letter, x in [
+            ("N", n_portfolio),
+            ("D", n_training_dataset),
+            ("S", n_training_fold),
+            ("M", n_training_config),
+            ("X", max_models),
+            ("Z", max_models_per_type),
+        ]
     ]
     # if n_ensemble:
     #     suffix += f"-C{n_ensemble}"
@@ -157,39 +168,43 @@ def filter_configurations_above_budget(repo, test_tid, configs, max_runtime, qua
     dd = repo._zeroshot_context.df_configs
     dd = dd[dd["framework"].isin(set(configs))]
     dd = dd[dd.tid != test_tid]
-    df_configs_runtime = dd.pivot_table(
-        index="framework", columns="tid", values="time_train_s"
-    ).quantile(q=quantile, axis=1).sort_values()
+    df_configs_runtime = (
+        dd.pivot_table(
+            index="framework",
+            columns="tid",
+            values="time_train_s",
+        )
+        .quantile(q=quantile, axis=1)
+        .sort_values()
+    )
 
     configs_fast_enough = set(df_configs_runtime[df_configs_runtime < max_runtime].index.tolist())
-    configs = [c for c in configs if c in configs_fast_enough]
-    return configs
+    return [c for c in configs if c in configs_fast_enough]
 
 
 def zeroshot_results(
-        repo: EvaluationRepository,
-        dataset_names: List[str],
-        n_eval_folds: int,
-        framework_types: List[str] | None = None,
-        configs: list[str] | None = None,
-        n_ensembles: List[int] = [None],
-        n_portfolios: List[int] = [n_portfolios_default],
-        n_training_datasets: List[int] = [None],
-        n_training_folds: List[int] = [None],
-        n_training_configs: List[int] = [None],
-        n_max_models: List[int] = [None],
-        n_max_models_per_type: List[int] = [None],
-        max_runtimes: List[float] = [default_runtime],
-        engine: str = "ray",
-        seeds: list = [0],
-        method_prefix: str = None,
-        n_ensemble_in_name: bool = False,
-        ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
-        ensemble_kwargs: dict = None,
-        patience_callback: list | None = None,
+    repo: EvaluationRepository,
+    dataset_names: list[str],
+    n_eval_folds: int,
+    framework_types: list[str] | None = None,
+    configs: list[str] | None = None,
+    n_ensembles: list[int] | None = None,
+    n_portfolios: list[int] | None = None,
+    n_training_datasets: list[int] | None = None,
+    n_training_folds: list[int] | None = None,
+    n_training_configs: list[int] | None = None,
+    n_max_models: list[int] | None = None,
+    n_max_models_per_type: list[int] | None = None,
+    max_runtimes: list[float] | None = None,
+    engine: str = "ray",
+    seeds: list | None = None,
+    method_prefix: str | None = None,
+    n_ensemble_in_name: bool = False,
+    ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+    ensemble_kwargs: dict | None = None,
+    patience_callback: list | None = None,
 ) -> list[ResultRow]:
-    """
-    :param dataset_names: list of dataset to use when fitting zeroshot
+    """:param dataset_names: list of dataset to use when fitting zeroshot
     :param n_eval_folds: number of folds to consider for evaluation
     :param n_ensembles: number of caruana sizes to consider
     :param n_portfolios: number of folds to use when fitting zeroshot
@@ -203,6 +218,24 @@ def zeroshot_results(
     :param seeds: the seeds for the random number generator used for shuffling the configs
     :return: evaluation obtained on all combinations
     """
+    if seeds is None:
+        seeds = [0]
+    if max_runtimes is None:
+        max_runtimes = [default_runtime]
+    if n_max_models_per_type is None:
+        n_max_models_per_type = [None]
+    if n_max_models is None:
+        n_max_models = [None]
+    if n_training_configs is None:
+        n_training_configs = [None]
+    if n_training_folds is None:
+        n_training_folds = [None]
+    if n_training_datasets is None:
+        n_training_datasets = [None]
+    if n_portfolios is None:
+        n_portfolios = [n_portfolios_default]
+    if n_ensembles is None:
+        n_ensembles = [None]
 
     def evaluate_dataset(
         test_dataset,
@@ -238,10 +271,7 @@ def zeroshot_results(
 
         # restrict number of evaluation fold
         if n_training_fold is None:
-            if n_eval_folds is None:
-                n_training_fold = len(repo.folds)
-            else:
-                n_training_fold = n_eval_folds
+            n_training_fold = len(repo.folds) if n_eval_folds is None else n_eval_folds
 
         # gets all tids that are possible available
         test_tid = repo.dataset_to_tid(test_dataset)
@@ -281,10 +311,12 @@ def zeroshot_results(
             if tid in selected_tids and fold < n_training_fold:
                 train_tasks.append(task)
                 n_folds_in_dataset = min(n_training_fold, len(repo.dataset_to_folds(repo.tid_to_dataset(tid))))
-                train_task_weight[task] = 1/n_folds_in_dataset
+                train_task_weight[task] = 1 / n_folds_in_dataset
 
         # fit zeroshot portfolio on all available tasks
-        indices = zeroshot_configs(-df_rank[train_tasks].values.T, n_portfolio, weights=[train_task_weight[task] for task in train_tasks])
+        indices = zeroshot_configs(
+            -df_rank[train_tasks].values.T, n_portfolio, weights=[train_task_weight[task] for task in train_tasks]
+        )
         portfolio_configs = [df_rank.index[i] for i in indices]
         # TODO: Technically we should exclude data from the fold when computing the average runtime and also pass the
         #  current fold when filtering by runtime.
@@ -344,10 +376,7 @@ def zeroshot_results(
                 model_frameworks[config_type] = []
             model_frameworks[config_type].append(config)
     else:
-        model_frameworks = {
-            framework: sorted([x for x in configs if framework in x])
-            for framework in framework_types
-        }
+        model_frameworks = {framework: sorted([x for x in configs if framework in x]) for framework in framework_types}
 
     tasks = repo.tasks()
     if n_eval_folds is not None:
@@ -358,14 +387,39 @@ def zeroshot_results(
 
     batch_folds = True  # It is debatable whether True or False is faster.
     if batch_folds:
-        inputs = list(itertools.product(dataset_names, n_portfolios, n_ensembles, n_training_datasets, n_training_folds,
-                                          n_training_configs, max_runtimes, n_max_models, n_max_models_per_type, seeds, [None]))
+        inputs = list(
+            itertools.product(
+                dataset_names,
+                n_portfolios,
+                n_ensembles,
+                n_training_datasets,
+                n_training_folds,
+                n_training_configs,
+                max_runtimes,
+                n_max_models,
+                n_max_models_per_type,
+                seeds,
+                [None],
+            )
+        )
     else:
-        inputs = list(itertools.product(tasks, n_portfolios, n_ensembles, n_training_datasets, n_training_folds,
-                                          n_training_configs, max_runtimes, n_max_models, n_max_models_per_type, seeds))
+        inputs = list(
+            itertools.product(
+                tasks,
+                n_portfolios,
+                n_ensembles,
+                n_training_datasets,
+                n_training_folds,
+                n_training_configs,
+                max_runtimes,
+                n_max_models,
+                n_max_models_per_type,
+                seeds,
+            )
+        )
         n_inputs = len(inputs)
         for i in range(n_inputs):
-            inputs[i] = (inputs[i][0][0], *inputs[i][1:], [inputs[i][0][1]],)
+            inputs[i] = (inputs[i][0][0], *inputs[i][1:], [inputs[i][0][1]])
 
     list_rows = parallel_for(
         evaluate_dataset,

--- a/packages/tabarena/src/tabarena/portfolio/zeroshot_selection.py
+++ b/packages/tabarena/src/tabarena/portfolio/zeroshot_selection.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pandas as pd
-import numpy as np
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def zeroshot_configs(
@@ -9,8 +13,7 @@ def zeroshot_configs(
     output_size: int,
     weights: list[int] | None = None,
 ) -> list[int]:
-    """
-    :param val_scores: a tensor with shape (n_task, n_configs) that contains evaluations to consider
+    """:param val_scores: a tensor with shape (n_task, n_configs) that contains evaluations to consider
     :param output_size: number of configurations to return, in some case where no configuration helps anymore,
     the portfolio can have smaller length.
     :return: a list of index configuration for the portfolio where all indices are in [0, `n_configs` - 1]
@@ -41,8 +44,8 @@ def zeroshot_configs(
         best_mean = cur_best_mean
 
         # Update ranks for choosing each configuration considering the previously chosen ones
-        ranks.clip(upper=ranks[best_idx], axis=0, inplace=True)
+        ranks = ranks.clip(upper=ranks[best_idx], axis=0)
         # Drop the chosen configuration as a future candidate
-        df_val_scores.drop(columns=best_idx, inplace=True)
+        df_val_scores = df_val_scores.drop(columns=best_idx)
         res.append(best_idx)
     return res

--- a/packages/tabarena/src/tabarena/predictions/__init__.py
+++ b/packages/tabarena/src/tabarena/predictions/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from .tabular_predictions import TabularModelPredictions, TabularPredictionsInMemory, TabularPredictionsMemmap
 from .tabular_predictions_opt import TabularPredictionsInMemoryOpt

--- a/packages/tabarena/src/tabarena/predictions/tabular_predictions.py
+++ b/packages/tabarena/src/tabarena/predictions/tabular_predictions.py
@@ -1,42 +1,41 @@
+from __future__ import annotations
+
 import copy
-from collections import defaultdict
-import tempfile
-from typing import List, Tuple, Optional, Dict, Union
-
-import pickle
-from pathlib import Path
-import numpy as np
 import json
+import tempfile
+from collections import defaultdict
+from pathlib import Path
 
+import numpy as np
 
 # dictionary mapping the config name to predictions for a given dataset fold split
-ConfigPredictionsDict = Dict[str, np.array]
+ConfigPredictionsDict = dict[str, np.array]
 
 # dictionary mapping a particular fold of a dataset (a task) to split to config name to predictions
-TaskPredictionsDict = Dict[str, ConfigPredictionsDict]
+TaskPredictionsDict = dict[str, ConfigPredictionsDict]
 
 # dictionary mapping the folds of a dataset to split to config name to predictions
-DatasetPredictionsDict = Dict[int, TaskPredictionsDict]
+DatasetPredictionsDict = dict[int, TaskPredictionsDict]
 
 # dictionary mapping dataset to fold to split to config name to predictions
-TabularPredictionsDict = Dict[str, DatasetPredictionsDict]
+TabularPredictionsDict = dict[str, DatasetPredictionsDict]
 
 
 class TabularModelPredictions:
-    def __init__(self, datasets: List[str] = None):
-        """
-        Contains a collection of model evaluations, can be instantiated by either `TabularPredictionsInMemory`
+    def __init__(self, datasets: list[str] | None = None):
+        """Contains a collection of model evaluations, can be instantiated by either `TabularPredictionsInMemory`
         which contains all evaluations in memory with a dictionary or `TabularPredictionsMemmap` which stores
         all model evaluations on disk and retrieve them on the fly with memmap.
-        :param datasets: if specified, only consider the given list of dataset
+        :param datasets: if specified, only consider the given list of dataset.
         """
         if datasets:
             self.restrict_datasets(datasets)
 
     @classmethod
-    def from_dict(cls, pred_dict: TabularPredictionsDict, datasets: Optional[List[str]] = None, output_dir: str = None):
-        """
-        Instantiates from a dictionary of predictions
+    def from_dict(
+        cls, pred_dict: TabularPredictionsDict, datasets: list[str] | None = None, output_dir: str | None = None
+    ):
+        """Instantiates from a dictionary of predictions
         :param pred_dict:
         :param datasets: if specified, only consider the given list of dataset
         :param output_dir: directory where files are written (used for `TabularPredictionsMemmap`)
@@ -45,16 +44,14 @@ class TabularModelPredictions:
         raise NotImplementedError()
 
     def to_dict(self) -> TabularPredictionsDict:
-        """
-        :return: the whole dictionary of predictions
-        """
+        """:return: the whole dictionary of predictions"""
         raise NotImplementedError()
 
     @classmethod
-    def from_data_dir(cls, data_dir: Union[str, Path], datasets: Optional[List[str]] = None):
+    def from_data_dir(cls, data_dir: str | Path, datasets: list[str] | None = None):
         raise NotImplementedError()
 
-    def to_data_dir(self, data_dir: Union[str, Path], dtype: str = "float32"):
+    def to_data_dir(self, data_dir: str | Path, dtype: str = "float32"):
         # TODO: No need to convert to dict for TabularPredictionsMemmap, can just clone the files to the new directory instead to be more efficient.
         self._cache_data(pred_dict=self.to_dict(), data_dir=data_dir, dtype=dtype)
 
@@ -63,7 +60,8 @@ class TabularModelPredictions:
         assert dtype in ["float16", "float32"]
 
         if data_dir[:2] == "s3":
-            from autogluon.common.utils.s3_utils import is_s3_url, upload_s3_folder, s3_path_to_bucket_prefix
+            from autogluon.common.utils.s3_utils import is_s3_url, s3_path_to_bucket_prefix, upload_s3_folder
+
             if is_s3_url(str(data_dir)):
                 s3_bucket, s3_prefix = s3_path_to_bucket_prefix(data_dir)
                 with tempfile.TemporaryDirectory() as temp_dir:
@@ -82,11 +80,12 @@ class TabularModelPredictions:
                 # print(f"Converting {dataset} fold {fold} to {target_folder}")
 
                 models = list(folds["pred_proba_dict_val"].keys())
-                assert set(list(folds["pred_proba_dict_test"].keys())) == set(models), \
+                assert set(folds["pred_proba_dict_test"].keys()) == set(models), (
                     "different models available on validation and testing"
+                )
 
                 def get_split(split_key, models):
-                    model_results = pred_dict[dataset][fold][split_key]
+                    model_results = folds[split_key]  # noqa: B023
                     return np.array([model_results[model] for model in models])
 
                 pred_val = get_split("pred_proba_dict_val", models)
@@ -108,48 +107,46 @@ class TabularModelPredictions:
 
                 # Dumps data to memmap tensors, alternatively could use .npy but it would make model loading much
                 # slower in cases when only some models are loaded
-                fp = np.memmap(str(target_folder / "pred-val.dat"), dtype=dtype, mode='w+', shape=pred_val.shape)
+                fp = np.memmap(str(target_folder / "pred-val.dat"), dtype=dtype, mode="w+", shape=pred_val.shape)
                 fp[:] = pred_val[:]
                 fp.flush()
-                fp = np.memmap(str(target_folder / "pred-test.dat"), dtype=dtype, mode='w+', shape=pred_test.shape)
+                fp = np.memmap(str(target_folder / "pred-test.dat"), dtype=dtype, mode="w+", shape=pred_test.shape)
                 fp[:] = pred_test[:]
                 fp.flush()
 
-    def predict_val(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
-        """
-        Obtains validation predictions on a given dataset and fold for a list of models
+    def predict_val(
+        self, dataset: str, fold: int, models: list[str] | None = None, model_fallback: str | None = None
+    ) -> np.array:
+        """Obtains validation predictions on a given dataset and fold for a list of models
         :param: model_fallback to use for fallback if one model of `models` is not found
         :return: predictions with shape (num_models, num_rows, num_classes) for classification and
-        (num_models, num_rows, ) for regression
+        (num_models, num_rows, ) for regression.
         """
         raise NotImplementedError()
 
-    def predict_test(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
-        """
-        Obtains test predictions on a given dataset and fold for a list of models
+    def predict_test(
+        self, dataset: str, fold: int, models: list[str] | None = None, model_fallback: str | None = None
+    ) -> np.array:
+        """Obtains test predictions on a given dataset and fold for a list of models
         :param: model_fallback to use for fallback if one model of `models` is not found
         :return: predictions with shape (num_models, num_rows, num_classes) for classification and
-        (num_models, num_rows, ) for regression
+        (num_models, num_rows, ) for regression.
         """
         raise NotImplementedError()
 
     @property
-    def datasets(self) -> List[str]:
-        """
-        :return: list of datasets that are present in the collection
-        """
-        return sorted(list(self.model_available_dict().keys()))
+    def datasets(self) -> list[str]:
+        """:return: list of datasets that are present in the collection"""
+        return sorted(self.model_available_dict().keys())
 
-    def restrict_datasets(self, datasets: List[str]):
+    def restrict_datasets(self, datasets: list[str]):
         raise NotImplementedError()
 
     @property
-    def folds(self) -> List[int]:
-        """
-        :return: list of folds that are present in all datasets
-        """
+    def folds(self) -> list[int]:
+        """:return: list of folds that are present in all datasets"""
         all_folds = []
-        for dataset, fold_dict in self.model_available_dict().items():
+        for _dataset, fold_dict in self.model_available_dict().items():
             all_folds.append(fold_dict.keys())
         return list(set.intersection(*map(set, all_folds))) if all_folds else []
 
@@ -163,37 +160,31 @@ class TabularModelPredictions:
                 dataset_fold_lst.append((dataset, fold))
         return dataset_fold_lst
 
-    def restrict_folds(self, folds: List[int]):
+    def restrict_folds(self, folds: list[int]):
         raise NotImplementedError()
 
     @property
-    def models(self) -> List[str]:
-        """
-        :return: list of models that are present in all datasets and folds
-        """
+    def models(self) -> list[str]:
+        """:return: list of models that are present in all datasets and folds"""
         all_models = []
-        for dataset, fold_dict in self.model_available_dict().items():
-            for fold, models in fold_dict.items():
+        for _dataset, fold_dict in self.model_available_dict().items():
+            for _fold, models in fold_dict.items():
                 all_models.append(models)
         return list(set.intersection(*map(set, all_models))) if all_models else []
 
-    def models_exist(self) -> List[str]:
-        """
-        :return: list of models that are present in any task
-        """
+    def models_exist(self) -> list[str]:
+        """:return: list of models that are present in any task"""
         all_models = set()
-        for dataset, fold_dict in self.model_available_dict().items():
-            for fold, models in fold_dict.items():
+        for _dataset, fold_dict in self.model_available_dict().items():
+            for _fold, models in fold_dict.items():
                 all_models = all_models.union(models)
-        return sorted(list(all_models))
+        return sorted(all_models)
 
-    def restrict_models(self, models: List[str]):
+    def restrict_models(self, models: list[str]):
         raise NotImplementedError()
 
-    def model_available_dict(self) -> Dict[str, Dict[int, List[str]]]:
-        """
-        :return: a dictionary listing all evaluations available mapping dataset to fold to list of models available.
-        """
+    def model_available_dict(self) -> dict[str, dict[int, list[str]]]:
+        """:return: a dictionary listing all evaluations available mapping dataset to fold to list of models available."""
         model_available_dict = self._model_available_dict()
         return self._filter_empty(model_available_dict)
 
@@ -207,30 +198,30 @@ class TabularModelPredictions:
             res[dataset] = {fold: models for fold, models in folds.items() if models}
         return {dataset: folds for dataset, folds in res.items() if folds}
 
-    def _model_available_dict(self) -> Dict[str, Dict[int, List[str]]]:
+    def _model_available_dict(self) -> dict[str, dict[int, list[str]]]:
         raise NotImplementedError()
 
     @staticmethod
     def _keep_only_models_in_both_validation_and_test(pred_dict: TabularPredictionsDict):
-        """
-        :return: a dictionary where all splits contains the same set of models
-        """
+        """:return: a dictionary where all splits contains the same set of models"""
         for dataset, folds in pred_dict.items():
             for fold, splits in folds.items():
                 models = set.intersection(*[set(model_dict.keys()) for model_dict in splits.values()])
                 for split, split_dict in splits.items():
                     restrict = lambda model_dict, models: {k: v for k, v in model_dict.items() if k in models}
-                    pred_dict[dataset][fold][split] = restrict(pred_dict[dataset][fold][split], models)
+                    pred_dict[dataset][fold][split] = restrict(split_dict, models)
 
 
 class TabularPredictionsInMemory(TabularModelPredictions):
-    def __init__(self, pred_dict: TabularPredictionsDict, datasets: Optional[List[str]] = None):
+    def __init__(self, pred_dict: TabularPredictionsDict, datasets: list[str] | None = None):
         # TODO assert that models are all both in validation and test set
         self.pred_dict = pred_dict
-        super(TabularPredictionsInMemory, self).__init__(datasets=datasets)
+        super().__init__(datasets=datasets)
 
     @classmethod
-    def from_dict(cls, pred_dict: TabularPredictionsDict, datasets: Optional[List[str]] = None, output_dir: str = None):
+    def from_dict(
+        cls, pred_dict: TabularPredictionsDict, datasets: list[str] | None = None, output_dir: str | None = None
+    ):
         # Optional, avoids changing passed object
         pred_dict = copy.deepcopy(pred_dict)
         cls._keep_only_models_in_both_validation_and_test(pred_dict)
@@ -240,28 +231,36 @@ class TabularPredictionsInMemory(TabularModelPredictions):
         return self.pred_dict
 
     @classmethod
-    def from_data_dir(cls, data_dir: Union[str, Path], datasets: Optional[List[str]] = None):
+    def from_data_dir(cls, data_dir: str | Path, datasets: list[str] | None = None):
         memmap = TabularPredictionsMemmap.from_data_dir(data_dir=data_dir, datasets=datasets)
         return cls.from_dict(pred_dict=memmap.to_dict(), datasets=datasets)
 
-    def predict_val(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
-        assert model_fallback is None, ("config_fallback not supported for in memory data-structure, "
-                                        "try saving repo via `repo.to_dir(path)`, "
-                                        "then calling `repo = EvaluationRepository.from_dir(path, prediction_format='memmap')` to enable config_fallback")
+    def predict_val(
+        self, dataset: str, fold: int, models: list[str] | None = None, model_fallback: str | None = None
+    ) -> np.array:
+        assert model_fallback is None, (
+            "config_fallback not supported for in memory data-structure, "
+            "try saving repo via `repo.to_dir(path)`, "
+            "then calling `repo = EvaluationRepository.from_dir(path, prediction_format='memmap')` to enable config_fallback"
+        )
         return self._load_pred(dataset=dataset, fold=fold, models=models, split="val")
 
-    def predict_test(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
-        assert model_fallback is None, ("config_fallback not supported for in memory data-structure, "
-                                        "try saving repo via `repo.to_dir(path)`, "
-                                        "then calling `repo = EvaluationRepository.from_dir(path, prediction_format='memmap')` to enable config_fallback")
+    def predict_test(
+        self, dataset: str, fold: int, models: list[str] | None = None, model_fallback: str | None = None
+    ) -> np.array:
+        assert model_fallback is None, (
+            "config_fallback not supported for in memory data-structure, "
+            "try saving repo via `repo.to_dir(path)`, "
+            "then calling `repo = EvaluationRepository.from_dir(path, prediction_format='memmap')` to enable config_fallback"
+        )
         return self._load_pred(dataset=dataset, fold=fold, models=models, split="test")
 
-    def _load_pred(self, dataset: str, split: str, fold: int, models: List[str] = None):
+    def _load_pred(self, dataset: str, split: str, fold: int, models: list[str] | None = None):
         if models is None:
             models = self.models
 
         def get_split(split, models):
-            split_key = 'pred_proba_dict_test' if split == "test" else 'pred_proba_dict_val'
+            split_key = "pred_proba_dict_test" if split == "test" else "pred_proba_dict_val"
             model_results = self.pred_dict[dataset][fold][split_key]
             return np.array([self._get_model_results(model=model, model_pred_probas=model_results) for model in models])
 
@@ -271,18 +270,14 @@ class TabularPredictionsInMemory(TabularModelPredictions):
     def _get_model_results(self, model: str, model_pred_probas: dict) -> np.array:
         return model_pred_probas[model]
 
-    def restrict_datasets(self, datasets: List[str]):
-        self.pred_dict = {
-            dataset: fold_dict for dataset, fold_dict in self.pred_dict.items() if dataset in datasets
-        }
+    def restrict_datasets(self, datasets: list[str]):
+        self.pred_dict = {dataset: fold_dict for dataset, fold_dict in self.pred_dict.items() if dataset in datasets}
 
-    def restrict_folds(self, folds: List[int]):
+    def restrict_folds(self, folds: list[int]):
         for dataset, fold_dict in self.pred_dict.items():
-            self.pred_dict[dataset] = {
-                fold: fold_info for fold, fold_info in fold_dict.items() if fold in folds
-            }
+            self.pred_dict[dataset] = {fold: fold_info for fold, fold_info in fold_dict.items() if fold in folds}
 
-    def restrict_models(self, models: List[str]):
+    def restrict_models(self, models: list[str]):
         selected_models = set(models)
         for dataset, fold_dict in self.pred_dict.items():
             for fold, fold_info in fold_dict.items():
@@ -291,11 +286,9 @@ class TabularPredictionsInMemory(TabularModelPredictions):
                         model: v for model, v in model_dict.items() if model in selected_models
                     }
 
-    def _model_available_dict(self) -> Dict[str, Dict[int, List[str]]]:
+    def _model_available_dict(self) -> dict[str, dict[int, list[str]]]:
         return {
-            dataset: {
-                fold: list(fold_info['pred_proba_dict_val'].keys()) for fold, fold_info in fold_dict.items()
-            }
+            dataset: {fold: list(fold_info["pred_proba_dict_val"].keys()) for fold, fold_info in fold_dict.items()}
             for dataset, fold_dict in self.pred_dict.items()
         }
 
@@ -305,21 +298,26 @@ def path_memmap(folder_memmap: Path, dataset: str, fold: int):
 
 
 class TabularPredictionsMemmap(TabularModelPredictions):
-    def __init__(self, data_dir: Union[str, Path], datasets: Optional[List[str]] = None):
-        """
-        :param data_dir: data where the predictions has been saved
+    def __init__(self, data_dir: str | Path, datasets: list[str] | None = None):
+        """:param data_dir: data where the predictions has been saved
         :param datasets: if specified, the predictions only contains those datasets
         """
         self.data_dir = Path(data_dir)
         self.metadata_dict = self._load_metadatas(data_dir)
-        super(TabularPredictionsMemmap, self).__init__(datasets=datasets)
+        super().__init__(datasets=datasets)
 
     @classmethod
-    def from_data_dir(cls, data_dir: Union[str, Path], datasets: Optional[List[str]] = None):
+    def from_data_dir(cls, data_dir: str | Path, datasets: list[str] | None = None):
         return cls(data_dir=data_dir, datasets=datasets)
 
     @classmethod
-    def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str = None, datasets: Optional[List[str]] = None, dtype: str = "float32"):
+    def from_dict(
+        cls,
+        pred_dict: TabularPredictionsDict,
+        output_dir: str | None = None,
+        datasets: list[str] | None = None,
+        dtype: str = "float32",
+    ):
         cls._keep_only_models_in_both_validation_and_test(pred_dict)
         cls._cache_data(pred_dict=pred_dict, data_dir=output_dir, dtype=dtype)
         return cls(data_dir=output_dir, datasets=datasets)
@@ -334,9 +332,11 @@ class TabularPredictionsMemmap(TabularModelPredictions):
                     },
                     "pred_proba_dict_test": {
                         model: self.predict_test(dataset, fold, [model]).squeeze() for model in models
-                    }
-                } for fold, models in fold_dict.items()
-            } for dataset, fold_dict in model_available_dict.items()
+                    },
+                }
+                for fold, models in fold_dict.items()
+            }
+            for dataset, fold_dict in model_available_dict.items()
         }
 
     @staticmethod
@@ -344,7 +344,7 @@ class TabularPredictionsMemmap(TabularModelPredictions):
         res = defaultdict(dict)
         metadata_files = list(Path(data_dir).rglob("*metadata.json"))
         for metadata_file in metadata_files:
-            with open(metadata_file, "r") as f:
+            with open(metadata_file) as f:
                 metadata = json.load(f)
             dataset = metadata.pop("dataset")
             fold = metadata.pop("fold")
@@ -357,15 +357,19 @@ class TabularPredictionsMemmap(TabularModelPredictions):
                 metadata_task["model_indices"] = model_indices
         return res
 
-    def predict_val(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
-        pred = self._load_pred(dataset=dataset, fold=fold, models=models, split="val", model_fallback=model_fallback)
-        return pred
+    def predict_val(
+        self, dataset: str, fold: int, models: list[str] | None = None, model_fallback: str | None = None
+    ) -> np.array:
+        return self._load_pred(dataset=dataset, fold=fold, models=models, split="val", model_fallback=model_fallback)
 
-    def predict_test(self, dataset: str, fold: int, models: List[str] = None, model_fallback: str = None) -> np.array:
-        pred = self._load_pred(dataset=dataset, fold=fold, models=models, split="test", model_fallback=model_fallback)
-        return pred
+    def predict_test(
+        self, dataset: str, fold: int, models: list[str] | None = None, model_fallback: str | None = None
+    ) -> np.array:
+        return self._load_pred(dataset=dataset, fold=fold, models=models, split="test", model_fallback=model_fallback)
 
-    def _load_pred(self, dataset: str, split: str, fold: int, models: List[str] = None, model_fallback: str = None):
+    def _load_pred(
+        self, dataset: str, split: str, fold: int, models: list[str] | None = None, model_fallback: str | None = None
+    ):
         assert dataset in self.metadata_dict, f"{dataset} not available."
         assert fold in self.metadata_dict[dataset], f"Fold {fold} of {dataset} not available."
 
@@ -373,7 +377,7 @@ class TabularPredictionsMemmap(TabularModelPredictions):
         task_folder = path_memmap(folder_memmap=self.data_dir, dataset=dataset, fold=fold)
         metadata = self.metadata_dict[dataset][fold]
         model_indices_all = metadata["model_indices"]
-        model_indices_available = {m: model_indices_all[m] for m in metadata['models']}
+        model_indices_available = {m: model_indices_all[m] for m in metadata["models"]}
         if model_fallback:
             # we use the model fallback if a model is not present
             models = [m if m in model_indices_available else model_fallback for m in models]
@@ -386,55 +390,43 @@ class TabularPredictionsMemmap(TabularModelPredictions):
                 raise Exception(
                     f"Tried to get predictions on dataset={dataset}, fold={fold}, split={split}, model_fallback={model_fallback} | "
                     f"The specified `model_fallback` does not exist for this task ..."
-                    f"\n\tPlease specify a valid `model_fallback`."
+                    f"\n\tPlease specify a valid `model_fallback`.",
                 ) from e
-            else:
-                raise Exception(
-                    f"Tried to get predictions on dataset={dataset}, fold={fold}, split={split}, model_fallback={model_fallback} | "
-                    f"Missing {len(missing_models)} out of {len(models)} requested model results for this task: {missing_models}"
-                    f"\n\tEither remove these models from the request or specify `model_fallback` to fill missing values."
-                ) from e
+            raise Exception(
+                f"Tried to get predictions on dataset={dataset}, fold={fold}, split={split}, model_fallback={model_fallback} | "
+                f"Missing {len(missing_models)} out of {len(models)} requested model results for this task: {missing_models}"
+                f"\n\tEither remove these models from the request or specify `model_fallback` to fill missing values.",
+            ) from e
         dtype = metadata["dtype"]
         pred = np.memmap(
             str(task_folder / f"pred-{split}.dat"),
             dtype=dtype,
-            mode='r',
-            shape=tuple(metadata[f"pred_{split}_shape"])
+            mode="r",
+            shape=tuple(metadata[f"pred_{split}_shape"]),
         )
-        pred = pred[model_indices]
-        return pred
+        return pred[model_indices]
 
-    def restrict_datasets(self, datasets: List[str]):
+    def restrict_datasets(self, datasets: list[str]):
         datasets = set(datasets)
-        self.metadata_dict = {
-            dataset: folds
-            for dataset, folds in self.metadata_dict.items()
-            if dataset in datasets
-        }
+        self.metadata_dict = {dataset: folds for dataset, folds in self.metadata_dict.items() if dataset in datasets}
 
-    def restrict_folds(self, folds: List[int]):
+    def restrict_folds(self, folds: list[int]):
         folds = set(folds)
         self.metadata_dict = {
-            dataset: {
-                fold: fold_metadata
-                for fold, fold_metadata in fold_dict.items() if fold in folds
-            }
+            dataset: {fold: fold_metadata for fold, fold_metadata in fold_dict.items() if fold in folds}
             for dataset, fold_dict in self.metadata_dict.items()
         }
 
-    def restrict_models(self, models: List[str]):
+    def restrict_models(self, models: list[str]):
         selected_models = set(models)
         for dataset, fold_dict in self.metadata_dict.items():
-            for fold, fold_metadata in fold_dict.items():
+            for fold, _fold_metadata in fold_dict.items():
                 self.metadata_dict[dataset][fold]["models"] = [
-                    m for m in self.metadata_dict[dataset][fold]["models"]
-                    if m in selected_models
+                    m for m in self.metadata_dict[dataset][fold]["models"] if m in selected_models
                 ]
 
-    def _model_available_dict(self) -> Dict[str, Dict[int, List[str]]]:
+    def _model_available_dict(self) -> dict[str, dict[int, list[str]]]:
         return {
-            dataset: {
-                fold: fold_info["models"] for fold, fold_info in fold_dict.items()
-            }
+            dataset: {fold: fold_info["models"] for fold, fold_info in fold_dict.items()}
             for dataset, fold_dict in self.metadata_dict.items()
         }

--- a/packages/tabarena/src/tabarena/predictions/tabular_predictions_opt.py
+++ b/packages/tabarena/src/tabarena/predictions/tabular_predictions_opt.py
@@ -1,25 +1,32 @@
+from __future__ import annotations
+
 import copy
-from typing import Dict, List
+from typing import TYPE_CHECKING
 
-import numpy as np
+from .tabular_predictions import TabularPredictionsDict, TabularPredictionsInMemory
+from .task_predictions import ConfigPredictionsDict, TaskModelPredictionsOpt
 
-from .task_predictions import TaskModelPredictionsOpt, ConfigPredictionsDict
-from .tabular_predictions import TabularPredictionsInMemory, TabularPredictionsDict
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class TabularPredictionsInMemoryOpt(TabularPredictionsInMemory):
-    """
-    A model predictions data representation optimized for `ray.put(self)` operations to minimize overhead.
+    """A model predictions data representation optimized for `ray.put(self)` operations to minimize overhead.
     Ray has a large overhead when using a shared object with many numpy arrays (such as 500,000).
     This class converts many smaller numpy arrays into fewer larger numpy arrays,
     eliminating the vast majority of the overhead.
     """
-    def __init__(self, pred_dict_opt: Dict[str, Dict[int, Dict[str, TaskModelPredictionsOpt]]], datasets: List[str] = None):
+
+    def __init__(
+        self, pred_dict_opt: dict[str, dict[int, dict[str, TaskModelPredictionsOpt]]], datasets: list[str] | None = None
+    ):
         super().__init__(pred_dict=pred_dict_opt, datasets=datasets)
         self.pred_dict = pred_dict_opt
 
     @classmethod
-    def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str = None, datasets: List[str] = None):
+    def from_dict(
+        cls, pred_dict: TabularPredictionsDict, output_dir: str | None = None, datasets: list[str] | None = None
+    ):
         pred_dict_opt = cls._stack_pred_dict(pred_dict=pred_dict)
         return cls(pred_dict_opt=pred_dict_opt, datasets=datasets)
 
@@ -33,12 +40,14 @@ class TabularPredictionsInMemoryOpt(TabularPredictionsInMemory):
                     },
                     "pred_proba_dict_test": {
                         model: self.predict_test(dataset, fold, [model]).squeeze() for model in models
-                    }
-                } for fold, models in fold_dict.items()
-            } for dataset, fold_dict in model_available_dict.items()
+                    },
+                }
+                for fold, models in fold_dict.items()
+            }
+            for dataset, fold_dict in model_available_dict.items()
         }
 
-    def restrict_models(self, models: List[str]):
+    def restrict_models(self, models: list[str]):
         task_names = self.datasets
         for t in task_names:
             available_folds = list(self.pred_dict[t].keys())
@@ -55,7 +64,9 @@ class TabularPredictionsInMemoryOpt(TabularPredictionsInMemory):
                 self.pred_dict.pop(t)
 
     @classmethod
-    def _stack_pred_dict(cls, pred_dict: TabularPredictionsDict) -> Dict[str, Dict[int, Dict[str, TaskModelPredictionsOpt]]]:
+    def _stack_pred_dict(
+        cls, pred_dict: TabularPredictionsDict
+    ) -> dict[str, dict[int, dict[str, TaskModelPredictionsOpt]]]:
         pred_dict = copy.deepcopy(pred_dict)  # TODO: Avoid the deep copy, create from scratch to min mem usage
         datasets = list(pred_dict.keys())
         for dataset in datasets:
@@ -65,17 +76,15 @@ class TabularPredictionsInMemoryOpt(TabularPredictionsInMemory):
                 for split in splits:
                     model_pred_probas: ConfigPredictionsDict = pred_dict[dataset][fold][split]
                     pred_dict[dataset][fold][split] = TaskModelPredictionsOpt.from_config_predictions(
-                        config_predictions=model_pred_probas
+                        config_predictions=model_pred_probas,
                     )
         return pred_dict
 
     def _get_model_results(self, model: str, model_pred_probas: TaskModelPredictionsOpt) -> np.array:
         return model_pred_probas.get_model_predictions(model=model)
 
-    def _model_available_dict(self) -> Dict[str, Dict[int, List[str]]]:
+    def _model_available_dict(self) -> dict[str, dict[int, list[str]]]:
         return {
-            dataset: {
-                fold: list(fold_info['pred_proba_dict_val'].models) for fold, fold_info in fold_dict.items()
-            }
+            dataset: {fold: list(fold_info["pred_proba_dict_val"].models) for fold, fold_info in fold_dict.items()}
             for dataset, fold_dict in self.pred_dict.items()
         }

--- a/packages/tabarena/src/tabarena/predictions/task_predictions.py
+++ b/packages/tabarena/src/tabarena/predictions/task_predictions.py
@@ -1,8 +1,9 @@
-from typing import List, Dict, Tuple, Optional
+from __future__ import annotations
+
 import numpy as np
 
 # dictionary mapping the config name to predictions for a given dataset fold split
-ConfigPredictionsDict = Dict[str, np.array]
+ConfigPredictionsDict = dict[str, np.array]
 
 
 class AbstractTaskModelPredictions:
@@ -10,39 +11,37 @@ class AbstractTaskModelPredictions:
         raise NotImplementedError
 
     @property
-    def models(self) -> List[str]:
+    def models(self) -> list[str]:
         raise NotImplementedError
 
-    def subset(self, models: List[str], inplace: bool = False):
+    def subset(self, models: list[str], inplace: bool = False):
         raise NotImplementedError
 
 
 class TaskModelPredictionsEmpty(AbstractTaskModelPredictions):
-    """
-    Empty task with no models
-    """
+    """Empty task with no models."""
+
     def get_model_predictions(self, model: str) -> np.array:
         raise AssertionError(f'Cannot get predictions from an empty task... (model="{model}")')
 
     @property
-    def models(self) -> List[str]:
+    def models(self) -> list[str]:
         return []
 
-    def subset(self, models: List[str], inplace: bool = False):
+    def subset(self, models: list[str], inplace: bool = False):
         if len(models) != 0:
-            raise AssertionError(f'Trying to subset an empty task to models: {models}')
+            raise AssertionError(f"Trying to subset an empty task to models: {models}")
         if inplace:
             return self
-        else:
-            return self.__class__()
+        return self.__class__()
 
 
 class TaskModelPredictionsOpt(AbstractTaskModelPredictions):
-    """
-    Optimized logic to store predictions for a given task for many models.
+    """Optimized logic to store predictions for a given task for many models.
     This combines all model predictions into a single numpy array, eliminating overheads when working with Ray.
     """
-    def __init__(self, config_predictions_opt: np.array, model_index: Dict[str, int]):
+
+    def __init__(self, config_predictions_opt: np.array, model_index: dict[str, int]):
         self.config_predictions_opt = config_predictions_opt
         self.model_index = model_index
 
@@ -52,16 +51,15 @@ class TaskModelPredictionsOpt(AbstractTaskModelPredictions):
         return cls(config_predictions_opt=config_predictions_opt, model_index=model_index)
 
     @property
-    def models(self) -> List[str]:
+    def models(self) -> list[str]:
         return list(self.model_index.keys())
 
     def get_model_predictions(self, model: str) -> np.array:
         index = self.model_index[model]
         return self.config_predictions_opt[index]
 
-    def subset(self, models: List[str], inplace: bool = False):
-        """
-        Subset available models to `models`.
+    def subset(self, models: list[str], inplace: bool = False):
+        """Subset available models to `models`.
         If `inplace=True`, alters and returns self, otherwise returns a new TaskModelPredictionsOpt object.
         Raises an AssertionError if a model in `models` is missing from `self.models`.
         """
@@ -83,13 +81,12 @@ class TaskModelPredictionsOpt(AbstractTaskModelPredictions):
             self.config_predictions_opt = config_predictions_opt
             self.model_index = model_index
             return self
-        else:
-            return self.__class__(config_predictions_opt=config_predictions_opt, model_index=model_index)
+        return self.__class__(config_predictions_opt=config_predictions_opt, model_index=model_index)
 
     @classmethod
-    def _stack_pred_w_index(cls,
-                           model_pred_probas: Dict[str, np.array],
-                           models: Optional[List[str]] = None) -> Tuple[np.array, Dict[str, int]]:
+    def _stack_pred_w_index(
+        cls, model_pred_probas: dict[str, np.array], models: list[str] | None = None
+    ) -> tuple[np.array, dict[str, int]]:
         if models is None:
             models = list(model_pred_probas.keys())
         res = cls._stack_pred(model_pred_probas=model_pred_probas, models=models)
@@ -97,18 +94,16 @@ class TaskModelPredictionsOpt(AbstractTaskModelPredictions):
         return res, model_index_dict
 
     @staticmethod
-    def _stack_pred(model_pred_probas: Dict[str, np.array], models: Optional[List[str]] = None) -> np.array:
-        """
-        :param fold_dict: dictionary mapping fold to split to config name to predictions
+    def _stack_pred(model_pred_probas: dict[str, np.array], models: list[str] | None = None) -> np.array:
+        """:param fold_dict: dictionary mapping fold to split to config name to predictions
         :return:
         """
         if models is None:
             models = list(model_pred_probas.keys())
         num_samples = len(model_pred_probas[models[0]])
-        output_dims = set(
-            config_evals.shape[1] if config_evals.ndim > 1 else None
-            for config_evals in model_pred_probas.values()
-        )
+        output_dims = {
+            config_evals.shape[1] if config_evals.ndim > 1 else None for config_evals in model_pred_probas.values()
+        }
         assert len(output_dims) == 1
         output_dim = next(iter(output_dims))
         n_models = len(models)
@@ -126,5 +121,5 @@ class TaskModelPredictionsOpt(AbstractTaskModelPredictions):
         return res
 
     @staticmethod
-    def _models_to_index_dict(models: List[str]) -> Dict[str, int]:
+    def _models_to_index_dict(models: list[str]) -> dict[str, int]:
         return {m: i for i, m in enumerate(models)}

--- a/packages/tabarena/src/tabarena/repository/__init__.py
+++ b/packages/tabarena/src/tabarena/repository/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .evaluation_repository import EvaluationRepository
 from .evaluation_repository_collection import EvaluationRepositoryCollection
 from .evaluation_repository_zeroshot import EvaluationRepositoryZeroshot

--- a/packages/tabarena/src/tabarena/repository/abstract_repository.py
+++ b/packages/tabarena/src/tabarena/repository/abstract_repository.py
@@ -2,58 +2,61 @@ from __future__ import annotations
 
 import copy
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import TYPE_CHECKING, Self
 
 import numpy as np
 import pandas as pd
-from typing_extensions import Self
 
-from ..benchmark.task.openml import OpenMLTaskWrapper
-from ..simulation.simulation_context import ZeroshotSimulatorContext
-from ..simulation.single_best_config_scorer import SingleBestConfigScorer
-from ..utils.cache import SaveLoadMixin
+from tabarena.benchmark.task.openml import OpenMLTaskWrapper
+from tabarena.simulation.single_best_config_scorer import SingleBestConfigScorer
+from tabarena.utils.cache import SaveLoadMixin
+
+if TYPE_CHECKING:
+    from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
 
 
 class AbstractRepository(ABC, SaveLoadMixin):
     def __init__(
         self,
         zeroshot_context: ZeroshotSimulatorContext,
-        config_fallback: str | None = None
+        config_fallback: str | None = None,
     ):
         self._zeroshot_context = zeroshot_context
         self._config_fallback = None
         self.set_config_fallback(config_fallback)
 
-    def set_config_fallback(self, config_fallback: str = None):
+    def set_config_fallback(self, config_fallback: str | None = None):
         if config_fallback:
-            assert config_fallback in self.configs(), f"Missing config_fallback={config_fallback!r} in configs: {self.configs()}"
+            assert config_fallback in self.configs(), (
+                f"Missing config_fallback={config_fallback!r} in configs: {self.configs()}"
+            )
         self._config_fallback = config_fallback
 
     def print_info(self):
         self._zeroshot_context.print_info()
 
     @property
-    def _dataset_to_tid_dict(self) -> Dict[str, int]:
+    def _dataset_to_tid_dict(self) -> dict[str, int]:
         return self._zeroshot_context.dataset_to_tid_dict
 
     @property
-    def _tid_to_dataset_dict(self) -> Dict[int, str]:
+    def _tid_to_dataset_dict(self) -> dict[int, str]:
         return {v: k for k, v in self._dataset_to_tid_dict.items()}
 
     # TODO: tasks
-    def subset(self,
-               *,
-               datasets: List[str] = None,
-               folds: List[int] = None,
-               configs: List[str] = None,
-               baselines: List[str] = None,
-               problem_types: List[str] = None,
-               force_to_dense: bool = False,
-               inplace: bool = False,
-               verbose: bool = True,
-               ) -> Self:
-        """
-        Method to subset the repository object and force to a dense representation.
+    def subset(
+        self,
+        *,
+        datasets: list[str] | None = None,
+        folds: list[int] | None = None,
+        configs: list[str] | None = None,
+        baselines: list[str] | None = None,
+        problem_types: list[str] | None = None,
+        force_to_dense: bool = False,
+        inplace: bool = False,
+        verbose: bool = True,
+    ) -> Self:
+        """Method to subset the repository object and force to a dense representation.
 
         :param datasets: The list of datasets to subset. Ignored if unspecified.
         :param folds: The list of folds to subset. Ignored if unspecified.
@@ -99,8 +102,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
 
     @abstractmethod
     def force_to_dense(self, inplace: bool = False, verbose: bool = True) -> Self:
-        """
-        Method to force the repository to a dense representation inplace.
+        """Method to force the repository to a dense representation inplace.
 
         The following operations will be applied in order:
         1. subset to only datasets that contain at least one result for all folds (self.n_folds())
@@ -119,7 +121,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
         verbose: bool, default = True
             Whether to log verbose details about the force to dense operation.
 
-        Returns
+        Returns:
         -------
         Return dense repo if inplace=False or self after inplace updates in this call.
         """
@@ -133,15 +135,16 @@ class AbstractRepository(ABC, SaveLoadMixin):
     def task_metadata(self) -> pd.DataFrame:
         return self._df_metadata
 
-    def tids(self, problem_type: str = None) -> List[int]:
-        """
-        Note: returns the taskid of the datasets rather than the string name.
+    def tids(self, problem_type: str | None = None) -> list[int]:
+        """Note: returns the taskid of the datasets rather than the string name.
 
         :param problem_type: If specified, only datasets with the given problem_type are returned.
         """
         return self._zeroshot_context.get_tids(problem_type=problem_type)
 
-    def datasets(self, *, configs: list[str] = None, problem_type: str | list[str] = None, union: bool = True) -> list[str]:
+    def datasets(
+        self, *, configs: list[str] | None = None, problem_type: str | list[str] | None = None, union: bool = True
+    ) -> list[str]:
         """repo_subset2.datasets()
         Return all valid datasets.
         By default, will return all datasets that appear in any config at least once.
@@ -154,26 +157,24 @@ class AbstractRepository(ABC, SaveLoadMixin):
             If True, will return the union of datasets present in each config.
             If False, will return the intersection of datasets present in each config.
 
-        Returns
+        Returns:
         -------
         A list of dataset names satisfying the above conditions.
         """
         return self._zeroshot_context.get_datasets(configs=configs, problem_type=problem_type, union=union)
 
     def tasks(self) -> list[tuple[str, int]]:
-        dataset_folds = self._zeroshot_context.get_tasks(as_dataset_fold=True)
-        return dataset_folds
+        return self._zeroshot_context.get_tasks(as_dataset_fold=True)
 
     def configs(
         self,
         *,
-        datasets: list[str] = None,
-        tasks: list[tuple[str, int]] = None,
-        config_types: list[str] = None,
+        datasets: list[str] | None = None,
+        tasks: list[tuple[str, int]] | None = None,
+        config_types: list[str] | None = None,
         union: bool = True,
     ) -> list[str]:
-        """
-        Return all valid configs.
+        """Return all valid configs.
         By default, will return all configs that appear in any task at least once.
 
         Parameters
@@ -190,16 +191,19 @@ class AbstractRepository(ABC, SaveLoadMixin):
             If True, will return the union of configs present in each task.
             If False, will return the intersection of configs present in each task.
 
-        Returns
+        Returns:
         -------
         A list of config names satisfying the above conditions.
         """
-        return self._zeroshot_context.get_configs(datasets=datasets, tasks=tasks, config_types=config_types, union=union)
+        return self._zeroshot_context.get_configs(
+            datasets=datasets, tasks=tasks, config_types=config_types, union=union
+        )
 
     # TODO: unit test
-    def baselines(self, *, datasets: list[str] = None, tasks: list[tuple[str, int]] = None, union: bool = True) -> list[str]:
-        """
-        Return all valid baselines.
+    def baselines(
+        self, *, datasets: list[str] | None = None, tasks: list[tuple[str, int]] | None = None, union: bool = True
+    ) -> list[str]:
+        """Return all valid baselines.
         By default, will return all baselines that appear in any task at least once.
 
         Parameters
@@ -214,7 +218,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
             If True, will return the union of baselines present in each task.
             If False, will return the intersection of baselines present in each task.
 
-        Returns
+        Returns:
         -------
         A list of baseline names satisfying the above conditions.
         """
@@ -223,7 +227,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
     def dataset_to_tid(self, dataset: str) -> int:
         return self._dataset_to_tid_dict[dataset]
 
-    def datasets_to_tids(self, datasets: list[str] = None) -> pd.Series:
+    def datasets_to_tids(self, datasets: list[str] | None = None) -> pd.Series:
         if datasets is None:
             datasets = self.datasets()
         return pd.Series({dataset: self._dataset_to_tid_dict[dataset] for dataset in datasets}, name="tid")
@@ -233,14 +237,13 @@ class AbstractRepository(ABC, SaveLoadMixin):
 
     def metrics(
         self,
-        datasets: List[str] = None,
-        folds: List[int] = None,
-        tasks: list[tuple[str, int]] = None,
-        configs: List[str] = None,
+        datasets: list[str] | None = None,
+        folds: list[int] | None = None,
+        tasks: list[tuple[str, int]] | None = None,
+        configs: list[str] | None = None,
         set_index: bool = True,
     ) -> pd.DataFrame:
-        """
-        :param datasets:
+        """:param datasets:
         :param folds:
         :param configs: list of configs to query metrics
         :return: pd.DataFrame of metrics for each dataset-fold-framework combination.
@@ -277,9 +280,10 @@ class AbstractRepository(ABC, SaveLoadMixin):
 
         return df
 
-    def dataset_fold_config_pairs(self, datasets: List[str] = None, folds: List[int] = None, configs: List[str] = None) -> list:
-        """
-        Returns a list of all (dataset, fold, config) tuples available in the repo.
+    def dataset_fold_config_pairs(
+        self, datasets: list[str] | None = None, folds: list[int] | None = None, configs: list[str] | None = None
+    ) -> list:
+        """Returns a list of all (dataset, fold, config) tuples available in the repo.
 
         Parameters
         ----------
@@ -293,8 +297,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
         return self.metrics(datasets=datasets, folds=folds, configs=configs).index.tolist()
 
     def predict_test(self, dataset: str, fold: int, config: str, binary_as_multiclass: bool = False) -> np.ndarray:
-        """
-        Returns the predictions on the test set for a given configuration on a given dataset and fold
+        """Returns the predictions on the test set for a given configuration on a given dataset and fold.
 
         Parameters
         ----------
@@ -314,16 +317,17 @@ class AbstractRepository(ABC, SaveLoadMixin):
             The internal representation is of form (n_rows) as it requires less memory,
             so there is a conversion overhead introduced when `binary_as_multiclass=True`.
 
-        Returns
+        Returns:
         -------
         The model predictions on the test set with shape (n_rows, n_classes) for multiclass or (n_rows) in case of regression.
         For binary, shape depends on `binary_as_multiclass` value.
         """
-        return self.predict_test_multi(dataset=dataset, fold=fold, configs=[config], binary_as_multiclass=binary_as_multiclass).squeeze()
+        return self.predict_test_multi(
+            dataset=dataset, fold=fold, configs=[config], binary_as_multiclass=binary_as_multiclass
+        ).squeeze()
 
     def predict_val(self, dataset: str, fold: int, config: str, binary_as_multiclass: bool = False) -> np.ndarray:
-        """
-        Parameters
+        """Parameters
         ----------
         dataset: str
             The dataset to get predictions from. Must be a value in `self.datasets()`.
@@ -341,17 +345,25 @@ class AbstractRepository(ABC, SaveLoadMixin):
             The internal representation is of form (n_rows) as it requires less memory,
             so there is a conversion overhead introduced when `binary_as_multiclass=True`.
 
-        Returns
+        Returns:
         -------
         The model predictions on the validation set with shape (n_rows, n_classes) for multiclass or (n_rows) in case of regression.
         For binary, shape depends on `binary_as_multiclass` value.
         """
-        return self.predict_val_multi(dataset=dataset, fold=fold, configs=[config], binary_as_multiclass=binary_as_multiclass).squeeze()
+        return self.predict_val_multi(
+            dataset=dataset, fold=fold, configs=[config], binary_as_multiclass=binary_as_multiclass
+        ).squeeze()
 
     @abstractmethod
-    def predict_test_multi(self, dataset: str, fold: int, configs: List[str] = None, binary_as_multiclass: bool = False, enforce_binary_1d: bool = False) -> np.ndarray:
-        """
-        Returns the predictions on the test set for a given list of configurations on a given dataset and fold
+    def predict_test_multi(
+        self,
+        dataset: str,
+        fold: int,
+        configs: list[str] | None = None,
+        binary_as_multiclass: bool = False,
+        enforce_binary_1d: bool = False,
+    ) -> np.ndarray:
+        """Returns the predictions on the test set for a given list of configurations on a given dataset and fold.
 
         Parameters
         ----------
@@ -372,7 +384,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
             The internal representation is of form (n_configs, n_rows) as it requires less memory,
             so there is a conversion overhead introduced when `binary_as_multiclass=True`.
 
-        Returns
+        Returns:
         -------
         The model predictions with shape (n_configs, n_rows, n_classes) for multiclass or (n_configs, n_rows) in case of regression.
         For binary, shape depends on `binary_as_multiclass` value.
@@ -381,9 +393,15 @@ class AbstractRepository(ABC, SaveLoadMixin):
         raise NotImplementedError
 
     @abstractmethod
-    def predict_val_multi(self, dataset: str, fold: int, configs: List[str] = None, binary_as_multiclass: bool = False, enforce_binary_1d: bool = False) -> np.ndarray:
-        """
-        Returns the predictions on the validation set for a given list of configurations on a given dataset and fold
+    def predict_val_multi(
+        self,
+        dataset: str,
+        fold: int,
+        configs: list[str] | None = None,
+        binary_as_multiclass: bool = False,
+        enforce_binary_1d: bool = False,
+    ) -> np.ndarray:
+        """Returns the predictions on the validation set for a given list of configurations on a given dataset and fold.
 
         Parameters
         ----------
@@ -404,7 +422,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
             The internal representation is of form (n_configs, n_rows) as it requires less memory,
             so there is a conversion overhead introduced when `binary_as_multiclass=True`.
 
-        Returns
+        Returns:
         -------
         The model predictions with shape (n_configs, n_rows, n_classes) for multiclass or (n_configs, n_rows) in case of regression.
         For binary, shape depends on `binary_as_multiclass` value.
@@ -414,15 +432,14 @@ class AbstractRepository(ABC, SaveLoadMixin):
 
     def dataset_metadata(self, dataset: str) -> dict:
         metadata = self._df_metadata[self._df_metadata["dataset"] == dataset]
-        return dict(zip(metadata.columns, metadata.values[0]))
+        return dict(zip(metadata.columns, metadata.values[0], strict=False))
 
     def dataset_info(self, dataset: str) -> dict:
-        """
-        Parameters
+        """Parameters
         ----------
         dataset: str
 
-        Returns
+        Returns:
         -------
         Dictionary with two keys:
             "metric": The evaluation metric name used for scoring on the dataset
@@ -430,14 +447,13 @@ class AbstractRepository(ABC, SaveLoadMixin):
         """
         return self._zeroshot_context.df_metrics.loc[dataset].to_dict()
 
-    def datasets_info(self, datasets: list[str] = None) -> pd.DataFrame:
-        """
-        Parameters
+    def datasets_info(self, datasets: list[str] | None = None) -> pd.DataFrame:
+        """Parameters
         ----------
         datasets: list[str]. default = None
             If None, uses all datasets
 
-        Returns
+        Returns:
         -------
         Pandas DataFrame with index "dataset" and two columns:
             "metric": The evaluation metric name used for scoring on the dataset
@@ -448,45 +464,44 @@ class AbstractRepository(ABC, SaveLoadMixin):
         return self._zeroshot_context.df_metrics.loc[datasets]
 
     @property
-    def folds(self) -> List[int]:
-        """Folds with any result"""
+    def folds(self) -> list[int]:
+        """Folds with any result."""
         return sorted(self._zeroshot_context.folds)
 
     def n_folds(self) -> int:
-        """Number of folds with any result"""
+        """Number of folds with any result."""
         return len(self.folds)
 
     def n_datasets(self) -> int:
-        """Number of datasets with any result"""
+        """Number of datasets with any result."""
         return len(self.datasets())
 
     def n_configs(self) -> int:
-        """Number of configs with any result"""
+        """Number of configs with any result."""
         return len(self.configs())
 
     def task_name_from_tid(self, tid: int, fold: int) -> str:
-        """Returns the task associated with a (tid, fold)"""
+        """Returns the task associated with a (tid, fold)."""
         return self._zeroshot_context.task_name_from_tid(tid=tid, fold=fold)
 
     def task_name(self, dataset: str, fold: int) -> str:
-        """Returns the task associated with a (dataset, fold)"""
+        """Returns the task associated with a (dataset, fold)."""
         return self.task_name_from_tid(tid=self.dataset_to_tid(dataset), fold=fold)
 
     def task_to_dataset(self, task: str) -> str:
-        """Returns the dataset associated with a task"""
+        """Returns the dataset associated with a task."""
         return self._zeroshot_context.task_to_dataset_dict[task]
 
     def task_to_fold(self, task: str) -> int:
-        """Returns the fold associated with a task"""
+        """Returns the fold associated with a task."""
         return self._zeroshot_context.task_to_fold(task=task)
 
     def dataset_to_folds(self, dataset: str) -> list[int]:
         return self._zeroshot_context.dataset_to_folds(dataset=dataset)
 
     def config_hyperparameters(self, config: str, include_ag_args: bool = True) -> dict | None:
-        """
-        Returns config hyperparameters as defined in AutoGluon
-        If no hyperparameters exist for the config, return None
+        """Returns config hyperparameters as defined in AutoGluon
+        If no hyperparameters exist for the config, return None.
 
         Parameters
         ----------
@@ -495,15 +510,18 @@ class AbstractRepository(ABC, SaveLoadMixin):
         include_ag_args: bool, default = True
             If True, includes the `ag_args` hyperparameter which is used in determining the name of the model in AutoGluon
         """
-        config_hyperparameters = self._zeroshot_context.get_config_hyperparameters(config=config, include_ag_args=include_ag_args)
+        config_hyperparameters = self._zeroshot_context.get_config_hyperparameters(
+            config=config, include_ag_args=include_ag_args
+        )
         if config_hyperparameters is not None:
             return config_hyperparameters["hyperparameters"]
         return None
 
-    def configs_hyperparameters(self, configs: list[str] | None = None, include_ag_args: bool = True) -> dict[str, dict | None]:
-        """
-        Returns a dictionary mapping of config names to hyperparameters as defined in AutoGluon
-        If no hyperparameters exist for a config, its value will be None
+    def configs_hyperparameters(
+        self, configs: list[str] | None = None, include_ag_args: bool = True
+    ) -> dict[str, dict | None]:
+        """Returns a dictionary mapping of config names to hyperparameters as defined in AutoGluon
+        If no hyperparameters exist for a config, its value will be None.
 
         Note that this is not the same as the `hyperparameters` argument to AutoGluon's `TabularPredictor.fit()`.
         To get this, refer to `self.autogluon_hyperparameters_dict()`.
@@ -516,14 +534,14 @@ class AbstractRepository(ABC, SaveLoadMixin):
         include_ag_args: bool, default = True
             If True, includes the `ag_args` hyperparameter which is used in determining the name of the model in AutoGluon
         """
-        configs_hyperparameters = self._zeroshot_context.get_configs_hyperparameters(configs=configs, include_ag_args=include_ag_args)
-        configs_hyperparameters = {k: v["hyperparameters"] if v is not None else v for k, v in configs_hyperparameters.items()}
-        return configs_hyperparameters
+        configs_hyperparameters = self._zeroshot_context.get_configs_hyperparameters(
+            configs=configs, include_ag_args=include_ag_args
+        )
+        return {k: v["hyperparameters"] if v is not None else v for k, v in configs_hyperparameters.items()}
 
     def config_type(self, config: str) -> str | None:
-        """
-        Returns the AutoGluon `hyperparameters` type string for a given config.
-        If no type string exists, the value will be None
+        """Returns the AutoGluon `hyperparameters` type string for a given config.
+        If no type string exists, the value will be None.
 
         For example:
             "LightGBM_c1_BAG_L1" -> "GBM"
@@ -532,9 +550,8 @@ class AbstractRepository(ABC, SaveLoadMixin):
         return self.configs_type(configs=[config])[config]
 
     def configs_type(self, configs: list[str] | None = None) -> dict[str, str | None]:
-        """
-        Returns the AutoGluon `hyperparameters` type strings for a given config list, returned as a dict of config -> type
-        If no type string exists, the value will be None
+        """Returns the AutoGluon `hyperparameters` type strings for a given config list, returned as a dict of config -> type
+        If no type string exists, the value will be None.
 
         For example:
             "LightGBM_c1_BAG_L1" -> "GBM"
@@ -546,8 +563,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
         return configs_type
 
     def config_types(self, configs: list[str] | None = None) -> list[str | None]:
-        """
-        Returns the AutoGluon `hyperparameters` type strings for a given config list, returned as a list of config types.
+        """Returns the AutoGluon `hyperparameters` type strings for a given config list, returned as a list of config types.
 
         Parameters
         ----------
@@ -555,7 +571,7 @@ class AbstractRepository(ABC, SaveLoadMixin):
             If specified, will return the types of configs present in the list.
             Otherwise, will consider all configs.
 
-        Returns
+        Returns:
         -------
         config_types: list[str | None]
             The list of config types present in `configs`.
@@ -568,9 +584,10 @@ class AbstractRepository(ABC, SaveLoadMixin):
                 config_types.add(config_type)
         return list(config_types)
 
-    def autogluon_hyperparameters_dict(self, configs: list[str], ordered: bool = True, include_ag_args: bool = True) -> dict[str, list[dict]]:
-        """
-        Returns the AutoGluon hyperparameters dict to fit the given list of configs in AutoGluon.
+    def autogluon_hyperparameters_dict(
+        self, configs: list[str], ordered: bool = True, include_ag_args: bool = True
+    ) -> dict[str, list[dict]]:
+        """Returns the AutoGluon hyperparameters dict to fit the given list of configs in AutoGluon.
 
         The output `hyperparameters` would be passed to AutoGluon via:
 
@@ -589,7 +606,9 @@ class AbstractRepository(ABC, SaveLoadMixin):
         configs_hyperparameters = self.configs_hyperparameters(configs=configs, include_ag_args=include_ag_args)
         configs_type = self.configs_type(configs=configs)
 
-        self._verify_autogluon_hyperparameters(configs=configs, configs_hyperparameters=configs_hyperparameters, configs_type=configs_type)
+        self._verify_autogluon_hyperparameters(
+            configs=configs, configs_hyperparameters=configs_hyperparameters, configs_type=configs_type
+        )
 
         ordered_priority = -1
         hyperparameters = {}
@@ -621,15 +640,14 @@ class AbstractRepository(ABC, SaveLoadMixin):
                 f"Cannot create AutoGluon hyperparameters dict using {len(configs)} configs={configs}...\n"
                 f"Found {len(invalid_configs)} invalid configs: {invalid_configs}\n"
                 f"These configs either have no hyperparameters or no type specified:\n"
-                f"{invalid_str}"
+                f"{invalid_str}",
             )
 
     def _construct_single_best_config_scorer(self, **kwargs) -> SingleBestConfigScorer:
         return SingleBestConfigScorer.from_repo(repo=self, **kwargs)
 
     def _convert_binary_to_multiclass(self, predictions: np.ndarray, dataset: str) -> np.ndarray:
-        """
-        Converts binary predictions in (n_rows) format to (n_rows, n_classes) format.
+        """Converts binary predictions in (n_rows) format to (n_rows, n_classes) format.
         Converts binary predictions in (n_configs, n_rows) format to (n_configs, n_rows, n_classes) format.
         Skips conversion if dataset's problem_type != "binary".
 
@@ -640,25 +658,22 @@ class AbstractRepository(ABC, SaveLoadMixin):
         dataset: str
             The dataset the predictions originate from.
 
-        Returns
+        Returns:
         -------
         Returns converted predictions if binary, else returns original predictions.
         """
         if self.dataset_info(dataset)["problem_type"] == "binary":
             return np.stack([1 - predictions, predictions], axis=predictions.ndim)
-        else:
-            return predictions
+        return predictions
 
     def _convert_binary_to_1d_multi(self, predictions: np.ndarray, dataset: str) -> np.ndarray:
-        if self.dataset_info(dataset)["problem_type"] == "binary":
-            if len(predictions.shape) == 3:
-                predictions = predictions[:, :, 1]
+        if self.dataset_info(dataset)["problem_type"] == "binary" and len(predictions.shape) == 3:
+            predictions = predictions[:, :, 1]
         return predictions
 
     # TODO: repo.reproduce(config, dataset, fold)
     def get_openml_task(self, dataset: str) -> OpenMLTaskWrapper:
-        """
-        Fetch an OpenML task given a dataset name
+        """Fetch an OpenML task given a dataset name.
 
         Parameters
         ----------
@@ -666,10 +681,9 @@ class AbstractRepository(ABC, SaveLoadMixin):
             The dataset name used to fetch the OpenML task.
             Must be part of `repo.datasets`
 
-        Returns
+        Returns:
         -------
         OpenMLTaskWrapper object
         """
         tid = self.dataset_to_tid(dataset=dataset)
-        task = OpenMLTaskWrapper.from_task_id(task_id=tid)
-        return task
+        return OpenMLTaskWrapper.from_task_id(task_id=tid)

--- a/packages/tabarena/src/tabarena/repository/ensemble_mixin.py
+++ b/packages/tabarena/src/tabarena/repository/ensemble_mixin.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import copy
 import itertools
-from typing import Literal, Tuple, Type
+from typing import Literal
 
 import numpy as np
 import pandas as pd
 
+from tabarena.simulation.ensemble_selection_config_scorer import (
+    EnsembleScorer,
+    EnsembleScorerMaxModels,
+    EnsembleSelectionConfigScorer,
+)
+from tabarena.utils.aux_metric import get_aux_metric_map
+from tabarena.utils.parallel_for import parallel_for
+
 from .time_utils import filter_configs_by_runtime, get_runtime
-from ..simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels, EnsembleSelectionConfigScorer
-from ..utils.aux_metric import get_aux_metric_map
-from ..utils.parallel_for import parallel_for
 
 
 # FIXME: Type hints for AbstractRepository, how to do? Protocol?
@@ -23,19 +28,18 @@ class EnsembleMixin:
         self,
         dataset: str,
         fold: int,
-        configs: list[str] = None,
+        configs: list[str] | None = None,
         *,
-        time_limit: float = None,
-        ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
-        ensemble_kwargs: dict = None,
+        time_limit: float | None = None,
+        ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+        ensemble_kwargs: dict | None = None,
         ensemble_size: int = 100,
         rank: bool = False,
         fit_order: Literal["original", "random"] = "original",
         seed: int = 0,
         patience_callback: list | None = None,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-        """
-        Evaluates an ensemble of a list of configs on a given task (dataset, fold).
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Evaluates an ensemble of a list of configs on a given task (dataset, fold).
 
         Parameters
         ----------
@@ -63,7 +67,7 @@ class EnsembleMixin:
         seed: int, default = 0
             The random seed used to shuffle `configs` if `fit_order="random"`.
 
-        Returns
+        Returns:
         -------
         result: pd.DataFrame
             A single-row multi-index (dataset, fold) DataFrame with the following columns:
@@ -94,7 +98,7 @@ class EnsembleMixin:
             set_index=False,
         )
 
-        configs_all = sorted(list(config_metrics["framework"].unique()))
+        configs_all = sorted(config_metrics["framework"].unique())
         if configs is None:
             configs = configs_all
 
@@ -125,6 +129,7 @@ class EnsembleMixin:
             dataset_metadata = self.task_metadata[self.task_metadata["dataset"] == dataset].iloc[0]
             num_samples_train = dataset_metadata["n_samples_train_per_fold"]
             from autogluon.core.callbacks._smooth_count import max_models_from_num_samples_val
+
             max_models = max_models_from_num_samples_val(
                 num_samples_val=num_samples_train,
                 points=patience_callback,
@@ -139,10 +144,9 @@ class EnsembleMixin:
                 if len(configs_fit_order) > 0:
                     raise AssertionError(
                         f"Can't fit an ensemble with no configs when self._config_fallback is None "
-                        f"(No configs are trainable in the provided time_limit={time_limit}.)"
+                        f"(No configs are trainable in the provided time_limit={time_limit}.)",
                     )
-                else:
-                    raise AssertionError(f"Can't fit an ensemble with no configs when self._config_fallback is None.")
+                raise AssertionError("Can't fit an ensemble with no configs when self._config_fallback is None.")
             configs_to_use = [self._config_fallback]
             config_metrics = self.metrics(
                 tasks=[task_tuple],
@@ -192,15 +196,13 @@ class EnsembleMixin:
             fold=fold,
             config_names=configs_to_use,
             config_metrics=config_metrics,
-            runtime_col='time_train_s',
+            runtime_col="time_train_s",
             fail_if_missing=fail_if_missing,
         )
         time_train_s = sum(runtimes.values())
 
         # compute the ensemble time_infer_s by summing all considered config's time_infer_s that have non-zero weight
-        config_selected_ensemble = [
-            config for i, config in enumerate(configs_to_use) if ensemble_weights[i] != 0
-        ]
+        config_selected_ensemble = [config for i, config in enumerate(configs_to_use) if ensemble_weights[i] != 0]
 
         config_metrics_inference = config_metrics[config_metrics["framework"].isin(config_selected_ensemble)]
 
@@ -210,7 +212,7 @@ class EnsembleMixin:
             fold=fold,
             config_names=config_selected_ensemble,
             config_metrics=config_metrics_inference,
-            runtime_col='time_infer_s',
+            runtime_col="time_infer_s",
             fail_if_missing=fail_if_missing,
         )
         time_infer_s = sum(latencies.values())
@@ -243,23 +245,22 @@ class EnsembleMixin:
 
     def evaluate_ensembles(
         self,
-        datasets: list[str] = None,
-        folds: list[int] = None,
-        configs: list[str] = None,
+        datasets: list[str] | None = None,
+        folds: list[int] | None = None,
+        configs: list[str] | None = None,
         *,
-        ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
-        ensemble_kwargs: dict = None,
+        ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+        ensemble_kwargs: dict | None = None,
         ensemble_size: int = 100,
         patience_callback: list | None = None,
-        time_limit: float = None,
+        time_limit: float | None = None,
         fit_order: Literal["original", "random"] = "original",
         seed: int = 0,
         rank: bool = False,
         backend_group_folds: bool = False,
         backend: Literal["ray", "native"] = "ray",
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-        """
-        Evaluates an ensemble of a list of configs on a given set of tasks (datasets x folds).
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Evaluates an ensemble of a list of configs on a given set of tasks (datasets x folds).
 
         Identical to calling `evaluate_ensemble` once for each task and then concatenating the results,
         however this method will be much faster due to parallelization.
@@ -294,7 +295,7 @@ class EnsembleMixin:
         backend: Literal["ray", "native"], default = "ray"
             The backend to use when running the list of tasks.
 
-        Returns
+        Returns:
         -------
         result: pd.DataFrame
             A multi-index (dataset, fold) DataFrame where each row corresponds to a task, with the following columns:
@@ -366,7 +367,9 @@ class EnsembleMixin:
         )
 
         df_out = pd.concat([l[0] for l in list_rows], axis=0)
-        df_ensemble_weights = pd.concat([l[1] for l in list_rows], axis=0)  # FIXME: Is this guaranteed same columns in each?
+        df_ensemble_weights = pd.concat(
+            [l[1] for l in list_rows], axis=0
+        )  # FIXME: Is this guaranteed same columns in each?
 
         return df_out, df_ensemble_weights
 
@@ -374,18 +377,17 @@ class EnsembleMixin:
         self,
         df_info: pd.DataFrame | list[dict[str]],
         *,
-        ensemble_cls: Type[EnsembleScorer] = EnsembleScorerMaxModels,
-        ensemble_kwargs: dict = None,
+        ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+        ensemble_kwargs: dict | None = None,
         ensemble_size: int = 100,
-        time_limit: float = None,
+        time_limit: float | None = None,
         fit_order: Literal["original", "random"] = "original",
         seed: int = 0,
         rank: bool = False,
         backend_group_folds: bool = True,
         backend: Literal["ray", "native"] = "ray",
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-        """
-        Identical to calling `evaluate_ensemble` once for each row in df_info,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Identical to calling `evaluate_ensemble` once for each row in df_info,
         however this method will be much faster due to parallelization.
 
         Parameters
@@ -411,7 +413,7 @@ class EnsembleMixin:
         backend: Literal["ray", "native"], default = "ray"
             The backend to use when running the list of tasks.
 
-        Returns
+        Returns:
         -------
         result: pd.DataFrame
             A multi-index (dataset, fold) DataFrame where each row corresponds to a task, with the following columns:
@@ -460,7 +462,7 @@ class EnsembleMixin:
                 if dataset not in inputs_dict:
                     inputs_dict[dataset] = []
                 inputs_dict[dataset].append(input_dict)
-            inputs = [{"df_info": inputs_dict[dataset]} for dataset in inputs_dict.keys()]
+            inputs = [{"df_info": inputs_dict[dataset]} for dataset in inputs_dict]
             context.update({"backend": "native", "backend_group_folds": False})
             par_func = self.__class__.evaluate_ensembles_per
         else:
@@ -472,25 +474,25 @@ class EnsembleMixin:
             context=context,
             engine=backend,
             # To reduce log spam in outer parallel mode.
-            progress_bar=backend != "sequential"
+            progress_bar=backend != "sequential",
         )
 
         df_out = pd.concat([l[0] for l in list_rows], axis=0)
-        df_ensemble_weights = pd.concat([l[1] for l in list_rows],
-                                        axis=0)  # FIXME: Is this guaranteed same columns in each?
+        df_ensemble_weights = pd.concat(
+            [l[1] for l in list_rows], axis=0
+        )  # FIXME: Is this guaranteed same columns in each?
 
         return df_out, df_ensemble_weights
 
     def _construct_ensemble_selection_config_scorer(
         self,
         ensemble_size: int = 10,
-        backend: str = 'ray',
-        **kwargs
+        backend: str = "ray",
+        **kwargs,
     ) -> EnsembleSelectionConfigScorer:
-        config_scorer = EnsembleSelectionConfigScorer.from_repo(
+        return EnsembleSelectionConfigScorer.from_repo(
             repo=self,
             ensemble_size=ensemble_size,  # 100 is better, but 10 allows to simulate 10x faster
             backend=backend,
             **kwargs,
         )
-        return config_scorer

--- a/packages/tabarena/src/tabarena/repository/evaluation_repository.py
+++ b/packages/tabarena/src/tabarena/repository/evaluation_repository.py
@@ -3,36 +3,36 @@ from __future__ import annotations
 import copy
 import os
 from pathlib import Path
-from typing import Any, List, Literal
-
-import numpy as np
-import pandas as pd
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 from .abstract_repository import AbstractRepository
 from .ensemble_mixin import EnsembleMixin
 from .ground_truth_mixin import GroundTruthMixin
-from .. import repository
-from ..predictions.tabular_predictions import TabularModelPredictions
-from ..simulation.configuration_list_scorer import ConfigurationListScorer
-from ..simulation.ground_truth import GroundTruth
-from ..simulation.simulation_context import ZeroshotSimulatorContext
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
+
+    from tabarena import repository
+    from tabarena.predictions.tabular_predictions import TabularModelPredictions
+    from tabarena.simulation.configuration_list_scorer import ConfigurationListScorer
+    from tabarena.simulation.ground_truth import GroundTruth
+    from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
 
 
 class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
-    """
-    Simple Repository class that implements core functionality related to
+    """Simple Repository class that implements core functionality related to
     fetching model predictions, available datasets, folds, etc.
     """
+
     def __init__(
-            self,
-            zeroshot_context: ZeroshotSimulatorContext,
-            tabular_predictions: TabularModelPredictions,
-            ground_truth: GroundTruth,
-            config_fallback: str = None,
+        self,
+        zeroshot_context: ZeroshotSimulatorContext,
+        tabular_predictions: TabularModelPredictions,
+        ground_truth: GroundTruth,
+        config_fallback: str | None = None,
     ):
-        """
-        :param zeroshot_context:
+        """:param zeroshot_context:
         :param tabular_predictions:
         :param ground_truth:
         :param config_fallback: if specified, used to replace the result of a configuration that is missing, if not
@@ -43,15 +43,18 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
         self._tabular_predictions: TabularModelPredictions = tabular_predictions
         self._ground_truth = ground_truth
         if self._tabular_predictions is not None:
-            assert all(self._zeroshot_context.dataset_to_tid_dict[x] in self._tid_to_dataset_dict for x in self._tabular_predictions.datasets)
+            assert all(
+                self._zeroshot_context.dataset_to_tid_dict[x] in self._tid_to_dataset_dict
+                for x in self._tabular_predictions.datasets
+            )
 
     def to_zeroshot(self) -> repository.EvaluationRepositoryZeroshot:
-        """
-        Returns a version of the repository as an EvaluationRepositoryZeroshot object.
+        """Returns a version of the repository as an EvaluationRepositoryZeroshot object.
 
         :return: EvaluationRepositoryZeroshot object
         """
         from .evaluation_repository_zeroshot import EvaluationRepositoryZeroshot
+
         self_zeroshot = copy.copy(self)  # Shallow copy so that the class update does not alter self
         self_zeroshot.__class__ = EvaluationRepositoryZeroshot
         return self_zeroshot
@@ -71,8 +74,7 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             self._ground_truth.restrict_datasets(datasets=datasets)
 
     def force_to_dense(self, inplace: bool = False, verbose: bool = True) -> Self:
-        """
-        Method to force the repository to a dense representation inplace.
+        """Method to force the repository to a dense representation inplace.
 
         The following operations will be applied in order:
         1. subset to only datasets that contain at least one result for all folds (self.n_folds())
@@ -91,7 +93,7 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
         verbose: bool, default = True
             Whether to log verbose details about the force to dense operation.
 
-        Returns
+        Returns:
         -------
         Return dense repo if inplace=False or self after inplace updates in this call.
         """
@@ -99,6 +101,7 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             return copy.deepcopy(self).force_to_dense(inplace=True, verbose=verbose)
 
         from tabarena.simulation.dense_utils import intersect_folds_and_datasets, prune_zeroshot_gt
+
         # keep only dataset whose folds are all present
         intersect_folds_and_datasets(self._zeroshot_context, self._tabular_predictions, self._ground_truth)
 
@@ -108,22 +111,23 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
         self.subset(datasets=datasets, inplace=inplace, force_to_dense=False)
 
         self._tabular_predictions.restrict_models(self.configs())
-        self._ground_truth = prune_zeroshot_gt(zeroshot_pred_proba=self._tabular_predictions,
-                                               zeroshot_gt=self._ground_truth,
-                                               dataset_to_tid_dict=self._dataset_to_tid_dict,
-                                               verbose=verbose, )
+        self._ground_truth = prune_zeroshot_gt(
+            zeroshot_pred_proba=self._tabular_predictions,
+            zeroshot_gt=self._ground_truth,
+            dataset_to_tid_dict=self._dataset_to_tid_dict,
+            verbose=verbose,
+        )
         return self
 
     def predict_test_multi(
         self,
         dataset: str,
         fold: int,
-        configs: List[str] = None,
+        configs: list[str] | None = None,
         binary_as_multiclass: bool = False,
         enforce_binary_1d: bool = False,
     ) -> np.ndarray:
-        """
-        Returns the predictions on the test set for a given list of configurations on a given dataset and fold
+        """Returns the predictions on the test set for a given list of configurations on a given dataset and fold.
 
         Parameters
         ----------
@@ -144,7 +148,7 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             The internal representation is of form (n_configs, n_rows) as it requires less memory,
             so there is a conversion overhead introduced when `binary_as_multiclass=True`.
 
-        Returns
+        Returns:
         -------
         The model predictions with shape (n_configs, n_rows, n_classes) for multiclass or (n_configs, n_rows) in case of regression.
         For binary, shape depends on `binary_as_multiclass` value.
@@ -157,7 +161,7 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             model_fallback=self._config_fallback,
         )
         if enforce_binary_1d:
-            assert not binary_as_multiclass, f"Cannot set both `enforce_binary_1d` and `binary_as_multiclass` to True"
+            assert not binary_as_multiclass, "Cannot set both `enforce_binary_1d` and `binary_as_multiclass` to True"
             predictions = self._convert_binary_to_1d_multi(predictions=predictions, dataset=dataset)
         elif binary_as_multiclass:
             predictions = self._convert_binary_to_multiclass(dataset=dataset, predictions=predictions)
@@ -167,12 +171,11 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
         self,
         dataset: str,
         fold: int,
-        configs: List[str] = None,
+        configs: list[str] | None = None,
         binary_as_multiclass: bool = False,
         enforce_binary_1d: bool = False,
     ) -> np.ndarray:
-        """
-        Returns the predictions on the validation set for a given list of configurations on a given dataset and fold
+        """Returns the predictions on the validation set for a given list of configurations on a given dataset and fold.
 
         Parameters
         ----------
@@ -193,7 +196,7 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             The internal representation is of form (n_configs, n_rows) as it requires less memory,
             so there is a conversion overhead introduced when `binary_as_multiclass=True`.
 
-        Returns
+        Returns:
         -------
         The model predictions with shape (n_configs, n_rows, n_classes) for multiclass or (n_configs, n_rows) in case of regression.
         For binary, shape depends on `binary_as_multiclass` value.
@@ -206,21 +209,20 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             model_fallback=self._config_fallback,
         )
         if enforce_binary_1d:
-            assert not binary_as_multiclass, f"Cannot set both `enforce_binary_1d` and `binary_as_multiclass` to True"
+            assert not binary_as_multiclass, "Cannot set both `enforce_binary_1d` and `binary_as_multiclass` to True"
             predictions = self._convert_binary_to_1d_multi(predictions=predictions, dataset=dataset)
         elif binary_as_multiclass:
             predictions = self._convert_binary_to_multiclass(dataset=dataset, predictions=predictions)
         return predictions
 
-    def _construct_config_scorer(self,
-                                 config_scorer_type: str = 'ensemble',
-                                 **config_scorer_kwargs) -> ConfigurationListScorer:
-        if config_scorer_type == 'ensemble':
+    def _construct_config_scorer(
+        self, config_scorer_type: str = "ensemble", **config_scorer_kwargs
+    ) -> ConfigurationListScorer:
+        if config_scorer_type == "ensemble":
             return self._construct_ensemble_selection_config_scorer(**config_scorer_kwargs)
-        elif config_scorer_type == 'single':
+        if config_scorer_type == "single":
             return self._construct_single_best_config_scorer(**config_scorer_kwargs)
-        else:
-            raise ValueError(f'Invalid config_scorer_type: {config_scorer_type}')
+        raise ValueError(f"Invalid config_scorer_type: {config_scorer_type}")
 
     # TODO: 1. Cleanup results_lst_simulation_artifacts, 2. Make context work with tasks instead of datasets x folds
     # TODO: Get raw data from repo method (X, y)
@@ -236,14 +238,15 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
         results_lst_simulation_artifacts: list[dict[str, dict[int, dict]]],
         df_baselines: pd.DataFrame = None,
         task_metadata: pd.DataFrame = None,
-        configs_hyperparameters: dict[str, dict[str, Any]] = None,
+        configs_hyperparameters: dict[str, dict[str, Any]] | None = None,
         pct: bool = False,
         score_against_only_baselines: bool = False,
     ) -> Self:
+        from autogluon.common.utils.simulation_utils import convert_simulation_artifacts_to_tabular_predictions_dict
+
         from tabarena.predictions import TabularPredictionsInMemory
         from tabarena.simulation.ground_truth import GroundTruth
         from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
-        from autogluon.common.utils.simulation_utils import convert_simulation_artifacts_to_tabular_predictions_dict
 
         required_columns = [
             "dataset",
@@ -259,12 +262,18 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
         if df_configs is not None:
             for column in required_columns:
                 if column not in df_configs:
-                    raise AssertionError(f"Missing required column in df_configs: {column}\ndf_configs columns: {list(df_configs.columns)}")
+                    raise AssertionError(
+                        f"Missing required column in df_configs: {column}\ndf_configs columns: {list(df_configs.columns)}"
+                    )
 
         if results_lst_simulation_artifacts is not None:
-            simulation_artifacts_full = cls._convert_sim_artifacts(results_lst_simulation_artifacts=results_lst_simulation_artifacts)
+            simulation_artifacts_full = cls._convert_sim_artifacts(
+                results_lst_simulation_artifacts=results_lst_simulation_artifacts
+            )
 
-            zeroshot_pp, zeroshot_gt = convert_simulation_artifacts_to_tabular_predictions_dict(simulation_artifacts=simulation_artifacts_full)
+            zeroshot_pp, zeroshot_gt = convert_simulation_artifacts_to_tabular_predictions_dict(
+                simulation_artifacts=simulation_artifacts_full
+            )
 
             predictions = TabularPredictionsInMemory.from_dict(zeroshot_pp)
             ground_truth = GroundTruth.from_dict(zeroshot_gt)
@@ -281,13 +290,11 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
             score_against_only_baselines=score_against_only_baselines,
         )
 
-        repo = cls(
+        return cls(
             zeroshot_context=zeroshot_context,
             tabular_predictions=predictions,
             ground_truth=ground_truth,
         )
-
-        return repo
 
     def to_dir(self, path: str | Path):
         from tabarena.contexts.context import BenchmarkContext, construct_context
@@ -348,15 +355,16 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
         if update_relative_path:
             context.benchmark_paths.relative_path = str(Path(path))
 
-        repo = context.load_repo(prediction_format=prediction_format, verbose=verbose)
-        return repo
+        return context.load_repo(prediction_format=prediction_format, verbose=verbose)
 
     @classmethod
-    def _convert_sim_artifacts(cls, results_lst_simulation_artifacts: list[dict[str, dict[int, dict[str, Any]]]]) -> dict[str, dict[int, dict[str, Any]]]:
+    def _convert_sim_artifacts(
+        cls, results_lst_simulation_artifacts: list[dict[str, dict[int, dict[str, Any]]]]
+    ) -> dict[str, dict[int, dict[str, Any]]]:
         # FIXME: Don't require all results in memory at once
         simulation_artifacts_full = {}
         for simulation_artifacts in results_lst_simulation_artifacts:
-            for k in simulation_artifacts.keys():
+            for k in simulation_artifacts:
                 if k not in simulation_artifacts_full:
                     simulation_artifacts_full[k] = {}
                 for f in simulation_artifacts[k]:
@@ -366,9 +374,10 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
                         for method in simulation_artifacts[k][f]["pred_proba_dict_val"]:
                             if method in simulation_artifacts_full[k][f]["pred_proba_dict_val"]:
                                 raise AssertionError(f"Two results exist for dataset {k}, fold {f}, method {method}!")
-                            else:
-                                simulation_artifacts_full[k][f]["pred_proba_dict_val"][method] = simulation_artifacts[k][f]["pred_proba_dict_val"][method]
-                                simulation_artifacts_full[k][f]["pred_proba_dict_test"][method] = simulation_artifacts[k][f]["pred_proba_dict_test"][method]
+                            simulation_artifacts_full[k][f]["pred_proba_dict_val"][method] = simulation_artifacts[k][f][
+                                "pred_proba_dict_val"
+                            ][method]
+                            simulation_artifacts_full[k][f]["pred_proba_dict_test"][method] = simulation_artifacts[k][
+                                f
+                            ]["pred_proba_dict_test"][method]
         return simulation_artifacts_full
-
-

--- a/packages/tabarena/src/tabarena/repository/evaluation_repository_collection.py
+++ b/packages/tabarena/src/tabarena/repository/evaluation_repository_collection.py
@@ -2,27 +2,28 @@ from __future__ import annotations
 
 import copy
 from collections import defaultdict
-from typing import Literal
 from functools import reduce
+from typing import TYPE_CHECKING, Literal, Self
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_integer_dtype, is_float_dtype
-from typing_extensions import Self
+from pandas.api.types import is_float_dtype, is_integer_dtype
+
+from tabarena.contexts.utils import prune_zeroshot_gt
+from tabarena.simulation.ground_truth import GroundTruth
+from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
 
 from .abstract_repository import AbstractRepository
 from .ensemble_mixin import EnsembleMixin
 from .ground_truth_mixin import GroundTruthMixin
-from .evaluation_repository import EvaluationRepository
-from ..contexts.utils import prune_zeroshot_gt
-from ..simulation.ground_truth import GroundTruth
-from ..simulation.simulation_context import ZeroshotSimulatorContext
+
+if TYPE_CHECKING:
+    from .evaluation_repository import EvaluationRepository
 
 
 # TODO: Improve error message for overlap
 class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTruthMixin):
-    """
-    Repository collection class that implements core functionality related to
+    """Repository collection class that implements core functionality related to
     fetching model predictions, available datasets, folds, etc.
 
     This class allows to merge a list of other repositories together into a single object.
@@ -52,14 +53,15 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
         If "first", will use the result from the repo earlier in the `repos` list.
         If "last", will use the result from the repo later in the `repos` list.
     """
+
     def __init__(
         self,
-        repos: list[EvaluationRepository | "EvaluationRepositoryCollection"],
-        config_fallback: str = None,
+        repos: list[EvaluationRepository | EvaluationRepositoryCollection],
+        config_fallback: str | None = None,
         overlap: Literal["raise", "first", "last"] = "raise",
     ):
         self.overlap = overlap
-        self.repos: list[EvaluationRepository | "EvaluationRepositoryCollection"] = repos
+        self.repos: list[EvaluationRepository | EvaluationRepositoryCollection] = repos
 
         zeroshot_context = merge_zeroshot([repo._zeroshot_context for repo in self.repos])
         self._ground_truth: GroundTruth = merge_ground_truth([repo._ground_truth for repo in self.repos])
@@ -68,47 +70,70 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
 
     def _compute_repo_mapping(self) -> dict[tuple[str, int, str], int]:
         repo_result_combinations = self._generate_dataset_fold_config_combinations(repos=self.repos)
-        return self._combination_mapping_to_repo_index(repo_result_combinations=repo_result_combinations, overlap=self.overlap)
+        return self._combination_mapping_to_repo_index(
+            repo_result_combinations=repo_result_combinations, overlap=self.overlap
+        )
 
     def get_result_to_repo_idx(self, dataset: str, fold: int, config: str) -> int | None:
-        """
-        Returns the repo idx in `self.repos` containing the specified (dataset, fold, config) result.
+        """Returns the repo idx in `self.repos` containing the specified (dataset, fold, config) result.
         Returns None if no such repo exists.
         """
         return self._mapping.get((dataset, fold, config), None)
 
-    def get_result_to_repo(self, dataset: str, fold: int, config: str) -> EvaluationRepository | "EvaluationRepositoryCollection" | None:
-        """
-        Returns the repo in `self.repos` containing the specified (dataset, fold, config) result.
+    def get_result_to_repo(
+        self, dataset: str, fold: int, config: str
+    ) -> EvaluationRepository | EvaluationRepositoryCollection | None:
+        """Returns the repo in `self.repos` containing the specified (dataset, fold, config) result.
         Returns None if no such repo exists.
         """
         repo_idx = self._mapping.get((dataset, fold, config), None)
         if repo_idx is None:
             return repo_idx
-        else:
-            return self.repos[repo_idx]
+        return self.repos[repo_idx]
 
     def predict_test_multi(
         self,
         dataset: str,
         fold: int,
-        configs: list[str] = None,
+        configs: list[str] | None = None,
         binary_as_multiclass: bool = False,
         enforce_binary_1d: bool = False,
     ) -> np.ndarray:
-        return self._predict_multi(predict_func="predict_test_multi", dataset=dataset, fold=fold, configs=configs, binary_as_multiclass=binary_as_multiclass, enforce_binary_1d=enforce_binary_1d)
+        return self._predict_multi(
+            predict_func="predict_test_multi",
+            dataset=dataset,
+            fold=fold,
+            configs=configs,
+            binary_as_multiclass=binary_as_multiclass,
+            enforce_binary_1d=enforce_binary_1d,
+        )
 
     def predict_val_multi(
         self,
         dataset: str,
         fold: int,
-        configs: list[str] = None,
+        configs: list[str] | None = None,
         binary_as_multiclass: bool = False,
         enforce_binary_1d: bool = False,
     ) -> np.ndarray:
-        return self._predict_multi(predict_func="predict_val_multi", dataset=dataset, fold=fold, configs=configs, binary_as_multiclass=binary_as_multiclass, enforce_binary_1d=enforce_binary_1d)
+        return self._predict_multi(
+            predict_func="predict_val_multi",
+            dataset=dataset,
+            fold=fold,
+            configs=configs,
+            binary_as_multiclass=binary_as_multiclass,
+            enforce_binary_1d=enforce_binary_1d,
+        )
 
-    def _predict_multi(self, predict_func: str, dataset: str, fold: int, configs: list[str] = None, binary_as_multiclass: bool = False, enforce_binary_1d: bool = False) -> np.ndarray:
+    def _predict_multi(
+        self,
+        predict_func: str,
+        dataset: str,
+        fold: int,
+        configs: list[str] | None = None,
+        binary_as_multiclass: bool = False,
+        enforce_binary_1d: bool = False,
+    ) -> np.ndarray:
         if configs is None:
             configs = self.configs()
 
@@ -120,13 +145,15 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
             repo_idx = self.get_result_to_repo_idx(dataset=dataset, fold=fold, config=config)
             if repo_idx is None:
                 if self._config_fallback is None:
-                    raise ValueError(f"The following combination is not present in this repository: (dataset='{dataset}', fold={fold}, config='{config}')")
+                    raise ValueError(
+                        f"The following combination is not present in this repository: (dataset='{dataset}', fold={fold}, config='{config}')"
+                    )
                 # get fallback
                 repo_idx = self.get_result_to_repo_idx(dataset=dataset, fold=fold, config=self._config_fallback)
                 if repo_idx is None:
                     raise ValueError(
                         f"The following combination is not present in this repository: (dataset='{dataset}', fold={fold}, config='{config}')"
-                        f"\nAdditionally, the fallback config is not present in (dataset='{dataset}', fold={fold}, config='{self._config_fallback}')"
+                        f"\nAdditionally, the fallback config is not present in (dataset='{dataset}', fold={fold}, config='{self._config_fallback}')",
                     )
                 repo_map[repo_idx].append(self._config_fallback)
             else:
@@ -136,7 +163,13 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
 
         for repo_idx, config_lst in repo_map.items():
             f = getattr(self.repos[repo_idx], predict_func)
-            predict_map[repo_idx] = f(dataset=dataset, fold=fold, configs=config_lst, binary_as_multiclass=binary_as_multiclass, enforce_binary_1d=enforce_binary_1d)
+            predict_map[repo_idx] = f(
+                dataset=dataset,
+                fold=fold,
+                configs=config_lst,
+                binary_as_multiclass=binary_as_multiclass,
+                enforce_binary_1d=enforce_binary_1d,
+            )
 
         # predict_map[repo_idx] has shape
         #  (n_configs, n_rows, n_classes) if multiclass classification
@@ -145,7 +178,7 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
         # We ignore the first dimension because we need all configs in the final result,
         # and each repo could only have a subset of the configs.
         shape = predict_map[repo_idx].shape[1:]
-        predict_multi = np.zeros(shape=(len(configs),) + shape, dtype=predict_map[repo_idx].dtype)
+        predict_multi = np.zeros(shape=(len(configs), *shape), dtype=predict_map[repo_idx].dtype)
 
         for repo_idx, predict in predict_map.items():
             predict_multi[repo_idx_map[repo_idx], :] = predict
@@ -171,8 +204,7 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
         self._mapping = self._compute_repo_mapping()
 
     def force_to_dense(self, inplace: bool = False, verbose: bool = True) -> Self:
-        """
-        Method to force the repository to a dense representation inplace.
+        """Method to force the repository to a dense representation inplace.
 
         The following operations will be applied in order:
         1. subset to only datasets that contain at least one result for all folds (self.n_folds())
@@ -191,7 +223,7 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
         verbose: bool, default = True
             Whether to log verbose details about the force to dense operation.
 
-        Returns
+        Returns:
         -------
         Return dense repo if inplace=False or self after inplace updates in this call.
         """
@@ -199,7 +231,12 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
             return copy.deepcopy(self).force_to_dense(inplace=True, verbose=verbose)
 
         datasets = self.datasets(union=True)
-        n_folds_per_dataset = pd.Series({dataset: len(dataset_folds) for dataset, dataset_folds in self._zeroshot_context.dataset_to_folds_dict.items()})
+        n_folds_per_dataset = pd.Series(
+            {
+                dataset: len(dataset_folds)
+                for dataset, dataset_folds in self._zeroshot_context.dataset_to_folds_dict.items()
+            }
+        )
 
         n_folds = self.n_folds()
         datasets_dense = list(n_folds_per_dataset[n_folds_per_dataset == n_folds].index)
@@ -234,10 +271,10 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
         return self
 
     @staticmethod
-    def _generate_dataset_fold_config_combinations(repos: list[EvaluationRepository]) -> list[list[tuple[str, int, str]]]:
-        """
-        Returns the combinations (dataset, fold, config) for each repository
-        """
+    def _generate_dataset_fold_config_combinations(
+        repos: list[EvaluationRepository],
+    ) -> list[list[tuple[str, int, str]]]:
+        """Returns the combinations (dataset, fold, config) for each repository."""
         return [repo.dataset_fold_config_pairs() for repo in repos]
 
     @staticmethod
@@ -245,15 +282,13 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
         repo_result_combinations: list[list[tuple[str, int, str]]],
         overlap: Literal["raise", "first", "last"] = "raise",
     ) -> dict[tuple[str, int, str], int]:
-        """
-        Returns a dictionary mapping each (dataset, fold, config) to the repository index
-        """
+        """Returns a dictionary mapping each (dataset, fold, config) to the repository index."""
         if overlap == "first":
             len_combinations = len(repo_result_combinations)
             # traverse the repositories in reverse order to match `overlap` order
             mapping = {
                 (dataset, fold, config): repo_index
-                for repo_index in range(len_combinations-1, -1, -1)
+                for repo_index in range(len_combinations - 1, -1, -1)
                 for (dataset, fold, config) in repo_result_combinations[repo_index]
             }
         elif overlap in ["last", "raise"]:
@@ -274,7 +309,9 @@ class EvaluationRepositoryCollection(AbstractRepository, EnsembleMixin, GroundTr
         return mapping
 
 
-def merge_zeroshot(zeroshot_contexts: list[ZeroshotSimulatorContext], require_matching_flags: bool = False) -> ZeroshotSimulatorContext:
+def merge_zeroshot(
+    zeroshot_contexts: list[ZeroshotSimulatorContext], require_matching_flags: bool = False
+) -> ZeroshotSimulatorContext:
     assert isinstance(zeroshot_contexts, list)
 
     df_baselines_lst = [z.df_baselines for z in zeroshot_contexts]
@@ -294,22 +331,23 @@ def merge_zeroshot(zeroshot_contexts: list[ZeroshotSimulatorContext], require_ma
         df_configs = None
 
     df_metadata_lst = [z.df_metadata for z in zeroshot_contexts]
-    df_metadata_lst = [df_metadata for df_metadata in df_metadata_lst if df_metadata is not None and len(df_metadata) > 0]
-    if df_metadata_lst:
-        df_metadata = merge_metadata_frames(df_list=df_metadata_lst)
-    else:
-        df_metadata = None
+    df_metadata_lst = [
+        df_metadata for df_metadata in df_metadata_lst if df_metadata is not None and len(df_metadata) > 0
+    ]
+    df_metadata = merge_metadata_frames(df_list=df_metadata_lst) if df_metadata_lst else None
 
     configs_hyperparameters = {}
     for z in zeroshot_contexts:
         if z.configs_hyperparameters is not None:
             intersection = set(configs_hyperparameters.keys()).intersection(set(z.configs_hyperparameters.keys()))
             for k in intersection:
-                assert configs_hyperparameters[k] == z.configs_hyperparameters[k], (f"Inconsistent hyperparameters for config={k} found!\n"
-                                                                                    f"Hyperparameters 1:\n"
-                                                                                    f"\t{configs_hyperparameters[k]}\n"
-                                                                                    f"Hyperparameters 2:\n"
-                                                                                    f"\t{z.configs_hyperparameters[k]}")
+                assert configs_hyperparameters[k] == z.configs_hyperparameters[k], (
+                    f"Inconsistent hyperparameters for config={k} found!\n"
+                    f"Hyperparameters 1:\n"
+                    f"\t{configs_hyperparameters[k]}\n"
+                    f"Hyperparameters 2:\n"
+                    f"\t{z.configs_hyperparameters[k]}"
+                )
             configs_hyperparameters.update(z.configs_hyperparameters)
     if len(configs_hyperparameters) == 0:
         configs_hyperparameters = None
@@ -321,7 +359,9 @@ def merge_zeroshot(zeroshot_contexts: list[ZeroshotSimulatorContext], require_ma
         for z in zeroshot_contexts[1:]:
             assert pct == z.pct, f"Inconsistent `pct` value found! ({pct}, {z.pct})"
         for z in zeroshot_contexts[1:]:
-            assert score_against_only_baselines == z.score_against_only_baselines, f"Inconsistent `score_against_only_baselines` value found! ({score_against_only_baselines}, {z.score_against_only_baselines})"
+            assert score_against_only_baselines == z.score_against_only_baselines, (
+                f"Inconsistent `score_against_only_baselines` value found! ({score_against_only_baselines}, {z.score_against_only_baselines})"
+            )
 
     folds = None
     if any(z.folds is None for z in zeroshot_contexts):
@@ -331,7 +371,7 @@ def merge_zeroshot(zeroshot_contexts: list[ZeroshotSimulatorContext], require_ma
         for z in zeroshot_contexts:
             folds += [f for f in z.folds if f not in folds]
 
-    zeroshot_context_merged = ZeroshotSimulatorContext(
+    return ZeroshotSimulatorContext(
         df_configs=df_configs,
         df_baselines=df_baselines,
         df_metadata=df_metadata,
@@ -340,8 +380,6 @@ def merge_zeroshot(zeroshot_contexts: list[ZeroshotSimulatorContext], require_ma
         pct=pct,
         score_against_only_baselines=score_against_only_baselines,
     )
-
-    return zeroshot_context_merged
 
 
 # TODO: Does not yet verify equivalence
@@ -361,19 +399,17 @@ def merge_ground_truth(ground_truths: list[GroundTruth]) -> GroundTruth:
                 label_val_dict[d] = {}
             label_test_dict[d].update(gt._label_test_dict[d])
             label_val_dict[d].update(gt._label_val_dict[d])
-    ground_truth_merged = GroundTruth(label_test_dict=label_test_dict, label_val_dict=label_val_dict)
-    return ground_truth_merged
+    return GroundTruth(label_test_dict=label_test_dict, label_val_dict=label_val_dict)
 
 
 def merge_metadata_frames(df_list: list[pd.DataFrame]) -> pd.DataFrame:
-    """
-    Merge a list of metadata DataFrames such that:
+    """Merge a list of metadata DataFrames such that:
     - Only well-defined instance key columns are used as join keys.
     - For non-key columns:
         * If one side is NaN and the other has a value, the value is used.
         * If both have the same non-NaN value, that value is used.
         * If both have different non-NaN values, this is treated as a conflict.
-          (By default we raise; you can change to keep multiple rows if you want.)
+          (By default we raise; you can change to keep multiple rows if you want.).
 
     Result:
         - There is at most one row per instance unless there is a true conflict.
@@ -423,10 +459,9 @@ def merge_metadata_frames(df_list: list[pd.DataFrame]) -> pd.DataFrame:
                 mask_both_notnull = s_l.notna() & s_r.notna()
                 mask_conflict = mask_both_notnull & (s_l != s_r)
                 if mask_conflict.any():
-                    conflict_examples = merged.loc[mask_conflict, join_cols + [col_l, col_r]]
+                    conflict_examples = merged.loc[mask_conflict, [*join_cols, col_l, col_r]]
                     raise ValueError(
-                        f"Conflict detected in column '{col}' for some instances.\n"
-                        f"Examples:\n{conflict_examples}"
+                        f"Conflict detected in column '{col}' for some instances.\nExamples:\n{conflict_examples}",
                     )
 
                 # 2) coalesce WITHOUT combine_first to avoid FutureWarning
@@ -457,6 +492,4 @@ def merge_metadata_frames(df_list: list[pd.DataFrame]) -> pd.DataFrame:
     df_metadata = reduce(merge_pair, df_list)
 
     # Remove any exact duplicates that might remain
-    df_metadata = df_metadata.drop_duplicates(ignore_index=True)
-
-    return df_metadata
+    return df_metadata.drop_duplicates(ignore_index=True)

--- a/packages/tabarena/src/tabarena/repository/evaluation_repository_zeroshot.py
+++ b/packages/tabarena/src/tabarena/repository/evaluation_repository_zeroshot.py
@@ -1,23 +1,29 @@
-from typing import List, Optional, Union
+from __future__ import annotations
 
-import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
+
+from tabarena.simulation.sim_output import SimulationOutputGenerator
+from tabarena.simulation.sim_runner import run_zs_simulation
 
 from .evaluation_repository import EvaluationRepository
-from ..portfolio import Portfolio, PortfolioCV
-from ..simulation.sim_output import SimulationOutputGenerator
-from ..simulation.sim_runner import run_zs_simulation
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from tabarena.portfolio import Portfolio, PortfolioCV
 
 
 class EvaluationRepositoryZeroshot(EvaluationRepository):
     """An extension of EvaluationRepository that includes zeroshot simulation methods."""
-    def generate_output_from_portfolio_cv(self,
-                                          portfolio_cv: PortfolioCV,
-                                          name: str,
-                                          config_scorer_type: str = 'ensemble',
-                                          config_scorer_kwargs: dict = None) -> pd.DataFrame:
-        """
-        Generates an AutoGluon-Benchmark compatible pandas DataFrame output that can be used to compare
+
+    def generate_output_from_portfolio_cv(
+        self,
+        portfolio_cv: PortfolioCV,
+        name: str,
+        config_scorer_type: str = "ensemble",
+        config_scorer_kwargs: dict | None = None,
+    ) -> pd.DataFrame:
+        """Generates an AutoGluon-Benchmark compatible pandas DataFrame output that can be used to compare
         with existing baselines and other simulation results.
 
         The input portfolios for this method are cross-validated simulation portfolios, where each task may have
@@ -49,19 +55,19 @@ class EvaluationRepositoryZeroshot(EvaluationRepository):
                 problem_type        binary
                 tid                   3593
         """
-        sog = SimulationOutputGenerator(repo=self,
-                                        config_scorer_type=config_scorer_type,
-                                        config_scorer_kwargs=config_scorer_kwargs)
-        df_result = sog.from_portfolio_cv(portfolio_cv=portfolio_cv, name=name)
-        return df_result
+        sog = SimulationOutputGenerator(
+            repo=self, config_scorer_type=config_scorer_type, config_scorer_kwargs=config_scorer_kwargs
+        )
+        return sog.from_portfolio_cv(portfolio_cv=portfolio_cv, name=name)
 
-    def generate_output_from_portfolio(self,
-                                       portfolio: Union[Portfolio, List[str]],
-                                       name: str,
-                                       config_scorer_type: str = 'ensemble',
-                                       config_scorer_kwargs: dict = None) -> pd.DataFrame:
-        """
-        Generates an AutoGluon-Benchmark compatible pandas DataFrame output that can be used to compare
+    def generate_output_from_portfolio(
+        self,
+        portfolio: Portfolio | list[str],
+        name: str,
+        config_scorer_type: str = "ensemble",
+        config_scorer_kwargs: dict | None = None,
+    ) -> pd.DataFrame:
+        """Generates an AutoGluon-Benchmark compatible pandas DataFrame output that can be used to compare
         with existing baselines and other simulation results.
 
         The input for this method is a single portfolio used for all valid tasks.
@@ -84,21 +90,21 @@ class EvaluationRepositoryZeroshot(EvaluationRepository):
         :return: A pandas DataFrame with identical format to the output of `self.generate_output_from_portfolio_cv`.
             Refer to `self.generate_output_from_portfolio_cv` for details.
         """
-        sog = SimulationOutputGenerator(repo=self,
-                                        config_scorer_type=config_scorer_type,
-                                        config_scorer_kwargs=config_scorer_kwargs)
-        df_result = sog.from_portfolio(portfolio=portfolio, name=name)
-        return df_result
+        sog = SimulationOutputGenerator(
+            repo=self, config_scorer_type=config_scorer_type, config_scorer_kwargs=config_scorer_kwargs
+        )
+        return sog.from_portfolio(portfolio=portfolio, name=name)
 
     # TODO: add simulate_zeroshot_debug
-    def simulate_zeroshot(self,
-                          num_zeroshot: int = 10,
-                          n_splits: int = 2,
-                          backend: str = 'ray',
-                          config_scorer_type: str = 'ensemble',
-                          config_scorer_kwargs: dict = None) -> PortfolioCV:
-        """
-        Perform greedy-forward selection zeroshot simulation.
+    def simulate_zeroshot(
+        self,
+        num_zeroshot: int = 10,
+        n_splits: int = 2,
+        backend: str = "ray",
+        config_scorer_type: str = "ensemble",
+        config_scorer_kwargs: dict | None = None,
+    ) -> PortfolioCV:
+        """Perform greedy-forward selection zeroshot simulation.
 
         :param num_zeroshot: The number of models in the portfolio to select.
         :param n_splits: The number of splits to perform in cross-validation.
@@ -116,17 +122,17 @@ class EvaluationRepositoryZeroshot(EvaluationRepository):
         """
         if config_scorer_kwargs is None:
             config_scorer_kwargs = {}
-        if config_scorer_type == 'ensemble':
+        if config_scorer_type == "ensemble":
             config_scorer = self._construct_ensemble_selection_config_scorer(**config_scorer_kwargs)
-        elif config_scorer_type == 'single':
+        elif config_scorer_type == "single":
             config_scorer = self._construct_single_best_config_scorer(**config_scorer_kwargs)
         else:
-            raise ValueError(f'Unknown config_scorer_type: {config_scorer_type}')
+            raise ValueError(f"Unknown config_scorer_type: {config_scorer_type}")
         results_cv: PortfolioCV = run_zs_simulation(
             zsc=self._zeroshot_context,
             config_scorer=config_scorer,
             n_splits=n_splits,
-            config_generator_kwargs={'num_zeroshot': num_zeroshot},
+            config_generator_kwargs={"num_zeroshot": num_zeroshot},
             backend=backend,
         )
         return results_cv

--- a/packages/tabarena/src/tabarena/repository/ground_truth_mixin.py
+++ b/packages/tabarena/src/tabarena/repository/ground_truth_mixin.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class GroundTruthMixin:

--- a/packages/tabarena/src/tabarena/repository/repo_utils.py
+++ b/packages/tabarena/src/tabarena/repository/repo_utils.py
@@ -1,51 +1,69 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
-import pandas as pd
-
 if TYPE_CHECKING:
+    import pandas as pd
+
     from .abstract_repository import AbstractRepository
 
 
-def convert_time_infer_s_from_sample_to_batch(df: pd.DataFrame, repo: "AbstractRepository", task_metadata: pd.DataFrame = None) -> pd.DataFrame:
-    """
-    Temp: Multiply by 0.1 since 90% of the instances are used for training and 10% for test
+def convert_time_infer_s_from_sample_to_batch(
+    df: pd.DataFrame, repo: AbstractRepository, task_metadata: pd.DataFrame = None
+) -> pd.DataFrame:
+    """Temp: Multiply by 0.1 since 90% of the instances are used for training and 10% for test
     # TODO: Change this in future, not all tasks will use 90% train / 10% test. Instead keep track of train/test rows per dataset_fold pair.
     """
     if repo is not None:
         assert task_metadata is None, "Only one of repo and task_metadata can be specified."
         task_metadata = repo.task_metadata
     if task_metadata is None:
-        raise AssertionError(f"task_metadata or repo must be specified.")
+        raise AssertionError("task_metadata or repo must be specified.")
     df = df.copy(deep=True)
     if "dataset" in df.columns:
-        df["time_infer_s"] = df["time_infer_s"] * df["dataset"].map(
-            task_metadata.set_index("dataset")["NumberOfInstances"]
-        ) * 0.1
+        df["time_infer_s"] = (
+            df["time_infer_s"]
+            * df["dataset"].map(
+                task_metadata.set_index("dataset")["NumberOfInstances"],
+            )
+            * 0.1
+        )
     else:
-        df["time_infer_s"] = df["time_infer_s"] * df.index.get_level_values("dataset").map(
-            task_metadata.set_index("dataset")["NumberOfInstances"]
-        ) * 0.1
+        df["time_infer_s"] = (
+            df["time_infer_s"]
+            * df.index.get_level_values("dataset").map(
+                task_metadata.set_index("dataset")["NumberOfInstances"],
+            )
+            * 0.1
+        )
     return df
 
 
-def convert_time_infer_s_from_batch_to_sample(df: pd.DataFrame, repo: "AbstractRepository" = None, task_metadata: pd.DataFrame = None) -> pd.DataFrame:
-    """
-    Temp: Multiply by 0.1 since 90% of the instances are used for training and 10% for test
+def convert_time_infer_s_from_batch_to_sample(
+    df: pd.DataFrame, repo: AbstractRepository = None, task_metadata: pd.DataFrame = None
+) -> pd.DataFrame:
+    """Temp: Multiply by 0.1 since 90% of the instances are used for training and 10% for test
     # TODO: Change this in future, not all tasks will use 90% train / 10% test. Instead keep track of train/test rows per dataset_fold pair.
     """
     if repo is not None:
         assert task_metadata is None, "Only one of repo and task_metadata can be specified."
         task_metadata = repo.task_metadata
     if task_metadata is None:
-        raise AssertionError(f"task_metadata or repo must be specified.")
+        raise AssertionError("task_metadata or repo must be specified.")
 
     df = df.copy(deep=True)
     if "dataset" in df.columns:
-        df["time_infer_s"] = df["time_infer_s"] / (df["dataset"].map(
-            task_metadata.set_index("dataset")["NumberOfInstances"]
-        ) * 0.1)
+        df["time_infer_s"] = df["time_infer_s"] / (
+            df["dataset"].map(
+                task_metadata.set_index("dataset")["NumberOfInstances"],
+            )
+            * 0.1
+        )
     else:
-        df["time_infer_s"] = df["time_infer_s"] / (df.index.get_level_values("dataset").map(
-            task_metadata.set_index("dataset")["NumberOfInstances"]
-        ) * 0.1)
+        df["time_infer_s"] = df["time_infer_s"] / (
+            df.index.get_level_values("dataset").map(
+                task_metadata.set_index("dataset")["NumberOfInstances"],
+            )
+            * 0.1
+        )
     return df

--- a/packages/tabarena/src/tabarena/repository/time_utils.py
+++ b/packages/tabarena/src/tabarena/repository/time_utils.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
-from typing import List, Optional, Dict
-import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
 
-from .abstract_repository import AbstractRepository
+import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from .abstract_repository import AbstractRepository
 
 
 # FIXME: Should move into repo?
 def get_runtime(
-        repo: AbstractRepository,
-        dataset: str,
-        fold: int,
-        config_metrics: pd.DataFrame | None = None,
-        config_names: Optional[List[str]] = None,
-        runtime_col: str = 'time_train_s',
-        fail_if_missing: bool = True
-) -> Dict[str, float]:
-    """
-    :param repo:
+    repo: AbstractRepository,
+    dataset: str,
+    fold: int,
+    config_metrics: pd.DataFrame | None = None,
+    config_names: list[str] | None = None,
+    runtime_col: str = "time_train_s",
+    fail_if_missing: bool = True,
+) -> dict[str, float]:
+    """:param repo:
     :param dataset:
     :param fold:
     :param config_names:
@@ -45,45 +47,50 @@ def get_runtime(
     if len(missing_configurations) > 0:
         if fail_if_missing:
             raise ValueError(
-                f"not all configurations could be found in available data for the task {task}\n" \
-                f"requested: {config_names}\n" \
-                f"available: {list(runtime_configs.keys())}."
+                f"not all configurations could be found in available data for the task {task}\n"
+                f"requested: {config_names}\n"
+                f"available: {list(runtime_configs.keys())}.",
             )
+        # todo take mean of framework
+        if repo._config_fallback is not None:
+            config_metrics_fallback = repo.metrics(tasks=[task], configs=[repo._config_fallback])
+            fill_value = config_metrics_fallback.loc[(dataset, fold, repo._config_fallback), runtime_col]
         else:
-            # todo take mean of framework
-            if repo._config_fallback is not None:
-                config_metrics_fallback = repo.metrics(tasks=[task], configs=[repo._config_fallback])
-                fill_value = config_metrics_fallback.loc[(dataset, fold, repo._config_fallback), runtime_col]
-            else:
-                fill_value = np.mean(list(runtime_configs.values()))
-            # print(f"Imputing missing value {fill_value} for configurations {missing_configurations} on task {task}")
-            for configuration in missing_configurations:
-                runtime_configs[configuration] = fill_value
+            fill_value = np.mean(list(runtime_configs.values()))
+        # print(f"Imputing missing value {fill_value} for configurations {missing_configurations} on task {task}")
+        for configuration in missing_configurations:
+            runtime_configs[configuration] = fill_value
     return runtime_configs
 
 
 def sort_by_runtime(
     repo: AbstractRepository,
-    config_names: List[str],
+    config_names: list[str],
     ascending: bool = True,
-) -> List[str]:
+) -> list[str]:
     df_metrics = repo._zeroshot_context.df_configs
-    config_sorted = df_metrics.pivot_table(
-        index="framework", columns="tid", values="time_train_s"
-    ).median(axis=1).sort_values(ascending=ascending).index.tolist()
+    config_sorted = (
+        df_metrics.pivot_table(
+            index="framework",
+            columns="tid",
+            values="time_train_s",
+        )
+        .median(axis=1)
+        .sort_values(ascending=ascending)
+        .index.tolist()
+    )
     return [c for c in config_sorted if c in set(config_names)]
 
 
 def filter_configs_by_runtime(
-        repo: AbstractRepository,
-        dataset: str,
-        fold: int,
-        config_names: List[str],
-        config_metrics: pd.DataFrame = None,
-        max_cumruntime: Optional[float] = None
-) -> List[str]:
-    """
-    :param repo:
+    repo: AbstractRepository,
+    dataset: str,
+    fold: int,
+    config_names: list[str],
+    config_metrics: pd.DataFrame = None,
+    max_cumruntime: float | None = None,
+) -> list[str]:
+    """:param repo:
     :param tid:
     :param fold:
     :param config_names:
@@ -93,15 +100,20 @@ def filter_configs_by_runtime(
     """
     if not max_cumruntime:
         return config_names
-    else:
-        assert dataset in repo.datasets()
-        assert fold in repo.dataset_to_folds(dataset=dataset)
-        runtime_configs = get_runtime(repo=repo, dataset=dataset, fold=fold, config_names=config_names, config_metrics=config_metrics, fail_if_missing=False)
-        cumruntime = np.cumsum([runtime_configs[config] for config in config_names])
-        # str_runtimes = ", ".join([f"{name}: {time}" for name, time in zip(runtime_configs.keys(), cumruntime)])
-        # print(f"Cumulative runtime:\n {str_runtimes}")
+    assert dataset in repo.datasets()
+    assert fold in repo.dataset_to_folds(dataset=dataset)
+    runtime_configs = get_runtime(
+        repo=repo,
+        dataset=dataset,
+        fold=fold,
+        config_names=config_names,
+        config_metrics=config_metrics,
+        fail_if_missing=False,
+    )
+    cumruntime = np.cumsum([runtime_configs[config] for config in config_names])
+    # str_runtimes = ", ".join([f"{name}: {time}" for name, time in zip(runtime_configs.keys(), cumruntime)])
+    # print(f"Cumulative runtime:\n {str_runtimes}")
 
-        # gets index where cumulative runtime is below the target and next index is above the target
-        i = np.searchsorted(cumruntime, max_cumruntime)
-        return config_names[:i]
-
+    # gets index where cumulative runtime is below the target and next index is above the target
+    i = np.searchsorted(cumruntime, max_cumruntime)
+    return config_names[:i]

--- a/packages/tabarena/src/tabarena/simulation/config_generator.py
+++ b/packages/tabarena/src/tabarena/simulation/config_generator.py
@@ -1,45 +1,49 @@
+from __future__ import annotations
+
 import copy
-from collections import defaultdict
 import math
 import random
 import time
-from typing import Any, Dict, List
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import ray
 from sklearn.model_selection import RepeatedKFold
 
-from .configuration_list_scorer import ConfigurationListScorer
-from .simulation_context import ZeroshotSimulatorContext
-from ..portfolio import Portfolio, PortfolioCV
+from tabarena.portfolio import Portfolio, PortfolioCV
+
+if TYPE_CHECKING:
+    from .configuration_list_scorer import ConfigurationListScorer
+    from .simulation_context import ZeroshotSimulatorContext
 
 
 @ray.remote
 def score_config_ray(config_scorer, existing_configs, new_config) -> float:
-    configs = existing_configs + [new_config]
-    score = config_scorer.score(configs)
-    return score
+    configs = [*existing_configs, new_config]
+    return config_scorer.score(configs)
 
 
 class ZeroshotConfigGenerator:
-    def __init__(self, config_scorer, configs: List[str], backend='ray'):
+    def __init__(self, config_scorer, configs: list[str], backend="ray"):
         self.config_scorer = config_scorer
         self.all_configs = configs
         self.backend = backend
 
-    def select_zeroshot_configs(self,
-                                num_zeroshot: int,
-                                zeroshot_configs: List[str] = None,
-                                removal_stage=False,
-                                removal_threshold=0,
-                                config_scorer_test=None,
-                                return_all_metadata: bool = False,
-                                ) -> (List[Dict[str, Any]]):
+    def select_zeroshot_configs(
+        self,
+        num_zeroshot: int,
+        zeroshot_configs: list[str] | None = None,
+        removal_stage=False,
+        removal_threshold=0,
+        config_scorer_test=None,
+        return_all_metadata: bool = False,
+    ) -> list[dict[str, Any]]:
         zeroshot_configs = [] if zeroshot_configs is None else copy.deepcopy(zeroshot_configs)
         metadata_list = []
 
         iteration = 0
-        if self.backend == 'ray':
+        if self.backend == "ray":
             if not ray.is_initialized():
                 ray.init()
             config_scorer = ray.put(self.config_scorer)
@@ -66,13 +70,13 @@ class ZeroshotConfigGenerator:
 
             zeroshot_configs.append(best_next_config)
             fit_time = time_end - time_start
-            msg = f'{iteration}\t: Train: {round(best_train_score, 2)}'
+            msg = f"{iteration}\t: Train: {round(best_train_score, 2)}"
             if config_scorer_test:
                 test_score = config_scorer_test.score(zeroshot_configs)
-                msg += f'\t| Test: {round(test_score, 2)} \t| Overfit: {round(test_score-best_train_score, 2)}'
+                msg += f"\t| Test: {round(test_score, 2)} \t| Overfit: {round(test_score - best_train_score, 2)}"
             else:
                 test_score = None
-            msg += f' | {round(fit_time, 2)}s | {self.backend} | {best_next_config}'
+            msg += f" | {round(fit_time, 2)}s | {self.backend} | {best_next_config}"
             # print('here, make metadata')
             metadata_out = dict(
                 configs=copy.deepcopy(zeroshot_configs),
@@ -95,7 +99,7 @@ class ZeroshotConfigGenerator:
             # FIXME: Get this from prune instead
             metadata_out = self._get_metadata_from_configs(
                 configs=zeroshot_configs,
-                step=iteration+1,
+                step=iteration + 1,
                 train_score=None,
                 test_score=None,
                 config_scorer=self.config_scorer,
@@ -111,15 +115,17 @@ class ZeroshotConfigGenerator:
         # TODO: metadata_list not updated by prune_zeroshot_configs
         return metadata_list
 
-    def _get_metadata_from_configs(self,
-                                   configs,
-                                   new_config=None,
-                                   step=None,
-                                   train_score=None,
-                                   test_score=None,
-                                   fit_time=None,
-                                   config_scorer=None,
-                                   config_scorer_test=None) -> Dict[str, Any]:
+    def _get_metadata_from_configs(
+        self,
+        configs,
+        new_config=None,
+        step=None,
+        train_score=None,
+        test_score=None,
+        fit_time=None,
+        config_scorer=None,
+        config_scorer_test=None,
+    ) -> dict[str, Any]:
         if train_score is None and config_scorer is not None:
             train_score = config_scorer.score(configs)
         if test_score is None and config_scorer_test is not None:
@@ -141,7 +147,7 @@ class ZeroshotConfigGenerator:
         # todo could use np.inf but would need unit-test (also to check that ray/sequential returns the same selection)
         best_score = 999999999
         for config in configs:
-            config_selected = prior_configs + [config]
+            config_selected = [*prior_configs, config]
             config_score = config_scorer.score(config_selected)
             if config_score < best_score:
                 best_score = config_score
@@ -153,18 +159,20 @@ class ZeroshotConfigGenerator:
         # Create and execute all tasks in parallel
         results = []
         for i in range(len(configs)):
-            results.append(score_config_ray.remote(
-                config_scorer,
-                prior_configs,
-                configs[i],
-            ))
+            results.append(
+                score_config_ray.remote(
+                    config_scorer,
+                    prior_configs,
+                    configs[i],
+                )
+            )
         result = ray.get(results)
         result_idx_min = result.index(min(result))
         best_next_config = configs[result_idx_min]
         best_score = result[result_idx_min]
         return best_next_config, best_score
 
-    def prune_zeroshot_configs(self, zeroshot_configs: List[str], removal_threshold=0) -> List[str]:
+    def prune_zeroshot_configs(self, zeroshot_configs: list[str], removal_threshold=0) -> list[str]:
         zeroshot_configs = copy.deepcopy(zeroshot_configs)
         best_score = self.config_scorer.score(zeroshot_configs)
         finished_removal = False
@@ -178,12 +186,11 @@ class ZeroshotConfigGenerator:
                     if config_score <= (best_score + removal_threshold):
                         best_score = config_score
                         best_remove_config = config
-                else:
-                    if config_score <= best_score:
-                        best_score = config_score
-                        best_remove_config = config
+                elif config_score <= best_score:
+                    best_score = config_score
+                    best_remove_config = config
             if best_remove_config is not None:
-                print(f'REMOVING: {best_score} | {best_remove_config}')
+                print(f"REMOVING: {best_score} | {best_remove_config}")
                 zeroshot_configs.remove(best_remove_config)
             else:
                 finished_removal = True
@@ -191,16 +198,17 @@ class ZeroshotConfigGenerator:
 
 
 class ZeroshotConfigGeneratorCV:
-    def __init__(self,
-                 n_splits: int,
-                 zeroshot_simulator_context: ZeroshotSimulatorContext,
-                 config_scorer: ConfigurationListScorer,
-                 config_generator_kwargs=None,
-                 configs: List[str] = None,
-                 n_repeats: int = 1,
-                 backend='ray'):
-        """
-        Runs zero-shot selection on `n_splits` ("train", "test") folds of datasets.
+    def __init__(
+        self,
+        n_splits: int,
+        zeroshot_simulator_context: ZeroshotSimulatorContext,
+        config_scorer: ConfigurationListScorer,
+        config_generator_kwargs=None,
+        configs: list[str] | None = None,
+        n_repeats: int = 1,
+        backend="ray",
+    ):
+        """Runs zero-shot selection on `n_splits` ("train", "test") folds of datasets.
         For each split, zero-shot configurations are selected using the datasets belonging on the "train" split and the
         performance of the zero-shot configuration is evaluated using the datasets in the "test" split.
         :param n_splits: number of splits for RepeatedKFold
@@ -232,7 +240,7 @@ class ZeroshotConfigGeneratorCV:
                 self.dataset_to_task_map[dataset] = [task]
         for dataset in self.dataset_to_task_map:
             self.dataset_to_task_map[dataset] = sorted(self.dataset_to_task_map[dataset])
-        self.unique_datasets = np.array((sorted(list(self.unique_datasets))))
+        self.unique_datasets = np.array(sorted(self.unique_datasets))
 
         if configs is None:
             configs = zeroshot_simulator_context.get_configs()
@@ -249,41 +257,38 @@ class ZeroshotConfigGeneratorCV:
     def get_n_configs(self) -> int:
         return len(self.configs)
 
-    def _get_tasks_from_datasets(self, datasets: List[str], num_folds=None) -> List[str]:
+    def _get_tasks_from_datasets(self, datasets: list[str], num_folds=None) -> list[str]:
         tasks = []
         for d in datasets:
             tasks += self._get_tasks_from_dataset(dataset=d, num_folds=num_folds)
         return tasks
 
-    def _get_tasks_from_dataset(self, dataset: str, num_folds=None) -> List[str]:
+    def _get_tasks_from_dataset(self, dataset: str, num_folds=None) -> list[str]:
         if num_folds is None:
             return self.dataset_to_task_map[dataset]
-        else:
-            return self.dataset_to_task_map[dataset][:num_folds]
+        return self.dataset_to_task_map[dataset][:num_folds]
 
     def _get_split(self, fold: int) -> int:
-        """
-        Note: fold 0 is the first fold, not fold 1.
+        """Note: fold 0 is the first fold, not fold 1.
         split 0 is the first split.
         """
         return fold % self.n_splits
 
     def _get_repeat(self, fold: int) -> int:
-        """
-        repeat 0 is the first repeat
-        """
+        """Repeat 0 is the first repeat."""
         return int(fold / self.n_splits)
 
-    def run_and_return_all_steps(self,
-                                 sample_train_folds: int = None,
-                                 sample_train_ratio: float = None,
-                                 sample_configs_ratio: float = None,
-                                 # TODO: Sample configs
-                                 score_all: bool = True,
-                                 score_final: bool = True,
-                                 return_all_metadata: bool = True) -> List[PortfolioCV]:
-        """
-        Run cross-validated zeroshot simulation.
+    def run_and_return_all_steps(
+        self,
+        sample_train_folds: int | None = None,
+        sample_train_ratio: float | None = None,
+        sample_configs_ratio: float | None = None,
+        # TODO: Sample configs
+        score_all: bool = True,
+        score_final: bool = True,
+        return_all_metadata: bool = True,
+    ) -> list[PortfolioCV]:
+        """Run cross-validated zeroshot simulation.
 
         :param sample_train_folds:
             Number of folds to filter training data to for each fold. Used for debugging.
@@ -308,14 +313,15 @@ class ZeroshotConfigGeneratorCV:
         n_configs_total = self.get_n_configs()
         is_first_fold = True
         configs = self.configs
-        print(f'Fitting CV\n'
-              f'\tscorer={self.config_scorer.__class__.__name__}\n'
-              f'\tn_splits={self.n_splits}, n_repeats={self.n_repeats}, n_configs={n_configs_total}\n'
-              f'\tn_datasets={self.get_n_datasets()}, n_tasks={self.get_n_tasks()}\n'
-              f'\tsample_train_folds={sample_train_folds} '
-              f'| sample_train_ratio={sample_train_ratio} '
-              f'| sample_configs_ratio={sample_configs_ratio}'
-              )
+        print(
+            f"Fitting CV\n"
+            f"\tscorer={self.config_scorer.__class__.__name__}\n"
+            f"\tn_splits={self.n_splits}, n_repeats={self.n_repeats}, n_configs={n_configs_total}\n"
+            f"\tn_datasets={self.get_n_datasets()}, n_tasks={self.get_n_tasks()}\n"
+            f"\tsample_train_folds={sample_train_folds} "
+            f"| sample_train_ratio={sample_train_ratio} "
+            f"| sample_configs_ratio={sample_configs_ratio}",
+        )
         for i, (train_index, test_index) in enumerate(self.kf.split(self.unique_datasets)):
             split = self._get_split(i)
             repeat = self._get_repeat(i)
@@ -337,82 +343,83 @@ class ZeroshotConfigGeneratorCV:
             test_tasks = self._get_tasks_from_datasets(datasets=X_test)
             len_train_tasks = len(train_tasks)
             len_train_datasets = len(X_train)
-            print(f'Fitting Fold {i + 1}/{self.n_splits*self.n_repeats} (R{repeat+1}S{split+1})...\n'
-                  f'\ttrain_datasets: {len_train_datasets}/{len_X_train_og} | train_tasks: {len_train_tasks}\n'
-                  f'\ttest_datasets : {len(X_test)}/{len_X_test_og} | test_tasks : {len(test_tasks)}\n'
-                  f'\tn_configs={n_configs_avail}/{n_configs_total}'
-                  )
-            metadata_fold = self.run_fold(train_tasks,
-                                          test_tasks,
-                                          configs=configs,
-                                          score_all=score_all,
-                                          score_final=score_final,
-                                          return_all_metadata=return_all_metadata)
+            print(
+                f"Fitting Fold {i + 1}/{self.n_splits * self.n_repeats} (R{repeat + 1}S{split + 1})...\n"
+                f"\ttrain_datasets: {len_train_datasets}/{len_X_train_og} | train_tasks: {len_train_tasks}\n"
+                f"\ttest_datasets : {len(X_test)}/{len_X_test_og} | test_tasks : {len(test_tasks)}\n"
+                f"\tn_configs={n_configs_avail}/{n_configs_total}",
+            )
+            metadata_fold = self.run_fold(
+                train_tasks,
+                test_tasks,
+                configs=configs,
+                score_all=score_all,
+                score_final=score_final,
+                return_all_metadata=return_all_metadata,
+            )
             for j, m in enumerate(metadata_fold):
                 # FIXME: It is possible not all folds will have results match up correctly
                 #  if we introduce config pruning.
                 #  This logic should probably only be present in scenarios where we are debugging
                 #  Otherwise we should only take the final result of each fold.
                 results_fold_i = Portfolio(
-                    configs=m['configs'],
-                    train_score=m['train_score'],
-                    test_score=m['test_score'],
+                    configs=m["configs"],
+                    train_score=m["train_score"],
+                    test_score=m["test_score"],
                     train_datasets=X_train,
                     test_datasets=X_test,
                     train_datasets_fold=train_tasks,
                     test_datasets_fold=test_tasks,
                     fold=i + 1,
-                    split=split+1,
-                    repeat=repeat+1,
-                    step=m['step'],
+                    split=split + 1,
+                    repeat=repeat + 1,
+                    step=m["step"],
                     n_configs_avail=n_configs_avail,
                 )
                 results_dict_by_len[j].append(results_fold_i)
             is_first_fold = False
         for val in results_dict_by_len.values():
-            assert (self.n_splits * self.n_repeats) == len(val)  # Ensure no bugs such as only getting a subset of fold results
-        portfolio_cv_list = [PortfolioCV(portfolios=v) for k, v in results_dict_by_len.items()]
-        return portfolio_cv_list
+            assert (self.n_splits * self.n_repeats) == len(
+                val
+            )  # Ensure no bugs such as only getting a subset of fold results
+        return [PortfolioCV(portfolios=v) for k, v in results_dict_by_len.items()]
 
-    def run(self,
-            sample_train_folds=None,
-            sample_train_ratio=None,
-            score_all=False,
-            score_final=True) -> PortfolioCV:
-        """
-        Identical to `run_and_return_all_steps`, but the output is simply the final PortfolioCV.
+    def run(self, sample_train_folds=None, sample_train_ratio=None, score_all=False, score_final=True) -> PortfolioCV:
+        """Identical to `run_and_return_all_steps`, but the output is simply the final PortfolioCV.
 
         score_all is also set to False by default to speed up the simulation.
         """
-        results_cv_list = self.run_and_return_all_steps(sample_train_folds=sample_train_folds,
-                                                        sample_train_ratio=sample_train_ratio,
-                                                        score_all=score_all,
-                                                        score_final=score_final,
-                                                        return_all_metadata=False)
+        results_cv_list = self.run_and_return_all_steps(
+            sample_train_folds=sample_train_folds,
+            sample_train_ratio=sample_train_ratio,
+            score_all=score_all,
+            score_final=score_final,
+            return_all_metadata=False,
+        )
 
         assert len(results_cv_list) == 1
-        results_cv = results_cv_list[0]
+        return results_cv_list[0]
 
-        return results_cv
-
-    def run_fold(self,
-                 train_tasks: List[str],
-                 test_tasks: List[str],
-                 configs: List[str] = None,
-                 score_all=False,
-                 score_final=True,
-                 return_all_metadata=False) -> List[Dict[str, Any]]:
+    def run_fold(
+        self,
+        train_tasks: list[str],
+        test_tasks: list[str],
+        configs: list[str] | None = None,
+        score_all=False,
+        score_final=True,
+        return_all_metadata=False,
+    ) -> list[dict[str, Any]]:
         if configs is None:
             configs = self.configs
         config_scorer_train = self.config_scorer.subset(tasks=train_tasks)
         config_scorer_test = self.config_scorer.subset(tasks=test_tasks)
 
-        zs_config_generator = ZeroshotConfigGenerator(config_scorer=config_scorer_train,
-                                                      configs=configs,
-                                                      backend=self.backend)
+        zs_config_generator = ZeroshotConfigGenerator(
+            config_scorer=config_scorer_train, configs=configs, backend=self.backend
+        )
 
-        num_zeroshot = self.config_generator_kwargs.get('num_zeroshot', 10)
-        removal_stage = self.config_generator_kwargs.get('removal_stage', False)
+        num_zeroshot = self.config_generator_kwargs.get("num_zeroshot", 10)
+        removal_stage = self.config_generator_kwargs.get("removal_stage", False)
 
         metadata_list = zs_config_generator.select_zeroshot_configs(
             num_zeroshot=num_zeroshot,
@@ -424,9 +431,9 @@ class ZeroshotConfigGeneratorCV:
         # FIXME: SPEEDUP WITH RAY
         # zeroshot_configs = zs_config_generator.prune_zeroshot_configs(zeroshot_configs, removal_threshold=0)
 
-        if score_final and metadata_list[-1]['test_score'] is None:
-            score = config_scorer_test.score(metadata_list[-1]['configs'])
-            print(f'test_score: {score}')
-            metadata_list[-1]['test_score'] = score
+        if score_final and metadata_list[-1]["test_score"] is None:
+            score = config_scorer_test.score(metadata_list[-1]["configs"])
+            print(f"test_score: {score}")
+            metadata_list[-1]["test_score"] = score
 
         return metadata_list

--- a/packages/tabarena/src/tabarena/simulation/configuration_list_scorer.py
+++ b/packages/tabarena/src/tabarena/simulation/configuration_list_scorer.py
@@ -1,20 +1,21 @@
-from typing import List, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..repository.abstract_repository import AbstractRepository
+    from tabarena.repository.abstract_repository import AbstractRepository
 
 
 class ConfigurationListScorer:
-    def __init__(self, tasks: List[str]):
-        self.tasks: List[str] = tasks
+    def __init__(self, tasks: list[str]):
+        self.tasks: list[str] = tasks
 
     @classmethod
-    def from_repo(cls, repo: "AbstractRepository", **kwargs):
+    def from_repo(cls, repo: AbstractRepository, **kwargs):
         raise NotImplementedError()
 
-    def score(self, configs: List[str]) -> float:
-        """
-        :param configs: list of configuration to select from.
+    def score(self, configs: list[str]) -> float:
+        """:param configs: list of configuration to select from.
         :return: a score obtained after evaluating the list of configurations. Current strategies include:
         * `SingleBestConfigScorer`: picking the test-error of the configuration with the lowest validation score
         * `EnsembleSelectionConfigScorer`: returning the test-error when evaluating an ensemble of the configurations
@@ -22,5 +23,5 @@ class ConfigurationListScorer:
         """
         raise NotImplementedError()
 
-    def subset(self, tasks: List[str]) -> "ConfigurationListScorer":
+    def subset(self, tasks: list[str]) -> ConfigurationListScorer:
         raise NotImplementedError()

--- a/packages/tabarena/src/tabarena/simulation/convert_memmap.py
+++ b/packages/tabarena/src/tabarena/simulation/convert_memmap.py
@@ -1,12 +1,12 @@
-"""
-Script to convert old pickle format to memmap representation. Can be removed at some point, just left for future reference.
-"""
+"""Script to convert old pickle format to memmap representation. Can be removed at some point, just left for future reference."""
+
+from __future__ import annotations
+
 import json
 import pickle
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 
 from tabarena.predictions.tabular_predictions import path_memmap
 from tabarena.utils.parallel_for import parallel_for
@@ -18,8 +18,7 @@ def load_pickle(filename):
 
 
 def convert_memmap_pred_from_pickle(folder_pickle: Path, output_dir: Path, dtype: str = "float32"):
-    """
-    Converts old format to memmap, can be deleted once we converted previous pickle formats.
+    """Converts old format to memmap, can be deleted once we converted previous pickle formats.
     :param folder_pickle:
     :param output_dir:
     :param dtype:
@@ -41,8 +40,9 @@ def convert_memmap_pred_from_pickle(folder_pickle: Path, output_dir: Path, dtype
             return
         preds = load_pickle(filename)
         models = list(preds[dataset][fold]["pred_proba_dict_val"].keys())
-        assert set(preds[dataset][fold]["pred_proba_dict_test"].keys()) == set(models), \
+        assert set(preds[dataset][fold]["pred_proba_dict_test"].keys()) == set(models), (
             "different models available on validation and testing"
+        )
         pred_val = np.stack([preds[dataset][fold]["pred_proba_dict_val"][model] for model in models])
         pred_test = np.stack([preds[dataset][fold]["pred_proba_dict_test"][model] for model in models])
 
@@ -58,14 +58,17 @@ def convert_memmap_pred_from_pickle(folder_pickle: Path, output_dir: Path, dtype
 
             f.write(json.dumps(metadata_dict))
 
-        fp = np.memmap(target_folder / "pred-val.dat", dtype=dtype, mode='w+', shape=pred_val.shape)
+        fp = np.memmap(target_folder / "pred-val.dat", dtype=dtype, mode="w+", shape=pred_val.shape)
         fp[:] = pred_val[:]
 
-        fp = np.memmap(target_folder / "pred-test.dat", dtype=dtype, mode='w+', shape=pred_test.shape)
+        fp = np.memmap(target_folder / "pred-test.dat", dtype=dtype, mode="w+", shape=pred_test.shape)
         fp[:] = pred_test[:]
 
     parallel_for(
-        convert_file, context={}, inputs=[[x] for x in pkl_files], engine="sequential", #engine_kwargs={"num_cpus": 32}
+        convert_file,
+        context={},
+        inputs=[[x] for x in pkl_files],
+        engine="sequential",  # engine_kwargs={"num_cpus": 32}
     )
 
 
@@ -85,17 +88,20 @@ def convert_memmap_label_from_pickle(folder_pickle: Path, output_dir: Path, dtyp
             print(f"skipping generation of {dataset} {fold} as files already exists")
             return
         labels = load_pickle(filename)[dataset][fold]
-        labels_val = labels['y_val']
-        labels_test = labels['y_test']
+        labels_val = labels["y_val"]
+        labels_test = labels["y_test"]
         labels_val.to_csv(target_folder / "label-val.csv.zip", index=True)
         labels_test.to_csv(target_folder / "label-test.csv.zip", index=True)
 
     parallel_for(
-        convert_file, context={}, inputs=[[x] for x in pkl_files], engine="sequential",
+        convert_file,
+        context={},
+        inputs=[[x] for x in pkl_files],
+        engine="sequential",
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     context = "2023_08_21_micro"
     prefix = "/home/ubuntu/workspace/code/autogluon-zeroshot/data/results/"
     path_pickle = f"{prefix}{context}/zeroshot_metadata/"

--- a/packages/tabarena/src/tabarena/simulation/dense_utils.py
+++ b/packages/tabarena/src/tabarena/simulation/dense_utils.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING
 
-from ..predictions.tabular_predictions import TabularModelPredictions
-from .ground_truth import GroundTruth
-from .simulation_context import ZeroshotSimulatorContext
+if TYPE_CHECKING:
+    from tabarena.predictions.tabular_predictions import TabularModelPredictions
+
+    from .ground_truth import GroundTruth
+    from .simulation_context import ZeroshotSimulatorContext
 
 
-def intersect_folds_and_datasets(zsc: ZeroshotSimulatorContext,
-                                 zeroshot_pred_proba: TabularModelPredictions,
-                                 zeroshot_gt: GroundTruth):
-    zpp_datasets = [dataset for dataset in zeroshot_pred_proba.datasets]
+def intersect_folds_and_datasets(
+    zsc: ZeroshotSimulatorContext, zeroshot_pred_proba: TabularModelPredictions, zeroshot_gt: GroundTruth
+):
+    zpp_datasets = list(zeroshot_pred_proba.datasets)
     zsc_datasets = zsc.get_datasets()
     zsc_datasets_set = set(zsc_datasets)
     valid_datasets = [dataset for dataset in zpp_datasets if dataset in zsc_datasets_set]
@@ -26,10 +28,15 @@ def intersect_folds_and_datasets(zsc: ZeroshotSimulatorContext,
     zsc.subset_datasets(zpp_datasets, only_configs=True)
 
 
-def prune_zeroshot_gt(dataset_to_tid_dict, zeroshot_pred_proba: TabularModelPredictions | None, zeroshot_gt: GroundTruth, verbose: bool = True) -> GroundTruth:
+def prune_zeroshot_gt(
+    dataset_to_tid_dict,
+    zeroshot_pred_proba: TabularModelPredictions | None,
+    zeroshot_gt: GroundTruth,
+    verbose: bool = True,
+) -> GroundTruth:
     num_datasets_start = len(zeroshot_gt.datasets)
     if zeroshot_pred_proba is not None:
-        dataset_pred = set(dataset for dataset in zeroshot_pred_proba.datasets if dataset in dataset_to_tid_dict)
+        dataset_pred = {dataset for dataset in zeroshot_pred_proba.datasets if dataset in dataset_to_tid_dict}
     else:
         dataset_pred = set(dataset_to_tid_dict.keys())
     for dataset in zeroshot_gt.datasets:
@@ -37,64 +44,58 @@ def prune_zeroshot_gt(dataset_to_tid_dict, zeroshot_pred_proba: TabularModelPred
             zeroshot_gt.remove_dataset(dataset=dataset)
     num_datasets_end = len(zeroshot_gt.datasets)
     if verbose:
-        print(f'Aligning GroundTruth with TabularPredictions... (Dataset count {num_datasets_start} -> {num_datasets_end})')
+        print(
+            f"Aligning GroundTruth with TabularPredictions... (Dataset count {num_datasets_start} -> {num_datasets_end})"
+        )
     assert len(dataset_pred) == num_datasets_end
     return zeroshot_gt
 
 
 def is_dense_folds(tabular_predictions: TabularModelPredictions) -> bool:
-    """
-    Return True if all datasets have all folds
-    """
+    """Return True if all datasets have all folds."""
     return set(tabular_predictions.folds) == set(get_folds_dense(tabular_predictions))
 
 
 def is_dense(tabular_predictions: TabularModelPredictions) -> bool:
-    """
-    Return True if all datasets have all folds, and all tasks have all models
-    """
+    """Return True if all datasets have all folds, and all tasks have all models."""
     return is_dense_folds(tabular_predictions) and is_dense_models(tabular_predictions)
 
 
 def is_dense_models(tabular_predictions: TabularModelPredictions) -> bool:
-    """
-    Return True if all tasks have all models
-    """
+    """Return True if all tasks have all models."""
     models_dense = get_models(tabular_predictions, present_in_all=True)
     models_sparse = get_models(tabular_predictions, present_in_all=False)
     return set(models_dense) == set(models_sparse)
 
 
-def get_models_dense(tabular_predictions: TabularModelPredictions) -> List[str]:
-    """
-    Returns models that appears in all lists, eg that are available for all tasks and splits
-    """
+def get_models_dense(tabular_predictions: TabularModelPredictions) -> list[str]:
+    """Returns models that appears in all lists, eg that are available for all tasks and splits."""
     return sorted(list_models_available(tabular_predictions, present_in_all=True))
 
-def get_models(tabular_predictions: TabularModelPredictions, present_in_all=False) -> List[str]:
-    """
-    Gets all valid models
+
+def get_models(tabular_predictions: TabularModelPredictions, present_in_all=False) -> list[str]:
+    """Gets all valid models
     :param present_in_all:
         If True, only returns models present in every dataset (dense)
-        If False, returns every model that appears in at least 1 dataset (sparse)
+        If False, returns every model that appears in at least 1 dataset (sparse).
     """
     if not present_in_all:
         return tabular_predictions.models_exist()
-    else:
-        return get_models_dense(tabular_predictions)
+    return get_models_dense(tabular_predictions)
 
 
-def force_to_dense(tabular_predictions: TabularModelPredictions,
-                   first_prune_method: str = 'task',
-                   second_prune_method: str = 'dataset',
-                   assert_not_empty: bool = True,
-                   verbose: bool = True):
-    """
-    Force to be dense in all dimensions.
+def force_to_dense(
+    tabular_predictions: TabularModelPredictions,
+    first_prune_method: str = "task",
+    second_prune_method: str = "dataset",
+    assert_not_empty: bool = True,
+    verbose: bool = True,
+):
+    """Force to be dense in all dimensions.
     This means all models will be present in all tasks, and all folds will be present in all datasets.
-    # TODO: Not guaranteed to be dense if first_prune_method = 'dataset'
+    # TODO: Not guaranteed to be dense if first_prune_method = 'dataset'.
     """
-    if first_prune_method in ['dataset', 'fold']:
+    if first_prune_method in ["dataset", "fold"]:
         first_method = force_to_dense_folds
         second_method = force_to_dense_models
     else:
@@ -102,20 +103,23 @@ def force_to_dense(tabular_predictions: TabularModelPredictions,
         second_method = force_to_dense_folds
     if verbose:
         print(
-            f'Forcing {tabular_predictions.__class__.__name__} to dense representation via two-stage filtering using '
-            f'`first_prune_method="{first_prune_method}"`, `second_prune_method="{second_prune_method}"`...')
-    first_method(tabular_predictions, prune_method=first_prune_method, assert_not_empty=assert_not_empty, verbose=verbose)
-    second_method(tabular_predictions, prune_method=second_prune_method, assert_not_empty=assert_not_empty, verbose=verbose)
+            f"Forcing {tabular_predictions.__class__.__name__} to dense representation via two-stage filtering using "
+            f'`first_prune_method="{first_prune_method}"`, `second_prune_method="{second_prune_method}"`...'
+        )
+    first_method(
+        tabular_predictions, prune_method=first_prune_method, assert_not_empty=assert_not_empty, verbose=verbose
+    )
+    second_method(
+        tabular_predictions, prune_method=second_prune_method, assert_not_empty=assert_not_empty, verbose=verbose
+    )
 
     if verbose:
-        print(f'The {tabular_predictions.__class__.__name__} object is now guaranteed to be dense.')
+        print(f"The {tabular_predictions.__class__.__name__} object is now guaranteed to be dense.")
     assert is_dense(tabular_predictions)
 
 
-def get_datasets_with_folds(tabular_predictions: TabularModelPredictions, folds: List[int]) -> List[str]:
-    """
-    Get list of datasets that have results for all input folds
-    """
+def get_datasets_with_folds(tabular_predictions: TabularModelPredictions, folds: list[int]) -> list[str]:
+    """Get list of datasets that have results for all input folds."""
     datasets = tabular_predictions.datasets
     valid_datasets = []
     for dataset in datasets:
@@ -124,113 +128,129 @@ def get_datasets_with_folds(tabular_predictions: TabularModelPredictions, folds:
             valid_datasets.append(dataset)
     return valid_datasets
 
-def force_to_dense_folds(tabular_predictions: TabularModelPredictions,
-                         prune_method: str = 'dataset',
-                         assert_not_empty: bool = True,
-                         verbose: bool = True):
-    """
-    Force the pred dict to contain only dense fold results (no missing folds for any dataset)
+
+def force_to_dense_folds(
+    tabular_predictions: TabularModelPredictions,
+    prune_method: str = "dataset",
+    assert_not_empty: bool = True,
+    verbose: bool = True,
+):
+    """Force the pred dict to contain only dense fold results (no missing folds for any dataset)
     :param prune_method:
         If 'dataset', prunes any dataset that doesn't contain results for all folds
-        If 'fold', prunes any fold that doesn't exist for all datasets
+        If 'fold', prunes any fold that doesn't exist for all datasets.
     """
     if verbose:
-        print(f'Forcing {tabular_predictions.__class__.__name__} to dense fold representation using `prune_method="{prune_method}"`...')
-    valid_prune_methods = ['dataset', 'fold']
+        print(
+            f'Forcing {tabular_predictions.__class__.__name__} to dense fold representation using `prune_method="{prune_method}"`...'
+        )
+    valid_prune_methods = ["dataset", "fold"]
     if prune_method not in valid_prune_methods:
-        raise ValueError(f'`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}')
+        raise ValueError(f"`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}")
     pre_num_models = len(tabular_predictions.models)
     pre_num_datasets = len(tabular_predictions.datasets)
     pre_num_folds = len(tabular_predictions.folds)
-    if prune_method == 'dataset':
+    if prune_method == "dataset":
         datasets_dense = get_datasets_with_folds(tabular_predictions, folds=tabular_predictions.folds)
         tabular_predictions.restrict_datasets(datasets=datasets_dense)
-    elif prune_method == 'fold':
+    elif prune_method == "fold":
         folds_dense = get_folds_dense(tabular_predictions)
         tabular_predictions.restrict_folds(folds=folds_dense)
     else:
-        raise ValueError(f'`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}')
+        raise ValueError(f"`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}")
     post_num_models = len(tabular_predictions.models)
     post_num_datasets = len(tabular_predictions.datasets)
     post_num_folds = len(tabular_predictions.folds)
 
     if verbose:
-        print(f'\tPre : datasets={pre_num_datasets} | models={pre_num_models} | folds={pre_num_folds}')
-        print(f'\tPost: datasets={post_num_datasets} | models={post_num_models} | folds={post_num_folds}')
+        print(f"\tPre : datasets={pre_num_datasets} | models={pre_num_models} | folds={pre_num_folds}")
+        print(f"\tPost: datasets={post_num_datasets} | models={post_num_models} | folds={post_num_folds}")
     assert is_dense_folds(tabular_predictions)
     if assert_not_empty:
         assert not is_empty(tabular_predictions)
 
 
-def force_to_dense_models(tabular_predictions: TabularModelPredictions,
-                          prune_method: str = 'task',
-                          assert_not_empty: bool = True,
-                          verbose: bool = True):
-    """
-    Force the pred dict to contain only dense results (no missing result for any task/model)
+def force_to_dense_models(
+    tabular_predictions: TabularModelPredictions,
+    prune_method: str = "task",
+    assert_not_empty: bool = True,
+    verbose: bool = True,
+):
+    """Force the pred dict to contain only dense results (no missing result for any task/model)
     :param prune_method:
         If 'task', prunes any task that doesn't contain results for all models
-        If 'model', prunes any model that doesn't have results for all tasks
+        If 'model', prunes any model that doesn't have results for all tasks.
     """
     if verbose:
-        print(f'Forcing {tabular_predictions.__class__.__name__} to dense model representation using `prune_method="{prune_method}"`...')
-    valid_prune_methods = ['task', 'model']
+        print(
+            f'Forcing {tabular_predictions.__class__.__name__} to dense model representation using `prune_method="{prune_method}"`...'
+        )
+    valid_prune_methods = ["task", "model"]
     if prune_method not in valid_prune_methods:
-        raise ValueError(f'`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}')
+        raise ValueError(f"`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}")
     datasets = tabular_predictions.datasets
     valid_models = get_models(tabular_predictions, present_in_all=False)
     pre_num_models = len(valid_models)
     pre_num_datasets = len(datasets)
     pre_num_folds = len(tabular_predictions.folds)
-    if prune_method == 'task':
+    if prune_method == "task":
         valid_tasks = []
         for dataset, fold in list_tasks_available(tabular_predictions):
-            models_in_task = list_models_available(tabular_predictions, datasets=[dataset], folds=[fold], present_in_all=True)
+            models_in_task = list_models_available(
+                tabular_predictions, datasets=[dataset], folds=[fold], present_in_all=True
+            )
             models_in_task_set = set(models_in_task)
             if all(m in models_in_task_set for m in valid_models):
                 valid_tasks.append((dataset, fold))
         restrict_tasks(tabular_predictions, tasks=valid_tasks)
-    elif prune_method == 'model':
+    elif prune_method == "model":
         valid_models = get_models(tabular_predictions, present_in_all=True)
         tabular_predictions.restrict_models(models=valid_models)
     else:
-        raise ValueError(f'`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}')
+        raise ValueError(f"`prune_method={prune_method}` is invalid. Valid values: {valid_prune_methods}")
     post_num_models = len(tabular_predictions.models)
     post_num_datasets = len(tabular_predictions.datasets)
     post_num_folds = len(tabular_predictions.folds)
 
     if verbose:
-        print(f'\tPre : datasets={pre_num_datasets} | models={pre_num_models} | folds={pre_num_folds}')
-        print(f'\tPost: datasets={post_num_datasets} | models={post_num_models} | folds={post_num_folds}')
+        print(f"\tPre : datasets={pre_num_datasets} | models={pre_num_models} | folds={pre_num_folds}")
+        print(f"\tPost: datasets={post_num_datasets} | models={post_num_models} | folds={post_num_folds}")
     assert is_dense_models(tabular_predictions)
     if assert_not_empty:
         assert not is_empty(tabular_predictions)
 
+
 def list_models_available(
-        tabular_predictions: TabularModelPredictions,
-        datasets: Optional[List[str]] = None,
-        folds: Optional[List[int]] = None,
-        present_in_all: bool = False,
-) -> List[int]:
+    tabular_predictions: TabularModelPredictions,
+    datasets: list[str] | None = None,
+    folds: list[int] | None = None,
+    present_in_all: bool = False,
+) -> list[int]:
     model_available_dict = tabular_predictions.model_available_dict()
     datasets = datasets if datasets else tabular_predictions.datasets
     res = []
     for dataset in datasets:
-        for fold in folds if folds else list_folds_available(tabular_predictions, datasets=[dataset], present_in_all=False):
+        for fold in (
+            folds if folds else list_folds_available(tabular_predictions, datasets=[dataset], present_in_all=False)
+        ):
             # for split in splits if splits else splits:
             res.append(model_available_dict[dataset][fold])
     agg_fun = set.intersection if present_in_all else set.union
-    return sorted(list(agg_fun(*map(set, res)))) if res else []
+    return sorted(agg_fun(*map(set, res))) if res else []
 
-def list_tasks_available(tabular_predictions: TabularModelPredictions) -> List[Tuple[str, int]]:
+
+def list_tasks_available(tabular_predictions: TabularModelPredictions) -> list[tuple[str, int]]:
     model_available_dict = tabular_predictions.model_available_dict()
     all_tasks = []
     for dataset, fold_dict in model_available_dict.items():
-        for fold in fold_dict.keys():
+        for fold in fold_dict:
             all_tasks.append((dataset, fold))
-    return list(sorted(all_tasks))
+    return sorted(all_tasks)
 
-def list_folds_available(tabular_predictions: TabularModelPredictions, datasets: List[str] = None, present_in_all: bool = True) -> List[int]:
+
+def list_folds_available(
+    tabular_predictions: TabularModelPredictions, datasets: list[str] | None = None, present_in_all: bool = True
+) -> list[int]:
     model_available_dict = tabular_predictions.model_available_dict()
     datasets = datasets if datasets else tabular_predictions.datasets
     all_folds = []
@@ -238,23 +258,25 @@ def list_folds_available(tabular_predictions: TabularModelPredictions, datasets:
         if dataset in model_available_dict:
             all_folds.append(model_available_dict[dataset].keys())
     agg_fun = set.intersection if present_in_all else set.union
-    return sorted(list(agg_fun(*map(set, all_folds)))) if all_folds else []
+    return sorted(agg_fun(*map(set, all_folds))) if all_folds else []
 
 
-def restrict_tasks(tabular_predictions: TabularModelPredictions, tasks: List[Tuple[str, int]]):
-    datasets = set(dataset for dataset, _ in tasks)
-    folds = set(fold for _, fold in tasks)
+def restrict_tasks(tabular_predictions: TabularModelPredictions, tasks: list[tuple[str, int]]):
+    datasets = {dataset for dataset, _ in tasks}
+    folds = {fold for _, fold in tasks}
     tabular_predictions.restrict_datasets(datasets)
     tabular_predictions.restrict_folds(folds)
 
-def get_folds_dense(tabular_predictions: TabularModelPredictions) -> List[int]:
-    """
-    Returns folds that appear in all datasets
-    """
+
+def get_folds_dense(tabular_predictions: TabularModelPredictions) -> list[int]:
+    """Returns folds that appear in all datasets."""
     return list_folds_available(tabular_predictions, present_in_all=True)
+
 
 def is_empty(tabular_predictions: TabularModelPredictions):
     return len(tabular_predictions.models) == 0
+
+
 def print_summary(tabular_predictions: TabularModelPredictions):
     folds = tabular_predictions.folds
     datasets = tabular_predictions.datasets
@@ -272,10 +294,11 @@ def print_summary(tabular_predictions: TabularModelPredictions):
     num_folds_dense = len(folds_dense)
     num_models_dense = len(models_dense)
 
-    print(f'Summary of {tabular_predictions.__class__.__name__}:\n'
-          f'\tdatasets={num_datasets}\t| folds={num_folds} (dense={num_folds_dense})\t| tasks={num_tasks}\t'
-          f'| models={num_models} (dense={num_models_dense})\n'
-          f'\tis_dense={is_dense(tabular_predictions)} | '
-          f'is_dense_folds={is_dense_folds(tabular_predictions)} | '
-          f'is_dense_models={is_dense_models(tabular_predictions)}')
-
+    print(
+        f"Summary of {tabular_predictions.__class__.__name__}:\n"
+        f"\tdatasets={num_datasets}\t| folds={num_folds} (dense={num_folds_dense})\t| tasks={num_tasks}\t"
+        f"| models={num_models} (dense={num_models_dense})\n"
+        f"\tis_dense={is_dense(tabular_predictions)} | "
+        f"is_dense_folds={is_dense_folds(tabular_predictions)} | "
+        f"is_dense_models={is_dense_models(tabular_predictions)}"
+    )

--- a/packages/tabarena/src/tabarena/simulation/ensemble_scorer_calibrated.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble_scorer_calibrated.py
@@ -24,14 +24,13 @@ class EnsembleScorerCalibrated(EnsembleScorerMaxModels):
 
     def get_calibrator(self):
         from probmetrics.calibrators import get_calibrator
+
         # also: pip install probmetrics pytorch-minimize
         return get_calibrator(self.calibrator_type)
 
     @staticmethod
     def _to_binary_1d(pred_proba: np.ndarray) -> np.ndarray:
-        """
-        Convert binary proba output to 1d positive-class probabilities if needed.
-        """
+        """Convert binary proba output to 1d positive-class probabilities if needed."""
         # If already 1d, assume it's positive-class proba
         if pred_proba.ndim == 1:
             return pred_proba
@@ -49,8 +48,7 @@ class EnsembleScorerCalibrated(EnsembleScorerMaxModels):
         pred_test: np.ndarray,
         problem_type: str,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """
-        Fit a calibrator on (pred_fit, y_fit), then transform both pred_val and pred_test.
+        """Fit a calibrator on (pred_fit, y_fit), then transform both pred_val and pred_test.
         Handles binary->1d conversion.
         """
         calibrator = self.get_calibrator()
@@ -230,7 +228,7 @@ class EnsembleScorerCalibratedCV(EnsembleScorerCalibrated):
         if self.optimize_on != "val":
             # This class intentionally only supports CV calibration on validation.
             raise ValueError(
-                f"{self.__class__.__name__} only supports optimize_on='val', got optimize_on={self.optimize_on!r}"
+                f"{self.__class__.__name__} only supports optimize_on='val', got optimize_on={self.optimize_on!r}",
             )
 
     def _get_cv_splitter(self, n_splits: int, problem_type: str, random_state: int):
@@ -254,10 +252,9 @@ class EnsembleScorerCalibratedCV(EnsembleScorerCalibrated):
         evaluator,
         random_state: int,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """
-        Returns:
+        """Returns:
           - calibrated_val_oof: out-of-fold calibrated probabilities for validation-side data
-          - calibrated_test: calibrated probabilities for test, using calibrator fit on full validation-side data
+          - calibrated_test: calibrated probabilities for test, using calibrator fit on full validation-side data.
 
         For binary, outputs are 1d positive-class probabilities.
         For multiclass, outputs are 2d probabilities.
@@ -325,10 +322,9 @@ class EnsembleScorerCalibratedCV(EnsembleScorerCalibrated):
         evaluator,
         models: list[str],
     ):
-        """
-        optimize_on='val' only:
-          - pred_val becomes OOF-calibrated (per model)
-          - pred_test becomes calibrated via calibrator fit on full val-side (per model)
+        """optimize_on='val' only:
+        - pred_val becomes OOF-calibrated (per model)
+        - pred_test becomes calibrated via calibrator fit on full val-side (per model).
         """
         pred_val_out = copy.deepcopy(pred_val)
         pred_test_out = copy.deepcopy(pred_test)

--- a/packages/tabarena/src/tabarena/simulation/ensemble_selection_config_scorer.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble_selection_config_scorer.py
@@ -42,7 +42,7 @@ def get_fast_roc_auc() -> Scorer:
         print(
             f"Warning: Failed to obtain c++ roc_auc metric ({type(e).__name__}: {e}). "
             "Try installing g++ or set TABARENA_SKIP_FAST_ROC_AUC=1. "
-            "Falling back to sklearn implementation..."
+            "Falling back to sklearn implementation...",
         )
         return get_metric(metric="roc_auc", problem_type="binary")
     return fast_roc_auc_cpp
@@ -54,6 +54,7 @@ class TaskEvaluator:
       - knows how to predict/score given (y, pred)
     It does NOT know anything about repo/dataset/fold/models or optimize_on.
     """
+
     def __init__(
         self,
         *,
@@ -96,7 +97,9 @@ class TaskEvaluator:
         ensemble.problem_type = self._predict_problem_type
         return ensemble
 
-    def predict(self, *, ensemble, pred: np.ndarray, y: np.ndarray, eval_metric: Scorer | None = None) -> tuple[np.ndarray, np.ndarray]:
+    def predict(
+        self, *, ensemble, pred: np.ndarray, y: np.ndarray, eval_metric: Scorer | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
         if eval_metric is None:
             eval_metric = self._eval_metric
 
@@ -141,8 +144,12 @@ class TaskEvaluator:
         results: dict[str, object] = {"metric_error": self.error(y=y_test_proc, y_pred=y_test_pred)}
 
         if self._aux_eval_metric is not None:
-            y_test_pred_aux, y_test_proc_aux = self.predict(ensemble=ensemble, pred=pred_test, y=y_test, eval_metric=self._aux_eval_metric)
-            results["aux_metric_error"] = self.error(y=y_test_proc_aux, y_pred=y_test_pred_aux, eval_metric=self._aux_eval_metric)
+            y_test_pred_aux, y_test_proc_aux = self.predict(
+                ensemble=ensemble, pred=pred_test, y=y_test, eval_metric=self._aux_eval_metric
+            )
+            results["aux_metric_error"] = self.error(
+                y=y_test_proc_aux, y_pred=y_test_pred_aux, eval_metric=self._aux_eval_metric
+            )
 
         if return_metric_error_val:
             if pred_val is None or y_val is None:
@@ -150,8 +157,12 @@ class TaskEvaluator:
             y_val_pred, y_val_proc = self.predict(ensemble=ensemble, pred=pred_val, y=y_val)
             results["metric_error_val"] = self.error(y=y_val_proc, y_pred=y_val_pred)
             if self._aux_eval_metric is not None:
-                y_val_pred_aux, y_val_proc_aux = self.predict(ensemble=ensemble, pred=pred_val, y=y_val, eval_metric=self._aux_eval_metric)
-                results["aux_metric_error_val"] = self.error(y=y_val_proc_aux, y_pred=y_val_pred_aux, eval_metric=self._aux_eval_metric)
+                y_val_pred_aux, y_val_proc_aux = self.predict(
+                    ensemble=ensemble, pred=pred_val, y=y_val, eval_metric=self._aux_eval_metric
+                )
+                results["aux_metric_error_val"] = self.error(
+                    y=y_val_proc_aux, y_pred=y_val_pred_aux, eval_metric=self._aux_eval_metric
+                )
 
         if hasattr(ensemble, "weights_"):
             results["ensemble_weights"] = ensemble.weights_
@@ -222,7 +233,9 @@ class EnsembleScorer:
     # -------------------------
     # Metrics helpers
     # -------------------------
-    def _get_metric_from_name(self, metric_name: str, problem_type: str, use_fast_metrics: bool | None = None) -> Scorer:
+    def _get_metric_from_name(
+        self, metric_name: str, problem_type: str, use_fast_metrics: bool | None = None
+    ) -> Scorer:
         if use_fast_metrics is None:
             use_fast_metrics = self.use_fast_metrics
         if use_fast_metrics:
@@ -244,8 +257,12 @@ class EnsembleScorer:
     ) -> tuple[Scorer, Scorer]:
         fit_metric_name = self.proxy_fit_metric_map.get(metric_name, metric_name)
 
-        eval_metric = self._get_metric_from_name(metric_name=metric_name, problem_type=problem_type, use_fast_metrics=use_fast_metrics)
-        fit_eval_metric = self._get_metric_from_name(metric_name=fit_metric_name, problem_type=problem_type, use_fast_metrics=use_fast_metrics)
+        eval_metric = self._get_metric_from_name(
+            metric_name=metric_name, problem_type=problem_type, use_fast_metrics=use_fast_metrics
+        )
+        fit_eval_metric = self._get_metric_from_name(
+            metric_name=fit_metric_name, problem_type=problem_type, use_fast_metrics=use_fast_metrics
+        )
 
         return eval_metric, fit_eval_metric
 
@@ -362,7 +379,14 @@ class EnsembleScorerMaxModels(EnsembleScorer):
         If specified, will limit ensemble candidates of a given model type to the top `max_models_per_type` highest validation score models.
         If "auto", scales dynamically with the number of rows in the dataset.
     """
-    def __init__(self, repo: EvaluationRepository, max_models: int | None = None, max_models_per_type: int | str | None = None, **kwargs):
+
+    def __init__(
+        self,
+        repo: EvaluationRepository,
+        max_models: int | None = None,
+        max_models_per_type: int | str | None = None,
+        **kwargs,
+    ):
         super().__init__(repo=repo, **kwargs)
         assert self.repo is not None
         if max_models is not None:
@@ -378,7 +402,11 @@ class EnsembleScorerMaxModels(EnsembleScorer):
     def filter_models(self, dataset: str, fold: int, models: list[str]) -> list[str]:
         """Filters models by user-defined logic. Used in class extensions."""
         if self.max_models is not None or self.max_models_per_type is not None:
-            if self.max_models_per_type is not None and isinstance(self.max_models_per_type, str) and self.max_models_per_type == "auto":
+            if (
+                self.max_models_per_type is not None
+                and isinstance(self.max_models_per_type, str)
+                and self.max_models_per_type == "auto"
+            ):
                 max_models_per_type = self._get_max_models_per_type_auto(dataset=dataset)
             else:
                 max_models_per_type = self.max_models_per_type
@@ -425,20 +453,21 @@ class EnsembleScorerMaxModels(EnsembleScorer):
 
 # FIXME: Add temperature scaling!!
 class EnsembleSelectionConfigScorer(ConfigurationListScorer):
-    def __init__(self,
-                 tasks: list[str],
-                 repo: EvaluationRepository,
-                 ranker: RankScorer,
-                 tid_to_dataset_name_dict: dict[int, str],
-                 task_metrics_metadata: dict[int, dict[str, str]],
-                 ensemble_size=100,
-                 ensemble_selection_kwargs=None,
-                 backend: str = "native",
-                 use_fast_metrics: bool = True,
-                 proxy_fit_metric_map: dict | str | None = None,  # TODO: Add unit test
-                 ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
-                 ensemble_kwargs: dict | None = None,
-                 ):
+    def __init__(
+        self,
+        tasks: list[str],
+        repo: EvaluationRepository,
+        ranker: RankScorer,
+        tid_to_dataset_name_dict: dict[int, str],
+        task_metrics_metadata: dict[int, dict[str, str]],
+        ensemble_size=100,
+        ensemble_selection_kwargs=None,
+        backend: str = "native",
+        use_fast_metrics: bool = True,
+        proxy_fit_metric_map: dict | str | None = None,  # TODO: Add unit test
+        ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+        ensemble_kwargs: dict | None = None,
+    ):
         """A scorer object to evaluate configs via simulating ensemble selection.
 
         :param tasks: The list of tasks to consider for scoring.
@@ -502,7 +531,8 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         task_metrics_metadata = zeroshot_simulator_context.df_metrics
         task_metrics_metadata = {
             dataset: task_metrics_metadata.loc[dataset].to_dict()
-            for dataset in task_metrics_metadata.index if dataset in dataset_to_tid_dict
+            for dataset in task_metrics_metadata.index
+            if dataset in dataset_to_tid_dict
         }
 
         return cls(
@@ -547,7 +577,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             engine=engine,
             progress_bar=progress_bar,
         )
-        return dict(zip(self.tasks, results_rows))
+        return dict(zip(self.tasks, results_rows, strict=False))
 
     def compute_ranks(self, errors: dict[str, float]) -> dict[str, float]:
         ranks = {}

--- a/packages/tabarena/src/tabarena/simulation/ground_truth.py
+++ b/packages/tabarena/src/tabarena/simulation/ground_truth.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import tempfile
-
-import pandas as pd
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class GroundTruth:
-    def __init__(self, label_val_dict: dict[str, dict[int, pd.Series]], label_test_dict: dict[str, dict[int, pd.Series]]):
-        """
-
-        :param label_val_dict: dictionary from tid to fold to labels series where the index are openml rows and
+    def __init__(
+        self, label_val_dict: dict[str, dict[int, pd.Series]], label_test_dict: dict[str, dict[int, pd.Series]]
+    ):
+        """:param label_val_dict: dictionary from tid to fold to labels series where the index are openml rows and
         values are the labels
         :param label_test_dict: same as `label_val_dict`
         """
@@ -20,10 +22,10 @@ class GroundTruth:
 
     @property
     def datasets(self) -> list[str]:
-        return sorted(list(self._label_val_dict.keys()))
+        return sorted(self._label_val_dict.keys())
 
     def dataset_folds(self, dataset: str) -> list[int]:
-        return sorted(list(self._label_val_dict[dataset].keys()))
+        return sorted(self._label_val_dict[dataset].keys())
 
     def dataset_fold_lst(self) -> list[tuple[str, int]]:
         datasets = self.datasets
@@ -66,10 +68,10 @@ class GroundTruth:
     def from_dict(cls, label_dict):
         label_val_dict = dict()
         label_test_dict = dict()
-        for dataset in label_dict.keys():
+        for dataset in label_dict:
             label_val_dict[dataset] = dict()
             label_test_dict[dataset] = dict()
-            for fold in label_dict[dataset].keys():
+            for fold in label_dict[dataset]:
                 labels_val = label_dict[dataset][fold]["y_val"]
                 labels_test = label_dict[dataset][fold]["y_test"]
                 label_val_dict[dataset][fold] = labels_val
@@ -79,7 +81,8 @@ class GroundTruth:
     # TODO: Unit test
     def to_data_dir(self, data_dir: str):
         if data_dir[:2] == "s3":
-            from autogluon.common.utils.s3_utils import is_s3_url, upload_s3_folder, s3_path_to_bucket_prefix
+            from autogluon.common.utils.s3_utils import is_s3_url, s3_path_to_bucket_prefix, upload_s3_folder
+
             if is_s3_url(str(data_dir)):
                 s3_bucket, s3_prefix = s3_path_to_bucket_prefix(data_dir)
                 with tempfile.TemporaryDirectory() as temp_dir:

--- a/packages/tabarena/src/tabarena/simulation/sim_output.py
+++ b/packages/tabarena/src/tabarena/simulation/sim_output.py
@@ -1,19 +1,25 @@
+from __future__ import annotations
+
 import copy
-from typing import List, Union
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
 from tabarena.portfolio import Portfolio, PortfolioCV
 
+if TYPE_CHECKING:
+    from tabarena.repository.evaluation_repository_zeroshot import EvaluationRepositoryZeroshot
+
 
 # FIXME: Ideally this should be easier, but not really possible with current logic.
 def metric_error_to_score(metric_error: float, metric: str):
-    if metric.startswith('neg_'):
+    if metric.startswith("neg_"):
         metric_score = -metric_error
-    elif metric == 'auc':
+    elif metric == "auc":
         metric_score = 1 - metric_error
     else:
         from autogluon.core.metrics import get_metric
+
         metric_func = get_metric(metric=metric)
         metric_score = metric_func.convert_error_to_score(metric_error)
     return metric_score
@@ -23,8 +29,7 @@ def metric_error_to_score(metric_error: float, metric: str):
 # FIXME: accurate time_infer_s
 # FIXME: accurate score_val
 class SimulationOutputGenerator:
-    """
-    Generate an output pandas DataFrame that is compatible with the AutoMLBenchmark results format.
+    """Generate an output pandas DataFrame that is compatible with the AutoMLBenchmark results format.
     Useful to compare directly with AutoML frameworks and baselines.
 
     Given a portfolio, create an output DataFrame with the following columns:
@@ -53,32 +58,21 @@ class SimulationOutputGenerator:
         The sum of the training times of the individual models in the portfolio.
 
     """
-    def __init__(self,
-                 repo,
-                 config_scorer_type='ensemble',
-                 config_scorer_kwargs: dict = None):
-        if config_scorer_kwargs is None:
-            config_scorer_kwargs = {}
-        else:
-            config_scorer_kwargs = copy.deepcopy(config_scorer_kwargs)
 
-        from tabarena.repository.evaluation_repository_zeroshot import EvaluationRepositoryZeroshot
+    def __init__(self, repo, config_scorer_type="ensemble", config_scorer_kwargs: dict | None = None):
+        config_scorer_kwargs = {} if config_scorer_kwargs is None else copy.deepcopy(config_scorer_kwargs)
+
         self.repo: EvaluationRepositoryZeroshot = repo
 
         self.config_scorer_type = config_scorer_type
         self.config_scorer_kwargs = config_scorer_kwargs
 
-        assert self.config_scorer_type in ['ensemble', 'single']
+        assert self.config_scorer_type in ["ensemble", "single"]
 
-    def from_portfolio(self,
-                       portfolio: Union[List[str], Portfolio],
-                       *,
-                       name: str,
-                       tasks: List[str] = None,
-                       minimal_columns=True,) -> pd.DataFrame:
-        """
-        Create from a single portfolio (Not cross-validated)
-        """
+    def from_portfolio(
+        self, portfolio: list[str] | Portfolio, *, name: str, tasks: list[str] | None = None, minimal_columns=True
+    ) -> pd.DataFrame:
+        """Create from a single portfolio (Not cross-validated)."""
         if isinstance(portfolio, Portfolio):
             if tasks is None and portfolio.test_datasets_fold is not None:
                 tasks = portfolio.test_datasets_fold
@@ -92,51 +86,50 @@ class SimulationOutputGenerator:
         config_scorer_test = repo._construct_config_scorer(
             tasks=tasks,
             config_scorer_type=self.config_scorer_type,
-            **self.config_scorer_kwargs
+            **self.config_scorer_kwargs,
         )
 
         zsc = repo._zeroshot_context
 
-        df_raw_subset = zsc.df_configs[zsc.df_configs['task'].isin(tasks)]
-        df_raw_subset = df_raw_subset[df_raw_subset['framework'].isin(portfolio)]
-        df_total_train_and_infer_times = df_raw_subset[['task', 'time_train_s', 'time_infer_s']].groupby('task').sum()
-        df_raw_subset = df_raw_subset.drop_duplicates(subset=['task'])
+        df_raw_subset = zsc.df_configs[zsc.df_configs["task"].isin(tasks)]
+        df_raw_subset = df_raw_subset[df_raw_subset["framework"].isin(portfolio)]
+        df_total_train_and_infer_times = df_raw_subset[["task", "time_train_s", "time_infer_s"]].groupby("task").sum()
+        df_raw_subset = df_raw_subset.drop_duplicates(subset=["task"])
 
-        score_per_dataset, metadata = config_scorer_test.compute_errors(portfolio)
+        score_per_dataset, _metadata = config_scorer_test.compute_errors(portfolio)
 
-        df_raw_subset['metric_error'] = [score_per_dataset[row[0]] for row in zip(df_raw_subset['task'])]
+        df_raw_subset["metric_error"] = [score_per_dataset[row[0]] for row in zip(df_raw_subset["task"], strict=False)]
         # TODO: Add back?
         # df_raw_subset['metric_score'] = [metric_error_to_score(row[0], row[1]) for row in
         #                                  zip(df_raw_subset['metric_error'], df_raw_subset['metric'])]
-        df_raw_subset['framework'] = name
-        df_raw_subset = df_raw_subset.set_index('task', drop=True)
-        df_raw_subset['time_train_s'] = df_total_train_and_infer_times['time_train_s']
+        df_raw_subset["framework"] = name
+        df_raw_subset = df_raw_subset.set_index("task", drop=True)
+        df_raw_subset["time_train_s"] = df_total_train_and_infer_times["time_train_s"]
 
         # FIXME: time_infer_s is not correct since it assumes all models are used in final ensemble
         #  In reality the infer_speed is faster.
-        df_raw_subset['time_infer_s'] = df_total_train_and_infer_times['time_infer_s']
+        df_raw_subset["time_infer_s"] = df_total_train_and_infer_times["time_infer_s"]
         df_raw_subset["portfolio"] = [portfolio] * len(df_raw_subset)
         df_raw_subset = df_raw_subset.reset_index(drop=True)
         if minimal_columns:
             # TODO: Add val_error
             min_cols = [
-                'dataset',
-                'fold',
-                'framework',
-                'metric_error',
-                'time_train_s',
-                'time_infer_s',
-                'metric',
-                'problem_type',
-                'tid',
-                'portfolio',
+                "dataset",
+                "fold",
+                "framework",
+                "metric_error",
+                "time_train_s",
+                "time_infer_s",
+                "metric",
+                "problem_type",
+                "tid",
+                "portfolio",
             ]
             df_raw_subset = df_raw_subset[min_cols]
         return df_raw_subset
 
     def from_portfolio_cv(self, portfolio_cv: PortfolioCV, name: str, minimal_columns=True) -> pd.DataFrame:
-        """
-        Create from a cross-validated portfolio, using the results only from
+        """Create from a cross-validated portfolio, using the results only from
         the holdout to construct an output that is not overfit.
         """
         assert portfolio_cv.are_test_folds_unique()
@@ -144,21 +137,22 @@ class SimulationOutputGenerator:
         portfolios = portfolio_cv.portfolios
         num_folds = len(portfolios)
         for i in range(len(portfolios)):
-            print(f'Fold {portfolios[i].fold} Selected Configs: {portfolios[i].configs}')
+            print(f"Fold {portfolios[i].fold} Selected Configs: {portfolios[i].configs}")
 
         for i in range(len(portfolios)):
-            print(f'Fold {portfolios[i].fold} Test Score: {portfolios[i].test_score}')
+            print(f"Fold {portfolios[i].fold} Test Score: {portfolios[i].test_score}")
 
-        print(f'Final Test Score: {portfolio_cv.get_test_score_overall()}')
+        print(f"Final Test Score: {portfolio_cv.get_test_score_overall()}")
 
         df_raw_all = []
         for f in range(num_folds):
-            print(f'Computing scores for each dataset... (fold={f})')
+            print(f"Computing scores for each dataset... (fold={f})")
             portfolio = portfolios[f]
-            df_raw_subset = self.from_portfolio(portfolio=portfolio.configs,
-                                                tasks=portfolio.test_datasets_fold,
-                                                name=name,
-                                                minimal_columns=minimal_columns)
+            df_raw_subset = self.from_portfolio(
+                portfolio=portfolio.configs,
+                tasks=portfolio.test_datasets_fold,
+                name=name,
+                minimal_columns=minimal_columns,
+            )
             df_raw_all.append(df_raw_subset)
-        df_raw_all = pd.concat(df_raw_all, ignore_index=True)
-        return df_raw_all
+        return pd.concat(df_raw_all, ignore_index=True)

--- a/packages/tabarena/src/tabarena/simulation/sim_runner.py
+++ b/packages/tabarena/src/tabarena/simulation/sim_runner.py
@@ -1,30 +1,37 @@
-from datetime import datetime
+from __future__ import annotations
+
 import math
 import os
-from typing import Dict, List
+from datetime import datetime
+from typing import TYPE_CHECKING
 
 import boto3
 import matplotlib.pyplot as plt
-
-from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
 
+from tabarena.utils import catchtime
+
 from .config_generator import ZeroshotConfigGeneratorCV
-from .simulation_context import ZeroshotSimulatorContext
-from ..portfolio import PortfolioCV
-from ..utils import catchtime
+
+if TYPE_CHECKING:
+    from tabarena.portfolio import PortfolioCV
+
+    from .simulation_context import ZeroshotSimulatorContext
 
 
 # TODO: Return type hints + docstring
-def run_zs_sim_end_to_end(subcontext_name: str,
-                          num_zeroshot: int = 10,
-                          n_splits: int = 2,
-                          config_scorer_type: str = 'ensemble',
-                          config_scorer_kwargs: dict = None,
-                          subcontext_load_kwargs: dict = None,
-                          backend='ray'):
-    from ..contexts import get_subcontext
-    from ..repository import EvaluationRepository
+def run_zs_sim_end_to_end(
+    subcontext_name: str,
+    num_zeroshot: int = 10,
+    n_splits: int = 2,
+    config_scorer_type: str = "ensemble",
+    config_scorer_kwargs: dict | None = None,
+    subcontext_load_kwargs: dict | None = None,
+    backend="ray",
+):
+    from tabarena.contexts import get_subcontext
+    from tabarena.repository import EvaluationRepository
+
     if isinstance(subcontext_name, str):
         benchmark_subcontext = get_subcontext(subcontext_name)
         if subcontext_load_kwargs is None:
@@ -45,16 +52,13 @@ def run_zs_sim_end_to_end(subcontext_name: str,
         n_splits=n_splits,
         backend=backend,
     )
-    print(f'Final Score: {results_cv.get_test_score_overall()}')
+    print(f"Final Score: {results_cv.get_test_score_overall()}")
     return results_cv, repo
 
 
-def run_zs_simulation(zsc: ZeroshotSimulatorContext,
-                      config_scorer,
-                      n_splits=10,
-                      config_generator_kwargs=None,
-                      configs=None,
-                      backend='ray') -> PortfolioCV:
+def run_zs_simulation(
+    zsc: ZeroshotSimulatorContext, config_scorer, n_splits=10, config_generator_kwargs=None, configs=None, backend="ray"
+) -> PortfolioCV:
     zs_config_generator_cv = ZeroshotConfigGeneratorCV(
         n_splits=n_splits,
         zeroshot_simulator_context=zsc,
@@ -67,43 +71,56 @@ def run_zs_simulation(zsc: ZeroshotSimulatorContext,
 
     portfolios = portfolio_cv.portfolios
     for i in range(len(portfolios)):
-        print(f'Fold {portfolios[i].fold} Selected Configs: {portfolios[i].configs}')
+        print(f"Fold {portfolios[i].fold} Selected Configs: {portfolios[i].configs}")
 
     for i in range(len(portfolios)):
-        print(f'Fold {portfolios[i].fold} | '
-              f'Test Score: {portfolios[i].test_score} | '
-              f'Train Score: {portfolios[i].train_score}')
+        print(
+            f"Fold {portfolios[i].fold} | "
+            f"Test Score: {portfolios[i].test_score} | "
+            f"Train Score: {portfolios[i].train_score}"
+        )
 
-    print(f'Overall (CV) | '
-          f'Test Score: {portfolio_cv.get_test_score_overall()} | '
-          f'Train Score: {portfolio_cv.get_train_score_overall()} | '
-          f'Overfit Score: {portfolio_cv.get_test_train_rank_diff()}')
+    print(
+        f"Overall (CV) | "
+        f"Test Score: {portfolio_cv.get_test_score_overall()} | "
+        f"Train Score: {portfolio_cv.get_train_score_overall()} | "
+        f"Overfit Score: {portfolio_cv.get_test_train_rank_diff()}"
+    )
 
     return portfolio_cv
 
 
-def plot_results_multi(portfolio_cv_lists: List[List[PortfolioCV]],
-                       title: str = None,
-                       footnote: str = None,
-                       save_prefix: str = None,
-                       save_to_s3: bool = True,
-                       x_axis_col: str = 'step'):
+def plot_results_multi(
+    portfolio_cv_lists: list[list[PortfolioCV]],
+    title: str | None = None,
+    footnote: str | None = None,
+    save_prefix: str | None = None,
+    save_to_s3: bool = True,
+    x_axis_col: str = "step",
+):
     if title is None:
-        title = f"Overfitting Delta"
+        title = "Overfitting Delta"
     fig = plt.figure(dpi=300)
     ax = fig.subplots()
     for portfolio_cv_list in portfolio_cv_lists:
-        df, num_train_tasks, num_test_tasks, n_configs_avail = get_test_train_rank_diff_df(portfolio_cv_list=portfolio_cv_list)
-        ax.scatter(df[x_axis_col], df['overfit_delta'], alpha=0.5, label=f'tr_tasks={num_train_tasks}, n_conf={n_configs_avail}')
+        df, num_train_tasks, num_test_tasks, n_configs_avail = get_test_train_rank_diff_df(
+            portfolio_cv_list=portfolio_cv_list
+        )
+        ax.scatter(
+            df[x_axis_col],
+            df["overfit_delta"],
+            alpha=0.5,
+            label=f"tr_tasks={num_train_tasks}, n_conf={n_configs_avail}",
+        )
     ax.set_xlabel(x_axis_col)
-    ax.set_ylabel('Overfit delta rank (lower is better)')
+    ax.set_ylabel("Overfit delta rank (lower is better)")
     ax.set_title(title)
     if footnote is not None:
-        plt.figtext(0.99, 0.01, footnote, horizontalalignment='right')
+        plt.figtext(0.99, 0.01, footnote, horizontalalignment="right")
     ax.grid()
     ax.legend()
     if save_prefix is not None:
-        save_path = f'{save_prefix}overfit_delta_comparison.png'
+        save_path = f"{save_prefix}overfit_delta_comparison.png"
         mkdir_path(save_path)
         plt.savefig(save_path)
     plt.show()
@@ -128,42 +145,45 @@ def plot_results_multi(portfolio_cv_lists: List[List[PortfolioCV]],
     fig.set_dpi(300)
     # ax.scatter(df['num_configs'], df['test_score'], alpha=0.5, label='test')
     # ax.scatter(df['num_configs'], df['train_score'], alpha=0.5, label='train')
-    for ax, portfolio_cv_list in zip(axes_flat[:num_lists], portfolio_cv_lists):
-        df, num_train_tasks, num_test_tasks, n_configs_avail = get_test_train_rank_diff_df(portfolio_cv_list=portfolio_cv_list)
-        ax.errorbar(df[x_axis_col], df['test_error'], alpha=0.5, label=f'test', yerr=df['test_error_std'], fmt='o')
-        ax.errorbar(df[x_axis_col], df['train_error'], alpha=0.5, label=f'train', yerr=df['train_error_std'], fmt='o')
+    for ax, portfolio_cv_list in zip(axes_flat[:num_lists], portfolio_cv_lists, strict=False):
+        df, num_train_tasks, _num_test_tasks, n_configs_avail = get_test_train_rank_diff_df(
+            portfolio_cv_list=portfolio_cv_list
+        )
+        ax.errorbar(df[x_axis_col], df["test_error"], alpha=0.5, label="test", yerr=df["test_error_std"], fmt="o")
+        ax.errorbar(df[x_axis_col], df["train_error"], alpha=0.5, label="train", yerr=df["train_error_std"], fmt="o")
 
         # ax.set_xlabel('num_configs')  # Add an x-label to the axes.
         # ax.set_ylabel('rank (lower is better)')  # Add a y-label to the axes.
-        ax.set_title(f'tr_tasks={num_train_tasks}, n_conf={n_configs_avail}')  # Add a title to the axes.
+        ax.set_title(f"tr_tasks={num_train_tasks}, n_conf={n_configs_avail}")  # Add a title to the axes.
         ax.grid()
     axes_flat[0].legend()
     # axes[0].set_xlabel('num_configs')  # Add an x-label to the axes.
     # axes.flat[0].set_ylabel('rank (lower is better)')  # Add a y-label to the axes.
     if footnote is not None:
-        plt.figtext(0.99, 0.01, footnote, horizontalalignment='right')
+        plt.figtext(0.99, 0.01, footnote, horizontalalignment="right")
     fig.suptitle(title)
     fig.supxlabel(x_axis_col)
-    fig.supylabel('rank (lower is better)')
+    fig.supylabel("rank (lower is better)")
     if save_prefix is not None:
-        save_path = f'{save_prefix}train_test_comparison.png'
+        save_path = f"{save_prefix}train_test_comparison.png"
         mkdir_path(save_path)
         plt.savefig(save_path)
     plt.show()
 
     if save_prefix is not None and save_to_s3:
-        s3 = boto3.resource('s3')
+        s3 = boto3.resource("s3")
 
         # FIXME: Won't work nicely if save_prefix is absolute path
-        s3_bucket = 'autogluon-zeroshot'
-        s3_prefix = f'{save_prefix}'
+        s3_bucket = "autogluon-zeroshot"
+        s3_prefix = f"{save_prefix}"
 
-        for f in ['overfit_delta_comparison.png', 'train_test_comparison.png']:
+        for f in ["overfit_delta_comparison.png", "train_test_comparison.png"]:
             s3.Bucket(s3_bucket).upload_file(f"{save_prefix}{f}", f"{s3_prefix}{f}")
 
 
-def get_test_train_rank_diff_df(portfolio_cv_list: List[PortfolioCV]):
+def get_test_train_rank_diff_df(portfolio_cv_list: list[PortfolioCV]):
     from collections import defaultdict
+
     df_dict = defaultdict(list)
 
     num_train_tasks = None
@@ -172,7 +192,7 @@ def get_test_train_rank_diff_df(portfolio_cv_list: List[PortfolioCV]):
 
     for portfolio_cv in portfolio_cv_list:
         portfolio_cv.print_summary()
-        assert portfolio_cv.is_dense(), f'PortfolioCV is not dense!'
+        assert portfolio_cv.is_dense(), "PortfolioCV is not dense!"
         portfolios = portfolio_cv.portfolios
         if num_train_tasks is None:
             num_train_tasks = len(portfolios[0].train_datasets_fold)
@@ -189,38 +209,39 @@ def get_test_train_rank_diff_df(portfolio_cv_list: List[PortfolioCV]):
         # for i in range(len(portfolios)):
         #     print(f'Fold {portfolios[i].fold} Test Score: {portfolios[i].test_score}')
 
-        df_dict['n_configs'].append(n_configs)
-        df_dict['step'].append(step)
+        df_dict["n_configs"].append(n_configs)
+        df_dict["step"].append(step)
         if portfolio_cv.has_test_score():
-            df_dict['test_error'].append(portfolio_cv.get_test_score_overall())
-            df_dict['test_error_std'].append(portfolio_cv.get_test_score_stddev())
+            df_dict["test_error"].append(portfolio_cv.get_test_score_overall())
+            df_dict["test_error_std"].append(portfolio_cv.get_test_score_stddev())
         else:
-            df_dict['test_error'].append(None)
-            df_dict['test_error_std'].append(None)
-        df_dict['train_error'].append(portfolio_cv.get_train_score_overall())
-        df_dict['train_error_std'].append(portfolio_cv.get_train_score_stddev())
-
+            df_dict["test_error"].append(None)
+            df_dict["test_error_std"].append(None)
+        df_dict["train_error"].append(portfolio_cv.get_train_score_overall())
+        df_dict["train_error_std"].append(portfolio_cv.get_train_score_stddev())
 
     import pandas as pd
+
     df = pd.DataFrame(df_dict)
-    df['overfit_delta'] = df['test_error'] - df['train_error']
+    df["overfit_delta"] = df["test_error"] - df["train_error"]
     return df, num_train_tasks, num_test_tasks, n_configs_avail
 
 
 # TODO: Save list of list of porfolioCV, can then plot graphs separately from computing
-def run_zs_simulation_debug(zsc: ZeroshotSimulatorContext,
-                            config_scorer,
-                            n_splits=10,
-                            n_repeats=1,
-                            config_generator_kwargs=None,
-                            configs=None,
-                            score_all=True,
-                            backend='ray',
-                            save_prefix=None,
-                            num_halving=5) -> List[List[PortfolioCV]]:
-    """
-    num_halving:
-        The number of times the training data is halved to measure increase in overfitting / decrease in test score
+def run_zs_simulation_debug(
+    zsc: ZeroshotSimulatorContext,
+    config_scorer,
+    n_splits=10,
+    n_repeats=1,
+    config_generator_kwargs=None,
+    configs=None,
+    score_all=True,
+    backend="ray",
+    save_prefix=None,
+    num_halving=5,
+) -> list[list[PortfolioCV]]:
+    """num_halving:
+    The number of times the training data is halved to measure increase in overfitting / decrease in test score.
 
     """
     utcnow = datetime.utcnow()
@@ -240,13 +261,13 @@ def run_zs_simulation_debug(zsc: ZeroshotSimulatorContext,
         dict(
             sample_train_folds=None,
             sample_train_ratio=None,
-        )
+        ),
     ]
 
     if num_halving is not None and num_halving >= 1:
         cur_train_folds = num_folds
         cur_train_ratio = 1
-        for i in range(num_halving):
+        for _i in range(num_halving):
             if cur_train_folds == 1:
                 cur_train_ratio /= 2
             else:
@@ -256,7 +277,7 @@ def run_zs_simulation_debug(zsc: ZeroshotSimulatorContext,
                     sample_train_folds=cur_train_folds,
                     sample_train_ratio=cur_train_ratio,
                     # sample_configs_ratio=cur_train_ratio,
-                )
+                ),
             )
 
     portfolio_cv_lists = []
@@ -268,29 +289,31 @@ def run_zs_simulation_debug(zsc: ZeroshotSimulatorContext,
     # portfolio_cv_lists = load_pkl.load('s3://autogluon-zeroshot/output/unnamed/20230324_224848/pf_cv_lists.pkl')
 
     if save_prefix is None:
-        save_prefix = 'unnamed'
-    save_prefix = f'output/{save_prefix}/{timestamp}/'
+        save_prefix = "unnamed"
+    save_prefix = f"output/{save_prefix}/{timestamp}/"
 
     # TODO: Avoid hardcoding s3 bucket
     # TODO: Avoid forcing s3 save
-    s3_bucket = 'autogluon-zeroshot'
-    s3_save_path = f's3://{s3_bucket}/{save_prefix}'
+    s3_bucket = "autogluon-zeroshot"
+    s3_save_path = f"s3://{s3_bucket}/{save_prefix}"
 
-    print(f'Saving output artifacts to local: {save_prefix}')
-    print(f'Saving output artifacts to s3:    {s3_save_path}')
+    print(f"Saving output artifacts to local: {save_prefix}")
+    print(f"Saving output artifacts to s3:    {s3_save_path}")
 
     # TODO: Instead of saving each file individually to s3, just copy the entire output dir to s3
 
-    save_pkl.save(path=f'{save_prefix}pf_cv_lists.pkl', object=portfolio_cv_lists)
-    save_pkl.save(path=f'{s3_save_path}pf_cv_lists.pkl', object=portfolio_cv_lists)
+    save_pkl.save(path=f"{save_prefix}pf_cv_lists.pkl", object=portfolio_cv_lists)
+    save_pkl.save(path=f"{s3_save_path}pf_cv_lists.pkl", object=portfolio_cv_lists)
 
-    plot_results_multi(portfolio_cv_lists,
-                       title=f'Overfit Delta: n_configs={zs_config_generator_cv.get_n_configs()}, '
-                             f'n_tasks={zs_config_generator_cv.get_n_tasks()}, '
-                             f'n_splits={zs_config_generator_cv.n_splits}, '
-                             f'n_repeats={zs_config_generator_cv.n_repeats}',
-                       footnote=f'scorer={zs_config_generator_cv.config_scorer.__class__.__name__}',
-                       save_prefix=f'{save_prefix}plots/')
+    plot_results_multi(
+        portfolio_cv_lists,
+        title=f"Overfit Delta: n_configs={zs_config_generator_cv.get_n_configs()}, "
+        f"n_tasks={zs_config_generator_cv.get_n_tasks()}, "
+        f"n_splits={zs_config_generator_cv.n_splits}, "
+        f"n_repeats={zs_config_generator_cv.n_repeats}",
+        footnote=f"scorer={zs_config_generator_cv.config_scorer.__class__.__name__}",
+        save_prefix=f"{save_prefix}plots/",
+    )
 
     # plot_results(portfolio_cv_dict)
 
@@ -299,6 +322,6 @@ def run_zs_simulation_debug(zsc: ZeroshotSimulatorContext,
 
 def mkdir_path(path):
     path_parent = os.path.dirname(path)
-    if path_parent == '':
-        path_parent = '.'
+    if path_parent == "":
+        path_parent = "."
     os.makedirs(path_parent, exist_ok=True)

--- a/packages/tabarena/src/tabarena/simulation/sim_utils.py
+++ b/packages/tabarena/src/tabarena/simulation/sim_utils.py
@@ -1,19 +1,19 @@
+from __future__ import annotations
+
 import pandas as pd
 
 
 # FIXME: Doesn't work for multi-fold
 def get_dataset_to_tid_dict(df: pd.DataFrame) -> dict:
-    df_tid_to_dataset_map = df[['tid', 'dataset']].drop_duplicates(['tid', 'dataset'])
-    dataset_to_tid_dict = df_tid_to_dataset_map.set_index('dataset')
-    dataset_to_tid_dict = dataset_to_tid_dict['tid'].to_dict()
-    return dataset_to_tid_dict
+    df_tid_to_dataset_map = df[["tid", "dataset"]].drop_duplicates(["tid", "dataset"])
+    dataset_to_tid_dict = df_tid_to_dataset_map.set_index("dataset")
+    return dataset_to_tid_dict["tid"].to_dict()
 
 
 def get_task_to_dataset_dict(df: pd.DataFrame) -> dict:
-    df_tid_to_dataset_map = df[['task', 'dataset']].drop_duplicates(['task', 'dataset'])
-    dataset_to_tid_dict = df_tid_to_dataset_map.set_index('task')
-    dataset_to_tid_dict = dataset_to_tid_dict['dataset'].to_dict()
-    return dataset_to_tid_dict
+    df_tid_to_dataset_map = df[["task", "dataset"]].drop_duplicates(["task", "dataset"])
+    dataset_to_tid_dict = df_tid_to_dataset_map.set_index("task")
+    return dataset_to_tid_dict["dataset"].to_dict()
 
 
 def filter_datasets(df: pd.DataFrame, datasets: pd.DataFrame) -> pd.DataFrame:
@@ -28,7 +28,8 @@ def get_dataset_to_metric_problem_type(df_configs: pd.DataFrame, df_baselines: p
     for dataset in counts:
         if counts[dataset] != 1:
             df_dataset = df_min[df_min["dataset"] == dataset]
-            raise AssertionError(f"Error: Multiple `problem_type` or `metric` values defined in the data for dataset {dataset}\n:"
-                                 f"{df_dataset}")
-    df_min = df_min.set_index("dataset")
-    return df_min
+            raise AssertionError(
+                f"Error: Multiple `problem_type` or `metric` values defined in the data for dataset {dataset}\n:"
+                f"{df_dataset}"
+            )
+    return df_min.set_index("dataset")

--- a/packages/tabarena/src/tabarena/simulation/simulation_context.py
+++ b/packages/tabarena/src/tabarena/simulation/simulation_context.py
@@ -1,22 +1,31 @@
 from __future__ import annotations
 
 import copy
-from collections import defaultdict
 import json
+from collections import defaultdict
 from pathlib import Path
-from typing import Any, List, Union
-from typing_extensions import Self
+from typing import Any, Self
 
 import pandas as pd
 from autogluon.common.loaders import load_json, load_pd
 from autogluon.common.savers import save_json, save_pd
 
-from .ground_truth import GroundTruth
+from tabarena.predictions import (
+    TabularModelPredictions,
+    TabularPredictionsInMemory,
+    TabularPredictionsInMemoryOpt,
+    TabularPredictionsMemmap,
+)
+from tabarena.utils import task_to_tid_fold
+from tabarena.utils.rank_utils import RankScorer
 
-from .sim_utils import get_dataset_to_tid_dict, get_task_to_dataset_dict, filter_datasets, get_dataset_to_metric_problem_type
-from ..predictions import TabularModelPredictions, TabularPredictionsMemmap, TabularPredictionsInMemory, TabularPredictionsInMemoryOpt
-from ..utils import task_to_tid_fold
-from ..utils.rank_utils import RankScorer
+from .ground_truth import GroundTruth
+from .sim_utils import (
+    filter_datasets,
+    get_dataset_to_metric_problem_type,
+    get_dataset_to_tid_dict,
+    get_task_to_dataset_dict,
+)
 
 
 def _default_dict():
@@ -30,13 +39,12 @@ class ZeroshotSimulatorContext:
         df_configs: pd.DataFrame = None,
         df_baselines: pd.DataFrame = None,
         df_metadata: pd.DataFrame = None,
-        configs_hyperparameters: dict[str, dict[str, Any]] = None,
-        folds: List[int] | None = None,
+        configs_hyperparameters: dict[str, dict[str, Any]] | None = None,
+        folds: list[int] | None = None,
         pct: bool = False,
         score_against_only_baselines: bool = True,
     ):
-        """
-        Encapsulates results evaluated on multiple base models/datasets/folds.
+        """Encapsulates results evaluated on multiple base models/datasets/folds.
         :param df_configs: results of configs by multiple datasets/folds
         :param df_baselines: results of baseline systems by multiple datasets/folds
         :param folds: List of folds to be considered in a list of integers. If None, will not filter by fold.
@@ -57,21 +65,23 @@ class ZeroshotSimulatorContext:
 
         # TODO align_valid_folds returns 8 values and does many different things, it would help to break down to more
         #  modular functions
-        self.df_configs, \
-        self.df_baselines, \
-        self.df_configs_ranked, \
-        self.df_metrics, \
-        self.df_metadata, \
-        self.task_to_dataset_dict, \
-        self.dataset_to_folds_dict, \
-        self.dataset_to_tid_dict, \
-        self.dataset_to_problem_type_dict, \
-        self.task_to_fold_dict, \
-        self.folds, \
-        self.unique_tasks, \
-        self.unique_datasets, \
-        self.configs_hyperparameters, \
-        self.rank_scorer = self._align_valid_folds(
+        (
+            self.df_configs,
+            self.df_baselines,
+            self.df_configs_ranked,
+            self.df_metrics,
+            self.df_metadata,
+            self.task_to_dataset_dict,
+            self.dataset_to_folds_dict,
+            self.dataset_to_tid_dict,
+            self.dataset_to_problem_type_dict,
+            self.task_to_fold_dict,
+            self.folds,
+            self.unique_tasks,
+            self.unique_datasets,
+            self.configs_hyperparameters,
+            self.rank_scorer,
+        ) = self._align_valid_folds(
             df_configs=df_configs,
             df_baselines=df_baselines,
             df_metadata=df_metadata,
@@ -83,13 +93,12 @@ class ZeroshotSimulatorContext:
         self.dataset_to_tasks_dict = self._compute_dataset_to_tasks()
 
     def _compute_dataset_to_tasks(self) -> dict:
-        """
-        Returns the mapping of dataset parent to dataset fold names.
+        """Returns the mapping of dataset parent to dataset fold names.
         For example:
         {
             'DATASET_NAME': ['DATASET_NAME_1', 'DATASET_NAME_2', ..., 'DATASET_NAME_10'],
             ...,
-        }
+        }.
 
         """
         dataset_to_tasks_dict = dict()
@@ -106,21 +115,23 @@ class ZeroshotSimulatorContext:
     def _update_all(self, folds=None):
         if folds is None:
             folds = self.folds
-        self.df_configs, \
-        self.df_baselines, \
-        self.df_configs_ranked, \
-        self.df_metrics, \
-        self.df_metadata, \
-        self.task_to_dataset_dict, \
-        self.dataset_to_folds_dict, \
-        self.dataset_to_tid_dict, \
-        self.dataset_to_problem_type_dict, \
-        self.task_to_fold_dict, \
-        self.folds, \
-        self.unique_tasks, \
-        self.unique_datasets, \
-        self.configs_hyperparameters, \
-        self.rank_scorer = self._align_valid_folds(
+        (
+            self.df_configs,
+            self.df_baselines,
+            self.df_configs_ranked,
+            self.df_metrics,
+            self.df_metadata,
+            self.task_to_dataset_dict,
+            self.dataset_to_folds_dict,
+            self.dataset_to_tid_dict,
+            self.dataset_to_problem_type_dict,
+            self.task_to_fold_dict,
+            self.folds,
+            self.unique_tasks,
+            self.unique_datasets,
+            self.configs_hyperparameters,
+            self.rank_scorer,
+        ) = self._align_valid_folds(
             df_configs=self.df_configs,
             df_baselines=self.df_baselines,
             df_metadata=self.df_metadata,
@@ -164,10 +175,9 @@ class ZeroshotSimulatorContext:
         # assert that each dataset contains only one problem type
         dataset_problem_types = cls._compute_dataset_problem_types(df_configs=df_configs, df_baselines=df_baselines)
 
-        if df_metadata is not None:
-            if "dataset" not in df_metadata and "name" in df_metadata:
-                df_metadata = df_metadata.copy(deep=True)
-                df_metadata["dataset"] = df_metadata["name"]
+        if df_metadata is not None and "dataset" not in df_metadata and "name" in df_metadata:
+            df_metadata = df_metadata.copy(deep=True)
+            df_metadata["dataset"] = df_metadata["name"]
         cls._validate_df_metadata(df_metadata=df_metadata)
 
         df_configs, df_baselines, dataset_tid = cls._align_tid(
@@ -177,10 +187,12 @@ class ZeroshotSimulatorContext:
         )
 
         df_baselines = df_baselines.drop(columns=["tid"], errors="ignore").merge(dataset_tid, on=["dataset"])
-        df_baselines = df_baselines.drop(columns=["problem_type"], errors="ignore").merge(dataset_problem_types, on=["dataset"])
+        df_baselines = df_baselines.drop(columns=["problem_type"], errors="ignore").merge(
+            dataset_problem_types, on=["dataset"]
+        )
 
-        unique_dataset_folds_set = df_configs[['dataset', 'fold']].drop_duplicates()
-        unique_dataset_folds_set_baselines = df_baselines[['dataset', 'fold']].drop_duplicates()
+        unique_dataset_folds_set = df_configs[["dataset", "fold"]].drop_duplicates()
+        unique_dataset_folds_set_baselines = df_baselines[["dataset", "fold"]].drop_duplicates()
         unique_dataset_folds_set_to_concat = [unique_dataset_folds_set, unique_dataset_folds_set_baselines]
         unique_dataset_folds_set_to_concat = [u for u in unique_dataset_folds_set_to_concat if len(u) > 0]
         unique_dataset_folds_set = pd.concat(unique_dataset_folds_set_to_concat, ignore_index=True).drop_duplicates()
@@ -192,13 +204,15 @@ class ZeroshotSimulatorContext:
         sources_to_check.append(("df_configs", df_configs))
 
         for source, df_source in sources_to_check:
-            config_task_counts = df_source[['framework', 'dataset', 'fold']].value_counts()
+            config_task_counts = df_source[["framework", "dataset", "fold"]].value_counts()
             if config_task_counts.max() > 1:
-                raise AssertionError(f'Multiple rows in `{source}` exist for a config task pair! '
-                                     f'There should only ever be one row per config task pair. '
-                                     f'You might have multiple results from re-runs or other bugs that have not been de-duplicated.\n'
-                                     f'Config Task Counts:\n'
-                                     f'{config_task_counts}')
+                raise AssertionError(
+                    f"Multiple rows in `{source}` exist for a config task pair! "
+                    f"There should only ever be one row per config task pair. "
+                    f"You might have multiple results from re-runs or other bugs that have not been de-duplicated.\n"
+                    f"Config Task Counts:\n"
+                    f"{config_task_counts}"
+                )
 
         df_baselines = filter_datasets(df=df_baselines, datasets=unique_dataset_folds_set)
 
@@ -207,25 +221,25 @@ class ZeroshotSimulatorContext:
             df_configs = filter_datasets(df=df_configs, datasets=unique_dataset_folds_set)
             df_baselines = filter_datasets(df=df_baselines, datasets=unique_dataset_folds_set)
 
-        df_configs["task"] = df_configs["tid"].astype(str) + '_' + df_configs["fold"].astype(str)
-        df_baselines["task"] = df_baselines["tid"].astype(str) + '_' + df_baselines["fold"].astype(str)
+        df_configs["task"] = df_configs["tid"].astype(str) + "_" + df_configs["fold"].astype(str)
+        df_baselines["task"] = df_baselines["tid"].astype(str) + "_" + df_baselines["fold"].astype(str)
 
-        unique_tasks = sorted(list(df_configs["task"].unique()))
-        unique_datasets = sorted(list(df_configs["dataset"].unique()))
+        unique_tasks = sorted(df_configs["task"].unique())
+        unique_datasets = sorted(df_configs["dataset"].unique())
 
-        unique_tasks += sorted(list(df_baselines["task"].unique()))
-        unique_datasets += sorted(list(df_baselines["dataset"].unique()))
+        unique_tasks += sorted(df_baselines["task"].unique())
+        unique_datasets += sorted(df_baselines["dataset"].unique())
 
-        unique_tasks = sorted(list(set(unique_tasks)))
-        unique_datasets = sorted(list(set(unique_datasets)))
+        unique_tasks = sorted(set(unique_tasks))
+        unique_datasets = sorted(set(unique_datasets))
 
         unique_folds = cls._compute_folds_from_data(df_configs=df_configs, df_baselines=df_baselines)
 
         # FIXME: Remove scoring via baselines by default all-together, or maybe remove scoring period.
         if score_against_only_automl and len(df_baselines) > 0:
             assert len(df_baselines) != 0, (
-                f"`score_against_only_automl=True`, but `df_baselines` is empty. "
-                f"Either specify `df_baselines` or set `score_against_only_automl=False`."
+                "`score_against_only_automl=True`, but `df_baselines` is empty. "
+                "Either specify `df_baselines` or set `score_against_only_automl=False`."
             )
             df_comparison = df_baselines.copy(deep=True)
         else:
@@ -237,8 +251,9 @@ class ZeroshotSimulatorContext:
         )
         df_configs_ranked = df_configs.copy()
         if len(df_configs_ranked) > 0:
-            df_configs_ranked['rank'] = df_configs_ranked.apply(
-                lambda row: rank_scorer.rank(row["task"], row["metric_error"]), axis=1
+            df_configs_ranked["rank"] = df_configs_ranked.apply(
+                lambda row: rank_scorer.rank(row["task"], row["metric_error"]),
+                axis=1,
             )
         else:
             df_configs_ranked["rank"] = None
@@ -257,7 +272,7 @@ class ZeroshotSimulatorContext:
 
         cls._verify_configs_hyperparameters(configs_hyperparameters=configs_hyperparameters)
         configs_hyperparameters = copy.deepcopy(configs_hyperparameters)
-        unique_configs = sorted(list(df_configs["framework"].unique()))
+        unique_configs = sorted(df_configs["framework"].unique())
         # TODO: Avoid needing to do configs_base, make the names match to begin with
         configs_base = set([cls._config_name_to_config_base(config) for config in unique_configs] + unique_configs)
         configs_hyperparameters_keys = list(configs_hyperparameters.keys())
@@ -265,10 +280,14 @@ class ZeroshotSimulatorContext:
             if c not in configs_base:
                 configs_hyperparameters.pop(c)
 
-        dataset_to_problem_type_dict = df_metrics['problem_type'].to_dict()
+        dataset_to_problem_type_dict = df_metrics["problem_type"].to_dict()
 
-        task_to_fold_dict_configs = df_configs[["task", "fold"]].drop_duplicates().set_index("task").squeeze(axis=1).to_dict()
-        task_to_fold_dict_baselines = df_baselines[["task", "fold"]].drop_duplicates().set_index("task").squeeze(axis=1).to_dict()
+        task_to_fold_dict_configs = (
+            df_configs[["task", "fold"]].drop_duplicates().set_index("task").squeeze(axis=1).to_dict()
+        )
+        task_to_fold_dict_baselines = (
+            df_baselines[["task", "fold"]].drop_duplicates().set_index("task").squeeze(axis=1).to_dict()
+        )
         task_to_fold_dict = copy.copy(task_to_fold_dict_configs)
         for k, v in task_to_fold_dict_baselines.items():
             if k not in task_to_fold_dict:
@@ -277,7 +296,9 @@ class ZeroshotSimulatorContext:
         dataset_to_folds_configs = df_configs[["dataset", "fold"]].drop_duplicates()
         dataset_to_folds_baselines = df_baselines[["dataset", "fold"]].drop_duplicates()
 
-        dataset_to_folds_df = pd.concat([dataset_to_folds_configs, dataset_to_folds_baselines], ignore_index=True).drop_duplicates()
+        dataset_to_folds_df = pd.concat(
+            [dataset_to_folds_configs, dataset_to_folds_baselines], ignore_index=True
+        ).drop_duplicates()
         dataset_to_folds_dict = dataset_to_folds_df.groupby("dataset")["fold"].apply(list).apply(sorted).to_dict()
 
         return (
@@ -301,8 +322,9 @@ class ZeroshotSimulatorContext:
     @staticmethod
     def _validate_df_metadata(df_metadata: pd.DataFrame):
         if df_metadata is not None:
-            assert "dataset" in df_metadata, (f"Missing required `dataset` column in metadata.\n"
-                                              f"Columns: {list(df_metadata.columns)}")
+            assert "dataset" in df_metadata, (
+                f"Missing required `dataset` column in metadata.\nColumns: {list(df_metadata.columns)}"
+            )
             assert len(df_metadata) == len(df_metadata["dataset"].unique())
 
     @staticmethod
@@ -310,29 +332,35 @@ class ZeroshotSimulatorContext:
         if df_metadata is not None:
             df_metadata = copy.deepcopy(df_metadata)
             df_metadata = df_metadata[df_metadata["dataset"].isin(unique_datasets)]
-            metadata_datasets = sorted(list(df_metadata["dataset"].unique()))
-            present_datasets = sorted(list(unique_datasets))
-            if not metadata_datasets == present_datasets:
+            metadata_datasets = sorted(df_metadata["dataset"].unique())
+            present_datasets = sorted(unique_datasets)
+            if metadata_datasets != present_datasets:
                 missing_metadata_datasets = [d for d in present_datasets if d not in metadata_datasets]
                 raise AssertionError(
                     f"Datasets are present in df_configs / df_baselines, but are missing in df_metadata!\n"
-                    f"\t{len(missing_metadata_datasets)} missing datasets: {missing_metadata_datasets}"
+                    f"\t{len(missing_metadata_datasets)} missing datasets: {missing_metadata_datasets}",
                 )
 
             assert len(df_metadata) == len(unique_datasets)
         return df_metadata
 
     @classmethod
-    def _align_tid(cls, df_configs: pd.DataFrame, df_baselines: pd.DataFrame, df_metadata: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-        datasets = sorted(list(set(list(df_configs["dataset"].unique()) + list(df_baselines["dataset"].unique()))))
+    def _align_tid(
+        cls, df_configs: pd.DataFrame, df_baselines: pd.DataFrame, df_metadata: pd.DataFrame
+    ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        datasets = sorted(set(list(df_configs["dataset"].unique()) + list(df_baselines["dataset"].unique())))
         if df_metadata is None or "tid" not in df_metadata.columns:
             if len(df_configs) > 0 and len(df_baselines) > 0:
                 if "tid" in df_configs.columns:
-                    assert "tid" in df_baselines.columns, (f"If `tid` not in df_metadata, then df_configs and df_baselines "
-                                                           f"must both contain `tid` or both not contain `tid` columns.")
+                    assert "tid" in df_baselines.columns, (
+                        "If `tid` not in df_metadata, then df_configs and df_baselines "
+                        "must both contain `tid` or both not contain `tid` columns."
+                    )
                 else:
-                    assert "tid" not in df_baselines.columns, (f"If `tid` not in df_metadata, then df_configs and df_baselines "
-                                                               f"must both contain `tid` or both not contain `tid` columns.")
+                    assert "tid" not in df_baselines.columns, (
+                        "If `tid` not in df_metadata, then df_configs and df_baselines "
+                        "must both contain `tid` or both not contain `tid` columns."
+                    )
 
         df_configs = cls._fillna_tid(df=df_configs, df_metadata=df_metadata, datasets=datasets, name="df_configs")
         df_baselines = cls._fillna_tid(df=df_baselines, df_metadata=df_metadata, datasets=datasets, name="df_baselines")
@@ -342,7 +370,7 @@ class ZeroshotSimulatorContext:
             map_metadata_dataset_tid = df_metadata[["dataset", "tid"]].set_index("dataset")["tid"]
             map_dataset_tid = dataset_tid.set_index("dataset")["tid"]
             if not map_metadata_dataset_tid.loc[map_dataset_tid.index].equals(map_dataset_tid):
-                raise AssertionError(f"Mismatched dataset -> tid map between metadata and configs/baselines!")
+                raise AssertionError("Mismatched dataset -> tid map between metadata and configs/baselines!")
 
         return df_configs, df_baselines, dataset_tid
 
@@ -355,8 +383,10 @@ class ZeroshotSimulatorContext:
                 df["tid"] = df["dataset"].map(dataset_tid_map)
             else:
                 if len(df) > 0:
-                    print(f"Note: `tid` is missing from `{name}` columns. `tid` will be created by mapping the sorted unique `dataset` values to [0, n-1]. "
-                          f"These values will be unrelated to OpenML task IDs.")
+                    print(
+                        f"Note: `tid` is missing from `{name}` columns. `tid` will be created by mapping the sorted unique `dataset` values to [0, n-1]. "
+                        f"These values will be unrelated to OpenML task IDs."
+                    )
                 dataset_tid_map = {d: i for i, d in enumerate(datasets)}
                 df["tid"] = df["dataset"].map(dataset_tid_map).astype(int)
         return df
@@ -371,10 +401,14 @@ class ZeroshotSimulatorContext:
         if len(dataset_tid) != len(dataset_tid["dataset"].unique()):
             dataset_counts = dataset_tid["dataset"].value_counts()
             non_unique_datasets = dataset_counts[dataset_counts > 1]
-            dataset_tid_invalid = dataset_tid[dataset_tid["dataset"].isin(non_unique_datasets.index)].sort_values(by=["dataset", "tid"]).reset_index(drop=True)
+            dataset_tid_invalid = (
+                dataset_tid[dataset_tid["dataset"].isin(non_unique_datasets.index)]
+                .sort_values(by=["dataset", "tid"])
+                .reset_index(drop=True)
+            )
             raise ValueError(
                 f"{len(non_unique_datasets)} invalid datasets encountered! Datasets contain different task IDs (tid) within `df_configs`. "
-                f"Ensure the tid is unique.\nInvalid Datasets:\n{dataset_tid_invalid}"
+                f"Ensure the tid is unique.\nInvalid Datasets:\n{dataset_tid_invalid}",
             )
 
         assert len(dataset_tid) == len(dataset_tid["tid"].unique())
@@ -385,49 +419,56 @@ class ZeroshotSimulatorContext:
         # assert that each dataset contains only one problem type
         dataset_problem_types = df_configs[["dataset", "problem_type"]].drop_duplicates()
         dataset_problem_types_baselines = df_baselines[["dataset", "problem_type"]].drop_duplicates()
-        dataset_problem_types = pd.concat([dataset_problem_types, dataset_problem_types_baselines], ignore_index=True).drop_duplicates()
-        assert len(dataset_problem_types) == len(dataset_problem_types["dataset"].unique()), \
+        dataset_problem_types = pd.concat(
+            [dataset_problem_types, dataset_problem_types_baselines], ignore_index=True
+        ).drop_duplicates()
+        assert len(dataset_problem_types) == len(dataset_problem_types["dataset"].unique()), (
             "Error: datasets exist in `df_configs` that contain multiple problem_types!"
+        )
 
         dataset_problem_types_comparison = df_baselines[["dataset", "problem_type"]].drop_duplicates()
-        assert len(dataset_problem_types_comparison) == len(dataset_problem_types_comparison["dataset"].unique()), \
+        assert len(dataset_problem_types_comparison) == len(dataset_problem_types_comparison["dataset"].unique()), (
             "Error: datasets exist in `df_baselines` that contain multiple problem_types!"
+        )
         dataset_problem_types_map_configs = dataset_problem_types.set_index("dataset").squeeze(axis=1).to_dict()
-        dataset_problem_types_map_baselines = dataset_problem_types_comparison.set_index("dataset").squeeze(axis=1).to_dict()
-        for d in dataset_problem_types_map_configs.keys():
+        dataset_problem_types_map_baselines = (
+            dataset_problem_types_comparison.set_index("dataset").squeeze(axis=1).to_dict()
+        )
+        for d in dataset_problem_types_map_configs:
             problem_type_configs = dataset_problem_types_map_configs[d]
             if d in dataset_problem_types_map_baselines:
                 problem_type_baselines = dataset_problem_types_map_baselines[d]
-                assert problem_type_configs == problem_type_baselines, \
-                    (f"Error: Dataset `{d}` has a different `problem_type` between `df_configs` and `df_baselines`. They must match:\n"
-                     f"\tdf_configs  : {problem_type_configs}\n"
-                     f"\tdf_baselines: {problem_type_baselines}")
+                assert problem_type_configs == problem_type_baselines, (
+                    f"Error: Dataset `{d}` has a different `problem_type` between `df_configs` and `df_baselines`. They must match:\n"
+                    f"\tdf_configs  : {problem_type_configs}\n"
+                    f"\tdf_baselines: {problem_type_baselines}"
+                )
         return dataset_problem_types
 
     def df_dataset_folds(self) -> pd.DataFrame:
-        df_dataset_folds = self.df_configs[["dataset", "fold"]].drop_duplicates().reset_index(drop=True)
-        return df_dataset_folds
+        return self.df_configs[["dataset", "fold"]].drop_duplicates().reset_index(drop=True)
 
     def dataset_folds(self) -> list[tuple]:
         dataset_folds = self.df_dataset_folds().values.tolist()
-        dataset_folds = [tuple(dataset_fold) for dataset_fold in dataset_folds]
-        return dataset_folds
+        return [tuple(dataset_fold) for dataset_fold in dataset_folds]
 
     def dataset_to_folds(self, dataset: str) -> list[int]:
         return self.dataset_to_folds_dict[dataset]
 
     @staticmethod
-    def _validate_df(df: pd.DataFrame, name: str, required_columns: List[str]):
+    def _validate_df(df: pd.DataFrame, name: str, required_columns: list[str]):
         df_columns = list(df.columns)
         missing_required_columns = [c for c in required_columns if c not in df_columns]
         if missing_required_columns:
             present_required_columns = [c for c in required_columns if c in df_columns]
             present_extra_columns = [c for c in df_columns if c not in required_columns]
-            raise AssertionError(f"Missing required columns in `{name}`:\n"
-                                 f"\tMissing Required: {missing_required_columns}\n"
-                                 f"\tPresent Required: {present_required_columns}\n"
-                                 f"\tPresent    Extra: {present_extra_columns}\n"
-                                 f"{df}")
+            raise AssertionError(
+                f"Missing required columns in `{name}`:\n"
+                f"\tMissing Required: {missing_required_columns}\n"
+                f"\tPresent Required: {present_required_columns}\n"
+                f"\tPresent    Extra: {present_extra_columns}\n"
+                f"{df}"
+            )
 
     @classmethod
     def _validate_df_configs(cls, df_configs: pd.DataFrame):
@@ -463,30 +504,34 @@ class ZeroshotSimulatorContext:
         cls._validate_df(df=df_baselines, name="df_baselines", required_columns=required_columns)
 
     def print_info(self):
-        out = '====== Zeroshot Simulator Context Info ======\n'
-        out += f'# Configs: {len(self.get_configs())}\n'
+        out = "====== Zeroshot Simulator Context Info ======\n"
+        out += f"# Configs: {len(self.get_configs())}\n"
         out += f"# Baselines: {len(self.get_baselines())}\n"
-        out += f'# Datasets: {len(self.unique_datasets)}\n'
+        out += f"# Datasets: {len(self.unique_datasets)}\n"
         if self.folds is not None:
-            out += f'# Folds: {len(self.folds)}\n'
-            out += f'Folds: {self.folds}\n'
-        out += f'# Folds*Datasets: {len(self.unique_tasks)}\n'
-        out += '=============================================\n'
+            out += f"# Folds: {len(self.folds)}\n"
+            out += f"Folds: {self.folds}\n"
+        out += f"# Folds*Datasets: {len(self.unique_tasks)}\n"
+        out += "=============================================\n"
         print(out)
 
     def get_datasets(
         self,
         *,
-        configs: list[str] = None,
-        problem_type: str | list[str] = None,
+        configs: list[str] | None = None,
+        problem_type: str | list[str] | None = None,
         union: bool = True,
     ) -> list[str]:
         datasets = self.unique_datasets
         if problem_type is not None:
             if isinstance(problem_type, list):
-                datasets = [dataset for dataset in datasets if self.dataset_to_problem_type_dict[dataset] in problem_type]
+                datasets = [
+                    dataset for dataset in datasets if self.dataset_to_problem_type_dict[dataset] in problem_type
+                ]
             else:
-                datasets = [dataset for dataset in datasets if self.dataset_to_problem_type_dict[dataset] == problem_type]
+                datasets = [
+                    dataset for dataset in datasets if self.dataset_to_problem_type_dict[dataset] == problem_type
+                ]
         df_configs = self.df_configs
         if configs is not None:
             configs_set = set(configs)
@@ -501,7 +546,12 @@ class ZeroshotSimulatorContext:
             df_configs_filtered = df_configs[df_configs["framework"].isin(configs_set)]
             value_counts = df_configs_filtered.value_counts(["dataset", "fold"])
             value_counts_valid = value_counts[value_counts == n_configs]
-            dataset_value_counts = value_counts_valid.reset_index(drop=False)[["dataset", "count"]].groupby("dataset")["count"].sum().to_dict()
+            dataset_value_counts = (
+                value_counts_valid.reset_index(drop=False)[["dataset", "count"]]
+                .groupby("dataset")["count"]
+                .sum()
+                .to_dict()
+            )
             dataset_fold_counts = {d: len(folds) for d, folds in self.dataset_to_folds_dict.items()}
 
             # filter to only datasets that contain all configs
@@ -511,31 +561,30 @@ class ZeroshotSimulatorContext:
     def task_to_fold(self, task) -> int:
         return self.task_to_fold_dict[task]
 
-    def get_tids(self, problem_type=None) -> List[int]:
+    def get_tids(self, problem_type=None) -> list[int]:
         datasets = self.get_datasets(problem_type=problem_type)
-        tids = [self.dataset_to_tid_dict[dataset] for dataset in datasets]
-        return tids
+        return [self.dataset_to_tid_dict[dataset] for dataset in datasets]
 
     def get_tasks(
         self,
-        datasets: list[str] = None,
-        problem_type: str | list[str] = None,
+        datasets: list[str] | None = None,
+        problem_type: str | list[str] | None = None,
         as_dataset_fold: bool = False,
     ) -> list[str] | list[tuple[str, int]]:
-        """
-        :param datasets: a list of dataset parent names, only return folds that have a parent in this list
+        """:param datasets: a list of dataset parent names, only return folds that have a parent in this list
         :param problem_type: a problem type from AutoGluon in "multiclass", "binary", ... or list of problem types
         :return: List of datasets-folds formatted as `['359987_8', '359933_3', ...]` where the dataset is encoded before
         the "_" and the fold after.
         """
-        if datasets is not None:
-            tasks = self._get_tasks_from_datasets(datasets=datasets)
-        else:
-            tasks = self.unique_tasks
+        tasks = self._get_tasks_from_datasets(datasets=datasets) if datasets is not None else self.unique_tasks
         if problem_type is not None:
             if not isinstance(problem_type, list):
                 problem_type = [problem_type]
-            tasks = [task for task in tasks if self.dataset_to_problem_type_dict[self.task_to_dataset_dict[task]] in problem_type]
+            tasks = [
+                task
+                for task in tasks
+                if self.dataset_to_problem_type_dict[self.task_to_dataset_dict[task]] in problem_type
+            ]
         if as_dataset_fold:
             tasks = [self._task_to_dataset_fold(task) for task in tasks]
         return tasks
@@ -545,7 +594,7 @@ class ZeroshotSimulatorContext:
         dataset = self.tid_to_dataset_dict[tid]
         return dataset, fold
 
-    def _get_tasks_from_datasets(self, datasets: List[str]):
+    def _get_tasks_from_datasets(self, datasets: list[str]):
         dataset_folds = []
         for d in datasets:
             dataset_folds += self.dataset_to_tasks_dict[d]
@@ -559,9 +608,15 @@ class ZeroshotSimulatorContext:
     def task_name_from_tid(tid: int, fold: int) -> str:
         return f"{tid}_{fold}"
 
-    def get_configs(self, *, datasets: list[str] = None, tasks: list[tuple[str, int]] = None, config_types: list[str] = None, union: bool = True) -> list[str]:
-        """
-        Return all valid configs.
+    def get_configs(
+        self,
+        *,
+        datasets: list[str] | None = None,
+        tasks: list[tuple[str, int]] | None = None,
+        config_types: list[str] | None = None,
+        union: bool = True,
+    ) -> list[str]:
+        """Return all valid configs.
         By default, will return all configs that appear in any task at least once.
 
         Parameters
@@ -576,7 +631,7 @@ class ZeroshotSimulatorContext:
             If True, will return the union of configs present in each task.
             If False, will return the intersection of configs present in each task.
 
-        Returns
+        Returns:
         -------
         A list of config names satisfying the above conditions.
         """
@@ -590,12 +645,12 @@ class ZeroshotSimulatorContext:
             configs = [c for c in configs if configs_type[c] in config_types]
         return configs
 
-    def load_groundtruth(self, paths_gt: List[str]) -> GroundTruth:
+    def load_groundtruth(self, paths_gt: list[str]) -> GroundTruth:
         gt_val = defaultdict(_default_dict)
         gt_test = defaultdict(_default_dict)
         unique_datasets = set(self.unique_datasets)
         for p in paths_gt:
-            with open(Path(p).parent / "metadata.json", "r") as f:
+            with open(Path(p).parent / "metadata.json") as f:
                 metadata = json.load(f)
             dataset = metadata["dataset"]
             if dataset in unique_datasets:
@@ -606,41 +661,42 @@ class ZeroshotSimulatorContext:
                     gt_val[dataset][fold] = pd.read_csv(p, index_col=0)
         return GroundTruth(label_val_dict=gt_val, label_test_dict=gt_test)
 
-    def load_pred(self, path_pred_proba: Union[Path, str], datasets: List[str], prediction_format: str = "memmap") -> TabularModelPredictions:
-        """
-        :param prediction_format: Determines the format of the loaded tabular_predictions. Default = "memmap".
-            "memmap": Fast and low memory usage.
-            "memopt": Very fast and high memory usage.
-            "mem": Slow and high memory usage, simplest format to debug.
+    def load_pred(
+        self, path_pred_proba: Path | str, datasets: list[str], prediction_format: str = "memmap"
+    ) -> TabularModelPredictions:
+        """:param prediction_format: Determines the format of the loaded tabular_predictions. Default = "memmap".
+        "memmap": Fast and low memory usage.
+        "memopt": Very fast and high memory usage.
+        "mem": Slow and high memory usage, simplest format to debug.
         """
         assert prediction_format in ["memmap", "memopt", "mem"]
 
         class_map = {
             "memmap": TabularPredictionsMemmap,
             "memopt": TabularPredictionsInMemoryOpt,
-            "mem": TabularPredictionsInMemory
+            "mem": TabularPredictionsInMemory,
         }
 
         path_pred_proba = Path(path_pred_proba)
-        zeroshot_pred_proba: TabularModelPredictions = class_map[prediction_format].from_data_dir(data_dir=path_pred_proba, datasets=datasets)
+        zeroshot_pred_proba: TabularModelPredictions = class_map[prediction_format].from_data_dir(
+            data_dir=path_pred_proba, datasets=datasets
+        )
         all_datasets = self.get_datasets()
         valid_datasets = [d for d in zeroshot_pred_proba.datasets if d in all_datasets]
         zeroshot_pred_proba.restrict_datasets(datasets=valid_datasets)
         return zeroshot_pred_proba
 
-    def subset_datasets(self, datasets: List[str], only_configs: bool = False):
-        """
-        Only keep the provided datasets, drop all others
-        """
+    def subset_datasets(self, datasets: list[str], only_configs: bool = False):
+        """Only keep the provided datasets, drop all others."""
         for d in datasets:
             if d not in self.unique_datasets:
-                raise ValueError(f'Missing expected dataset {d} in ZeroshotSimulatorContext!')
+                raise ValueError(f"Missing expected dataset {d} in ZeroshotSimulatorContext!")
 
         # Remove datasets from internal dataframes
         self.df_configs = self.df_configs[self.df_configs["dataset"].isin(datasets)]
         self.df_configs_ranked = self.df_configs_ranked[self.df_configs_ranked["dataset"].isin(datasets)]
         if only_configs:
-            datasets_baselines = list(set(list(self.df_baselines["dataset"])))
+            datasets_baselines = list(set(self.df_baselines["dataset"]))
             datasets = [d for d in self.unique_datasets if d in datasets or d in datasets_baselines]
         unique_datasets_subset = []
         for d in self.unique_datasets:
@@ -658,33 +714,21 @@ class ZeroshotSimulatorContext:
 
     @classmethod
     def _compute_folds_from_data(cls, df_configs: pd.DataFrame, df_baselines: pd.DataFrame) -> list[int]:
-        return sorted(list(set(list(df_configs["fold"].unique()) + list(df_baselines["fold"].unique()))))
+        return sorted(set(list(df_configs["fold"].unique()) + list(df_baselines["fold"].unique())))
 
-    def subset_configs(self, configs: List[str]):
-        """
-        Only keep the provided configs, drop all others
-        """
-        self.df_configs = self.df_configs[
-            self.df_configs['framework'].isin(configs)
-        ]
-        self.df_configs_ranked = self.df_configs_ranked[
-            self.df_configs_ranked['framework'].isin(configs)
-        ]
+    def subset_configs(self, configs: list[str]):
+        """Only keep the provided configs, drop all others."""
+        self.df_configs = self.df_configs[self.df_configs["framework"].isin(configs)]
+        self.df_configs_ranked = self.df_configs_ranked[self.df_configs_ranked["framework"].isin(configs)]
         self._update_all()
 
-    def subset_baselines(self, baselines: List[str]):
-        """
-        Only keep the provided configs, drop all others
-        """
-        self.df_baselines = self.df_baselines[
-            self.df_baselines['framework'].isin(baselines)
-        ]
+    def subset_baselines(self, baselines: list[str]):
+        """Only keep the provided configs, drop all others."""
+        self.df_baselines = self.df_baselines[self.df_baselines["framework"].isin(baselines)]
         self._update_all()
 
-    def subset_folds(self, folds: List[int]):
-        """
-        Only keep the provided folds, drop all others
-        """
+    def subset_folds(self, folds: list[int]):
+        """Only keep the provided folds, drop all others."""
         self._update_all(folds=folds)
 
     def _update_unique_datasets(self, unique_datasets):
@@ -699,9 +743,8 @@ class ZeroshotSimulatorContext:
         self.unique_tasks = unique_tasks
         self.dataset_to_tasks_dict = dataset_to_tasks_dict
 
-    def _get_configs_from_df(self, df: pd.DataFrame, union: bool = True) -> List[str]:
-        """
-        Parameters
+    def _get_configs_from_df(self, df: pd.DataFrame, union: bool = True) -> list[str]:
+        """Parameters
         ----------
         df: pd.DataFrame
             A DataFrame containing the columns "task" and "framework".
@@ -709,7 +752,7 @@ class ZeroshotSimulatorContext:
             If True, will return the union of configs present in each task.
             If False, will return the intersection of configs present in each task.
 
-        Returns
+        Returns:
         -------
         The list of "framework" values present in `df` that satisfy the `union` value logic.
         """
@@ -721,17 +764,15 @@ class ZeroshotSimulatorContext:
             res = None
             for task in tasks:
                 methods = set(df.loc[df["task"] == task, "framework"].unique())
-                if res is None:
-                    res = methods
-                else:
-                    res = res.intersection(methods)
+                res = methods if res is None else res.intersection(methods)
         if res is None:
             res = []
-        return sorted(list(res))
+        return sorted(res)
 
-    def get_baselines(self, *, datasets: list[str] = None, tasks: list[tuple[str, int]] = None, union: bool = True) -> list[str]:
-        """
-        Return all valid baselines.
+    def get_baselines(
+        self, *, datasets: list[str] | None = None, tasks: list[tuple[str, int]] | None = None, union: bool = True
+    ) -> list[str]:
+        """Return all valid baselines.
         By default, will return all baselines that appear in any task at least once.
 
         Parameters
@@ -744,7 +785,7 @@ class ZeroshotSimulatorContext:
             If True, will return the union of baselines in each task.
             If False, will return the intersection of baselines present in each task.
 
-        Returns
+        Returns:
         -------
         A list of baseline names satisfying the above conditions.
         """
@@ -754,27 +795,35 @@ class ZeroshotSimulatorContext:
         df = self._filter_df_by_datasets(df=df, datasets=datasets, tasks=tasks)
         return self._get_configs_from_df(df=df, union=union)
 
-    def _filter_df_by_datasets(self, df: pd.DataFrame, configs: list[str] = None, datasets: list[str] = None, tasks: list[tuple[str, int]] = None) -> pd.DataFrame:
+    def _filter_df_by_datasets(
+        self,
+        df: pd.DataFrame,
+        configs: list[str] | None = None,
+        datasets: list[str] | None = None,
+        tasks: list[tuple[str, int]] | None = None,
+    ) -> pd.DataFrame:
         if configs is not None:
             df = df[df["framework"].isin(configs)]
         if datasets is not None:
             datasets_all = set(self.get_datasets())
             datasets_invalid = set(datasets).difference(datasets_all)
             if len(datasets_invalid) != 0:
-                raise ValueError(f"Invalid datasets specified: {sorted(list(datasets_invalid))}")
+                raise ValueError(f"Invalid datasets specified: {sorted(datasets_invalid)}")
             df = df[df["dataset"].isin(datasets)]
         if tasks is not None:
             tasks_all = set(self.get_tasks(as_dataset_fold=True))
             tasks_invalid = set(tasks).difference(tasks_all)
             if len(tasks_invalid) != 0:
-                raise ValueError(f"Invalid tasks specified: {sorted(list(tasks_invalid))}")
+                raise ValueError(f"Invalid tasks specified: {sorted(tasks_invalid)}")
 
             tasks_df = pd.DataFrame(tasks, columns=["dataset", "fold"])
             df = df.merge(tasks_df, on=["dataset", "fold"])
 
         return df
 
-    def get_configs_hyperparameters(self, configs: List[str] | None = None, include_ag_args: bool = True) -> dict[str, dict | None]:
+    def get_configs_hyperparameters(
+        self, configs: list[str] | None = None, include_ag_args: bool = True
+    ) -> dict[str, dict | None]:
         if configs is None:
             configs = self.get_configs()
         else:
@@ -782,9 +831,14 @@ class ZeroshotSimulatorContext:
             for config in configs:
                 if config not in valid_configs:
                     raise ValueError(f"User-specified config does not exist: '{config}'")
-        return {c: self.get_config_hyperparameters(config=c, include_ag_args=include_ag_args, check_valid=False) for c in configs}
+        return {
+            c: self.get_config_hyperparameters(config=c, include_ag_args=include_ag_args, check_valid=False)
+            for c in configs
+        }
 
-    def get_config_hyperparameters(self, config: str, include_ag_args: bool = True, check_valid: bool = True) -> dict | None:
+    def get_config_hyperparameters(
+        self, config: str, include_ag_args: bool = True, check_valid: bool = True
+    ) -> dict | None:
         if check_valid and config not in self.get_configs():
             raise ValueError(f"User-specified config does not exist: '{config}'")
         if self.configs_hyperparameters is None:
@@ -809,8 +863,7 @@ class ZeroshotSimulatorContext:
 
     @property
     def configs_type(self) -> dict[str, str | None]:
-        """
-        Returns a dict of config name -> config type.
+        """Returns a dict of config name -> config type.
         If model type is unknown, the value will be `None`.
 
         For example:
@@ -827,7 +880,7 @@ class ZeroshotSimulatorContext:
                 configs_type[config] = config_hyperparameters.get("model_type", None)
         return configs_type
 
-    def df_configs_task(self, dataset: str, fold: int, configs: list[str] = None) -> pd.DataFrame:
+    def df_configs_task(self, dataset: str, fold: int, configs: list[str] | None = None) -> pd.DataFrame:
         df_configs_task = self.df_configs[(self.df_configs["dataset"] == dataset) & (self.df_configs["fold"] == fold)]
         if configs is not None:
             configs = set(configs)
@@ -835,16 +888,29 @@ class ZeroshotSimulatorContext:
         return df_configs_task
 
     # TODO: Support max_models and max_models_per_type for simulation
-    def get_top_configs(self, dataset: str, fold: int, configs: list[str] = None, max_models: int = None, max_models_per_type: int = None) -> List[str]:
+    def get_top_configs(
+        self,
+        dataset: str,
+        fold: int,
+        configs: list[str] | None = None,
+        max_models: int | None = None,
+        max_models_per_type: int | None = None,
+    ) -> list[str]:
         df_configs_task = self.df_configs_task(dataset=dataset, fold=fold, configs=configs)
         df_configs_task_sorted = df_configs_task.sort_values(by=["metric_error_val", "framework"])
         df_configs_task_sorted["type"] = df_configs_task_sorted["framework"].map(self.configs_type).fillna("nan")
 
         if max_models_per_type is not None:
-            df_configs_task_sorted["rank_by_type"] = df_configs_task_sorted.groupby(["type", "task"])["metric_error_val"].rank("first").astype(int)
-            df_configs_task_sorted = df_configs_task_sorted[df_configs_task_sorted["rank_by_type"] <= max_models_per_type]
+            df_configs_task_sorted["rank_by_type"] = (
+                df_configs_task_sorted.groupby(["type", "task"])["metric_error_val"].rank("first").astype(int)
+            )
+            df_configs_task_sorted = df_configs_task_sorted[
+                df_configs_task_sorted["rank_by_type"] <= max_models_per_type
+            ]
         if max_models is not None:
-            df_configs_task_sorted["rank"] = df_configs_task_sorted.groupby("task")["metric_error_val"].rank("first").astype(int)
+            df_configs_task_sorted["rank"] = (
+                df_configs_task_sorted.groupby("task")["metric_error_val"].rank("first").astype(int)
+            )
             df_configs_task_sorted = df_configs_task_sorted[df_configs_task_sorted["rank"] <= max_models]
         return list(df_configs_task_sorted["framework"])
 
@@ -854,10 +920,16 @@ class ZeroshotSimulatorContext:
     @classmethod
     def _verify_configs_hyperparameters(cls, configs_hyperparameters: dict[str, dict[str, str | dict]]):
         for config, v in configs_hyperparameters.items():
-            assert isinstance(v, dict), f"configs_hyperparameters value for key {config} must be of type dict, found: {type(v)}"
-            assert "hyperparameters" in v, f"configs_hyperparameters value for key {config} must include a `hyperparameters` key"
-            assert isinstance(v["hyperparameters"], dict), (f"configs_hyperparameters['{config}']['hyperparameters'] "
-                                                            f"must be of type dict, found: {type(v['hyperparameters'])}")
+            assert isinstance(v, dict), (
+                f"configs_hyperparameters value for key {config} must be of type dict, found: {type(v)}"
+            )
+            assert "hyperparameters" in v, (
+                f"configs_hyperparameters value for key {config} must include a `hyperparameters` key"
+            )
+            assert isinstance(v["hyperparameters"], dict), (
+                f"configs_hyperparameters['{config}']['hyperparameters'] "
+                f"must be of type dict, found: {type(v['hyperparameters'])}"
+            )
 
     @classmethod
     def _create_empty_df_configs(cls) -> pd.DataFrame:
@@ -872,8 +944,7 @@ class ZeroshotSimulatorContext:
             "time_train_s",
             "time_infer_s",
         ]
-        df_configs = pd.DataFrame(columns=required_columns)
-        return df_configs
+        return pd.DataFrame(columns=required_columns)
 
     @classmethod
     def _create_empty_df_baselines(cls) -> pd.DataFrame:
@@ -887,8 +958,7 @@ class ZeroshotSimulatorContext:
             "time_train_s",
             "time_infer_s",
         ]
-        df_baselines = pd.DataFrame(columns=required_columns)
-        return df_baselines
+        return pd.DataFrame(columns=required_columns)
 
     def to_dir(self, path: str) -> dict:
         path_configs = "configs.parquet"

--- a/packages/tabarena/src/tabarena/simulation/single_best_config_scorer.py
+++ b/packages/tabarena/src/tabarena/simulation/single_best_config_scorer.py
@@ -1,23 +1,26 @@
-from typing import List, TYPE_CHECKING
+from __future__ import annotations
 
-import pandas as pd
+from typing import TYPE_CHECKING
 
 from .configuration_list_scorer import ConfigurationListScorer
 
 if TYPE_CHECKING:
-    from ..repository.abstract_repository import AbstractRepository
+    import pandas as pd
+
+    from tabarena.repository.abstract_repository import AbstractRepository
 
 
 class SingleBestConfigScorer(ConfigurationListScorer):
-    def __init__(self,
-                 df_results: pd.DataFrame,
-                 tasks: List[str] = None,
-                 score_col: str = 'rank',
-                 score_val_col: str = 'metric_error_val',
-                 model_col: str = 'framework',
-                 task_col: str = 'task'):
-        """
-        Enables to score the best configuration from a given list of configuration.
+    def __init__(
+        self,
+        df_results: pd.DataFrame,
+        tasks: list[str] | None = None,
+        score_col: str = "rank",
+        score_val_col: str = "metric_error_val",
+        model_col: str = "framework",
+        task_col: str = "task",
+    ):
+        """Enables to score the best configuration from a given list of configuration.
         The configuration selected is the one with the lowest validation score is selected and its test-score
         is returned.
         :param df_results: dataframe with results on base models on each dataset/fold.
@@ -35,14 +38,15 @@ class SingleBestConfigScorer(ConfigurationListScorer):
         self.model_col = model_col
         self.task_col = task_col
         if tasks is not None:
-            df_results = df_results[
-                df_results[task_col].isin(tasks)]
+            df_results = df_results[df_results[task_col].isin(tasks)]
         self.df_results = df_results
         self.datasets = list(self.df_results[task_col].unique())
-        self.df_pivot_val = self.df_results.pivot_table(index=self.model_col, columns=self.task_col, values=self.score_val_col)
+        self.df_pivot_val = self.df_results.pivot_table(
+            index=self.model_col, columns=self.task_col, values=self.score_val_col
+        )
 
     @classmethod
-    def from_repo(cls, repo: "AbstractRepository", **kwargs):
+    def from_repo(cls, repo: AbstractRepository, **kwargs):
         return cls(
             df_results=repo._zeroshot_context.df_configs_ranked,
             **kwargs,
@@ -50,18 +54,16 @@ class SingleBestConfigScorer(ConfigurationListScorer):
 
     def get_best_validation_configs_df(self, configs: list) -> pd.DataFrame:
         best_val_model_series = self.df_pivot_val.loc[configs].idxmin(axis=0).to_frame(name=self.model_col)
-        best_val_model_by_dataset_df = self.df_results.merge(best_val_model_series, on=[self.task_col, self.model_col])
-        return best_val_model_by_dataset_df
+        return self.df_results.merge(best_val_model_series, on=[self.task_col, self.model_col])
 
-    def score_per_dataset(self, configs: List[str], score_col=None) -> dict:
+    def score_per_dataset(self, configs: list[str], score_col=None) -> dict:
         if score_col is None:
             score_col = self.score_col
         best_val_model_by_dataset_df = self.get_best_validation_configs_df(configs=configs)
         return best_val_model_by_dataset_df[[self.task_col, score_col]].set_index(self.task_col).squeeze().to_dict()
 
-    def score(self, configs: List[str]) -> float:
-        """
-        :param configs: list of configuration to select from. The test score of the configuration with the best
+    def score(self, configs: list[str]) -> float:
+        """:param configs: list of configuration to select from. The test score of the configuration with the best
         validation score is returned.
         :return: the test-error selected with validation scores making sure that the test scores of each model are not
         used for the selection.
@@ -69,16 +71,13 @@ class SingleBestConfigScorer(ConfigurationListScorer):
         best_val_model_by_dataset_df = self.get_best_validation_configs_df(configs=configs)
         # this is the error without knowing the test score of each model and oracle picking the best,
         # instead using validation score to pick best
-        avg_error_real = best_val_model_by_dataset_df[self.score_col].mean()
-        return avg_error_real
+        return best_val_model_by_dataset_df[self.score_col].mean()
 
     def compute_errors(self, configs: list):
-        errors = self.score_per_dataset(score_col='metric_error', configs=configs)
-        return errors
+        return self.score_per_dataset(score_col="metric_error", configs=configs)
 
-    def subset(self, tasks: List[str]) -> "SingleBestConfigScorer":
-        """
-        :param tasks:
+    def subset(self, tasks: list[str]) -> SingleBestConfigScorer:
+        """:param tasks:
         :return: a scorer only considering the datasets passed as argument which can be used to evaluate performance
         on hold-out datasets.
         """
@@ -90,4 +89,3 @@ class SingleBestConfigScorer(ConfigurationListScorer):
             model_col=self.model_col,
             task_col=self.task_col,
         )
-

--- a/packages/tabarena/src/tabarena/tools/sync_pyproject_extras.py
+++ b/packages/tabarena/src/tabarena/tools/sync_pyproject_extras.py
@@ -36,10 +36,7 @@ def _expected_extras() -> dict[str, list[str]]:
         # TabICLv2 into the "tabicl" extra.
         module = info.model_cls.__module__
         parts = module.split(".")
-        if "ag" in parts:
-            folder = parts[parts.index("ag") + 1]
-        else:
-            folder = parts[-2] if len(parts) >= 2 else parts[-1]
+        folder = parts[parts.index("ag") + 1] if "ag" in parts else parts[-2] if len(parts) >= 2 else parts[-1]
         for spec in info.pip_extra:
             extras[folder].add(spec)
     return {k: sorted(v) for k, v in extras.items() if v}
@@ -52,11 +49,13 @@ def _pyproject_extras(pyproject_path: Path) -> dict[str, list[str]]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--check", action="store_true",
-                        help="Exit non-zero on drift.")
-    parser.add_argument("--pyproject", type=Path,
-                        default=Path(__file__).resolve().parents[3] / "pyproject.toml",
-                        help="Path to pyproject.toml (default: packages/tabarena/pyproject.toml).")
+    parser.add_argument("--check", action="store_true", help="Exit non-zero on drift.")
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path(__file__).resolve().parents[3] / "pyproject.toml",
+        help="Path to pyproject.toml (default: packages/tabarena/pyproject.toml).",
+    )
     args = parser.parse_args()
 
     expected = _expected_extras()

--- a/packages/tabarena/src/tabarena/utils/__init__.py
+++ b/packages/tabarena/src/tabarena/utils/__init__.py
@@ -1,11 +1,12 @@
-from typing import Tuple
+from __future__ import annotations
 
 from contextlib import contextmanager
 from time import perf_counter
+from typing import Tuple
 
 
 @contextmanager
-def catchtime(name: str, logger = None) -> float:
+def catchtime(name: str, logger=None) -> float:
     start = perf_counter()
     print_fun = print if logger is None else logger.info
     try:
@@ -23,7 +24,7 @@ def task_to_fold(task: str) -> int:
     return int(task.rsplit("_", 1)[1])
 
 
-def task_to_tid_fold(task: str) -> Tuple[int, int]:
+def task_to_tid_fold(task: str) -> tuple[int, int]:
     dataset_fold = task.rsplit("_", 1)
     tid = int(dataset_fold[0])
     fold = int(dataset_fold[1])

--- a/packages/tabarena/src/tabarena/utils/cache.py
+++ b/packages/tabarena/src/tabarena/utils/cache.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 import os
-from typing import Union
-
-import pandas as pd
 import pickle
 import sys
-import boto3
-from pathlib import Path
 from contextlib import contextmanager
-from time import perf_counter
 from dataclasses import dataclass
-from typing import Callable, Generic, Optional, TypeVar
+from pathlib import Path
+from time import perf_counter
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+import boto3
+import pandas as pd
 
 from tabarena.utils.pickle_utils import dumps_pickle, load_pickle
 
@@ -26,11 +25,13 @@ def _default_compress_results() -> bool:
     """
     return os.environ.get("TABARENA_DISABLE_RESULT_COMPRESSION", "").strip().lower() not in ("1", "true", "yes")
 
+
 from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
 from autogluon.common.utils import s3_utils
 
-from tabarena.utils import catchtime
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 default_cache_path = Path("~/cache-zeroshot/").expanduser()
 
@@ -59,13 +60,7 @@ class AbstractCacheFunction(Generic[T]):
     ) -> T:
         exists = self.exists
         cache_file = self.cache_file
-        if exists:
-            if ignore_cache:
-                run = True
-            else:
-                run = False
-        else:
-            run = True
+        run = (bool(ignore_cache)) if exists else True
 
         if run:
             msg = f'Generating cache (exists={exists}, ignore_cache={ignore_cache}, cache_file="{cache_file}")'
@@ -82,18 +77,16 @@ class AbstractCacheFunction(Generic[T]):
                 self.save_cache(data=data)
         if self._save_after_run and self._load_after_cache:
             return self.load_cache()
-        else:
-            return data
+        return data
 
     def _run(self, fun: Callable[..., T], fun_kwargs: dict | None = None) -> T:
-        assert fun is not None, f"`fun` must not be None if a saving a new cache is required!"
+        assert fun is not None, "`fun` must not be None if a saving a new cache is required!"
         if fun_kwargs is None:
             fun_kwargs = {}
         assert isinstance(fun_kwargs, dict)
         if self.include_self_in_call:
             return fun(cacher=self, **fun_kwargs)
-        else:
-            return fun(**fun_kwargs)
+        return fun(**fun_kwargs)
 
     @property
     def exists(self) -> bool:
@@ -112,9 +105,8 @@ class AbstractCacheFunction(Generic[T]):
 
 # TODO: Avoid storing results as pickle for safety
 class CacheFunctionDummy(AbstractCacheFunction[object]):
-    """
-    No caching
-    """
+    """No caching."""
+
     _save_after_run = False
     _load_after_cache = False
 
@@ -132,16 +124,23 @@ class CacheFunctionDummy(AbstractCacheFunction[object]):
 
 # TODO: Avoid storing results as pickle for safety
 class CacheFunctionPickle(AbstractCacheFunction[object]):
-    """
-    Note: This is unsafe. Know that loading pickle files can execute arbitrary code.
+    """Note: This is unsafe. Know that loading pickle files can execute arbitrary code.
     Only use this for trusted cache files, and consider switching to a safe cache format as soon as possible.
 
     Most generic cache function that saves and loads pickle files.
     Should work with almost any function.
     """
+
     _load_after_cache = False  # Loading a pickle is unnecessary when the contents are already in memory
 
-    def __init__(self, cache_name: str, cache_path: Path | str | None = None, include_self_in_call: bool = False, verbose: bool = True, compress: bool | None = None):
+    def __init__(
+        self,
+        cache_name: str,
+        cache_path: Path | str | None = None,
+        include_self_in_call: bool = False,
+        verbose: bool = True,
+        compress: bool | None = None,
+    ):
         super().__init__(include_self_in_call=include_self_in_call, verbose=verbose)
         self.cache_name = cache_name
         if cache_path is None:
@@ -166,40 +165,37 @@ class CacheFunctionPickle(AbstractCacheFunction[object]):
     def exists(self) -> bool:
         if self.is_s3:
             try:
-                s3 = boto3.client('s3')
+                s3 = boto3.client("s3")
                 bucket, key = s3_utils.s3_path_to_bucket_prefix(self.cache_file)
                 s3.head_object(Bucket=bucket, Key=key)
                 return True
             except s3.exceptions.ClientError as e:
-                if e.response['Error']['Code'] == '404':
+                if e.response["Error"]["Code"] == "404":
                     return False
-                else:
-                    raise
+                raise
         else:
             return Path(self.cache_file).exists()
 
     def save_cache(self, data: object) -> None:
         cache = dumps_pickle(data, compress=self.compress)
         if self.is_s3:
-            s3 = boto3.client('s3')
+            s3 = boto3.client("s3")
             bucket, key = s3_utils.s3_path_to_bucket_prefix(self.cache_file)
             if self.verbose:
-                print(f'Writing cache with size {round(sys.getsizeof(cache) / 1e6, 3)} MB to {self.cache_file}')
+                print(f"Writing cache with size {round(sys.getsizeof(cache) / 1e6, 3)} MB to {self.cache_file}")
             s3.put_object(Bucket=bucket, Key=key, Body=cache)
         else:
             cache_file = self.cache_file
             Path(cache_file).parent.mkdir(parents=True, exist_ok=True)
             with open(cache_file, "wb") as f:
                 if self.verbose:
-                    print(f'Writing cache with size {round(sys.getsizeof(cache) / 1e6, 3)} MB')
+                    print(f"Writing cache with size {round(sys.getsizeof(cache) / 1e6, 3)} MB")
                 f.write(cache)
 
     def delete_cache(self):
         if self.is_s3:
             raise NotImplementedError("Deleting S3 cache not implemented yet.")
-        else:
-            Path(self.cache_file).unlink(missing_ok=True)
-
+        Path(self.cache_file).unlink(missing_ok=True)
 
     def load_cache(self) -> object:
         # Transparently handles both raw and gzip-compressed ``.pkl`` files.
@@ -208,10 +204,10 @@ class CacheFunctionPickle(AbstractCacheFunction[object]):
 
 # TODO: Delete and use CacheFunctionPickle
 def cache_function(
-        fun: Callable[[], object],
-        cache_name: str,
-        ignore_cache: bool = False,
-        cache_path: Optional[Path | str] = None
+    fun: Callable[[], object],
+    cache_name: str,
+    ignore_cache: bool = False,
+    cache_path: Path | str | None = None,
 ):
     f"""
     :param fun: a function whose result obtained `fun()` will be cached, the output of the function must be serializable.
@@ -234,15 +230,19 @@ def cache_function(
             res = fun()
             with open(cache_file, "wb") as f:
                 cache = pickle.dumps(res)
-                print(f'Writing cache with size {round(sys.getsizeof(cache) / 1e6, 3)} MB')
+                print(f"Writing cache with size {round(sys.getsizeof(cache) / 1e6, 3)} MB")
                 f.write(cache)
             return res
 
 
 class CacheFunctionDF(AbstractCacheFunction[pd.DataFrame]):
-    _load_after_cache = True  # Loading from cache is necessary because .to_csv loses information from the original DataFrame
+    _load_after_cache = (
+        True  # Loading from cache is necessary because .to_csv loses information from the original DataFrame
+    )
 
-    def __init__(self, cache_name: str, cache_path: Path | str, include_self_in_call: bool = False, verbose: bool = True):
+    def __init__(
+        self, cache_name: str, cache_path: Path | str, include_self_in_call: bool = False, verbose: bool = True
+    ):
         super().__init__(include_self_in_call=include_self_in_call, verbose=verbose)
         self.cache_name = cache_name
         self.cache_path = cache_path
@@ -285,7 +285,7 @@ class Experiment:
     def data(self, ignore_cache: bool = False):
         kwargs = self.kwargs
         if kwargs is None:
-           kwargs = {}
+            kwargs = {}
         cacher = CacheFunctionDF(cache_name=self.name, cache_path=self.expname)
         return cacher.cache(
             lambda: pd.DataFrame(self.run_fun(**kwargs)),
@@ -299,7 +299,7 @@ class SimulationExperiment(Experiment):
     def data(self, ignore_cache: bool = False) -> object:
         kwargs = self.kwargs
         if kwargs is None:
-           kwargs = {}
+            kwargs = {}
         cacher = CacheFunctionPickle(cache_name=self.name, cache_path=self.expname)
         return cacher.cache(
             fun=lambda: self.run_fun(**kwargs),
@@ -310,35 +310,34 @@ class SimulationExperiment(Experiment):
 # TODO: Delete and use CacheFunctionDummy?
 @dataclass
 class DummyExperiment(Experiment):
-    """
-    Dummy Experiment class that doesn't perform caching and simply runs the run_fun and returns the result.
-    """
+    """Dummy Experiment class that doesn't perform caching and simply runs the run_fun and returns the result."""
 
     def data(self, ignore_cache: bool = False):
         return self.run_fun()
 
 
 class SaveLoadMixin:
-    """
-    Mixin class to add generic pickle save/load methods.
-    """
-    def save(self, path: Union[str, Path]):
+    """Mixin class to add generic pickle save/load methods."""
+
+    def save(self, path: str | Path):
         path = str(path)
-        assert path.endswith('.pkl')
+        assert path.endswith(".pkl")
         save_pkl.save(path=path, object=self)
 
     @classmethod
-    def load(cls, path: Union[str, Path]):
+    def load(cls, path: str | Path):
         path = str(path)
-        assert path.endswith('.pkl')
+        assert path.endswith(".pkl")
         obj = load_pkl.load(path=path)
         assert isinstance(obj, cls)
         return obj
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+
     def f():
         import time
+
         time.sleep(0.5)
         return [1, 2, 3]
 

--- a/packages/tabarena/src/tabarena/utils/cache_v2.py
+++ b/packages/tabarena/src/tabarena/utils/cache_v2.py
@@ -3,24 +3,27 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from autogluon.common import TabularDataset
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 
 
 class CacheMode(str, Enum):
     """How to interact with the on-disk cache."""
-    USE_IF_EXISTS = "use_if_exists"        # load if exists else compute+save
-    OVERWRITE = "overwrite"                # always compute+save (ignore existing)
-    LOAD_ONLY = "load_only"                # require cache; error if missing
+
+    USE_IF_EXISTS = "use_if_exists"  # load if exists else compute+save
+    OVERWRITE = "overwrite"  # always compute+save (ignore existing)
+    LOAD_ONLY = "load_only"  # require cache; error if missing
 
 
 @dataclass(frozen=True)
 class DiskCache(Generic[T]):
-    """
-    Generic on-disk cache for a single artifact.
+    """Generic on-disk cache for a single artifact.
 
     Parameters
     ----------
@@ -31,6 +34,7 @@ class DiskCache(Generic[T]):
     save_fn
         Callable that saves `obj` to `path`.
     """
+
     path: Path
     load_fn: Callable[[Path], T]
     save_fn: Callable[[Path, T], None]
@@ -42,9 +46,7 @@ class DiskCache(Generic[T]):
         *,
         mkdir: bool = True,
     ) -> T:
-        """
-        Load from cache or compute + save, depending on `mode`.
-        """
+        """Load from cache or compute + save, depending on `mode`."""
         path = Path(self.path)
 
         if mode == CacheMode.LOAD_ONLY:
@@ -65,6 +67,7 @@ class DiskCache(Generic[T]):
 
 
 # ---- Optional: convenience helper if you don't want to instantiate DiskCache each time ----
+
 
 def cached(
     *,

--- a/packages/tabarena/src/tabarena/utils/config_utils.py
+++ b/packages/tabarena/src/tabarena/utils/config_utils.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
 import copy
-from typing import Type, Literal
+from typing import TYPE_CHECKING, Literal
 
 from autogluon.core.searcher.local_random_searcher import LocalRandomSearcher
-from autogluon.core.models import AbstractModel
 
 from tabarena.benchmark.experiment import AGModelBagExperiment, AGModelExperiment
+
+if TYPE_CHECKING:
+    from autogluon.core.models import AbstractModel
 
 
 def configs_to_name_dict(configs, name_prefix, model_type):
     configs_dict = {}
     for c in configs:
         name_suffix = c["ag_args"]["name_suffix"]
-        c_name = f'{name_prefix}{name_suffix}'
+        c_name = f"{name_prefix}{name_suffix}"
         config_dict = dict()
-        config_dict['hyperparameters'] = c
-        config_dict['name_prefix'] = name_prefix
-        config_dict['name_suffix'] = name_suffix
-        config_dict['model_type'] = model_type
+        config_dict["hyperparameters"] = c
+        config_dict["name_prefix"] = name_prefix
+        config_dict["name_suffix"] = name_suffix
+        config_dict["model_type"] = model_type
         configs_dict[c_name] = config_dict
     return configs_dict
 
@@ -26,18 +28,19 @@ def configs_to_name_dict(configs, name_prefix, model_type):
 def combine_manual_and_random_configs(manual_configs, random_configs, name_id_suffix: str = ""):
     combined_configs = []
     for i, config in enumerate(manual_configs):
-        combined_configs.append(add_suffix_to_config(config=config, suffix=f'_c{i+1}{name_id_suffix}'))
+        combined_configs.append(add_suffix_to_config(config=config, suffix=f"_c{i + 1}{name_id_suffix}"))
     for i, config in enumerate(random_configs):
-        combined_configs.append(add_suffix_to_config(config=config, suffix=f'_r{i+1}{name_id_suffix}'))
+        combined_configs.append(add_suffix_to_config(config=config, suffix=f"_r{i + 1}{name_id_suffix}"))
     return combined_configs
 
 
 def add_suffix_to_config(config, suffix):
     if "ag_args" in config:
-        raise AssertionError(f"ag_args already exists in config!")
+        raise AssertionError("ag_args already exists in config!")
     config = copy.deepcopy(config)
-    config['ag_args'] = {'name_suffix': suffix}
+    config["ag_args"] = {"name_suffix": suffix}
     return config
+
 
 def add_seed_logic(config: dict, random_seed: int, vary_seed_across_folds: bool) -> dict:
     config = copy.deepcopy(config)
@@ -47,12 +50,14 @@ def add_seed_logic(config: dict, random_seed: int, vary_seed_across_folds: bool)
     config["ag_args_ensemble"]["vary_seed_across_folds"] = vary_seed_across_folds
     return config
 
+
 def add_fold_fitting_strategy(config: dict, fold_fitting_strategy: str) -> dict:
     config = copy.deepcopy(config)
     if "ag_args_ensemble" not in config:
         config["ag_args_ensemble"] = {}
     config["ag_args_ensemble"]["fold_fitting_strategy"] = fold_fitting_strategy
     return config
+
 
 def get_random_searcher(search_space, num_configs: None | int = None):
     searcher = LocalRandomSearcher(search_space=search_space)
@@ -97,16 +102,13 @@ class AGConfigGenerator(AbstractConfigGenerator):
 
     def generate_all_configs(self, num_random_configs):
         configs = self.generate_all_configs_lst(num_random_configs=num_random_configs)
-        configs_dict = configs_to_name_dict(configs=configs, name_prefix=self.name, model_type=self.model_type)
-        return configs_dict
+        return configs_to_name_dict(configs=configs, name_prefix=self.name, model_type=self.model_type)
 
     def generate_all_configs_lst(self, num_random_configs: int, name_id_suffix: str = "") -> list[dict]:
-        if num_random_configs > 0:
-            random_configs = self.get_searcher_configs(num_random_configs)
-        else:
-            random_configs = []
-        configs = combine_manual_and_random_configs(manual_configs=self.manual_configs, random_configs=random_configs, name_id_suffix=name_id_suffix)
-        return configs
+        random_configs = self.get_searcher_configs(num_random_configs) if num_random_configs > 0 else []
+        return combine_manual_and_random_configs(
+            manual_configs=self.manual_configs, random_configs=random_configs, name_id_suffix=name_id_suffix
+        )
 
     def generate_all_bag_experiments(
         self,
@@ -141,16 +143,15 @@ class AGConfigGenerator(AbstractConfigGenerator):
             locally without good CPUs for parallelism.
         """
         configs = self.generate_all_configs_lst(num_random_configs=num_random_configs, name_id_suffix=name_id_suffix)
-        experiments = generate_bag_experiments(
+        return generate_bag_experiments(
             model_cls=self.model_cls,
             configs=configs,
             name_suffix_from_ag_args=True,
             add_seed=add_seed,
             method_kwargs=method_kwargs,
             fold_fitting_strategy=fold_fitting_strategy,
-            **kwargs
+            **kwargs,
         )
-        return experiments
 
     def generate_all_holdout_experiments(
         self,
@@ -174,21 +175,20 @@ class AGConfigGenerator(AbstractConfigGenerator):
             runner by `method_kwargs=dict(init_kwargs=dict(path="./my_custom_path"))`
         """
         configs = self.generate_all_configs_lst(num_random_configs=num_random_configs, name_id_suffix=name_id_suffix)
-        experiments = generate_holdout_experiments(
+        return generate_holdout_experiments(
             model_cls=self.model_cls,
             configs=configs,
             name_suffix_from_ag_args=True,
             method_kwargs=method_kwargs,
-            **kwargs
+            **kwargs,
         )
-        return experiments
 
 
 class ConfigGenerator(AGConfigGenerator):
     def __init__(
         self,
         search_space: dict,
-        model_cls: Type[AbstractModel],
+        model_cls: type[AbstractModel],
         name: str | None = None,
         manual_configs: list[dict] | None = None,
     ):
@@ -212,7 +212,7 @@ class ConfigGenerator(AGConfigGenerator):
 class CustomAGConfigGenerator(AGConfigGenerator):
     def __init__(
         self,
-        model_cls: Type[AbstractModel],
+        model_cls: type[AbstractModel],
         search_space_func,
         name: str | None = None,
         manual_configs: list[dict] | None = None,
@@ -253,15 +253,9 @@ def generate_bag_experiments(
         kwargs = {}
 
     if add_seed == "static":
-        configs = [
-            add_seed_logic(config=config, random_seed=0, vary_seed_across_folds=False)
-            for config in configs
-        ]
+        configs = [add_seed_logic(config=config, random_seed=0, vary_seed_across_folds=False) for config in configs]
     elif add_seed == "fold-wise":
-        configs = [
-            add_seed_logic(config=config, random_seed=0, vary_seed_across_folds=True)
-            for config in configs
-        ]
+        configs = [add_seed_logic(config=config, random_seed=0, vary_seed_across_folds=True) for config in configs]
     elif add_seed == "fold-config-wise":
         offset_between_configs = num_bag_sets * num_bag_folds
         configs = [
@@ -270,19 +264,18 @@ def generate_bag_experiments(
         ]
     else:
         raise ValueError(
-            f"Invalid add_seed value: {add_seed}. Choose from 'static', 'fold-wise', or 'fold-config-wise'."
+            f"Invalid add_seed value: {add_seed}. Choose from 'static', 'fold-wise', or 'fold-config-wise'.",
         )
     if fold_fitting_strategy is not None:
         configs = [
-            add_fold_fitting_strategy(config=config, fold_fitting_strategy=fold_fitting_strategy)
-            for config in configs
+            add_fold_fitting_strategy(config=config, fold_fitting_strategy=fold_fitting_strategy) for config in configs
         ]
 
     for i, config in enumerate(configs):
         if name_suffix_from_ag_args:
             name_suffix = config.get("ag_args", {}).get("name_suffix", "")
         else:
-            name_suffix = f"_{name_id_prefix}{i+1}{name_id_suffix}"
+            name_suffix = f"_{name_id_prefix}{i + 1}{name_id_suffix}"
             if add_name_suffix_to_params:
                 config = add_suffix_to_config(config=config, suffix=name_suffix)
         name = f"{model_cls.ag_name}{name_suffix}{name_bag_suffix}"
@@ -317,7 +310,7 @@ def generate_holdout_experiments(
         if name_suffix_from_ag_args:
             name_suffix = config.get("ag_args", {}).get("name_suffix", "")
         else:
-            name_suffix = f"_{name_id_prefix}{i+1}{name_id_suffix}"
+            name_suffix = f"_{name_id_prefix}{i + 1}{name_id_suffix}"
             if add_name_suffix_to_params:
                 config = add_suffix_to_config(config=config, suffix=name_suffix)
         name = f"{model_cls.ag_name}{name_suffix}"

--- a/packages/tabarena/src/tabarena/utils/download.py
+++ b/packages/tabarena/src/tabarena/utils/download.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
 
-import pathlib
 import os
+import pathlib
 import urllib.request
 from urllib.error import HTTPError
-from tqdm import tqdm
 
 from tabarena.utils.parallel_for import parallel_for
 
@@ -17,8 +17,10 @@ def download_files(remote_to_local_tuple_list: list, dry_run: bool = False, verb
         if directory not in ["", "."]:
             pathlib.Path(directory).mkdir(parents=True, exist_ok=True)
         try:
-            urllib.request.urlretrieve(remote_path, local_path)
+            urllib.request.urlretrieve(remote_path, local_path)  # noqa: S310
         except HTTPError as e:
-            raise Exception(f"Failed to download file '{remote_path}' ... Maybe this file does not exist or is not public?") from e
+            raise Exception(
+                f"Failed to download file '{remote_path}' ... Maybe this file does not exist or is not public?"
+            ) from e
 
     parallel_for(download_file, inputs=remote_to_local_tuple_list, context={"dry_run": dry_run})

--- a/packages/tabarena/src/tabarena/utils/huggingfacehub_utils.py
+++ b/packages/tabarena/src/tabarena/utils/huggingfacehub_utils.py
@@ -1,19 +1,22 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
+
 from huggingface_hub import HfApi
 from tqdm import tqdm
 
 from tabarena.utils.result_utils import results_path
 
+
 def upload_hugging_face(
-        version: str,
-        repo_id: str,
-        local_dir: Path | None = None,
-        override_existing_files: bool = True,
-        continue_in_case_of_error: bool = True
+    version: str,
+    repo_id: str,
+    local_dir: Path | None = None,
+    override_existing_files: bool = True,
+    continue_in_case_of_error: bool = True,
 ):
-    """
-    Uploads tabrepo data to Hugging Face repository.
+    """Uploads tabrepo data to Hugging Face repository.
     You should set your env variable HF_TOKEN and ask write access to tabrepo before using the script.
 
     Args:
@@ -22,41 +25,49 @@ def upload_hugging_face(
         repo_id (str): The ID of the Hugging Face repository.
         local_dir (Path): path to load datasets, use tabrepo default if not specified
         override_existing_files (bool): Whether to re-upload files if they are already found in HuggingFace.
+
     Returns:
         None
     """
-    commit_message = f"Upload tabrepo new version"
-    if local_dir is None:
-        local_dir = str(results_path())
-    else:
-        local_dir = str(local_dir)
+    commit_message = "Upload tabrepo new version"
+    local_dir = str(results_path()) if local_dir is None else str(local_dir)
 
     for filename in ["baselines.parquet", "configs.parquet", "model_predictions"]:
-        assert (root / filename).exists(), f"Expected to found {filename} but could not be found in {root / filename}."
+        assert (root / filename).exists(), f"Expected to found {filename} but could not be found in {root / filename}."  # noqa: F821
     api = HfApi()
     for filename in ["baselines.parquet", "configs.parquet"]:
         path_in_repo = str(Path(version) / filename)
-        if api.file_exists(repo_id=repo_id, filename=path_in_repo, token=os.getenv("HF_TOKEN"), repo_type="dataset") and not override_existing_files:
+        if (
+            api.file_exists(repo_id=repo_id, filename=path_in_repo, token=os.getenv("HF_TOKEN"), repo_type="dataset")
+            and not override_existing_files
+        ):
             print(f"Skipping {path_in_repo} which already exists in the repo.")
             continue
 
         api.upload_file(
-            path_or_fileobj=root / filename,
+            path_or_fileobj=root / filename,  # noqa: F821
             path_in_repo=path_in_repo,
             repo_id=repo_id,
             repo_type="dataset",
             commit_message=commit_message,
             token=os.getenv("HF_TOKEN"),
         )
-    files = list(sorted(Path(root / "model_predictions").glob("*")))
+    files = sorted(Path(root / "model_predictions").glob("*"))  # noqa: F821
     for dataset_path in tqdm(files):
         print(dataset_path)
         try:
             path_in_repo = str(Path(version) / "model_predictions" / dataset_path.name)
             # ideally, we would just check if the folder exists but it is not possible AFAIK, we could alternatively
             # upload per file but it would create a lot of different commits.
-            if api.file_exists(repo_id=repo_id, filename=str(Path(path_in_repo) / "0" / "metadata.json"), token=os.getenv("HF_TOKEN"),
-                               repo_type="dataset") and not override_existing_files:
+            if (
+                api.file_exists(
+                    repo_id=repo_id,
+                    filename=str(Path(path_in_repo) / "0" / "metadata.json"),
+                    token=os.getenv("HF_TOKEN"),
+                    repo_type="dataset",
+                )
+                and not override_existing_files
+            ):
                 print(f"Skipping {path_in_repo} which already exists in the repo.")
                 continue
             api.upload_folder(
@@ -76,14 +87,13 @@ def upload_hugging_face(
 
 
 def download_from_huggingface(
-        version: str = "2023_11_14",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        datasets: list[str] | None = None,
-        local_dir: str | Path = None,
+    version: str = "2023_11_14",
+    force_download: bool = False,
+    local_files_only: bool = False,
+    datasets: list[str] | None = None,
+    local_dir: str | Path | None = None,
 ):
-    """
-    :param version: name of a tabrepo version such as `2023_11_14`
+    """:param version: name of a tabrepo version such as `2023_11_14`
     :param local_files_only: whether to use local files with no internet check on the Hub
     :param force_download: forces files to be downloaded
     :param datasets: list of datasets to download, if not specified all datasets will be downloaded
@@ -93,15 +103,9 @@ def download_from_huggingface(
     """
     # https://huggingface.co/datasets/Tabrepo/tabrepo/tree/main/2023_11_14/model_predictions
     api = HfApi()
-    if local_dir is None:
-        local_dir = str(results_path())
-    else:
-        local_dir = str(local_dir)
+    local_dir = str(results_path()) if local_dir is None else str(local_dir)
     print(f"Going to download tabrepo files to {local_dir}.")
-    if datasets is None:
-        allow_patterns = None
-    else:
-        allow_patterns = [f"*{version}*{d}*" for d in datasets]
+    allow_patterns = None if datasets is None else [f"*{version}*{d}*" for d in datasets]
 
     allow_patterns += [
         "*baselines.parquet",
@@ -118,14 +122,16 @@ def download_from_huggingface(
         force_download=force_download,
         local_files_only=local_files_only,
     )
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     # upload_hugging_face(
     #     version="2023_11_14",
     #     repo_id="tabrepo/tabrepo",
     #     override_existing_files=False,
     # )
     datasets = [
-        'Australian',
+        "Australian",
     ]
     download_from_huggingface(
         datasets=datasets,

--- a/packages/tabarena/src/tabarena/utils/memory_utils.py
+++ b/packages/tabarena/src/tabarena/utils/memory_utils.py
@@ -1,15 +1,15 @@
+from __future__ import annotations
+
 import os
-import time
 import threading
-from typing import Optional
+import time
 
 import psutil
 import torch
 
 
 class CpuMemoryTracker:
-    """
-    Tracks min and peak CPU RAM (RSS) for the current process, optionally
+    """Tracks min and peak CPU RAM (RSS) for the current process, optionally
     including all child processes (e.g., Ray workers) on the same node.
 
     Attributes (bytes, set after context finishes):
@@ -18,8 +18,7 @@ class CpuMemoryTracker:
     """
 
     def __init__(self, interval: float = 0.05, include_children: bool = True):
-        """
-        Parameters
+        """Parameters
         ----------
         interval : float, default=0.05
             Sampling interval in seconds.
@@ -32,15 +31,14 @@ class CpuMemoryTracker:
 
         self._proc = psutil.Process(os.getpid())
         self._stop_flag = False
-        self._sampler_thread: Optional[threading.Thread] = None
+        self._sampler_thread: threading.Thread | None = None
 
         # Public stats
-        self.min_rss: Optional[int] = None
+        self.min_rss: int | None = None
         self.peak_rss: int = 0
 
     def _get_current_rss(self) -> int:
-        """
-        Return current total RSS in bytes for this process (and optionally
+        """Return current total RSS in bytes for this process (and optionally
         all descendant processes).
         """
         total_rss = 0
@@ -69,8 +67,7 @@ class CpuMemoryTracker:
             rss = self._get_current_rss()
             if self.min_rss is None or rss < self.min_rss:
                 self.min_rss = rss
-            if rss > self.peak_rss:
-                self.peak_rss = rss
+            self.peak_rss = max(self.peak_rss, rss)
             time.sleep(self.interval)
 
     def __enter__(self):
@@ -96,13 +93,10 @@ class CpuMemoryTracker:
 
 
 class GpuMemoryTracker:
-    """
-    GPU memory tracker that automatically disables itself when CUDA is not available.
-    """
+    """GPU memory tracker that automatically disables itself when CUDA is not available."""
 
     def __init__(self, device=0, interval: float = 0.05):
-        """
-        Parameters
+        """Parameters
         ----------
         device : int or torch.device
             CUDA device index or device object. Ignored if CUDA unavailable.
@@ -130,13 +124,13 @@ class GpuMemoryTracker:
 
         # For sampling thread
         self._stop_flag = False
-        self._sampler_thread: Optional[threading.Thread] = None
+        self._sampler_thread: threading.Thread | None = None
 
         # Public stats (bytes)
-        self.min_allocated: Optional[int] = None
-        self.peak_allocated: Optional[int] = None
-        self.min_reserved: Optional[int] = None
-        self.peak_reserved: Optional[int] = None
+        self.min_allocated: int | None = None
+        self.peak_allocated: int | None = None
+        self.min_reserved: int | None = None
+        self.peak_reserved: int | None = None
 
     # ----------------------------
     # Helpers

--- a/packages/tabarena/src/tabarena/utils/normalized_scorer.py
+++ b/packages/tabarena/src/tabarena/utils/normalized_scorer.py
@@ -1,26 +1,31 @@
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
-import pandas as pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class NormalizedScorer:
-    def __init__(self,
-                 df_results: pd.DataFrame,
-                 tasks: List[str],
-                 baseline: str = None,
-                 metric_error_col: str = 'metric_error',
-                 task_col: str = 'task',
-                 framework_col: str = 'framework',
-                 ):
-        """
-        :param df_results: Dataframe of method performance containing columns `metric_error_col`,
+    def __init__(
+        self,
+        df_results: pd.DataFrame,
+        tasks: list[str],
+        baseline: str | None = None,
+        metric_error_col: str = "metric_error",
+        task_col: str = "task",
+        framework_col: str = "framework",
+    ):
+        """:param df_results: Dataframe of method performance containing columns `metric_error_col`,
         `dataset_col` and `framework_col`.
         :param tasks: tasks to consider
         """
         if isinstance(tasks[0], tuple):
             task_col = ["dataset", "fold"]
             all_tasks = df_results[task_col].drop_duplicates().values.tolist()
-            all_tasks = set([tuple(task) for task in all_tasks])
+            all_tasks = {tuple(task) for task in all_tasks}
         else:
             assert all(col in df_results for col in [metric_error_col, task_col, framework_col])
             all_tasks = set(df_results[task_col].unique())
@@ -29,12 +34,11 @@ class NormalizedScorer:
         self.topline_dict = df_results.groupby(task_col)[metric_error_col].min().to_dict()
         if baseline is not None:
             assert baseline in df_results[framework_col].unique()
-            self.baseline_dict = df_results[
-                df_results[framework_col] == baseline
-                ].groupby(task_col)[metric_error_col].min().to_dict()
+            self.baseline_dict = (
+                df_results[df_results[framework_col] == baseline].groupby(task_col)[metric_error_col].min().to_dict()
+            )
         else:
-            self.baseline_dict = df_results.groupby(task_col)[
-                metric_error_col].median(numeric_only=True).to_dict()
+            self.baseline_dict = df_results.groupby(task_col)[metric_error_col].median(numeric_only=True).to_dict()
 
     # TODO rename to score, create parent class
     def rank(self, task: str, error: float) -> float:

--- a/packages/tabarena/src/tabarena/utils/parallel_for.py
+++ b/packages/tabarena/src/tabarena/utils/parallel_for.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
-from tqdm import tqdm
-from typing import TypeVar, Callable, List, Union
+from typing import TYPE_CHECKING, TypeVar
 
-A = TypeVar('A')
-B = TypeVar('B')
+from tqdm import tqdm
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+A = TypeVar("A")
+B = TypeVar("B")
+
 
 def parallel_for(
     f: Callable[[object], B],
-    inputs: List[Union[list, dict]],
-    context: dict = None,
+    inputs: list[list | dict],
+    context: dict | None = None,
     engine: str = "ray",
     progress_bar: bool = True,
     desc: str | None = None,
-) -> List[B]:
-    """
-    Evaluates an embarrasingly parallel for-loop.
+) -> list[B]:
+    """Evaluates an embarrasingly parallel for-loop.
     :param f: the function to be evaluated, the function is evaluated on `f(x, **context)` for all `x` in `inputs`
     if inputs are a list and on the union of x and context keyword arguments else
     :param inputs: list of inputs to be evaluated
@@ -35,17 +39,21 @@ def parallel_for(
         ]
     if engine == "joblib":
         from joblib import Parallel, delayed
+
         return Parallel(n_jobs=-1, verbose=50)(
-            delayed(f)(**x, **context) if isinstance(x, dict) else delayed(f)(*x, **context)
-            for x in inputs
+            delayed(f)(**x, **context) if isinstance(x, dict) else delayed(f)(*x, **context) for x in inputs
         )
     if engine == "ray":
         import ray
+
         if not ray.is_initialized():
             ray.init()
+
         @ray.remote
         def remote_f(x, context):
             return f(**x, **context) if isinstance(x, dict) else f(*x, **context)
+
         remote_context = ray.put(context)
         remote_results = [remote_f.remote(x, remote_context) for x in inputs]
         return [ray.get(res) for res in tqdm(remote_results, desc=desc, disable=not progress_bar, mininterval=1)]
+    return None

--- a/packages/tabarena/src/tabarena/utils/pickle_utils.py
+++ b/packages/tabarena/src/tabarena/utils/pickle_utils.py
@@ -40,7 +40,7 @@ def read_pickle_bytes(path: str | Path) -> bytes:
 
 def load_pickle(path: str | Path) -> Any:
     """Load a (possibly gzip-compressed) pickle file."""
-    return pickle.loads(read_pickle_bytes(path))  # noqa: S301 — our own trusted artifacts
+    return pickle.loads(read_pickle_bytes(path))
 
 
 def fetch_all_pickles_new(
@@ -66,21 +66,16 @@ def fetch_all_pickles_new(
     out: list[Path] = []
     for r in roots:
         if r.is_file():
-            if isinstance(suffix, tuple):
-                ok = any(str(r).endswith(s) for s in suffix)
-            else:
-                ok = str(r).endswith(suffix)
+            ok = any(str(r).endswith(s) for s in suffix) if isinstance(suffix, tuple) else str(r).endswith(suffix)
             if not ok:
                 raise AssertionError(f"{r} is a file that does not end in `{suffix}`.")
             out.append(r)
     # Keep only directory roots for walking
     dir_roots: list[Path] = [r for r in roots if r.exists() and r.is_dir()]
-    bad_roots = [
-        r for r in roots if not r.exists() or (not r.is_dir() and not r.is_file())
-    ]
+    bad_roots = [r for r in roots if not r.exists() or (not r.is_dir() and not r.is_file())]
     if bad_roots:
         raise NotADirectoryError(
-            f"{', '.join(map(str, bad_roots))} not found or not directories"
+            f"{', '.join(map(str, bad_roots))} not found or not directories",
         )
 
     def scan(root: Path) -> list[Path]:
@@ -145,7 +140,7 @@ def fetch_all_pickles(
     if num_workers is not None and num_workers > 1:
         if max_files is not None:
             raise NotImplementedError(
-                "Limiting max_files is not currently implemented for num_workers > 1."
+                "Limiting max_files is not currently implemented for num_workers > 1.",
             )
         return _fetch_all_pickles_parallel(
             dir_path=dir_path,
@@ -162,9 +157,7 @@ def fetch_all_pickles(
         root = Path(cur_dir_path).expanduser()
         if not root.is_dir():
             if root.is_file():
-                assert str(root).endswith(suffix), (
-                    f"{root} is a file that does not end in `{suffix}`."
-                )
+                assert str(root).endswith(suffix), f"{root} is a file that does not end in `{suffix}`."
                 file_paths.append(root)
             else:
                 raise NotADirectoryError(f"{root} is not a directory")
@@ -174,8 +167,7 @@ def fetch_all_pickles(
                 top_dirs = [
                     Path(e.path)
                     for e in os.scandir(root)
-                    if e.is_dir(follow_symlinks=False)
-                    and fnmatch.fnmatch(e.name, prefix_glob)
+                    if e.is_dir(follow_symlinks=False) and fnmatch.fnmatch(e.name, prefix_glob)
                 ]
             else:
                 top_dirs = [root]
@@ -192,10 +184,7 @@ def fetch_all_pickles(
                             if fn.endswith(suffix):
                                 file_paths.append(dp / fn)
                                 pbar.update(1)
-                                if (
-                                    max_files is not None
-                                    and len(file_paths) == max_files
-                                ):
+                                if max_files is not None and len(file_paths) == max_files:
                                     return file_paths
             finally:
                 pbar.close()
@@ -237,9 +226,7 @@ def _fetch_all_pickles_parallel(
     for cur_dir_path in dir_path:
         root = Path(cur_dir_path).expanduser()
         if root.is_file():
-            assert str(root).endswith(suffix), (
-                f"{root} is a file that does not end in `{suffix}`."
-            )
+            assert str(root).endswith(suffix), f"{root} is a file that does not end in `{suffix}`."
             file_paths.append(root)
             continue
         if not root.is_dir():
@@ -250,21 +237,16 @@ def _fetch_all_pickles_parallel(
             top_dirs = [
                 Path(e.path)
                 for e in os.scandir(root)
-                if e.is_dir(follow_symlinks=False)
-                and fnmatch.fnmatch(e.name, prefix_glob)
+                if e.is_dir(follow_symlinks=False) and fnmatch.fnmatch(e.name, prefix_glob)
             ]
         else:
             top_dirs = [root]
 
         # Expand one level deeper for better parallelism across ray workers.
         for top in top_dirs:
-            subs = [
-                Path(e.path)
-                for e in os.scandir(top)
-                if e.is_dir(follow_symlinks=False)
-            ]
+            subs = [Path(e.path) for e in os.scandir(top) if e.is_dir(follow_symlinks=False)]
             if not subs:
-                warnings.warn(f"{top} does not contain results!")
+                warnings.warn(f"{top} does not contain results!", stacklevel=2)
                 continue
             work_units.extend(subs)
 
@@ -288,8 +270,7 @@ def _fetch_all_pickles_parallel(
             track_progress=True,
             tqdm_kwargs={
                 "desc": (
-                    f"Searching for pickles (suffix={suffix}, "
-                    f"name_pattern={name_pattern}, workers={num_workers})"
+                    f"Searching for pickles (suffix={suffix}, name_pattern={name_pattern}, workers={num_workers})"
                 ),
             },
             ray_remote_kwargs={"max_calls": 0},

--- a/packages/tabarena/src/tabarena/utils/rank_utils.py
+++ b/packages/tabarena/src/tabarena/utils/rank_utils.py
@@ -1,17 +1,18 @@
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
-import pandas as pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
-def get_rank(error: float,
-             error_lst: List[float],
-             ties_win: bool = False,
-             pct: bool = False,
-             include_partial: bool = True) -> float:
-    """
-    If ties_win=True, rank will equal a win if tied with an error in error_lst. (ex: rank 1.0)
-    If ties_win=False, rank will equal a tie if tied with an error in error_lst. (ex: rank 1.5)
+def get_rank(
+    error: float, error_lst: list[float], ties_win: bool = False, pct: bool = False, include_partial: bool = True
+) -> float:
+    """If ties_win=True, rank will equal a win if tied with an error in error_lst. (ex: rank 1.0)
+    If ties_win=False, rank will equal a tie if tied with an error in error_lst. (ex: rank 1.5).
 
     If pct=True, rescales output to be between 0 and 1, with 0 = best, 1 = worst.
 
@@ -24,7 +25,7 @@ def get_rank(error: float,
         Cannot be True when ties_win=True.
     """
     if ties_win and include_partial:
-        raise AssertionError('ties_win and include_partial cannot both be True.')
+        raise AssertionError("ties_win and include_partial cannot both be True.")
     rank = 0
     prior_err = 0
     win = False
@@ -43,13 +44,8 @@ def get_rank(error: float,
             if include_partial and error > 0:
                 # Add up to 0.5 rank based on distance between closest loss and closest win.
                 divisor = e - prior_err
-                if divisor == 0:
-                    partial_rank = 0.5
-                else:
-                    partial_rank = ((error - prior_err) / divisor) / 2
-                if partial_rank > 0.5:
-                    # Safeguard against divide by 0 edge-cases
-                    partial_rank = 0.5
+                partial_rank = 0.5 if divisor == 0 else (error - prior_err) / divisor / 2
+                partial_rank = min(partial_rank, 0.5)
                 rank += partial_rank
             # error_lst is assumed to be sorted, so we know that all future elements will be wins
             # once we find our first win, allowing us to break early
@@ -73,16 +69,15 @@ class RankScorer:
     def __init__(
         self,
         df_results: pd.DataFrame,
-        tasks: List[str],
-        metric_error_col: str = 'metric_error',
-        task_col: str = 'task',
-        framework_col: str = 'framework',
+        tasks: list[str],
+        metric_error_col: str = "metric_error",
+        task_col: str = "task",
+        framework_col: str = "framework",
         ties_win: bool = False,
         pct: bool = False,
         include_partial: bool = True,
     ):
-        """
-        :param df_results: Dataframe of method performance containing columns `metric_error_col`,
+        """:param df_results: Dataframe of method performance containing columns `metric_error_col`,
         `task_col` and `framework_col`.
         :param tasks: datasets to consider
         :param ties_win: whether ties count as a win (True) or a tie (False). Set False to ensure symmetric equivalence.
@@ -102,18 +97,16 @@ class RankScorer:
         self.error_dict = {dataset: df_pivot.loc[dataset].dropna().tolist() for dataset in tasks}
 
     def rank(self, task: str, error: float) -> float:
-        """
-        Get the rank of a result on a dataset given an error.
-        """
+        """Get the rank of a result on a dataset given an error."""
         if self.ties_win and not self.include_partial:
             rank = np.searchsorted(self.error_dict[task], error)
             if self.pct:
                 return rank / len(self.error_dict[task])
-            else:
-                return rank
-        else:
-            return get_rank(error=error,
-                            error_lst=self.error_dict[task],
-                            ties_win=self.ties_win,
-                            pct=self.pct,
-                            include_partial=self.include_partial)
+            return rank
+        return get_rank(
+            error=error,
+            error_lst=self.error_dict[task],
+            ties_win=self.ties_win,
+            pct=self.pct,
+            include_partial=self.include_partial,
+        )

--- a/packages/tabarena/src/tabarena/utils/ray_utils.py
+++ b/packages/tabarena/src/tabarena/utils/ray_utils.py
@@ -12,7 +12,11 @@ DEFAULT_REMOTE_KWARGS = {
 
 
 def run_function_as_ray_task(
-    *, func: callable, num_cpus: int, num_gpus: int, func_kwargs: dict
+    *,
+    func: callable,
+    num_cpus: int,
+    num_gpus: int,
+    func_kwargs: dict,
 ):
     """Run a function as a ray task with the given number of cpus and gpus. Blocks until the function is done."""
     remote_func = ray.remote(**DEFAULT_REMOTE_KWARGS)(func)
@@ -107,9 +111,7 @@ def ray_map_list(
     for list_element in list_to_map[:num_workers]:
         result_ref = remote_p.options(**remote_p_options).remote(
             **{
-                func_element_key_string: ray.put(list_element)
-                if put_list_elements
-                else list_element
+                func_element_key_string: ray.put(list_element) if put_list_elements else list_element,
             },
             **job_kwargs,
         )
@@ -139,9 +141,7 @@ def ray_map_list(
             unfinished_list = unfinished_list[1:]
             result_ref = remote_p.options(**remote_p_options).remote(
                 **{
-                    func_element_key_string: ray.put(list_element)
-                    if put_list_elements
-                    else list_element
+                    func_element_key_string: ray.put(list_element) if put_list_elements else list_element,
                 },
                 **job_kwargs,
             )

--- a/packages/tabarena/src/tabarena/utils/result_utils.py
+++ b/packages/tabarena/src/tabarena/utils/result_utils.py
@@ -1,7 +1,14 @@
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from autogluon.common.loaders import load_pd
 from autogluon.common.savers import save_pd
+
 from tabarena.loaders import Paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def results_path() -> Path:
@@ -10,25 +17,28 @@ def results_path() -> Path:
         res.mkdir(parents=True, exist_ok=True)
     return res
 
+
 def shrink_result_file_size(path_load, path_save):
     result_df = load_pd.load(path_load)
 
-    result_df = result_df.drop(columns=[
-        'app_version',
-        'can_infer',
-        'fit_order',
-        'mode',
-        'id',
-        'seed',
-        'stack_level',
-        'fit_time',
-        'fit_time_marginal',
-        'pred_time_test_marginal',
-        'pred_time_val_marginal',
-        'pred_time_val',
-        'utc',
-        'version',
-    ])
+    result_df = result_df.drop(
+        columns=[
+            "app_version",
+            "can_infer",
+            "fit_order",
+            "mode",
+            "id",
+            "seed",
+            "stack_level",
+            "fit_time",
+            "fit_time_marginal",
+            "pred_time_test_marginal",
+            "pred_time_val_marginal",
+            "pred_time_val",
+            "utc",
+            "version",
+        ]
+    )
 
     save_pd.save(path=path_save, df=result_df)
 

--- a/packages/tabarena/src/tabarena/utils/s3_downloader.py
+++ b/packages/tabarena/src/tabarena/utils/s3_downloader.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
-import os
 import fnmatch
 import logging
-from pathlib import Path
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Sequence, Tuple, Dict, List
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import boto3
-from botocore.config import Config
 from boto3.s3.transfer import TransferConfig
+from botocore.config import Config
 from tqdm import tqdm
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -21,10 +24,7 @@ def _should_exclude(key: str, exclude_globs: Sequence[str]) -> bool:
     if not exclude_globs:
         return False
     base = key.rsplit("/", 1)[-1]
-    for pat in exclude_globs:
-        if fnmatch.fnmatch(key, pat) or fnmatch.fnmatch(base, pat):
-            return True
-    return False
+    return any(fnmatch.fnmatch(key, pat) or fnmatch.fnmatch(base, pat) for pat in exclude_globs)
 
 
 def _safe_mkdirs(p: Path) -> None:
@@ -50,10 +50,8 @@ def copy_s3_prefix_to_local(
     connect_timeout_s: int = 10,
     read_timeout_s: int = 180,
     dry_run: bool = False,
-) -> Dict[str, List[str]]:
-    """
-    Recursively copy all objects under an S3 prefix to a local directory with progress tracking.
-    """
+) -> dict[str, list[str]]:
+    """Recursively copy all objects under an S3 prefix to a local directory with progress tracking."""
     dest_dir = Path(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
 
@@ -80,9 +78,9 @@ def copy_s3_prefix_to_local(
 
     paginator = s3.get_paginator("list_objects_v2")
 
-    to_download: List[Tuple[str, int, Path]] = []
-    excluded: List[str] = []
-    skipped: List[str] = []
+    to_download: list[tuple[str, int, Path]] = []
+    excluded: list[str] = []
+    skipped: list[str] = []
 
     logger.info("Listing s3://%s/%s ...", bucket, norm_prefix or "")
 
@@ -93,30 +91,33 @@ def copy_s3_prefix_to_local(
             size: int = obj["Size"]
             if key.endswith("/") and size == 0:
                 continue
-            if _should_exclude(key[len(norm_prefix):], exclude):
+            if _should_exclude(key[len(norm_prefix) :], exclude):
                 excluded.append(key)
                 continue
-            rel_key = key[len(norm_prefix):]
+            rel_key = key[len(norm_prefix) :]
             local_path = dest_dir / rel_key
             if _skip_because_same_size(local_path, size):
                 skipped.append(key)
             else:
                 to_download.append((key, size, local_path))
 
-    logger.log(30,
+    logger.log(
+        30,
         "Found %d objects: %d to download, %d skipped, %d excluded.",
         len(to_download) + len(skipped) + len(excluded),
-        len(to_download), len(skipped), len(excluded),
+        len(to_download),
+        len(skipped),
+        len(excluded),
     )
 
-    downloaded: List[str] = []
-    failed: List[str] = []
+    downloaded: list[str] = []
+    failed: list[str] = []
 
     if dry_run:
         logger.info("[DRY RUN] Would download %d files.", len(to_download))
         return {"downloaded": [], "skipped": skipped, "excluded": excluded, "failed": []}
 
-    def _download_one(item: Tuple[str, int, Path]) -> Tuple[str, bool, str | None]:
+    def _download_one(item: tuple[str, int, Path]) -> tuple[str, bool, str | None]:
         key, _size, local_path = item
         tmp_path = local_path.with_suffix(local_path.suffix + ".part")
         try:
@@ -133,18 +134,21 @@ def copy_s3_prefix_to_local(
             try:
                 if tmp_path.exists():
                     tmp_path.unlink()
-            except Exception:
+            except Exception:  # noqa: S110
                 pass
             return key, False, str(e)
 
     if to_download:
-        with ThreadPoolExecutor(max_workers=max_workers) as executor, tqdm(
-            total=len(to_download),
-            desc="Downloading files",
-            unit="file",
-            ncols=100,
-            dynamic_ncols=True,
-        ) as pbar:
+        with (
+            ThreadPoolExecutor(max_workers=max_workers) as executor,
+            tqdm(
+                total=len(to_download),
+                desc="Downloading files",
+                unit="file",
+                ncols=100,
+                dynamic_ncols=True,
+            ) as pbar,
+        ):
             futures = {executor.submit(_download_one, item): item[0] for item in to_download}
             for fut in as_completed(futures):
                 key = futures[fut]
@@ -161,7 +165,10 @@ def copy_s3_prefix_to_local(
 
     logger.info(
         "Download complete. %d succeeded, %d failed, %d skipped, %d excluded.",
-        len(downloaded), len(failed), len(skipped), len(excluded),
+        len(downloaded),
+        len(failed),
+        len(skipped),
+        len(excluded),
     )
 
     return {

--- a/packages/tabarena/src/tabarena/utils/s3_utils.py
+++ b/packages/tabarena/src/tabarena/utils/s3_utils.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import logging
 import os
-import xmltodict
 from pathlib import Path
+
+import xmltodict
 
 logger = logging.getLogger(__name__)
 
 
 def s3_get_object(Bucket: str, Key: str, s3=None, **kwargs) -> dict:
-    """
-    Get an S3 object, automatically falling back to an anonymous (unsigned) GET
+    """Get an S3 object, automatically falling back to an anonymous (unsigned) GET
     when a signed request is not possible or is denied.
 
     This helper first attempts a standard **signed** `GetObject` using the
@@ -31,7 +33,7 @@ def s3_get_object(Bucket: str, Key: str, s3=None, **kwargs) -> dict:
         e.g. `Range`, `VersionId`, `IfMatch`, `IfModifiedSince`, `IfNoneMatch`,
         `IfUnmodifiedSince`, `RequestPayer='requester'`, etc.
 
-    Returns
+    Returns:
     -------
     dict
         The standard `GetObject` response dict from boto3. The payload stream is
@@ -41,7 +43,7 @@ def s3_get_object(Bucket: str, Key: str, s3=None, **kwargs) -> dict:
     import boto3
     from botocore import UNSIGNED
     from botocore.config import Config
-    from botocore.exceptions import NoCredentialsError, PartialCredentialsError, ClientError
+    from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
 
     if s3 is None:
         s3 = boto3.client("s3")
@@ -52,7 +54,9 @@ def s3_get_object(Bucket: str, Key: str, s3=None, **kwargs) -> dict:
         # Note: even if you *have* creds, a signed request can be denied while the
         # object is still publicly readable; unsigned can succeed in that case.
         if isinstance(e, ClientError) and e.response["Error"]["Code"] not in {
-            "AccessDenied", "InvalidAccessKeyId", "SignatureDoesNotMatch"
+            "AccessDenied",
+            "InvalidAccessKeyId",
+            "SignatureDoesNotMatch",
         }:
             raise
 
@@ -60,23 +64,24 @@ def s3_get_object(Bucket: str, Key: str, s3=None, **kwargs) -> dict:
         return s3_unsigned.get_object(Bucket=Bucket, Key=Key, **kwargs)
 
 
-def parse_s3_uri(s3_uri: str = None):
-    """Helper function to parse an S3 URI into bucket and key parts"""
+def parse_s3_uri(s3_uri: str | None = None):
+    """Helper function to parse an S3 URI into bucket and key parts."""
     if s3_uri is None:
         raise ValueError("s3_uri cannot be None")
 
-    if s3_uri.startswith('s3://'):
+    if s3_uri.startswith("s3://"):
         s3_uri = s3_uri[5:]
-    parts = s3_uri.split('/', 1)
+    parts = s3_uri.split("/", 1)
     bucket = parts[0]
-    prefix = parts[1] if len(parts) > 1 else ''
-    if prefix and prefix.endswith('/'):
+    prefix = parts[1] if len(parts) > 1 else ""
+    if prefix and prefix.endswith("/"):
         prefix = prefix[:-1]
     return bucket, prefix
 
 
-def upload_task_to_s3(task_id: int, dataset_id: int, s3_dataset_cache: str = None) -> bool:
+def upload_task_to_s3(task_id: int, dataset_id: int, s3_dataset_cache: str | None = None) -> bool:
     import boto3
+
     """
     Uploads the task and dataset to S3.
     """
@@ -87,7 +92,7 @@ def upload_task_to_s3(task_id: int, dataset_id: int, s3_dataset_cache: str = Non
     assert local_cache_dir.is_dir()
 
     try:
-        s3_client = boto3.client('s3')
+        s3_client = boto3.client("s3")
         s3_bucket, s3_prefix = parse_s3_uri(s3_uri=s3_dataset_cache)
         logger.info(f"Attempting to upload task {task_id} to S3 bucket {s3_bucket}")
 
@@ -100,7 +105,7 @@ def upload_task_to_s3(task_id: int, dataset_id: int, s3_dataset_cache: str = Non
             s3_dataset_key_prefix = f"{s3_prefix}/tasks/{task_id}/org/openml/www/datasets/{dataset_id}"
             cache_dirs.append(dataset_cache_dir)
             s3_key_prefixes.append(s3_dataset_key_prefix)
-        for cache_dir, s3_key_prefix in zip(cache_dirs, s3_key_prefixes):
+        for cache_dir, s3_key_prefix in zip(cache_dirs, s3_key_prefixes, strict=False):
             for root, _, files in os.walk(cache_dir):
                 for filename in files:
                     local_path = os.path.join(root, filename)
@@ -111,12 +116,13 @@ def upload_task_to_s3(task_id: int, dataset_id: int, s3_dataset_cache: str = Non
         logger.info(f"Task {task_id} successfully uploaded to S3 at s3://{s3_bucket}/{s3_key}.")
         return True
     except Exception as e:
-        logger.error(f"Error upaloading to S3 for task {task_id}: {str(e)}")
+        logger.error(f"Error upaloading to S3 for task {task_id}: {e!s}")
         return False
 
 
-def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
+def download_task_from_s3(task_id: int, s3_dataset_cache: str | None = None) -> bool:
     import boto3
+
     """
     Downloads the task and dataset from S3 if available.
     """
@@ -128,7 +134,7 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
     os.makedirs(local_cache_dir, exist_ok=True)
 
     try:
-        s3_client = boto3.client('s3')
+        s3_client = boto3.client("s3")
         s3_bucket, s3_prefix = parse_s3_uri(s3_uri=s3_dataset_cache)
 
         task_cache_dir = local_cache_dir / "tasks" / str(task_id)
@@ -136,18 +142,18 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
 
         logger.info(f"Attempting to download task {task_id} from S3 bucket {s3_bucket}")
         s3_key_prefix = f"{s3_prefix}/tasks/{task_id}/org/openml/www/tasks/{task_id}"
-        logger.info(f"s3_key_prefix set to: " + s3_key_prefix)
+        logger.info("s3_key_prefix set to: " + s3_key_prefix)
         try:
             s3_task_prefix = f"{s3_prefix}/tasks/{task_id}/org/openml/www/tasks/{task_id}"
             response = s3_client.list_objects_v2(
                 Bucket=s3_bucket,
-                Prefix=f"{s3_task_prefix}/"
+                Prefix=f"{s3_task_prefix}/",
             )
 
-            for obj in response['Contents']:
-                s3_key = obj['Key']
+            for obj in response["Contents"]:
+                s3_key = obj["Key"]
                 filename = os.path.basename(s3_key)
-                if filename == '':
+                if filename == "":
                     continue
 
                 local_file_path = task_cache_dir / filename
@@ -156,7 +162,7 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
                         s3_client.download_file(
                             Bucket=s3_bucket,
                             Key=s3_key,
-                            Filename=str(local_file_path)
+                            Filename=str(local_file_path),
                         )
                         logger.info(f"Downloaded {filename} for task {task_id} from S3")
                     except s3_client.exceptions.ClientError as e:
@@ -164,7 +170,7 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
                 else:
                     logger.info(f"{filename} already exists for task {task_id}, skipping download")
 
-            with open(task_cache_dir / "task.xml", 'r') as f:
+            with open(task_cache_dir / "task.xml") as f:
                 task_xml = f.read()
 
             task_dict = xmltodict.parse(task_xml)["oml:task"]
@@ -174,9 +180,8 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
                     if input_item["@name"] == "source_data":
                         dataset_id = int(input_item["oml:data_set"]["oml:data_set_id"])
                         break
-            else:
-                if task_dict["oml:input"]["@name"] == "source_data":
-                    dataset_id = int(task_dict["oml:input"]["oml:data_set"]["oml:data_set_id"])
+            elif task_dict["oml:input"]["@name"] == "source_data":
+                dataset_id = int(task_dict["oml:input"]["oml:data_set"]["oml:data_set_id"])
 
             if dataset_id is not None:
                 dataset_id_str = str(dataset_id)
@@ -189,14 +194,14 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
                 try:
                     response = s3_client.list_objects_v2(
                         Bucket=s3_bucket,
-                        Prefix=f"{s3_dataset_prefix}/"
+                        Prefix=f"{s3_dataset_prefix}/",
                     )
 
-                    if 'Contents' in response:
-                        for obj in response['Contents']:
-                            s3_key = obj['Key']
+                    if "Contents" in response:
+                        for obj in response["Contents"]:
+                            s3_key = obj["Key"]
                             filename = os.path.basename(s3_key)
-                            if filename == '':
+                            if filename == "":
                                 continue
 
                             local_file_path = dataset_cache_dir / filename
@@ -205,7 +210,7 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
                                     s3_client.download_file(
                                         Bucket=s3_bucket,
                                         Key=s3_key,
-                                        Filename=str(local_file_path)
+                                        Filename=str(local_file_path),
                                     )
                                     logger.info(f"Downloaded {filename} for dataset {dataset_id} from S3")
                                 except s3_client.exceptions.ClientError as e:
@@ -225,5 +230,5 @@ def download_task_from_s3(task_id: int, s3_dataset_cache: str = None) -> bool:
             return False
 
     except Exception as e:
-        logger.error(f"Error accessing S3 for task {task_id}: {str(e)}")
+        logger.error(f"Error accessing S3 for task {task_id}: {e!s}")
         return False

--- a/packages/tabarena/src/tabarena/utils/temp_scaling/calibrators.py
+++ b/packages/tabarena/src/tabarena/utils/temp_scaling/calibrators.py
@@ -1,30 +1,33 @@
-"""
-Original code from https://github.com/dholzmueller/probmetrics
-Credit to David Holzmüller
+"""Original code from https://github.com/dholzmueller/probmetrics
+Credit to David Holzmüller.
 """
 
-from typing import Callable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 from sklearn.base import BaseEstimator, ClassifierMixin
 from torch import nn
 
-from tabarena.utils.temp_scaling.distributions import CategoricalDistribution, CategoricalProbs, CategoricalLogits
+from tabarena.utils.temp_scaling.distributions import CategoricalDistribution, CategoricalLogits, CategoricalProbs
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class Calibrator(BaseEstimator, ClassifierMixin):
-    """
-    Calibrator base class. To implement,
+    """Calibrator base class. To implement,
     - override at least one of _fit_impl and _fit_torch_impl
-    - override at least one of predict_proba and predict_proba_torch
+    - override at least one of predict_proba and predict_proba_torch.
     """
 
     def __init__(self):
         # assert self.__class__.fit == Calibrator.fit
         assert self.__class__.fit_torch == Calibrator.fit_torch
 
-    def fit(self, X, y) -> 'Calibrator':
+    def fit(self, X, y) -> Calibrator:
         assert isinstance(X, np.ndarray)
         assert isinstance(y, np.ndarray)
 
@@ -35,8 +38,9 @@ class Calibrator(BaseEstimator, ClassifierMixin):
             return self
 
         if self.__class__._fit_torch_impl != Calibrator._fit_torch_impl:
-            self._fit_torch_impl(y_pred=CategoricalProbs(torch.as_tensor(X)),
-                                 y_true_labels=torch.as_tensor(y, dtype=torch.long))
+            self._fit_torch_impl(
+                y_pred=CategoricalProbs(torch.as_tensor(X)), y_true_labels=torch.as_tensor(y, dtype=torch.long)
+            )
             return self
 
         raise NotImplementedError()
@@ -44,7 +48,7 @@ class Calibrator(BaseEstimator, ClassifierMixin):
     def _fit_impl(self, X: np.ndarray, y: np.ndarray) -> None:
         raise NotImplementedError()
 
-    def fit_torch(self, y_pred: CategoricalDistribution, y_true_labels: torch.Tensor) -> 'Calibrator':
+    def fit_torch(self, y_pred: CategoricalDistribution, y_true_labels: torch.Tensor) -> Calibrator:
         assert isinstance(y_true_labels, torch.Tensor)
         assert isinstance(y_pred, CategoricalDistribution)
         # default implementation, using sklearn
@@ -96,8 +100,15 @@ def bisection_search(f: Callable[[float], float], a: float, b: float, n_steps: i
 
 
 class TemperatureScalingCalibrator(Calibrator):
-    def __init__(self, opt: str = 'bisection', max_bisection_steps: int = 30, lr: float = 0.1, max_iter: int = 200,
-                 use_inv_temp: bool = True, inv_temp_init: float = 1 / 1.5):
+    def __init__(
+        self,
+        opt: str = "bisection",
+        max_bisection_steps: int = 30,
+        lr: float = 0.1,
+        max_iter: int = 200,
+        use_inv_temp: bool = True,
+        inv_temp_init: float = 1 / 1.5,
+    ):
         super().__init__()
         self.lr = lr
         self.max_bisection_steps = max_bisection_steps
@@ -115,9 +126,9 @@ class TemperatureScalingCalibrator(Calibrator):
         logits = y_pred.get_logits()
         labels = y_true_labels
 
-        if self.opt in ['lbfgs', 'lbfgs_line_search']:
+        if self.opt in ["lbfgs", "lbfgs_line_search"]:
             self._fit_lbfgs(logits, labels)
-        elif self.opt == 'bisection':
+        elif self.opt == "bisection":
             self._fit_bisection(logits, labels)
         else:
             raise ValueError(f'Unknown optimizer "{self.opt}"')
@@ -127,10 +138,15 @@ class TemperatureScalingCalibrator(Calibrator):
     def _fit_lbfgs(self, logits: torch.Tensor, labels: torch.Tensor):
         # following https://github.com/gpleiss/temperature_scaling/blob/master/temperature_scaling.py
         param = nn.Parameter(
-            torch.ones(1, device=logits.device) * (self.inv_temp_init if self.use_inv_temp else 1 / self.inv_temp_init))
+            torch.ones(1, device=logits.device) * (self.inv_temp_init if self.use_inv_temp else 1 / self.inv_temp_init)
+        )
         criterion = nn.CrossEntropyLoss()
-        optimizer = torch.optim.LBFGS([param], lr=self.lr, max_iter=self.max_iter,
-                                      line_search_fn='strong_wolfe' if self.opt == 'lbfgs_line_search' else None)
+        optimizer = torch.optim.LBFGS(
+            [param],
+            lr=self.lr,
+            max_iter=self.max_iter,
+            line_search_fn="strong_wolfe" if self.opt == "lbfgs_line_search" else None,
+        )
 
         def eval():
             optimizer.zero_grad()
@@ -212,12 +228,13 @@ class AutoGluonTemperatureScalingCalibratorFixed(AutoGluonTemperatureScalingCali
     def fit(self, X, y, scorer=None):
         if scorer is None:
             from autogluon.core.metrics import get_metric
+
             scorer = get_metric("log_loss", problem_type="multiclass")
         super().fit(X=X, y=y)
         if self.temperature == 1:
             return self
-        elif self.temperature <= 0:
-            print(f"NEGATIVE TEMP, SETTING TO 1")
+        if self.temperature <= 0:
+            print("NEGATIVE TEMP, SETTING TO 1")
             self.temperature = 1
             return self
         y_pred_proba_post = self.predict_proba(X)
@@ -225,7 +242,7 @@ class AutoGluonTemperatureScalingCalibratorFixed(AutoGluonTemperatureScalingCali
         err_og = scorer.error(y, X)
         err_post = scorer.error(y, y_pred_proba_post)
         if err_post > err_og:
-            print(f"WORSE ERROR: SETTING TO 1")
+            print("WORSE ERROR: SETTING TO 1")
             self.temperature = 1
         return self
 
@@ -234,12 +251,13 @@ class TemperatureScalingCalibratorFixed(TemperatureScalingCalibrator):
     def fit(self, X, y, scorer=None):
         if scorer is None:
             from autogluon.core.metrics import get_metric
+
             scorer = get_metric("log_loss", problem_type="multiclass")
         super().fit(X=X, y=y)
         if self.inv_temp_init == 1:
             return self
-        elif self.inv_temp_init <= 0:
-            print(f"NEGATIVE TEMP, SETTING TO 1")
+        if self.inv_temp_init <= 0:
+            print("NEGATIVE TEMP, SETTING TO 1")
             self.inv_temp_init = 1
             return self
         y_pred_proba_post = self.predict_proba(X)
@@ -247,7 +265,7 @@ class TemperatureScalingCalibratorFixed(TemperatureScalingCalibrator):
         err_og = scorer.error(y, X)
         err_post = scorer.error(y, y_pred_proba_post)
         if err_post > err_og:
-            print(f"WORSE ERROR: SETTING TO 1")
+            print("WORSE ERROR: SETTING TO 1")
             self.inv_temp_init = 1
         return self
 

--- a/packages/tabarena/src/tabarena/utils/temp_scaling/distributions.py
+++ b/packages/tabarena/src/tabarena/utils/temp_scaling/distributions.py
@@ -1,13 +1,15 @@
-"""
-Original code from https://github.com/dholzmueller/probmetrics
-Credit to David Holzmüller
+"""Original code from https://github.com/dholzmueller/probmetrics
+Credit to David Holzmüller.
 """
 
-from pathlib import Path
-from typing import Union, Optional, List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import torch
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # problem: should a distribution object store the tensor which it does computations on?
 # In favor:
@@ -20,9 +22,9 @@ import torch
 # but maybe the "constructor function" can just be the class itself.
 # or the heads just need to be implemented so that they know how to construct the distribution
 
+
 def to_one_hot(y: torch.Tensor, n_classes: int, label_smoothing_eps: float = 0.0) -> torch.Tensor:
-    """
-    Creates a one-hot representation of y.
+    """Creates a one-hot representation of y.
     :param y: Labels, shape (n_samples,).
     :param n_classes: Number of classes (needs to be specified because it might be larger than max(y)+1).
     :param label_smoothing_eps: Epsilon parameter for label smoothing.
@@ -33,31 +35,30 @@ def to_one_hot(y: torch.Tensor, n_classes: int, label_smoothing_eps: float = 0.0
         low = label_smoothing_eps / n_classes
         high = 1.0 - label_smoothing_eps + low
         return low + (high - low) * one_hot
-    else:
-        return one_hot
+    return one_hot
 
 
 class Distribution:
-    pass  # abstract base class
+    # abstract base class
 
     # maybe have get_metrics() and save() function
 
-    def get_metric_names(self) -> List[str]:
+    def get_metric_names(self) -> list[str]:
         pass  # indicate which metrics are applicable
 
-    def save(self, folder: Union[str, Path]):
+    def save(self, folder: str | Path):
         # todo: implement
         pass  # need a way to serialize the distribution (for storing predictions). Typically just name and tensor?
 
     @staticmethod
-    def load(folder: Union[str, Path]) -> 'Distribution':
+    def load(folder: str | Path) -> Distribution:
         # todo: implement
         pass
 
     def get_n_samples(self) -> int:
         pass
 
-    def __getitem__(self, *args) -> 'Distribution':
+    def __getitem__(self, *args) -> Distribution:
         raise NotImplementedError()
 
 
@@ -82,15 +83,14 @@ class CategoricalDistribution(Distribution):
     def is_dirac(self) -> bool:
         raise NotImplementedError()
 
-    def __getitem__(self, *args) -> 'CategoricalDistribution':
+    def __getitem__(self, *args) -> CategoricalDistribution:
         raise NotImplementedError()
 
-    def get_metric_names(self) -> List[str]:
+    def get_metric_names(self) -> list[str]:
         pass  # todo: implement
 
     @staticmethod
-    def from_labels(labels: torch.Tensor, n_classes: Optional[int] = None,
-                    ls_eps: float = 0.0) -> 'CategoricalDistribution':
+    def from_labels(labels: torch.Tensor, n_classes: int | None = None, ls_eps: float = 0.0) -> CategoricalDistribution:
         if ls_eps == 0.0:
             return CategoricalDirac(labels=labels, n_classes=n_classes)
 
@@ -99,10 +99,11 @@ class CategoricalDistribution(Distribution):
         return CategoricalProbs(probs=to_one_hot(labels, n_classes=n_classes, label_smoothing_eps=ls_eps))
 
     @staticmethod
-    def from_mixture(distributions: List['CategoricalDistribution'], weights: List[float]) -> 'CategoricalDistribution':
+    def from_mixture(distributions: list[CategoricalDistribution], weights: list[float]) -> CategoricalDistribution:
         assert len(distributions) >= 1
         return CategoricalProbs(
-            probs=sum([weight * dist.get_probs() for weight, dist in zip(weights, distributions)]))
+            probs=sum([weight * dist.get_probs() for weight, dist in zip(weights, distributions, strict=False)])
+        )
 
 
 class CategoricalLogits(CategoricalDistribution):
@@ -136,7 +137,7 @@ class CategoricalLogits(CategoricalDistribution):
     def is_dirac(self) -> bool:
         return False
 
-    def __getitem__(self, *args) -> 'CategoricalDistribution':
+    def __getitem__(self, *args) -> CategoricalDistribution:
         return CategoricalLogits(self.logits.__getitem__(*args))
 
 
@@ -171,14 +172,13 @@ class CategoricalProbs(CategoricalDistribution):
     def is_dirac(self) -> bool:
         return False
 
-    def __getitem__(self, *args) -> 'CategoricalDistribution':
+    def __getitem__(self, *args) -> CategoricalDistribution:
         return CategoricalProbs(self.probs.__getitem__(*args))
 
 
 class CategoricalDirac(CategoricalDistribution):
-    def __init__(self, labels: torch.Tensor, n_classes: Optional[int]):
-        """
-        labels should have shape (n_samples,)
+    def __init__(self, labels: torch.Tensor, n_classes: int | None):
+        """Labels should have shape (n_samples,)
         :param labels:
         :param n_classes:
         """
@@ -213,5 +213,5 @@ class CategoricalDirac(CategoricalDistribution):
     def get_n_samples(self) -> int:
         return self.labels.shape[0]
 
-    def __getitem__(self, *args) -> 'CategoricalDirac':
+    def __getitem__(self, *args) -> CategoricalDirac:
         return CategoricalDirac(labels=self.labels.__getitem__(*args), n_classes=self.get_n_classes())

--- a/packages/tabarena/src/tabarena/utils/test_utils.py
+++ b/packages/tabarena/src/tabarena/utils/test_utils.py
@@ -1,22 +1,22 @@
+from __future__ import annotations
+
 from math import prod
-from typing import List
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from tabarena.predictions.tabular_predictions import TabularPredictionsDict
+if TYPE_CHECKING:
+    from tabarena.predictions.tabular_predictions import TabularPredictionsDict
 
 
 def generate_dummy(shape, models):
-    return {
-        model: np.arange(prod(shape)).reshape(shape) + int(model)
-        for model in models
-    }
+    return {model: np.arange(prod(shape)).reshape(shape) + int(model) for model in models}
 
 
 def generate_artificial_dict(
-        num_folds: int,
-        models: List[str],
-        dataset_shapes: dict = None,
+    num_folds: int,
+    models: list[str],
+    dataset_shapes: dict | None = None,
 ) -> TabularPredictionsDict:
     if dataset_shapes is None:
         dataset_shapes = {

--- a/packages/tabarena/src/tabarena/utils/time_utils.py
+++ b/packages/tabarena/src/tabarena/utils/time_utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import time
 

--- a/packages/tabarena/src/tabarena/website/process_artifacts_to_website.py
+++ b/packages/tabarena/src/tabarena/website/process_artifacts_to_website.py
@@ -9,7 +9,9 @@ import pandas as pd
 
 
 def process_one_folder(
-        *, base_input_path: Path, base_output_path: Path,
+    *,
+    base_input_path: Path,
+    base_output_path: Path,
 ):
     base_output_path.mkdir(parents=True, exist_ok=True)
 
@@ -17,7 +19,7 @@ def process_one_folder(
 
     # N datasets file
     n_datasets = len(
-        pd.read_csv(base_input_path / "results_per_split.csv", low_memory=False)["dataset"].unique()
+        pd.read_csv(base_input_path / "results_per_split.csv", low_memory=False)["dataset"].unique(),
     )
     (base_output_path / f"n_datasets_{n_datasets}").touch()
 
@@ -27,7 +29,7 @@ def process_one_folder(
         shutil.copy(
             base_input_path / file_name,
             base_output_path / file_name,
-            )
+        )
 
     # Copy plots
     for fig_path in [
@@ -35,9 +37,8 @@ def process_one_folder(
         f"pareto_front_improvability_vs_time_infer.{figure_file_type}",
         f"winrate_matrix.{figure_file_type}",
         (
-                Path("tuning_trajectories")
-                / "placeholder_name",
-                f"pareto_n_configs_imp.{figure_file_type}",
+            Path("tuning_trajectories") / "placeholder_name",
+            f"pareto_n_configs_imp.{figure_file_type}",
         ),
     ]:
         # FIXME: cannot use this on my cluster as I am not able to install poppler.
@@ -60,9 +61,9 @@ def process_one_folder(
             shutil.copy(
                 base_input_path / fig_path[0] / fig_path[1],
                 base_output_path / fig_path[1],
-                )
+            )
         else:
             shutil.copy(
                 base_input_path / fig_path,
                 base_output_path / fig_path,
-                )
+            )

--- a/packages/tabarena/src/tabarena/website/process_pngs.py
+++ b/packages/tabarena/src/tabarena/website/process_pngs.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import zipfile
-from pathlib import Path
 from multiprocessing import Pool, cpu_count
+from pathlib import Path
 
 
 def process_png(png_path_str: str) -> None:

--- a/packages/tabarena/src/tabarena/website/website_format.py
+++ b/packages/tabarena/src/tabarena/website/website_format.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from tabarena.models._method_metadata import MethodMetadata
 
+
 class Constants:
     col_name: str = "method_type"
     tree: str = "Tree-based"
@@ -34,8 +35,7 @@ def strict_merge(
     how: str = "left",
     validate: str | None = None,
 ) -> pd.DataFrame:
-    """
-    Merge two DataFrames, but if they share non-key columns, require that the
+    """Merge two DataFrames, but if they share non-key columns, require that the
     shared columns have identical values (for matching keys) and raise if not.
     Prevents creating _x/_y columns by dropping shared columns from `right`
     after the check.
@@ -111,7 +111,7 @@ def get_model_family(model_name: str) -> str:
 
 
 def get_rename_map() -> dict[str, str]:
-    _rename_map = {
+    return {
         "TABM": "TabM",
         "REALMLP": "RealMLP",
         "GBM": "LightGBM",
@@ -136,7 +136,6 @@ def get_rename_map() -> dict[str, str]:
         "REALTABPFN-V2.5": "RealTabPFN-v2.5",
         "SAP-RPT-OSS": "SAP-RPT-OSS",
     }
-    return _rename_map
 
 
 def rename_method(model_name: str, rename_map: dict[str, str]) -> str:
@@ -162,7 +161,7 @@ def add_metadata(
                 "Hardware": "Missing",
                 "Verified": "Missing",
                 "ReferenceURL": None,
-            }
+            },
         )
     metadata = metadata_df.loc[method]
     config_type = metadata["config_type"]
@@ -186,14 +185,8 @@ def add_metadata(
     if include_url and metadata.get("reference_url", None) is not None:
         display_name = add_url(display_name, metadata["reference_url"])
 
-    if pd.isna(metadata["verified"]):
-        verified = "Unknown"
-    else:
-        verified = "✔️" if metadata["verified"] else "➖"
-    if pd.isna(metadata["compute"]):
-        hardware = "Unknown"
-    else:
-        hardware = metadata["compute"].upper()
+    verified = "Unknown" if pd.isna(metadata["verified"]) else "✔️" if metadata["verified"] else "➖"
+    hardware = "Unknown" if pd.isna(metadata["compute"]) else metadata["compute"].upper()
 
     return pd.Series(
         {
@@ -201,7 +194,7 @@ def add_metadata(
             "Hardware": hardware,
             "Verified": verified,
             **out_dict,
-        }
+        },
     )
 
 
@@ -218,15 +211,15 @@ def legacy_formatting(df_leaderboard: pd.DataFrame) -> pd.DataFrame:
 
     # Add Model Family Information
     df_leaderboard["Type"] = df_leaderboard.loc[:, "method"].apply(
-        lambda s: model_type_emoji[get_model_family(s)]
+        lambda s: model_type_emoji[get_model_family(s)],
     )
     df_leaderboard["TypeName"] = df_leaderboard.loc[:, "method"].apply(
-        lambda s: get_model_family(s)
+        lambda s: get_model_family(s),
     )
 
     _rename_map = get_rename_map()
     df_leaderboard["method"] = df_leaderboard["method"].apply(
-        lambda method: rename_method(model_name=method, rename_map=_rename_map)
+        lambda method: rename_method(model_name=method, rename_map=_rename_map),
     )
     return df_leaderboard
 
@@ -246,7 +239,9 @@ def format_leaderboard(
     if method_metadata_info is None:
         df_leaderboard = legacy_formatting(df_leaderboard=df_leaderboard)
     else:
-        method_info_map = strict_merge(df_leaderboard, method_metadata_info.drop(columns=["method_type"]), on=["ta_name", "ta_suite"])
+        method_info_map = strict_merge(
+            df_leaderboard, method_metadata_info.drop(columns=["method_type"]), on=["ta_name", "ta_suite"]
+        )
         method_info_map = method_info_map.set_index("method")
         df_leaderboard[["method", "Hardware", "Verified", "Type", "TypeName"]] = df_leaderboard.apply(
             partial(add_metadata, metadata_df=method_info_map, include_url=include_url),
@@ -277,7 +272,8 @@ def format_leaderboard(
         df_leaderboard.loc[imputed_mask, "imputed_bool"] = True
         if include_imputed_in_name:
             df_leaderboard.loc[imputed_mask, "method"] = df_leaderboard.loc[
-                imputed_mask, ["method", "imputed"]
+                imputed_mask,
+                ["method", "imputed"],
             ].apply(lambda row: row["method"] + f" [{row['imputed']:.2f}% IMPUTED]", axis=1)
     else:
         df_leaderboard["imputed_bool"] = None
@@ -285,7 +281,8 @@ def format_leaderboard(
 
     # FIXME: move to lb generation!
     df_leaderboard["method"] = df_leaderboard["method"].str.replace(
-        "(tuned + ensemble)", "(tuned + ensembled)"
+        "(tuned + ensemble)",
+        "(tuned + ensembled)",
     )
 
     df_leaderboard = df_leaderboard.loc[
@@ -311,14 +308,12 @@ def format_leaderboard(
 
     # round for better display
     df_leaderboard[["elo", "Elo 95% CI"]] = df_leaderboard[["elo", "Elo 95% CI"]].round(
-        0
+        0,
     )
     df_leaderboard[["median_time_train_s_per_1K", "rank", "hmr"]] = df_leaderboard[
         ["median_time_train_s_per_1K", "rank", "hmr"]
     ].round(2)
-    df_leaderboard[
-        ["normalized-score", "median_time_infer_s_per_1K", "improvability"]
-    ] = df_leaderboard[
+    df_leaderboard[["normalized-score", "median_time_infer_s_per_1K", "improvability"]] = df_leaderboard[
         ["normalized-score", "median_time_infer_s_per_1K", "improvability"]
     ].round(3)
 
@@ -330,13 +325,15 @@ def format_leaderboard(
         df_leaderboard = df_leaderboard.drop(columns=["Type", "TypeName"])
 
     if compact:
-        df_leaderboard = df_leaderboard[[
-            "method",
-            "elo",
-            "improvability",
-            "median_time_train_s_per_1K",
-            "median_time_infer_s_per_1K",
-        ]]
+        df_leaderboard = df_leaderboard[
+            [
+                "method",
+                "elo",
+                "improvability",
+                "median_time_train_s_per_1K",
+                "median_time_infer_s_per_1K",
+            ]
+        ]
 
         return df_leaderboard.rename(
             columns={
@@ -345,7 +342,7 @@ def format_leaderboard(
                 "method": "Model",
                 "elo": "Elo",
                 "improvability": "Impro%",
-            }
+            },
         )
 
     # rename some columns
@@ -361,5 +358,5 @@ def format_leaderboard(
             "improvability": "Improvability (%) [⬇️]",
             "imputed": "Imputed (%) [⬇️]",
             "imputed_bool": "Imputed",
-        }
+        },
     )

--- a/packages/tabflow_slurm/experiments/run_eval_beyondarena.py
+++ b/packages/tabflow_slurm/experiments/run_eval_beyondarena.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from tabarena.evaluation import BenchmarkRun, BeyondArenaEvalConfig, run_beyond_arena_eval
-
 from tabflow_slurm import PathSetup
 
 # Full BeyondArena baseline suite (matches the legacy run_eval.py model list).

--- a/packages/tabflow_slurm/experiments/run_eval_tabarena_v0pt1.py
+++ b/packages/tabflow_slurm/experiments/run_eval_tabarena_v0pt1.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from tabarena.evaluation import EvalMethod, TabArenaEvalConfig, run_eval
-
 from tabflow_slurm import PathSetup
 
 BENCHMARK_NAME = "example_tabarena_v0pt1_29052026"

--- a/packages/tabflow_slurm/experiments/run_setup_beyondarena.py
+++ b/packages/tabflow_slurm/experiments/run_setup_beyondarena.py
@@ -27,8 +27,8 @@ benchmark_plan = TabArenaBenchmarkPlan(
             name="gpu",
             resources={
                 "num_gpus": 1,
-                "fake_memory_for_estimates": 80, # we have 80 GB VRAM CPU.
-            }
+                "fake_memory_for_estimates": 80,  # we have 80 GB VRAM CPU.
+            },
         ),
     ],
     tasks_to_run_setup=BeyondArenaMetadataBundle(),

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/benchmark.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/benchmark.py
@@ -4,22 +4,21 @@ from __future__ import annotations
 
 import os
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import ray
-from tabarena.benchmark.experiment import TabArenaExperimentBundle
-from tabarena.utils.ray_utils import ray_map_list, to_batch_list
 
+from tabarena.utils.ray_utils import ray_map_list, to_batch_list
 from tabflow_slurm.setup.candidates import JobCandidate, should_run_job_batch
-from tabflow_slurm.setup.resources import ResourcesSetup
-from tabflow_slurm.setup.scheduler import SchedulerSetup, SlurmSetup
 
 if TYPE_CHECKING:
+    from tabarena.benchmark.experiment import TabArenaExperimentBundle
     from tabarena.benchmark.task.metadata import TabArenaMetadataBundle, TabArenaTaskMetadata
-
     from tabflow_slurm.setup.paths import PathSetup
+    from tabflow_slurm.setup.resources import ResourcesSetup
+    from tabflow_slurm.setup.scheduler import SchedulerSetup
 
 
 @dataclass
@@ -109,7 +108,7 @@ class TabArenaBenchmarkSetup:
 
         print(
             f"Approved {len(approved)} (task, fold, repeat, config) items"
-            f" -> {len(jobs)} array tasks (max {max_configs_per_job} items/task)."
+            f" -> {len(jobs)} array tasks (max {max_configs_per_job} items/task).",
         )
         return jobs, max_configs_per_job
 
@@ -135,7 +134,7 @@ class TabArenaBenchmarkSetup:
                         n_classes=split_md.num_classes_train,
                         n_samples_train_per_fold=split_md.num_instances_train,
                         problem_type=tm.problem_type,
-                    )
+                    ),
                 )
         return candidates
 
@@ -225,6 +224,6 @@ class TabArenaBenchmarkSetup:
                 self.path_setup.get_configs_path(
                     benchmark_name=self.benchmark_name,
                     safe_benchmark_name=self._safe_benchmark_name,
-                )
+                ),
             ).unlink(missing_ok=True)
         return run_commands

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/plan.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/plan.py
@@ -20,13 +20,11 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Literal
 
 from tabarena.benchmark.experiment import Experiment
-
 from tabflow_slurm.setup.benchmark import TabArenaBenchmarkSetup
 
 if TYPE_CHECKING:
     from tabarena.benchmark.experiment import TabArenaExperimentBundle
     from tabarena.benchmark.task.metadata import TabArenaMetadataBundle
-
     from tabflow_slurm.setup.paths import PathSetup
     from tabflow_slurm.setup.resources import ResourcesSetup
     from tabflow_slurm.setup.scheduler import SchedulerSetup
@@ -45,8 +43,7 @@ def _apply_overrides(base: Any, overrides: dict[str, Any], label: str) -> Any:
     unknown = set(overrides) - valid
     if unknown:
         raise ValueError(
-            f"Unknown {label} override key(s) {sorted(unknown)}. "
-            f"Valid {label} keys: {sorted(valid)}."
+            f"Unknown {label} override key(s) {sorted(unknown)}. Valid {label} keys: {sorted(valid)}.",
         )
     return replace(base, **overrides)
 
@@ -83,7 +80,7 @@ class SingleModel:
             return cls(*model)
         raise TypeError(
             f"Cannot interpret {model!r} as a model. Expected a SingleModel, "
-            f"a (name, n_configs) tuple, or a model name string."
+            f"a (name, n_configs) tuple, or a model name string.",
         )
 
     def to_entry(self) -> tuple[str, int | str | dict]:
@@ -219,7 +216,7 @@ class TabArenaBenchmarkPlan:
                     resources_setup=group["resources"],
                     ignore_cache=group["ignore_cache"],
                     num_ray_cpus=num_ray_cpus,
-                )
+                ),
             )
         return setups
 
@@ -235,7 +232,7 @@ class TabArenaBenchmarkPlan:
         for job in self.model_jobs:
             if "models" in job.experiment:
                 raise ValueError(
-                    "ModelJob.experiment must not set 'models'; use ModelJob.models instead."
+                    "ModelJob.experiment must not set 'models'; use ModelJob.models instead.",
                 )
             resources = _apply_overrides(self.resources_setup, job.resources, "resources")
             scheduler = _apply_overrides(self.scheduler_setup, job.scheduler, "scheduler")
@@ -256,7 +253,7 @@ class TabArenaBenchmarkPlan:
                         "ignore_cache": job.ignore_cache,
                         "models": list(job._model_entries()),
                         "name": job.name,
-                    }
+                    },
                 )
             else:
                 match["models"].extend(job._model_entries())
@@ -271,7 +268,7 @@ class TabArenaBenchmarkPlan:
         if current is not None and current != new:
             raise ValueError(
                 f"Jobs with identical settings merge into one run but have conflicting "
-                f"names {current!r} and {new!r}. Use the same name (or leave one unset)."
+                f"names {current!r} and {new!r}. Use the same name (or leave one unset).",
             )
         return new
 
@@ -299,7 +296,7 @@ class TabArenaBenchmarkPlan:
                 f"\n----- [{idx}/{n}] run '{label}' -----"
                 f"\n  models:    {models}"
                 f"\n  resources: {_format_resources(setup.resources_setup)}"
-                f"\n  partition: {_format_partition(setup.scheduler_setup, setup.resources_setup)}"
+                f"\n  partition: {_format_partition(setup.scheduler_setup, setup.resources_setup)}",
             )
             commands = setup.setup_jobs(print_run_commands=False) or []
             runs.append((label, models, commands))
@@ -324,7 +321,7 @@ class TabArenaBenchmarkPlan:
         print(
             f"\n{_SUMMARY_BAR}"
             f"\nPrefetching foundation-model weights for: {', '.join(model_names) or '(none)'}"
-            f"\n{_SUMMARY_BAR}"
+            f"\n{_SUMMARY_BAR}",
         )
         prefetch_weights(model_names)
 
@@ -336,7 +333,7 @@ class TabArenaBenchmarkPlan:
             f"\n{_SUMMARY_BAR}"
             f"\nPlan '{self.benchmark_name}' summary "
             f"— {len(runs)} run(s), {len(all_commands)} command(s) to launch"
-            f"\n{_SUMMARY_BAR}"
+            f"\n{_SUMMARY_BAR}",
         )
         prefix = f"{self.benchmark_name}_"
         for label, models, commands in runs:

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/scheduler.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/scheduler.py
@@ -251,7 +251,7 @@ class SlurmSetup(SchedulerSetup):
                 "##### Setup Jobs"
                 f"{batch_info}"
                 "\nRun the following command(s) to start the jobs:"
-                "\n" + "\n".join(run_commands) + "\n"
+                "\n" + "\n".join(run_commands) + "\n",
             )
         return run_commands
 
@@ -280,7 +280,7 @@ class SlurmSetup(SchedulerSetup):
                 json.dump({"defaults": defaults, "jobs": batch_jobs}, f)
 
             run_commands.append(
-                f"sbatch --array=0-{len(batch_jobs) - 1}%{self.array_job_limit} {base_command} {json_path}"
+                f"sbatch --array=0-{len(batch_jobs) - 1}%{self.array_job_limit} {base_command} {json_path}",
             )
         return run_commands
 

--- a/packages/tabflow_slurm/src/tabflow_slurm/slurm_utils.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/slurm_utils.py
@@ -63,7 +63,7 @@ def setup_slurm_job(
             print(
                 "WARNING: /dev/shm is full, switching to /tmp usage! "
                 f"Available shared memory size: {dev_shm_size} GB, "
-                f"Required minimum for Ray plasma store: {min_plasma_storage_size} GB."
+                f"Required minimum for Ray plasma store: {min_plasma_storage_size} GB.",
             )
             # Likely slower but runs at least.
             _plasma_directory = ray_dir
@@ -87,7 +87,7 @@ def setup_slurm_job(
                 runtime_env={
                     "env_vars": {
                         "LOKY_START_METHOD": "forkserver",
-                    }
+                    },
                 },
             )
     return ray_dir

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,8 +1,29 @@
 # https://github.com/charliermarsh/ruff
-target-version = "py39"
+target-version = "py311"
 line-length = 120
 output-format = "full"
-src = ["examples", "packages/tabflow_slurm/src"]
+src = [
+    "packages/tabarena/src",
+    "packages/bencheval/src",
+    "packages/tabflow_slurm/src",
+    "examples",
+    "tst",
+]
+
+# File-discovery exclusions. MUST be top-level (not under [lint]): top-level `extend-exclude`
+# prunes paths from both linting and formatting, and ADDS to ruff's built-in defaults
+# (.git, build, dist, .venv, node_modules, ...) rather than replacing them.
+extend-exclude = [
+    "docs", # not one of ruff's built-in default excludes
+    # --- Vendored upstream sources (not first-party; keep as-imported) ---
+    "packages/tabarena/src/tabarena/models/limix/_vendor",       # vendored LimiX (Apache-2.0)
+    "packages/tabarena/src/tabarena/models/tabm/_internal",      # vendored from yandex-research/tabm
+    "packages/tabarena/src/tabarena/models/modernnca/_internal", # vendored from LAMDA-Tabular/TALENT
+    # --- Archived / experimental examples ---
+    "examples/!old",
+    "examples/!experimental",
+    "examples/tmp",
+]
 
 [lint]
 # Extend what ruff is allowed to fix, even it it may break
@@ -56,7 +77,7 @@ select = [
     "T10",
     "T20",
     "TID",
-    "TCH",
+    "TC",
     "UP",
     "N",
     "W",
@@ -76,7 +97,7 @@ ignore = [
     "S101", # Use of assert detected.
     "W292", # No newline at end of file
     "PLC1901", # "" can be simplified to be falsey
-    "TCH003", # Move stdlib import into TYPE_CHECKING
+    "TC003", # Move stdlib import into TYPE_CHECKING
     "PLR2004", # Magic numbers, gets in the way a lot
     "PLR0915", # Too many statements
     "N803", # Argument name `X` should be lowercase
@@ -84,29 +105,75 @@ ignore = [
     "COM812", # Trailing comma missing (conflicts with formatter)
     "T201", # Remove prints
     "C408", # use of {} instead of dict
+    # --- Relaxed during the repo-wide ruff rollout (high-volume, non-auto-fixable, stylistic) ---
+    "D102", # Missing docstring in public method (consistent with ignored D104/D105; backfilling ~850 docstrings is out of scope)
+    "D103", # Missing docstring in public function (same rationale as D102)
+    "FBT001", # Boolean-typed positional arg (pervasive in existing public APIs; changing signatures is behavioral)
+    "FBT002", # Boolean default positional arg (same rationale as FBT001)
+    "PLC0415", # `import` outside top-level (the repo intentionally lazy-imports optional model deps inside _fit/class bodies)
+    "ERA001", # Commented-out code (cleanup is judgment-heavy; avoid churn)
+    # --- Stage 3: remaining high-volume, non-auto-fixable, stylistic rules (kept correctness/safety rules enabled) ---
+    # Docstrings (consistent with already-ignored D102/D103/D104/D105):
+    "D100", # Missing docstring in public module
+    "D101", # Missing docstring in public class
+    "D107", # Missing docstring in __init__
+    "D414", # Empty docstring section
+    "D415", # Docstring first line should end with punctuation
+    "D417", # Missing argument description in docstring
+    # Complexity metrics (consistent with already-ignored PLR0915; max-args already set to 10):
+    "C901", # Function is too complex
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments
+    # Unused arguments — required to honor shared interfaces (sklearn/AutoGluon fit/predict signatures):
+    "ARG001", # Unused function argument
+    "ARG002", # Unused method argument
+    "ARG003", # Unused class method argument
+    "ARG005", # Unused lambda argument
+    "FBT003", # Boolean positional value in call (consistent with already-ignored FBT001/FBT002)
+    # Ambiguous-unicode (math symbols/accents in strings, docstrings, comments are intentional):
+    "RUF001", "RUF002", "RUF003",
+    # pandas idiom opinions (noisy / frequent false positives; .values etc. are used deliberately):
+    "PD011", "PD003", "PD010", "PD013", "PD015",
+    "INP001", # Implicit namespace package (examples/scripts dirs intentionally have no __init__.py)
+    "PLW2901", # `for` loop variable overwritten (stylistic)
+    "NPY002", # Legacy numpy random (migration to Generator is a behavioral change; pervasive)
+    "E501", # Line too long (the ruff formatter is the authority for code line length; residual is unwrappable URLs/strings/comments)
+    "PTH", # Prefer pathlib over os.path (stylistic; os.path usage is correct and pervasive — avoid ~56 hand conversions)
+    "E741", # Ambiguous variable name (e.g. `l`) (stylistic)
+    "PLW0603", # Use of `global` (occasionally necessary; low value to refactor)
+    # Naming (consistent with already-ignored N802/N803/N806):
+    "A001", # Variable shadows a builtin (consistent with ignored A002/A003)
+    "N801", # Class name should use CapWords
+    "N812", # Lowercase imported as non-lowercase (e.g. `torch.nn.functional as F`)
+    "N999", # Invalid module name
+    # Broadly-applied stylistic opinions (pervasive, low value, non-auto-fixable):
+    "BLE001", # Blind `except Exception` (intentional in benchmark runners that must not crash)
+    "RUF059", # Unused variable in unpacking assignment
+    "B007", # Loop control variable not used within loop body
+    "RUF012", # Mutable class attribute should be annotated `ClassVar` (pervasive in ML config classes)
+    "UP035", # Deprecated import (typing aliases; harmless, low priority)
+    "SIM102", "SIM105", "SIM108", "SIM117", # if/with simplification opinions
+    "PLC0206", # Extracting value from dict without `.items()`
+    "E402", # Module import not at top of file (intentional after sys.path / lazy setup)
+    "S301", # `pickle` usage (intrinsic to the benchmark's result serialization)
+    "B021", # f-string docstring (only flagged instances have no placeholders; harmless)
 ]
 
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-    "docs",
+[lint.per-file-ignores]
+# Tests don't need module/class docstrings, and test packages are intentionally
+# implicit namespace packages (no __init__.py).
+"tst/**" = [
+    "D100", # Missing docstring in public module
+    "D101", # Missing docstring in public class
+    "INP001", # File is part of an implicit namespace package
+    "PT011", # pytest.raises(...) too broad — acceptable in tests
+    "PT018", # Composite assertion — acceptable in tests
+    "B017", # assert pytest.raises(Exception) — acceptable in tests
+    "RUF043", # pytest.raises pattern is a regex — acceptable in tests
+]
+# `__init__.py` files intentionally re-export names for the public API surface.
+"**/__init__.py" = [
+    "F401", # Imported but unused (re-export)
 ]
 
 [lint.isort]

--- a/tst/benchmark/experiment/test_experiment_resources.py
+++ b/tst/benchmark/experiment/test_experiment_resources.py
@@ -38,8 +38,10 @@ def test_autodetect_resources_fills_none_without_mutating_original():
     out = Experiment._autodetect_resources(mk)
 
     assert out is not mk  # a copy is returned
-    assert isinstance(out["fit_kwargs"]["num_cpus"], int) and out["fit_kwargs"]["num_cpus"] > 0
-    assert isinstance(out["fit_kwargs"]["memory_limit"], int) and out["fit_kwargs"]["memory_limit"] > 0
+    assert isinstance(out["fit_kwargs"]["num_cpus"], int)
+    assert out["fit_kwargs"]["num_cpus"] > 0
+    assert isinstance(out["fit_kwargs"]["memory_limit"], int)
+    assert out["fit_kwargs"]["memory_limit"] > 0
     assert out["fit_kwargs"]["num_gpus"] == 0
     # original left untouched (still requests auto-detection)
     assert mk["fit_kwargs"]["num_cpus"] is None

--- a/tst/benchmark/experiment/test_experiment_utils.py
+++ b/tst/benchmark/experiment/test_experiment_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+
 from tabarena.benchmark.experiment.experiment_runner_api import (
     _build_cache_prefix,
     _clean_repetitions_mode_args_for_matrix,
@@ -92,7 +93,10 @@ class _RecordingCache(AbstractCacheFunction):
     ],
 )
 def test_parse_repetitions_mode_and_args(
-    repetitions_mode, repetitions_mode_args, tasks, expected_output
+    repetitions_mode,
+    repetitions_mode_args,
+    tasks,
+    expected_output,
 ):
     if isinstance(expected_output, type) and issubclass(expected_output, BaseException):
         with pytest.raises(expected_output):
@@ -205,6 +209,7 @@ class TestCleanRepetitionsModeArgsForMatrix:
 
 def _make_minimal_experiment(name: str = "lgbm_test"):
     from autogluon.tabular.models import LGBModel
+
     from tabarena.benchmark.experiment import AGModelBagExperiment
 
     return AGModelBagExperiment(
@@ -428,7 +433,7 @@ class TestResolveTaskDisplayName:
 
     def test_task_id_preferred_over_tid(self):
         meta = pd.DataFrame(
-            {"task_id": [360], "tid": [999], "dataset": ["from_task_id"], "name": ["from_name"]}
+            {"task_id": [360], "tid": [999], "dataset": ["from_task_id"], "name": ["from_name"]},
         )
         # task_id is matched and dataset is the chosen name column
         assert _resolve_task_display_name(360, meta) == "from_task_id"
@@ -504,7 +509,9 @@ class TestExperimentBatchRunnerDelegation:
 
         task_metadata = pd.DataFrame({"tid": [0, 1], "dataset": ["d0", "d1"]})
         return ExperimentBatchRunner(
-            expname=str(tmp_path), task_metadata=task_metadata, **kwargs
+            expname=str(tmp_path),
+            task_metadata=task_metadata,
+            **kwargs,
         )
 
     def test_only_cache_no_cache_returns_empty(self, tmp_path):

--- a/tst/benchmark/experiment/test_validation_utils.py
+++ b/tst/benchmark/experiment/test_validation_utils.py
@@ -5,6 +5,7 @@ import importlib.util
 import numpy as np
 import pandas as pd
 import pytest
+
 from tabarena.benchmark.models.wrapper.validation_utils import (
     TabArenaValidationProtocolExecMixin,
     split_time_index_into_intervals,
@@ -286,8 +287,11 @@ def test_resolve_validation_splits_group_on_with_num_repeats_none():
         group_on="grp",
         group_labels=GroupLabelTypes.PER_SAMPLE,
     )
-    custom_splits, folds, repeats = v.resolve_validation_splits(
-        X=X, y=y, num_folds=8, num_repeats=None,
+    custom_splits, _folds, repeats = v.resolve_validation_splits(
+        X=X,
+        y=y,
+        num_folds=8,
+        num_repeats=None,
     )
     assert custom_splits is not None
     assert repeats == 1
@@ -388,18 +392,16 @@ def test_temporal_ordering_invariant_with_unsorted_input():
     time_vals = rng.integers(1, 15, size=n)  # values drawn from 1..14
     time_data = pd.Series(time_vals)
     intervals, _ = split_time_index_into_intervals(time_data=time_data, goal_n_intervals=5)
-    for _t1, _i1, _t2, _i2 in zip(time_data, intervals, time_data, intervals):
+    for _t1, _i1, _t2, _i2 in zip(time_data, intervals, time_data, intervals, strict=False):
         pass  # just verifying iteration works; real check below
 
     # Build sorted-by-time view and assert monotonicity
-    sorted_pairs = sorted(zip(time_data.tolist(), intervals.tolist()))
+    sorted_pairs = sorted(zip(time_data.tolist(), intervals.tolist(), strict=False))
     for idx in range(len(sorted_pairs) - 1):
         t_a, lbl_a = sorted_pairs[idx]
         t_b, lbl_b = sorted_pairs[idx + 1]
         if t_a < t_b:
-            assert lbl_a <= lbl_b, (
-                f"Temporal ordering violated: time {t_a} → label {lbl_a}, " f"time {t_b} → label {lbl_b}"
-            )
+            assert lbl_a <= lbl_b, f"Temporal ordering violated: time {t_a} → label {lbl_a}, time {t_b} → label {lbl_b}"
 
 
 def test_all_rows_covered_by_valid_label():
@@ -447,7 +449,9 @@ def test_balance_on_rows_vs_unique_produce_different_partitions_for_skewed_data(
 
     intervals_rows, n_rows = split_time_index_into_intervals(time_data=time_data, goal_n_intervals=2, balance_on="rows")
     intervals_unique, n_unique = split_time_index_into_intervals(
-        time_data=time_data, goal_n_intervals=2, balance_on="unique"
+        time_data=time_data,
+        goal_n_intervals=2,
+        balance_on="unique",
     )
 
     assert n_rows == n_unique == 2
@@ -482,7 +486,7 @@ def test_unsorted_input_labels_are_consistent_with_time_order():
     assert n == 3
     assert list(intervals) == [2, 1, 0, 2, 0]
     # Confirm the mapping is monotone: t=1,2 → 0; t=3 → 1; t=4,5 → 2
-    mapping = dict(zip(time_data.tolist(), intervals.tolist()))
+    mapping = dict(zip(time_data.tolist(), intervals.tolist(), strict=False))
     assert mapping[1] == mapping[2] == 0
     assert mapping[3] == 1
     assert mapping[4] == mapping[5] == 2
@@ -698,7 +702,7 @@ def test_time_on_to_groups_data_unsorted_input_gives_monotonic_output():
     X = pd.DataFrame({"time": [5, 3, 1, 4, 2]})
     groups, n = _Validation.time_on_to_groups_data(X=X, time_on="time", num_folds=3)
     assert n == 3
-    pairs = sorted(zip(X["time"].tolist(), groups.tolist()))
+    pairs = sorted(zip(X["time"].tolist(), groups.tolist(), strict=False))
     for i in range(len(pairs) - 1):
         t_a, lbl_a = pairs[i]
         t_b, lbl_b = pairs[i + 1]
@@ -818,7 +822,7 @@ def test_resolve_validation_splits_group_on_returns_custom_splits(monkeypatch):
         {
             "feature": np.arange(n, dtype=float),
             "group": [f"g{i % 20}" for i in range(n)],  # 20 unique groups
-        }
+        },
     )
     y = pd.Series(np.zeros(n))
     _patch_group_splits(v, monkeypatch, n)
@@ -843,7 +847,7 @@ def test_resolve_validation_splits_group_on_indices_do_not_overlap(monkeypatch):
         {
             "feature": np.arange(n, dtype=float),
             "group": [f"g{i % 20}" for i in range(n)],
-        }
+        },
     )
     y = pd.Series(np.zeros(n))
     _patch_group_splits(v, monkeypatch, n)
@@ -865,7 +869,7 @@ def test_resolve_validation_splits_group_on_tiny_data_uses_tiny_folds(monkeypatc
         {
             "feature": np.arange(n, dtype=float),
             "group": [f"g{i % 5}" for i in range(n)],
-        }
+        },
     )
     y = pd.Series(np.zeros(n))
     captured: dict = {}
@@ -920,7 +924,7 @@ def test_resolve_validation_splits_time_on_folds_capped_at_unique_values(monkeyp
         {
             "feature": np.arange(n, dtype=float),
             "time": [i % 4 for i in range(n)],
-        }
+        },
     )
     y = pd.Series(np.zeros(n))
     _patch_group_splits(v, monkeypatch, n)

--- a/tst/benchmark/preprocessing/test_preprocessing.py
+++ b/tst/benchmark/preprocessing/test_preprocessing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
+
 from tabarena.benchmark.preprocessing import (
     TabArenaModelAgnosticPreprocessing,
     TabArenaModelSpecificPreprocessing,
@@ -258,7 +259,7 @@ class TestTabArenaModelAgnosticPreprocessingFitTransform:
             {
                 "num": [1.0, 2.0, 3.0, 4.0, 5.0],
                 "cat": pd.Categorical(["a", "b", "a", "c", "b"]),
-            }
+            },
         )
         gen = _make_no_text_gen()
         X_out = gen.fit_transform(X)
@@ -453,14 +454,14 @@ class TestNoCatAsStringCategoryFeatureGeneratorUnseenHandling:
             {
                 "c1": pd.Categorical(["a", "b", "a", "b"]),
                 "c2": pd.Categorical(["x", "y", "x", "y"]),
-            }
+            },
         )
         gen = self._fit_gen(X_train)
         X_test = pd.DataFrame(
             {
                 "c1": pd.Categorical(["a", "NEW_C1"]),
                 "c2": pd.Categorical(["x", "y"]),
-            }
+            },
         )
         X_out = gen.transform(X_test.copy())
         assert X_out["c1"].isna().sum() == 0
@@ -606,14 +607,14 @@ class TestStringFixAsTypeFeatureGeneratorCategoricals:
             {
                 "c1": pd.Categorical(["a", "b"]),
                 "c2": pd.Categorical(["x", "y"]),
-            }
+            },
         )
         gen = self._fit_gen(X_train)
         X_test = pd.DataFrame(
             {
                 "c1": pd.Categorical(["a", "NOVEL"]),
                 "c2": pd.Categorical(["x", "ALSO_NEW"]),
-            }
+            },
         )
         X_out = gen.transform(X_test.copy())
         assert X_out["c1"].isna().sum() == 0
@@ -629,14 +630,14 @@ class TestStringFixAsTypeFeatureGeneratorCategoricals:
             {
                 "num": [1.0, 2.0, 3.0],
                 "cat": pd.Categorical(["a", "b", "c"]),
-            }
+            },
         )
         gen = self._fit_gen(X_train)
         X_test = pd.DataFrame(
             {
                 "num": [4.0, 5.0],
                 "cat": pd.Categorical(["a", "NEW"]),
-            }
+            },
         )
         X_out = gen.transform(X_test.copy())
         assert X_out["cat"].isna().sum() == 0
@@ -906,7 +907,7 @@ class TestStatisticalTextFeatureGenerator:
             {
                 "col_a": [phrases[i % len(phrases)] for i in range(n)],
                 "col_b": [phrases[(i + 1) % len(phrases)] for i in range(n)],
-            }
+            },
         )
         X_out, _ = gen._fit_transform(X.copy())
         a_cols = [c for c in X_out.columns if c.startswith("col_a.")]
@@ -992,7 +993,7 @@ class TestSemanticTextFeatureGeneratorCacheRoundTrip:
 
         embs = []
         for t in texts:
-            seed = int(hashlib.md5(t.encode()).hexdigest(), 16) % (2**31)
+            seed = int(hashlib.md5(t.encode()).hexdigest(), 16) % (2**31)  # noqa: S324
             rng = np.random.RandomState(seed)
             emb = rng.randn(32).astype(np.float32)
             emb /= np.linalg.norm(emb)
@@ -1074,7 +1075,8 @@ class TestSemanticTextFeatureGeneratorCacheRoundTrip:
 
         cache_path = tmp_path / "partial_cache.parquet"
         SemanticTextFeatureGenerator.save_embedding_cache(
-            cache=SemanticTextFeatureGenerator._embedding_look_up, path=cache_path
+            cache=SemanticTextFeatureGenerator._embedding_look_up,
+            path=cache_path,
         )
 
         # Clear and reload
@@ -1101,8 +1103,8 @@ class TestSemanticTextFeatureGeneratorCacheRoundTrip:
             {
                 "description": [
                     f"This is a detailed text description for sample number {i} with unique content" for i in range(50)
-                ]
-            }
+                ],
+            },
         )
 
         preprocessing = TabArenaModelAgnosticPreprocessing(
@@ -1177,7 +1179,7 @@ class TestTextEmbeddingDRParseSourceColumn:
     def test_multiple_dots_uses_first(self):
         # Only the first "." separator is used.
         result = TextEmbeddingDimensionalityReductionFeatureGenerator._parse_source_column(
-            "col.semantic_embedding.extra"
+            "col.semantic_embedding.extra",
         )
         assert result == "col"
 
@@ -1197,7 +1199,7 @@ class TestTextEmbeddingDRParseSourceColumn:
     def test_semantic_suffix_convention(self):
         # SemanticTextFeatureGenerator produces "description.semantic_embedding_5"
         result = TextEmbeddingDimensionalityReductionFeatureGenerator._parse_source_column(
-            "description.semantic_embedding_5"
+            "description.semantic_embedding_5",
         )
         assert result == "description"
 
@@ -1308,7 +1310,8 @@ class TestTextEmbeddingDRStaticMethods:
     )
     def test_num_components_for_variance(self, ratios, threshold, expected_min_k):
         k = TextEmbeddingDimensionalityReductionFeatureGenerator._num_components_for_variance(
-            np.array(ratios), threshold
+            np.array(ratios),
+            threshold,
         )
         assert k >= 1
         assert k <= len(ratios)
@@ -1544,7 +1547,7 @@ def _make_grouped_df(
             "num_a": rng.standard_normal(n_rows) + groups * 10,
             "num_b": rng.uniform(0, 1, n_rows),
             "cat_c": rng.choice(["x", "y", "z"], n_rows),
-        }
+        },
     )
     y = pd.Series(rng.standard_normal(n_rows), name="target")
     return X, y
@@ -1636,7 +1639,7 @@ class TestGroupAggregationFeatureGenerator:
                 "high_var": rng.standard_normal(n_rows) + groups * 1000,
                 # Low variance: nearly constant
                 "low_var": rng.standard_normal(n_rows) * 0.001,
-            }
+            },
         )
         y = pd.Series(rng.standard_normal(n_rows))
         gen = GroupAggregationFeatureGenerator(group_col="gid", n_top_features=1)
@@ -1655,7 +1658,7 @@ class TestGroupAggregationFeatureGenerator:
                 "a": rng.standard_normal(n_rows) + groups * 100,
                 "b": rng.standard_normal(n_rows) + groups * 10,
                 "c": rng.standard_normal(n_rows) + groups * 1,
-            }
+            },
         )
         y = pd.Series(rng.standard_normal(n_rows))
         gen = GroupAggregationFeatureGenerator(group_col="gid", n_top_features=3)
@@ -1698,7 +1701,7 @@ class TestGroupAggregationFeatureGenerator:
                 "num_a": rng.standard_normal(3),
                 "num_b": rng.uniform(0, 1, 3),
                 "cat_c": ["x", "y", "z"],
-            }
+            },
         )
         X_out = gen._transform(X_test)
         assert len(X_out) == 3
@@ -1727,7 +1730,7 @@ class TestGroupAggregationFeatureGenerator:
                 "g1": ["a", "a", "b", "b", "a", "b"],
                 "g2": [1, 1, 1, 1, 2, 2],
                 "val": rng.standard_normal(6),
-            }
+            },
         )
         y = pd.Series(rng.standard_normal(6))
         gen = GroupAggregationFeatureGenerator(group_col=["g1", "g2"], n_top_features=5)
@@ -1746,10 +1749,10 @@ class TestGroupAggregationFeatureGenerator:
             {
                 "gid": [0, 0, 0, 1, 1, 1],
                 "ts": pd.to_datetime(
-                    ["2020-01-03", "2020-01-01", "2020-01-02", "2020-02-01", "2020-02-03", "2020-02-02"]
+                    ["2020-01-03", "2020-01-01", "2020-01-02", "2020-02-01", "2020-02-03", "2020-02-02"],
                 ),
                 "val": [30.0, 10.0, 20.0, 100.0, 300.0, 200.0],
-            }
+            },
         )
         y = pd.Series([1.0] * 6)
         gen = GroupAggregationFeatureGenerator(group_col="gid", group_time_on="ts", n_top_features=100)
@@ -1794,7 +1797,7 @@ class TestGroupAggregationFeatureGenerator:
             {
                 "gid": [0, 0, 0, 0],
                 "val": rng.standard_normal(4),
-            }
+            },
         )
         y = pd.Series(rng.standard_normal(4))
         gen = GroupAggregationFeatureGenerator(group_col="gid", n_top_features=5)

--- a/tst/benchmark/preprocessing/test_text_cache.py
+++ b/tst/benchmark/preprocessing/test_text_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+
 from tabarena.benchmark.preprocessing import text_cache as tc
 from tabarena.loaders import set_tabarena_cache_root
 
@@ -100,8 +101,13 @@ def test_use_cache_loads_and_restores(cache_root):
 
 
 def test_require_raises_when_missing_for_text_task(cache_root):
-    with pytest.raises(FileNotFoundError, match="Text cache not found"), tc.use_text_cache_for_task(
-        _UT(), has_text=True, mode="require"
+    with (
+        pytest.raises(FileNotFoundError, match="Text cache not found"),
+        tc.use_text_cache_for_task(
+            _UT(),
+            has_text=True,
+            mode="require",
+        ),
     ):
         pass
 

--- a/tst/benchmark/task/test_beyond_arena_bundle.py
+++ b/tst/benchmark/task/test_beyond_arena_bundle.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+
 from tabarena.benchmark.task.metadata import (
     BeyondArenaMetadataBundle,
     SplitMetadata,
     TabArenaTaskMetadata,
 )
 from tabarena.benchmark.task.user_task import UserTask
-
 
 # ---------------------------------------------------------------------------
 # UserTask: portable (path-free) vs explicit-path task_id_str
@@ -121,7 +121,7 @@ def patched_data_foundry(monkeypatch):
 
     materialized: list[str] = []
 
-    def _fake_materialize(*, collection, task_id_str, data_foundry_uri, **_):  # noqa: ARG001
+    def _fake_materialize(*, collection, task_id_str, data_foundry_uri, **_):
         materialized.append(data_foundry_uri)
         return f"materialized::{data_foundry_uri}"
 

--- a/tst/benchmark/task/test_metadata_bundle.py
+++ b/tst/benchmark/task/test_metadata_bundle.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+
 from tabarena.benchmark.task.metadata import (
     SplitMetadata,
     TabArenaMetadataBundle,
@@ -237,7 +238,7 @@ class TestTabArenaV0pt1Conversion:
                     "tabarena_num_repeats": 2,
                     "num_folds": 3,
                 },
-            ]
+            ],
         )
         assert len(load_tabarena_v0_1_task_metadata(curated)) == 6
 
@@ -276,7 +277,7 @@ class TestTabArenaV0pt1Conversion:
                     "tabarena_num_repeats": 1,
                     "num_folds": 1,
                 },
-            ]
+            ],
         )
         result = _bundle(
             task_metadata=load_tabarena_v0_1_task_metadata(curated),
@@ -313,7 +314,7 @@ class TestTabArenaV0pt1Conversion:
                     "tabarena_num_repeats": 1,
                     "num_folds": 1,
                 },
-            ]
+            ],
         )
         assert load_tabarena_v0_1_task_metadata(curated)[0].eval_metric == "log_loss"
 
@@ -332,7 +333,7 @@ class TestTabArenaV0pt1Conversion:
                     "tabarena_num_repeats": 1,
                     "num_folds": 1,
                 },
-            ]
+            ],
         )
         assert load_tabarena_v0_1_task_metadata(curated)[0].eval_metric == "rmse"
 

--- a/tst/benchmark/task/test_metadata_sources.py
+++ b/tst/benchmark/task/test_metadata_sources.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+
 from tabarena.benchmark.task.metadata import (
     DataFoundryTaskMetadataSource,
     InMemoryTaskMetadataSource,
@@ -18,7 +19,6 @@ from tabarena.benchmark.task.metadata import (
     resolve_source,
 )
 from tabarena.benchmark.task.metadata.sources import tabarena_v0pt1 as v0pt1_mod
-from tabarena.benchmark.task.metadata.sources.base import TaskMetadataSource
 
 
 def _task(*, dataset_name: str, uri: str | None) -> TabArenaTaskMetadata:
@@ -103,8 +103,8 @@ def test_v0pt1_source_falls_back_to_rebuild_when_csv_missing(monkeypatch, tmp_pa
                 "num_classes": 2,
                 "tabarena_num_repeats": 1,
                 "num_folds": 1,
-            }
-        ]
+            },
+        ],
     )
     monkeypatch.setattr(
         "tabarena.nips2025_utils.fetch_metadata.load_curated_task_metadata",
@@ -134,7 +134,9 @@ def test_openml_source_honors_custom_cache_dir(monkeypatch, tmp_path):
 
     set_dirs: list[str] = []
     monkeypatch.setattr(
-        openml.config, "set_root_cache_directory", lambda root_cache_directory: set_dirs.append(root_cache_directory)
+        openml.config,
+        "set_root_cache_directory",
+        lambda root_cache_directory: set_dirs.append(root_cache_directory),
     )
     monkeypatch.setattr(openml.config, "get_cache_directory", lambda: str(tmp_path))
     monkeypatch.setattr(openml.tasks, "get_task", lambda task_id, **_: None)
@@ -194,7 +196,7 @@ def patched_data_foundry(monkeypatch):
 
     materialized: list[str] = []
 
-    def _fake_materialize(*, collection, task_id_str, data_foundry_uri, **_):  # noqa: ARG001
+    def _fake_materialize(*, collection, task_id_str, data_foundry_uri, **_):
         materialized.append(data_foundry_uri)
         return f"materialized::{data_foundry_uri}"
 

--- a/tst/benchmark/task/test_user_task.py
+++ b/tst/benchmark/task/test_user_task.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 from openml.tasks import OpenMLClassificationTask, OpenMLRegressionTask, TaskType
 from openml.tasks.split import OpenMLSplit
+
 from tabarena.benchmark.task import UserTask
 from tabarena.benchmark.task.metadata import (
     GroupLabelTypes,
@@ -37,7 +38,7 @@ def _make_dataset(problem_type: str, *, n: int = 10) -> tuple[pd.DataFrame, str,
         {
             "num": np.arange(n, dtype="int64"),
             "cat": pd.Series(["A", "B"] * (n // 2), dtype="category"),
-        }
+        },
     )
     if problem_type == "classification":
         dataset["target"] = ["neg", "pos"] * (n // 2)
@@ -298,7 +299,8 @@ def test_slug_is_readable_first_segment_plus_shorthash():
     ut = UserTask(task_name="blood_transfusion/019d7366-d9d0-777d-b0ae-e7a5175f7f09")
     readable, _, shorthash = ut.slug.rpartition("-")
     assert readable == "blood_transfusion"  # first /-segment
-    assert len(shorthash) == 12 and shorthash == ut._task_name_hash[:12]
+    assert len(shorthash) == 12
+    assert shorthash == ut._task_name_hash[:12]
 
 
 def test_slug_is_deterministic_and_unique():
@@ -554,14 +556,16 @@ def test_task_metadata_from_row_backward_compat_missing_optional_fields():
     df = meta.to_dataframe()
     row = df.iloc[0]
     # Simulate an old CSV that doesn't have the new columns
-    row = row.drop([
-        "has_datetime",
-        "has_text",
-        "has_categorical",
-        "has_numerical",
-        "has_binary",
-        "has_high_cardinality_categorical",
-    ])
+    row = row.drop(
+        [
+            "has_datetime",
+            "has_text",
+            "has_categorical",
+            "has_numerical",
+            "has_binary",
+            "has_high_cardinality_categorical",
+        ]
+    )
     reconstructed = TabArenaTaskMetadata.from_row(row)
     assert reconstructed.dataset_name == meta.dataset_name
     # New fields default to None when absent
@@ -672,7 +676,9 @@ def test_get_num_instance_groups_no_group():
 def test_get_num_instance_groups_per_sample_label():
     X = pd.DataFrame({"a": [1, 2, 3], "group": ["x", "x", "y"]})
     n = TabArenaTaskMetadataMixin.get_num_instance_groups(
-        X=X, group_on="group", group_labels=GroupLabelTypes.PER_SAMPLE
+        X=X,
+        group_on="group",
+        group_labels=GroupLabelTypes.PER_SAMPLE,
     )
     # PER_SAMPLE → returns len(X) regardless of groups
     assert n == 3
@@ -687,7 +693,9 @@ def test_get_num_instance_groups_per_group_label():
 def test_get_num_instance_groups_multi_column_group():
     X = pd.DataFrame({"g1": ["a", "a", "b"], "g2": [1, 2, 1]})
     n = TabArenaTaskMetadataMixin.get_num_instance_groups(
-        X=X, group_on=["g1", "g2"], group_labels=GroupLabelTypes.PER_GROUP
+        X=X,
+        group_on=["g1", "g2"],
+        group_labels=GroupLabelTypes.PER_GROUP,
     )
     # (a,1), (a,2), (b,1) → 3 unique groups
     assert n == 3
@@ -707,7 +715,7 @@ def _make_multiclass_dataset(n_per_class: int = 4) -> tuple[pd.DataFrame, str]:
             "num": np.arange(n, dtype="int64"),
             "cat": pd.Categorical(["A", "B"] * (n // 2)),
             "target": pd.Categorical(labels),
-        }
+        },
     )
     return df, "target"
 
@@ -721,7 +729,7 @@ def _make_4class_dataset(n_per_class: int = 3) -> tuple[pd.DataFrame, str]:
             "num": np.arange(n, dtype="int64"),
             "cat": pd.Categorical(["A", "B"] * (n // 2)),
             "target": pd.Categorical(labels),
-        }
+        },
     )
     return df, "target"
 
@@ -756,7 +764,9 @@ def test_get_dataset_stats_regression_basic(tmp_path):
     df, target, _, _ = _make_dataset("regression", n=10)
     task, _ = _task_from_user_task(df, target, "regression", {0: {0: (list(range(8)), [8, 9])}}, tmp_path, "ds-reg")
     n_inst, n_feat, n_cls, n_groups = task._get_dataset_stats(
-        oml_dataset=df, is_classification=False, target_name=target
+        oml_dataset=df,
+        is_classification=False,
+        target_name=target,
     )
     assert n_inst == 10
     assert n_feat == 2  # "num" and "cat"
@@ -789,7 +799,7 @@ def test_get_dataset_stats_num_features_excludes_target(tmp_path):
             "f3": range(n),
             "f4": range(n),
             "target": [0, 1] * (n // 2),
-        }
+        },
     )
     task, _ = _task_from_user_task(
         df,
@@ -938,7 +948,7 @@ def test_compute_metadata_dtype_flags_with_text_and_datetime(tmp_path):
             "txt": pd.array(["hello"] * 10, dtype="string"),
             "dt": pd.date_range("2020-01-01", periods=10, freq="D"),
             "target": [0, 1] * 5,
-        }
+        },
     )
     task, _ = _task_from_user_task(
         df,
@@ -976,7 +986,7 @@ def test_compute_metadata_dtype_flags_independent_columns(tmp_path):
             # Binary categorical
             "cat_b": pd.Series(["A", "B"] * (n // 2), dtype="category"),
             "target": pd.Series(["neg", "pos"] * (n // 2), dtype="category"),
-        }
+        },
     )
     task, _ = _task_from_user_task(
         df,
@@ -1066,7 +1076,7 @@ def test_compute_metadata_multi_fold_split_indices(tmp_path):
         0: {
             0: (list(range(15)), list(range(15, 20))),
             1: (list(range(5, 20)), list(range(5))),
-        }
+        },
     }
     task, _ = _task_from_user_task(df, target, "classification", splits, tmp_path, "cm-mf")
     meta = task.compute_metadata()
@@ -1081,7 +1091,7 @@ def test_compute_metadata_multi_fold_per_split_counts(tmp_path):
         0: {
             0: (list(range(15)), list(range(15, 20))),
             1: (list(range(5, 20)), list(range(5))),
-        }
+        },
     }
     task, _ = _task_from_user_task(df, target, "classification", splits, tmp_path, "cm-mf-cnt")
     meta = task.compute_metadata()
@@ -1208,7 +1218,7 @@ def test_create_local_openml_task_unsupported_arff_dtype_does_not_raise(col_name
             "num": np.arange(n, dtype="int64"),
             col_name: col_values,
             "target": np.linspace(0.0, 1.0, num=n),
-        }
+        },
     )
     assert df[col_name].dtype == dtype
 
@@ -1251,7 +1261,7 @@ def test_create_local_openml_task_non_string_categorical_does_not_raise(cat_valu
             "num": np.arange(n, dtype="int64"),
             "cat_col": cat_values,
             "target": np.linspace(0.0, 1.0, num=n),
-        }
+        },
     )
     assert df["cat_col"].dtype.name == "category"
     assert df["cat_col"].cat.categories.dtype == cat_dtype

--- a/tst/benchmark/test_results.py
+++ b/tst/benchmark/test_results.py
@@ -1,20 +1,23 @@
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from tabarena.benchmark.result import AGBagResult, BaselineResult, ConfigResult, ExperimentResults
 
-
-task_metadata = pd.DataFrame({
-    "dataset": ["d1"],
-    "tid": [0],
-})
+task_metadata = pd.DataFrame(
+    {
+        "dataset": ["d1"],
+        "tid": [0],
+    }
+)
 
 experiment_batch_runner = ExperimentResults(task_metadata=task_metadata)
 
 
 def _make_result_baseline():
-    result = dict(
+    return dict(
         framework="m1",
         metric_error=0.5,
         metric="log_loss",
@@ -29,7 +32,6 @@ def _make_result_baseline():
             name="d1",
         ),
     )
-    return result
 
 
 def _make_result_config():
@@ -39,21 +41,25 @@ def _make_result_config():
     y_test = np.array([0, 2, 1, 1, 1, 1])
     y_test_idx = np.array([1, 2, 5, 6, 9, 7])
 
-    pred_val = np.array([
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-    ])
+    pred_val = np.array(
+        [
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+        ]
+    )
 
-    pred_test = np.array([
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-        [0.3, 0.2, 0.5],
-    ])
+    pred_test = np.array(
+        [
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+            [0.3, 0.2, 0.5],
+        ]
+    )
 
     result = _make_result_baseline()
     result["metric_error_val"] = 0.5
@@ -67,7 +73,7 @@ def _make_result_config():
         ordered_class_labels=["class1", "class2", "class3"],
         ordered_class_labels_transformed=[0, 1, 2],
         num_classes=3,
-        label="class"
+        label="class",
     )
     method_metadata = dict(
         model_hyperparameters={"param1": 10},
@@ -88,32 +94,40 @@ def _make_result_ag_bag():
         np.array([1, 3]),
     ]
     pred_val_per_child = [
-        np.array([
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-        ]),
-        np.array([
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-        ]),
+        np.array(
+            [
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+            ]
+        ),
+        np.array(
+            [
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+            ]
+        ),
     ]
     pred_test_per_child = [
-        np.array([
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-        ]),
-        np.array([
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-            [0.3, 0.2, 0.5],
-        ]),
+        np.array(
+            [
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+            ]
+        ),
+        np.array(
+            [
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+                [0.3, 0.2, 0.5],
+            ]
+        ),
     ]
     bag_info = dict(
         val_idx_per_child=val_idx_per_child,
@@ -126,7 +140,7 @@ def _make_result_ag_bag():
 
 def test_result_baseline():
     result = _make_result_baseline()
-    result_obj = BaselineResult(result=result)
+    BaselineResult(result=result)
 
     repo = experiment_batch_runner.repo_from_results(results_lst=[result])
     assert repo.baselines() == ["m1"]
@@ -135,7 +149,7 @@ def test_result_baseline():
 
 def test_result_config():
     result = _make_result_config()
-    result_obj = ConfigResult(result=result)
+    ConfigResult(result=result)
 
     repo = experiment_batch_runner.repo_from_results(results_lst=[result])
     assert repo.baselines() == []
@@ -148,12 +162,12 @@ def test_result_config_calibrate():
     result_obj = ConfigResult(result=result)
 
     try:
-        import torch
+        import torch  # noqa: F401
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )
     result_obj_calibrated = result_obj.generate_calibrated()
     assert result_obj_calibrated.framework == "m1_CAL"
@@ -178,12 +192,12 @@ def test_result_ag_bag_calibrate():
     result_obj = AGBagResult(result=result)
 
     try:
-        import torch
+        import torch  # noqa: F401
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )
     result_obj_calibrated = result_obj.generate_calibrated()
     assert result_obj_calibrated.framework == "m1_CAL"

--- a/tst/benchmark/test_yaml_experiment_serialization.py
+++ b/tst/benchmark/test_yaml_experiment_serialization.py
@@ -37,12 +37,11 @@ def _init_memory_fs(monkeypatch):
 
             buf.close = _close_and_persist  # type: ignore[assignment]
             return buf
-        elif "r" in mode:
+        if "r" in mode:
             if path not in fs:
                 raise FileNotFoundError(path)
             return io.StringIO(fs[path])
-        else:
-            raise ValueError(f"Unsupported mode: {mode}")
+        raise ValueError(f"Unsupported mode: {mode}")
 
     # Patch builtins.open and os.path.exists so the serializers think the file is there.
     monkeypatch.setattr("builtins.open", mem_open, raising=True)
@@ -50,9 +49,7 @@ def _init_memory_fs(monkeypatch):
 
 
 def test_yaml_experiment_serialization(monkeypatch):
-    """
-    Verify that saving and loading experiments to/from yaml results in no changes to the object.
-    """
+    """Verify that saving and loading experiments to/from yaml results in no changes to the object."""
     # patch so no file is created on disk
     _init_memory_fs(monkeypatch=monkeypatch)
 
@@ -73,6 +70,6 @@ def test_yaml_experiment_serialization(monkeypatch):
     YamlExperimentSerializer.to_yaml(experiments=[experiment_default], path=yaml_path)
     experiments_loaded = YamlExperimentSerializer.from_yaml(path=yaml_path)
 
-    for cur_exp, cur_exp_loaded in zip(experiments_realmlp, experiments_loaded):
+    for cur_exp, cur_exp_loaded in zip(experiments_realmlp, experiments_loaded, strict=False):
         assert cur_exp.__class__ == cur_exp_loaded.__class__
         assert cur_exp.__dict__ == cur_exp_loaded.__dict__

--- a/tst/benchmark_metrics/run_bench_log_loss.py
+++ b/tst/benchmark_metrics/run_bench_log_loss.py
@@ -1,16 +1,21 @@
-import numpy as np
+from __future__ import annotations
 
+import numpy as np
 from autogluon.core.metrics import log_loss
 from sklearn.metrics import log_loss as sk_log_loss
-from tabarena.metrics._fast_log_loss import \
-    fast_log_loss_end_to_end, fast_log_loss, extract_true_class_prob
-from tabarena.metrics.bench_utils import benchmark_metrics_speed, print_benchmark_result,\
-    get_eval_speed, generate_y_true_and_y_pred_proba, generate_y_true_and_y_pred_binary
+
+from tabarena.metrics._fast_log_loss import extract_true_class_prob, fast_log_loss, fast_log_loss_end_to_end
+from tabarena.metrics.bench_utils import (
+    benchmark_metrics_speed,
+    generate_y_true_and_y_pred_binary,
+    generate_y_true_and_y_pred_proba,
+    get_eval_speed,
+    print_benchmark_result,
+)
 
 
 def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rtol=1e-06, binary_format=False):
-    """
-    Benchmarks 4 log_loss computing methods, verifying equivalent scores and comparing compute speed
+    """Benchmarks 4 log_loss computing methods, verifying equivalent scores and comparing compute speed.
 
     1. sk_log_loss       : sklearn log_loss, which will be our baseline
     2. ag_log_loss       : AutoGluon's default log_loss implementation, which is a slightly faster variant to sklearn.
@@ -24,10 +29,12 @@ def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rto
         Technically for the purposes of ZS simulation, we can run the preprocessing logic on all y_pred for all models,
         thus never paying the cost of preprocessing and massively reducing memory usage.
     """
-    print(f'Benchmarking log_loss... (num_samples={num_samples}, '
-          f'num_classes={num_classes}, '
-          f'binary_format={binary_format}, '
-          f'num_repeats={num_repeats}')
+    print(
+        f"Benchmarking log_loss... (num_samples={num_samples}, "
+        f"num_classes={num_classes}, "
+        f"binary_format={binary_format}, "
+        f"num_repeats={num_repeats}"
+    )
     if binary_format:
         assert num_classes == 2
         y_true, y_pred = generate_y_true_and_y_pred_binary(num_samples=num_samples)
@@ -35,9 +42,9 @@ def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rto
         y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
 
     benchmark_metrics = [
-        (sk_log_loss, 'sk_log_loss'),
-        (log_loss.error, 'ag_log_loss'),
-        (fast_log_loss_end_to_end.error, 'fast_log_loss_e2e')
+        (sk_log_loss, "sk_log_loss"),
+        (log_loss.error, "ag_log_loss"),
+        (fast_log_loss_end_to_end.error, "fast_log_loss_e2e"),
     ]
 
     baseline_speed, baseline_score = benchmark_metrics_speed(
@@ -50,7 +57,7 @@ def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rto
     )
 
     # fast log loss
-    func_name = 'fast_log_loss'
+    func_name = "fast_log_loss"
 
     # The time this takes can be ignored, as for our purposes this is only paid once,
     # but y_true_opt and y_pred_opt are re-used in many log_loss calls.
@@ -62,20 +69,19 @@ def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rto
         y_pred=y_pred_opt,
         num_repeats=num_repeats,
     )
-    print_benchmark_result(baseline_speed=baseline_speed,
-                           time_average_s=time_average_s,
-                           score=score,
-                           func_name=func_name)
+    print_benchmark_result(
+        baseline_speed=baseline_speed, time_average_s=time_average_s, score=score, func_name=func_name
+    )
     np.testing.assert_allclose(baseline_score, score, rtol=rtol)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     """
     Run a benchmark demonstrating the result equivalence of `fast_log_loss` with normal `log_loss`,
     but computed much faster.
-    
+
     Below is an example output using an m6i.32xlarge machine. fast_log_loss is at minimum 46x faster than sk_log_loss.
-    
+
     Benchmarking log_loss... (num_samples=100, num_classes=2, num_repeats=1000
         Time = 0.2790 ms	| Score = 0.9403822961581705	| Rel Speedup = 1.0x	| sk_log_loss
         Time = 0.2814 ms	| Score = 0.9403822961581705	| Rel Speedup = 1.0x	| ag_log_loss
@@ -159,11 +165,9 @@ if __name__ == '__main__':
         (1000000, 100, 3),
     ]:
         if num_classes == 2:
-            benchmark_log_loss(num_samples=num_samples,
-                               num_classes=num_classes,
-                               num_repeats=num_repeats,
-                               binary_format=True)
-        benchmark_log_loss(num_samples=num_samples,
-                           num_classes=num_classes,
-                           num_repeats=num_repeats,
-                           binary_format=False)
+            benchmark_log_loss(
+                num_samples=num_samples, num_classes=num_classes, num_repeats=num_repeats, binary_format=True
+            )
+        benchmark_log_loss(
+            num_samples=num_samples, num_classes=num_classes, num_repeats=num_repeats, binary_format=False
+        )

--- a/tst/benchmark_metrics/run_bench_roc_auc.py
+++ b/tst/benchmark_metrics/run_bench_roc_auc.py
@@ -1,20 +1,20 @@
-from sklearn.metrics import roc_auc_score
+from __future__ import annotations
 
 from autogluon.core.metrics import roc_auc
+from sklearn.metrics import roc_auc_score
+
 from tabarena.metrics._fast_roc_auc import fast_roc_auc_cpp
 from tabarena.metrics.bench_utils import benchmark_metrics_speed, generate_y_true_and_y_pred_binary
 
 
 def benchmark_root_mean_squared_error(num_samples: int, num_repeats: int):
-    """
-    Requires compiling C++ code to run `fast_roc_auc_cpp`
-    """
-    print(f'Benchmarking roc_auc... (num_samples={num_samples}, num_repeats={num_repeats}')
+    """Requires compiling C++ code to run `fast_roc_auc_cpp`."""
+    print(f"Benchmarking roc_auc... (num_samples={num_samples}, num_repeats={num_repeats}")
     y_true, y_pred = generate_y_true_and_y_pred_binary(num_samples=num_samples)
     benchmark_metrics = [
-        (roc_auc_score, 'sk_roc_auc'),
-        (roc_auc, 'ag_roc_auc'),
-        (fast_roc_auc_cpp, 'fast_roc_auc_cpp'),
+        (roc_auc_score, "sk_roc_auc"),
+        (roc_auc, "ag_roc_auc"),
+        (fast_roc_auc_cpp, "fast_roc_auc_cpp"),
     ]
     benchmark_metrics_speed(
         y_true=y_true,
@@ -26,7 +26,7 @@ def benchmark_root_mean_squared_error(num_samples: int, num_repeats: int):
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     for num_samples, num_repeats in [
         (2, 1000),
         (10, 1000),

--- a/tst/evaluation/context/test_beyond_arena.py
+++ b/tst/evaluation/context/test_beyond_arena.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
+
 from tabarena.evaluation.context.beyond_arena import BeyondArenaContext, _merge_warehouse_fields
 
 
@@ -31,9 +32,22 @@ def test_merge_repopulates_all_null_column():
 
 def test_subset_predicates_cover_beyond_subsets():
     expected = {
-        "binary", "multiclass", "classification", "regression",
-        "tiny", "small", "medium", "large",
-        "random", "iid", "temporal", "grouped",
-        "low-dim", "high-dim", "text", "high-cardinality", "lite",
+        "binary",
+        "multiclass",
+        "classification",
+        "regression",
+        "tiny",
+        "small",
+        "medium",
+        "large",
+        "random",
+        "iid",
+        "temporal",
+        "grouped",
+        "low-dim",
+        "high-dim",
+        "text",
+        "high-cardinality",
+        "lite",
     }
     assert expected <= set(BeyondArenaContext.SUBSET_PREDICATES)

--- a/tst/evaluation/test_benchmark_eval.py
+++ b/tst/evaluation/test_benchmark_eval.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
+
 from tabarena.evaluation import EvalMethod, TabArenaEvalConfig, run_eval
 from tabarena.loaders import get_tabarena_cache_root, set_tabarena_cache_root
 

--- a/tst/evaluation/test_beyond_metadata.py
+++ b/tst/evaluation/test_beyond_metadata.py
@@ -8,6 +8,7 @@ subset predicate column is present and usable on the collapsed frame.
 from __future__ import annotations
 
 import pandas as pd
+
 from tabarena.benchmark.task.metadata.sources.base import (
     InMemoryTaskMetadataSource,
     committed_metadata_path,

--- a/tst/models/test_ebm.py
+++ b/tst/models/test_ebm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 
@@ -5,13 +7,14 @@ def test_ebm():
     model_hyperparameters = {}
 
     try:
-        from autogluon.tabular.testing import FitHelper
         from autogluon.tabular.models import EBMModel
+        from autogluon.tabular.testing import FitHelper
+
         model_cls = EBMModel
         FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_iltm.py
+++ b/tst/models/test_iltm.py
@@ -6,6 +6,7 @@ import pytest
 def test_iltm():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.iltm.model import ILTMModel
 
         model_cls = ILTMModel
@@ -15,5 +16,5 @@ def test_iltm():
         )
     except ImportError as err:
         pytest.skip(
-            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}"
+            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}",
         )

--- a/tst/models/test_knn.py
+++ b/tst/models/test_knn.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from autogluon.tabular.testing import FitHelper
+
 from tabarena.models.knn.model import KNNNewModel
 
 

--- a/tst/models/test_limix.py
+++ b/tst/models/test_limix.py
@@ -6,6 +6,7 @@ import pytest
 def test_limix():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.limix.model import LimiXModel
 
         FitHelper.verify_model(model_cls=LimiXModel, model_hyperparameters={})
@@ -13,5 +14,5 @@ def test_limix():
         pytest.skip(
             "Import Error, skipping test... "
             "Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_modernnca.py
+++ b/tst/models/test_modernnca.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 
@@ -7,13 +9,14 @@ def test_modernnca():
 
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.modernnca.model import ModernNCAModel
+
         model_cls = ModernNCAModel
         FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )
-

--- a/tst/models/test_orionmsp.py
+++ b/tst/models/test_orionmsp.py
@@ -6,6 +6,7 @@ import pytest
 def test_orionmsp():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.orionmsp.model import (
             OrionMSPModel,
         )
@@ -16,5 +17,5 @@ def test_orionmsp():
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_perpetual_booster.py
+++ b/tst/models/test_perpetual_booster.py
@@ -12,6 +12,7 @@ def test_perpetual():
         from tabarena.models.perpetual_booster.model import (
             PerpetualBoosterModel,
         )
+
         model_cls = PerpetualBoosterModel
         FitHelper.verify_model(
             model_cls=model_cls,
@@ -21,5 +22,5 @@ def test_perpetual():
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_prefetch.py
+++ b/tst/models/test_prefetch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+
 import tabarena.models.prefetch as pf
 
 
@@ -37,7 +38,7 @@ def test_declared_prefetcher_called_once(monkeypatch):
 
 def test_shared_prefetcher_deduplicated(monkeypatch):
     calls: list[str] = []
-    shared = lambda: calls.append("tabpfn")  # noqa: E731 — two variants share one prefetcher
+    shared = lambda: calls.append("tabpfn")
     _patch_registry(
         monkeypatch,
         {"TabPFN-3": _fake_info("TabPFN-3", shared), "TabPFN-2.6": _fake_info("TabPFN-v2.6", shared)},

--- a/tst/models/test_realmlp.py
+++ b/tst/models/test_realmlp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 
@@ -7,12 +9,14 @@ def test_realmlp():
 
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.realmlp.model import RealMLPModel
+
         model_cls = RealMLPModel
         FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_registry.py
+++ b/tst/models/test_registry.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import types
 
 import pytest
+
 from tabarena.models import _registry
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models._registry import (
     discover_models,
     get_model_registry,
     register_model_info,
 )
-from tabarena.models._method_metadata import MethodMetadata
 
 
 class _DummyModel:
@@ -64,10 +65,14 @@ def patched_discovery(monkeypatch, fresh_registry):
         return result
 
     monkeypatch.setattr(
-        _registry, "pkgutil", types.SimpleNamespace(iter_modules=fake_iter_modules)
+        _registry,
+        "pkgutil",
+        types.SimpleNamespace(iter_modules=fake_iter_modules),
     )
     monkeypatch.setattr(
-        _registry, "importlib", types.SimpleNamespace(import_module=fake_import_module)
+        _registry,
+        "importlib",
+        types.SimpleNamespace(import_module=fake_import_module),
     )
     return state
 
@@ -137,10 +142,9 @@ def test_discover_models_skips_packages_without_info(patched_discovery, caplog):
 
     # Failure is logged rather than silently swallowed (the silent-skip
     # behaviour previously masked a real CatBoost discovery regression).
-    assert any(
-        "legacy" in record.message and "no info module" in record.message
-        for record in caplog.records
-    ), f"expected a warning mentioning 'legacy' and the import error, got: {[r.message for r in caplog.records]}"
+    assert any("legacy" in record.message and "no info module" in record.message for record in caplog.records), (
+        f"expected a warning mentioning 'legacy' and the import error, got: {[r.message for r in caplog.records]}"
+    )
 
 
 def test_discover_models_ignores_underscore_and_non_modelinfo_attrs(patched_discovery):

--- a/tst/models/test_sap_rpt_oss.py
+++ b/tst/models/test_sap_rpt_oss.py
@@ -6,6 +6,7 @@ import pytest
 def test_sap_rpt_oss():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.sap_rpt_oss.model import (
             SAPRPTOSSModel,
         )
@@ -16,5 +17,5 @@ def test_sap_rpt_oss():
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_tabdpt.py
+++ b/tst/models/test_tabdpt.py
@@ -8,15 +8,17 @@ def test_tabdpt():
 
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabdpt.model import TabDPTModel
 
         model_cls = TabDPTModel
         FitHelper.verify_model(
-            model_cls=model_cls, model_hyperparameters=model_hyperparameters
+            model_cls=model_cls,
+            model_hyperparameters=model_hyperparameters,
         )
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_tabicl.py
+++ b/tst/models/test_tabicl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 
@@ -6,12 +8,14 @@ def test_tabicl():
 
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabicl.model import TabICLModel
+
         model_cls = TabICLModel
         FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_tabiclv2.py
+++ b/tst/models/test_tabiclv2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 
@@ -6,12 +8,14 @@ def test_tabiclv2():
 
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabicl.model import TabICLv2Model
+
         model_cls = TabICLv2Model
         FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_tabm.py
+++ b/tst/models/test_tabm.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 import pytest
 
 
 def test_tabm():
-    toy_model_params = {"n_epochs": 10, "tabm_k": 2, "n_bins": 8, "num_emb_type": 'none'}
+    toy_model_params = {"n_epochs": 10, "tabm_k": 2, "n_bins": 8, "num_emb_type": "none"}
     model_hyperparameters = toy_model_params
 
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabm.model import TabMModel
+
         model_cls = TabMModel
         FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_tabpfn_3.py
+++ b/tst/models/test_tabpfn_3.py
@@ -6,6 +6,7 @@ import pytest
 def test_tabpfn_3():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabpfn_3.model import (
             TabPFN3Model,
         )
@@ -20,5 +21,5 @@ def test_tabpfn_3():
         )
     except ImportError as err:
         pytest.skip(
-            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}"
+            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}",
         )

--- a/tst/models/test_tabpfnv25.py
+++ b/tst/models/test_tabpfnv25.py
@@ -6,6 +6,7 @@ import pytest
 def test_tabpfnv25():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabpfnv2_5.model import (
             RealTabPFNv25Model,
         )
@@ -31,6 +32,5 @@ def test_tabpfnv25():
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )
-

--- a/tst/models/test_tabpfnv26.py
+++ b/tst/models/test_tabpfnv26.py
@@ -6,6 +6,7 @@ import pytest
 def test_tabpfn26():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabpfnv2_5.model import (
             TabPFNv26Model,
         )
@@ -19,7 +20,7 @@ def test_tabpfn26():
         )
     except ImportError as err:
         pytest.skip(
-            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}"
+            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}",
         )
 
 
@@ -32,6 +33,7 @@ def test_tabpfnv26_many_class(tmp_path):
         from autogluon.features.generators import AutoMLPipelineFeatureGenerator
         from sklearn.datasets import make_classification
         from sklearn.model_selection import train_test_split
+
         from tabarena.models.tabpfnv2_5.model import (
             TabPFNv26Model,
         )
@@ -85,5 +87,5 @@ def test_tabpfnv26_many_class(tmp_path):
         np.testing.assert_allclose(row_sums, 1.0, atol=1e-5)
     except ImportError as err:
         pytest.skip(
-            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}"
+            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}",
         )

--- a/tst/models/test_tabpfnwide.py
+++ b/tst/models/test_tabpfnwide.py
@@ -6,6 +6,7 @@ import pytest
 def test_tabpfnwide():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabpfnwide.model import (
             TabPFNWideModel,
         )
@@ -16,5 +17,5 @@ def test_tabpfnwide():
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_tabstar.py
+++ b/tst/models/test_tabstar.py
@@ -6,6 +6,7 @@ import pytest
 def test_tabstar():
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.tabstar.model import (
             TabSTARModel,
         )
@@ -16,5 +17,5 @@ def test_tabstar():
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/models/test_utils.py
+++ b/tst/models/test_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 
 import pytest
+
 from tabarena.models.utils import get_configs_generator_from_name
 
 # Maps every previously-hard-coded friendly name to the (module, generator)

--- a/tst/models/test_xrfm.py
+++ b/tst/models/test_xrfm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 
@@ -7,12 +9,14 @@ def test_xrfm():
 
     try:
         from autogluon.tabular.testing import FitHelper
+
         from tabarena.models.xrfm.model import XRFMModel
+
         model_cls = XRFMModel
         FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
     except ImportError as err:
         pytest.skip(
             f"Import Error, skipping test... "
             f"Ensure you have the proper dependencies installed to run this test:\n"
-            f"{err}"
+            f"{err}",
         )

--- a/tst/tabflow_slurm/test_plan.py
+++ b/tst/tabflow_slurm/test_plan.py
@@ -8,21 +8,22 @@ task metadata).
 from __future__ import annotations
 
 import pytest
+
 from tabarena.benchmark.experiment import TabArenaExperimentBundle
 from tabarena.benchmark.task.metadata import TabArenaMetadataBundle
 
 # Import a real submodule (see test_setup.py for why a bare namespace won't skip).
 pytest.importorskip("tabflow_slurm.setup", reason="tabflow_slurm is not installed")
 
-from tabflow_slurm.setup.paths import PathSetup  # noqa: E402
-from tabflow_slurm.setup.plan import (  # noqa: E402
+from tabflow_slurm.setup.paths import PathSetup
+from tabflow_slurm.setup.plan import (
     ModelJob,
     SingleModel,
     TabArenaBenchmarkPlan,
     _apply_overrides,
 )
-from tabflow_slurm.setup.resources import ResourcesSetup  # noqa: E402
-from tabflow_slurm.setup.scheduler import SlurmSetup  # noqa: E402
+from tabflow_slurm.setup.resources import ResourcesSetup
+from tabflow_slurm.setup.scheduler import SlurmSetup
 
 
 def _slurm(**kw) -> SlurmSetup:
@@ -140,7 +141,7 @@ class TestBuildSetups:
             [
                 ModelJob(models=("A", "all")),
                 ModelJob(models=("B", 0), resources={"num_gpus": 1}),
-            ]
+            ],
         )
         setups = plan.build_setups()
         assert len(setups) == 2
@@ -178,7 +179,7 @@ class TestBuildSetups:
             [
                 ModelJob(models=("A", 0)),
                 ModelJob(models=("B", 0), resources={"num_gpus": 1}),
-            ]
+            ],
         )
         names = [s.parallel_safe_benchmark_name for s in plan.build_setups()]
         assert names == ["my_bench_group0", "my_bench_group1"]
@@ -207,7 +208,7 @@ class TestBuildSetups:
             [
                 ModelJob(models=("A", 0)),
                 ModelJob(models=("B", 0), ignore_cache=True),
-            ]
+            ],
         )
         setups = plan.build_setups()
         assert len(setups) == 2

--- a/tst/tabflow_slurm/test_run_tabarena_experiment.py
+++ b/tst/tabflow_slurm/test_run_tabarena_experiment.py
@@ -9,13 +9,13 @@ import pytest
 # package, so `importorskip("tabflow_slurm")` would NOT skip. A submodule does.
 pytest.importorskip("tabflow_slurm.run_tabarena_experiment", reason="tabflow_slurm is not installed")
 
-from tabflow_slurm.run_tabarena_experiment import (  # noqa: E402
+from tabflow_slurm.run_tabarena_experiment import (
     _parse_int_list,
     _parse_int_or_none,
     _parse_task_id,
     _str2bool,
 )
-from tabflow_slurm.slurm_utils import setup_slurm_job  # noqa: E402
+from tabflow_slurm.slurm_utils import setup_slurm_job
 
 # ---------------------------------------------------------------------------
 # _str2bool

--- a/tst/tabflow_slurm/test_setup.py
+++ b/tst/tabflow_slurm/test_setup.py
@@ -14,6 +14,7 @@ The task-metadata loading/filtering moved into `TabArenaMetadataBundle`
 from __future__ import annotations
 
 import pytest
+
 from tabarena.benchmark.experiment import TabArenaExperimentBundle
 from tabarena.benchmark.task.metadata import TabArenaMetadataBundle
 
@@ -22,11 +23,11 @@ from tabarena.benchmark.task.metadata import TabArenaMetadataBundle
 # package, so `importorskip("tabflow_slurm")` would NOT skip. A submodule does.
 pytest.importorskip("tabflow_slurm.setup", reason="tabflow_slurm is not installed")
 
-from tabflow_slurm.setup.benchmark import TabArenaBenchmarkSetup  # noqa: E402
-from tabflow_slurm.setup.candidates import JobCandidate  # noqa: E402
-from tabflow_slurm.setup.paths import PathSetup  # noqa: E402
-from tabflow_slurm.setup.resources import ResourcesSetup  # noqa: E402
-from tabflow_slurm.setup.scheduler import SlurmSetup  # noqa: E402
+from tabflow_slurm.setup.benchmark import TabArenaBenchmarkSetup
+from tabflow_slurm.setup.candidates import JobCandidate
+from tabflow_slurm.setup.paths import PathSetup
+from tabflow_slurm.setup.resources import ResourcesSetup
+from tabflow_slurm.setup.scheduler import SlurmSetup
 
 # ---------------------------------------------------------------------------
 # PathSetup

--- a/tst/test_cache.py
+++ b/tst/test_cache.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import pandas as pd
+
 from tabarena.utils.cache import CacheFunctionDF, CacheFunctionDummy, CacheFunctionPickle
 
 
@@ -14,7 +17,6 @@ def test_cache_pickle():
 
 
 def test_cache_dataframe():
-
     def f():
         return pd.DataFrame({"a": [1, 2], "b": [3, 4]})
 

--- a/tst/test_dense.py
+++ b/tst/test_dense.py
@@ -1,11 +1,22 @@
+from __future__ import annotations
+
 import copy
 import tempfile
 
 import pytest
 
-from tabarena.predictions import TabularModelPredictions, TabularPredictionsMemmap, TabularPredictionsInMemory
-from tabarena.simulation.dense_utils import get_folds_dense, get_models_dense, is_dense_models, is_dense_folds, \
-    force_to_dense, print_summary, list_folds_available, list_models_available, is_empty
+from tabarena.predictions import TabularModelPredictions, TabularPredictionsInMemory, TabularPredictionsMemmap
+from tabarena.simulation.dense_utils import (
+    force_to_dense,
+    get_folds_dense,
+    get_models_dense,
+    is_dense_folds,
+    is_dense_models,
+    is_empty,
+    list_folds_available,
+    list_models_available,
+    print_summary,
+)
 from tabarena.utils.test_utils import generate_artificial_dict
 
 num_models = 13
@@ -38,14 +49,20 @@ def _make_empty_and_assert(pred_proba: TabularModelPredictions):
     assert pred_proba_copy.folds == []
     assert pred_proba_copy.models == []
 
-@pytest.mark.skip("skipping for now as dense tooling has not been fully updated, in particular now the case where "
-                  "some models are available only validation and not test splits is not supported anymore.")
-@pytest.mark.parametrize("cls", [
-    TabularPredictionsMemmap,
-    TabularPredictionsInMemory,
-])
+
+@pytest.mark.skip(
+    "skipping for now as dense tooling has not been fully updated, in particular now the case where "
+    "some models are available only validation and not test splits is not supported anymore."
+)
+@pytest.mark.parametrize(
+    "cls",
+    [
+        TabularPredictionsMemmap,
+        TabularPredictionsInMemory,
+    ],
+)
 def test_sparse_to_dense(cls):
-    """Tests sparse input"""
+    """Tests sparse input."""
     num_models = 13
     num_folds = 3
     dataset_shapes = {
@@ -55,12 +72,12 @@ def test_sparse_to_dense(cls):
     }
     models = [f"{i}" for i in range(num_models)]
     pred_dict = generate_artificial_dict(num_folds, models, dataset_shapes)
-    pred_dict['d1'].pop(0)
-    pred_dict['d1'][1]['pred_proba_dict_val'].pop('8')
-    pred_dict['d1'][1]['pred_proba_dict_test'].pop('8')
-    pred_dict['d2'][1]['pred_proba_dict_test'].pop('5')
-    pred_dict['d2'][1]['pred_proba_dict_val'].pop('5')
-    pred_dict['d3'].pop(2)
+    pred_dict["d1"].pop(0)
+    pred_dict["d1"][1]["pred_proba_dict_val"].pop("8")
+    pred_dict["d1"][1]["pred_proba_dict_test"].pop("8")
+    pred_dict["d2"][1]["pred_proba_dict_test"].pop("5")
+    pred_dict["d2"][1]["pred_proba_dict_val"].pop("5")
+    pred_dict["d3"].pop(2)
     with tempfile.TemporaryDirectory() as tmpdirname:
         pred_proba: TabularModelPredictions = cls.from_dict(pred_dict=pred_dict, output_dir=tmpdirname)
 
@@ -73,11 +90,23 @@ def test_sparse_to_dense(cls):
         assert list_folds_available(pred_proba, present_in_all=True) == [1]
         assert init_folds == [1]
         assert init_folds_dense == [1]
-        assert init_models == ['0', '1', '10', '11', '12', '2', '3', '4', '6', '7', '9']  # TODO check that this what is expected
+        assert init_models == [
+            "0",
+            "1",
+            "10",
+            "11",
+            "12",
+            "2",
+            "3",
+            "4",
+            "6",
+            "7",
+            "9",
+        ]  # TODO check that this what is expected
 
         # TODO now fails because of validation/test gap
-        assert init_models_dense == ['0', '1', '10', '11', '12', '2', '3', '4', '6', '7', '9']
-        assert sorted(init_datasets) == ['d1', 'd2', 'd3']
+        assert init_models_dense == ["0", "1", "10", "11", "12", "2", "3", "4", "6", "7", "9"]
+        assert sorted(init_datasets) == ["d1", "d2", "d3"]
         # TODO fix me
         # assert not is_dense_models(pred_proba)
         # assert not is_dense_folds(pred_proba)
@@ -85,20 +114,20 @@ def test_sparse_to_dense(cls):
 
         pred_proba_copy = copy.deepcopy(pred_proba)
         with pytest.raises(AssertionError):
-            force_to_dense(pred_proba_copy, first_prune_method='task', second_prune_method='dataset')
+            force_to_dense(pred_proba_copy, first_prune_method="task", second_prune_method="dataset")
         pred_proba_copy = copy.deepcopy(pred_proba)
         with pytest.raises(AssertionError):
-            force_to_dense(pred_proba_copy, first_prune_method='task', second_prune_method='fold')
+            force_to_dense(pred_proba_copy, first_prune_method="task", second_prune_method="fold")
 
-        print(f'Pre Dense')
+        print("Pre Dense")
         print_summary(pred_proba)
 
         _make_empty_and_assert(pred_proba=pred_proba)
 
         pred_proba.restrict_folds([0, 1])
-        force_to_dense(pred_proba, first_prune_method='task', second_prune_method='dataset')
+        force_to_dense(pred_proba, first_prune_method="task", second_prune_method="dataset")
 
-        print(f'Post Dense')
+        print("Post Dense")
         print_summary(pred_proba)
 
         post_folds = pred_proba.folds
@@ -111,7 +140,7 @@ def test_sparse_to_dense(cls):
         assert post_folds_dense == post_folds
         assert post_models == init_models
         assert post_models_dense == init_models
-        assert post_datasets == ['d3']
+        assert post_datasets == ["d3"]
         assert is_dense_models(pred_proba)
         assert is_dense_folds(pred_proba)
         assert not is_empty(pred_proba)

--- a/tst/test_elo_utils.py
+++ b/tst/test_elo_utils.py
@@ -1,29 +1,50 @@
-import pytest
-from bencheval.elo_utils import EloHelper
+from __future__ import annotations
+
 import pandas as pd
+import pytest
+
+from bencheval.elo_utils import EloHelper
 
 
 class TestEloHelper:
-    @pytest.mark.parametrize('battles,outcome', [
-        (pd.DataFrame({
-            "method_1": ["Winner", "Winner"],
-            "method_2": ["Loser", "Loser"],
-            "winner": ["1", "1"],
-            "dataset": ["dataset1", "dataset2"],
-        }), -1),
-        (pd.DataFrame({
-            "method_1": ["Model1", "Model1"],
-            "method_2": ["Model2", "Model2"],
-            "winner": ["tie", "tie"],
-            "dataset": ["dataset1", "dataset2"],
-        }), 0),
-        (pd.DataFrame({
-            "method_1": ["Loser", "Loser"],
-            "method_2": ["Winner", "Winner"],
-            "winner": ["2", "2"],
-            "dataset": ["dataset1", "dataset2"],
-        }), 1),
-    ])
+    @pytest.mark.parametrize(
+        ("battles", "outcome"),
+        [
+            (
+                pd.DataFrame(
+                    {
+                        "method_1": ["Winner", "Winner"],
+                        "method_2": ["Loser", "Loser"],
+                        "winner": ["1", "1"],
+                        "dataset": ["dataset1", "dataset2"],
+                    }
+                ),
+                -1,
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "method_1": ["Model1", "Model1"],
+                        "method_2": ["Model2", "Model2"],
+                        "winner": ["tie", "tie"],
+                        "dataset": ["dataset1", "dataset2"],
+                    }
+                ),
+                0,
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "method_1": ["Loser", "Loser"],
+                        "method_2": ["Winner", "Winner"],
+                        "winner": ["2", "2"],
+                        "dataset": ["dataset1", "dataset2"],
+                    }
+                ),
+                1,
+            ),
+        ],
+    )
     def test_compute_iterative_elo_scores(self, battles, outcome):
         elo_helper = EloHelper()
 

--- a/tst/test_impute.py
+++ b/tst/test_impute.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 
 import numpy as np
@@ -17,21 +19,22 @@ dataset_shapes = {
 }
 models = [f"{i}" for i in range(num_models)]
 
+
 def test_keep_only_models_in_both_validation_and_test():
     pred_dict = generate_artificial_dict(num_folds, models, dataset_shapes)
-    pred_dict["d2"][1]['pred_proba_dict_val'].pop("2")
+    pred_dict["d2"][1]["pred_proba_dict_val"].pop("2")
     TabularModelPredictions._keep_only_models_in_both_validation_and_test(pred_dict)
 
     # check that the intersection works as expected, model "2" should not be present in the test split as it was
     # absent from the validation split
-    assert "2" not in pred_dict["d2"][1]['pred_proba_dict_test']
+    assert "2" not in pred_dict["d2"][1]["pred_proba_dict_test"]
 
 
 def test_tabular_predictions():
     pred_dict = generate_artificial_dict(num_folds, models, dataset_shapes)
 
     # remove the second model from the second dataset and the second fold
-    pred_dict["d2"][1]['pred_proba_dict_val'].pop("2")
+    pred_dict["d2"][1]["pred_proba_dict_val"].pop("2")
     # pred_dict["d2"][1]['pred_proba_dict_test'].pop("2")
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -42,12 +45,12 @@ def test_tabular_predictions():
 
 
 def test_repository():
-    zsc, configs_full, pred_proba, zeroshot_gt = load_context_artificial()
+    zsc, _configs_full, pred_proba, zeroshot_gt = load_context_artificial()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # remove NeuralNetFastAI_r1 from fold 1 of abalone...
         pred_dict = pred_proba.pred_dict
-        pred_dict["abalone"][1]['pred_proba_dict_val'].pop("NeuralNetFastAI_r1")
+        pred_dict["abalone"][1]["pred_proba_dict_val"].pop("NeuralNetFastAI_r1")
         repo = EvaluationRepository(
             zeroshot_context=zsc,
             tabular_predictions=TabularPredictionsMemmap.from_dict(pred_dict, tmpdirname),

--- a/tst/test_metrics.py
+++ b/tst/test_metrics.py
@@ -1,21 +1,23 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sklearn
 from autogluon.core.metrics import log_loss, roc_auc
 
 from tabarena.metrics import _fast_log_loss, _fast_roc_auc
-from tabarena.metrics.bench_utils import generate_y_true_and_y_pred_proba, \
-    generate_y_true_and_y_pred_proba_bulk, generate_y_true_and_y_pred_binary
+from tabarena.metrics.bench_utils import (
+    generate_y_true_and_y_pred_binary,
+    generate_y_true_and_y_pred_proba,
+    generate_y_true_and_y_pred_proba_bulk,
+)
 
 
-@pytest.mark.parametrize('y_true,y_pred',
-                         [([0, 2, 1, 1],
-                           [[0.1, 0.2, 0.7],
-                            [0.2, 0.1, 0.7],
-                            [0.3, 0.4, 0.3],
-                            [0.01, 0.9, 0.09]])])
+@pytest.mark.parametrize(
+    ("y_true", "y_pred"), [([0, 2, 1, 1], [[0.1, 0.2, 0.7], [0.2, 0.1, 0.7], [0.3, 0.4, 0.3], [0.01, 0.9, 0.09]])]
+)
 def test_fast_log_loss(y_true, y_pred):
-    """Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations"""
+    """Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations."""
     y_true = np.array(y_true, dtype=np.int64)
     y_pred = np.array(y_pred, dtype=np.float32)
 
@@ -44,71 +46,78 @@ def assert_fast_roc_auc_equivalence(y_true, y_pred, rtol=1e-7):
     np.testing.assert_allclose(ag_score, fast_score, rtol=rtol)
 
 
-@pytest.mark.parametrize('y_true,y_pred',
-                         [
-                            ([0, 1, 0, 0], [0, 0, 0, 0]),
-                            ([0, 1, 0, 0], [1, 1, 1, 1]),
-                            ([0, 1, 0, 0], [0, 1, 0, 1]),
-                            ([0, 1, 0, 0], [0, 1, 0, 0]),
-                            ([0, 1, 0, 0], [1, 0, 1, 1]),
-                            ([0, 1, 0, 0], [0.6, 0.5, 0.4, 0.3]),
-                            ([0, 1, 0, 0], [0.5, 0.5, 0.6, 0.6]),
-                            ([0, 1, 0, 0], [0.6, 0.6, 0.6, 0.6]),
-                            ([1, 0, 1, 1], [0.6, 0.6, 0.6, 0.6]),
-                         ])
+@pytest.mark.parametrize(
+    ("y_true", "y_pred"),
+    [
+        ([0, 1, 0, 0], [0, 0, 0, 0]),
+        ([0, 1, 0, 0], [1, 1, 1, 1]),
+        ([0, 1, 0, 0], [0, 1, 0, 1]),
+        ([0, 1, 0, 0], [0, 1, 0, 0]),
+        ([0, 1, 0, 0], [1, 0, 1, 1]),
+        ([0, 1, 0, 0], [0.6, 0.5, 0.4, 0.3]),
+        ([0, 1, 0, 0], [0.5, 0.5, 0.6, 0.6]),
+        ([0, 1, 0, 0], [0.6, 0.6, 0.6, 0.6]),
+        ([1, 0, 1, 1], [0.6, 0.6, 0.6, 0.6]),
+    ],
+)
 def test_fast_roc_auc_ties(y_true, y_pred):
     """Ensure fast_roc_auc produces equivalent scores to AutoGluon and Scikit-Learn roc_auc implementations
-    when ties exist"""
+    when ties exist.
+    """
     y_true = np.array(y_true, dtype=np.bool_)
     y_pred = np.array(y_pred, dtype=np.float32)
     assert_fast_roc_auc_equivalence(y_true=y_true, y_pred=y_pred)
 
 
-@pytest.mark.parametrize('num_samples',
-                         [
-                             100,
-                             1000,
-                             10000,
-                             100000,
-                         ])
+@pytest.mark.parametrize(
+    "num_samples",
+    [
+        100,
+        1000,
+        10000,
+        100000,
+    ],
+)
 def test_fast_roc_auc_large(num_samples):
     y_true, y_pred = generate_y_true_and_y_pred_binary(num_samples=num_samples)
     assert_fast_roc_auc_equivalence(y_true=y_true, y_pred=y_pred)
 
 
-@pytest.mark.parametrize('num_samples,num_classes',
-                         [
-                             (1, 2),
-                             (1, 10),
-                             (1000, 2),
-                             (1000, 10),
-                             (10000, 2),
-                             (10000, 100),
-                         ])
+@pytest.mark.parametrize(
+    ("num_samples", "num_classes"),
+    [
+        (1, 2),
+        (1, 10),
+        (1000, 2),
+        (1000, 10),
+        (10000, 2),
+        (10000, 100),
+    ],
+)
 def test_fast_log_loss_large(num_samples, num_classes):
-    """
-    Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations
+    """Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations
     across various data dimensions.
     """
     y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
     assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=num_classes, rtol=1e-4)
 
 
-@pytest.mark.parametrize('num_configs,num_samples,num_classes',
-                         [
-                             (1, 1, 2),
-                             (2, 1, 2),
-                             (10, 1, 2),
-                             (10, 1, 10),
-                             (1, 1000, 2),
-                             (10, 1000, 10),
-                             (100, 1000, 10),
-                             (10, 10000, 2),
-                             (10, 10000, 100),
-                         ])
+@pytest.mark.parametrize(
+    ("num_configs", "num_samples", "num_classes"),
+    [
+        (1, 1, 2),
+        (2, 1, 2),
+        (10, 1, 2),
+        (10, 1, 10),
+        (1, 1000, 2),
+        (10, 1000, 10),
+        (100, 1000, 10),
+        (10, 10000, 2),
+        (10, 10000, 100),
+    ],
+)
 def test_fast_log_loss_bulk(num_configs, num_samples, num_classes):
-    """
-    Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations
+    """Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations
     in the scenario where we have multiple configs and potentially weight them.
     This verifies we can perform operations such as config weighting
     to the optimized predictions and still obtain equivalent log_loss results.
@@ -116,7 +125,7 @@ def test_fast_log_loss_bulk(num_configs, num_samples, num_classes):
     y_true, y_pred_bulk = generate_y_true_and_y_pred_proba_bulk(
         num_configs=num_configs,
         num_samples=num_samples,
-        num_classes=num_classes
+        num_classes=num_classes,
     )
     rtol = 1e-6
 
@@ -128,12 +137,12 @@ def test_fast_log_loss_bulk(num_configs, num_samples, num_classes):
     config_weights /= np.sum(config_weights)
     np.testing.assert_allclose(np.sum(config_weights), 1)
 
-    y_pred_bulk_weighted = [pred * weight for pred, weight in zip(y_pred_bulk, config_weights)]
+    y_pred_bulk_weighted = [pred * weight for pred, weight in zip(y_pred_bulk, config_weights, strict=False)]
     y_pred_ensemble = np.sum(y_pred_bulk_weighted, axis=0)
     assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred_ensemble, num_classes=num_classes, rtol=rtol)
 
     y_pred_bulk_opt = _fast_log_loss.extract_true_class_prob_bulk(y_true, y_pred_bulk)
-    y_pred_bulk_opt_weighted = [pred * weight for pred, weight in zip(y_pred_bulk_opt, config_weights)]
+    y_pred_bulk_opt_weighted = [pred * weight for pred, weight in zip(y_pred_bulk_opt, config_weights, strict=False)]
 
     y_pred_opt_ensemble = np.sum(y_pred_bulk_opt_weighted, axis=0)
     fast_loss_ensemble = _fast_log_loss.fast_log_loss(y_true, y_pred_opt_ensemble)

--- a/tst/test_normalized_scorer.py
+++ b/tst/test_normalized_scorer.py
@@ -1,5 +1,7 @@
-import pandas as pd
+from __future__ import annotations
+
 import numpy as np
+import pandas as pd
 
 from tabarena.utils.normalized_scorer import NormalizedScorer
 
@@ -7,15 +9,16 @@ dataset_col = "dataset"
 metric_col = "metric"
 framework_col = "framework"
 
-df_results_by_dataset = pd.DataFrame([
-    ["dataset1", "xgboost1", 1.0],
-    ["dataset1", "xgboost3", 3.0],
-    ["dataset1", "xgboost2", 2.0],
-    ["dataset2", "xgboost1", 10.0],
-    ["dataset2", "xgboost3", 30.0],
-    ["dataset2", "xgboost2", 20.0],
-],
-    columns=[dataset_col, framework_col, metric_col]
+df_results_by_dataset = pd.DataFrame(
+    [
+        ["dataset1", "xgboost1", 1.0],
+        ["dataset1", "xgboost3", 3.0],
+        ["dataset1", "xgboost2", 2.0],
+        ["dataset2", "xgboost1", 10.0],
+        ["dataset2", "xgboost3", 30.0],
+        ["dataset2", "xgboost2", 20.0],
+    ],
+    columns=[dataset_col, framework_col, metric_col],
 )
 
 

--- a/tst/test_parallel_for.py
+++ b/tst/test_parallel_for.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from tabarena.utils.parallel_for import parallel_for
 
 
 def f(x, v1, v2):
     return x + v1 + v2
+
 
 def test_parallel_for_list_arguments():
     for engine in [
@@ -12,10 +15,14 @@ def test_parallel_for_list_arguments():
         # "ray"
     ]:
         res = parallel_for(
-            f, [[1], [2], [3]], context=dict(v1=2, v2=3), engine=engine
+            f,
+            [[1], [2], [3]],
+            context=dict(v1=2, v2=3),
+            engine=engine,
         )
         print(res)
         assert res == [6, 7, 8]
+
 
 def test_parallel_for_dict_arguments():
     for engine in [
@@ -25,7 +32,10 @@ def test_parallel_for_dict_arguments():
         # "ray"
     ]:
         res = parallel_for(
-            f, [{"x": 1}, {"x": 2}, {"x": 3}], context=dict(v1=2, v2=3), engine=engine
+            f,
+            [{"x": 1}, {"x": 2}, {"x": 3}],
+            context=dict(v1=2, v2=3),
+            engine=engine,
         )
         print(res)
         assert res == [6, 7, 8]

--- a/tst/test_pickle_utils.py
+++ b/tst/test_pickle_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from tabarena.utils.cache import CacheFunctionPickle
 from tabarena.utils.pickle_utils import dumps_pickle, is_gzipped, load_pickle, read_pickle_bytes
 

--- a/tst/test_rank_scorer.py
+++ b/tst/test_rank_scorer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 
@@ -7,15 +9,16 @@ dataset_col = "dataset"
 metric_col = "metric"
 framework_col = "framework"
 
-df_results_by_dataset = pd.DataFrame([
-    ["task1", "xgboost1", 1.0],
-    ["task1", "xgboost3", 3.0],
-    ["task1", "xgboost2", 2.0],
-    ["task2", "xgboost1", 10.0],
-    ["task2", "xgboost3", 30.0],
-    ["task2", "xgboost2", 20.0],
-],
-    columns=[dataset_col, framework_col, metric_col]
+df_results_by_dataset = pd.DataFrame(
+    [
+        ["task1", "xgboost1", 1.0],
+        ["task1", "xgboost3", 3.0],
+        ["task1", "xgboost2", 2.0],
+        ["task2", "xgboost1", 10.0],
+        ["task2", "xgboost3", 30.0],
+        ["task2", "xgboost2", 20.0],
+    ],
+    columns=[dataset_col, framework_col, metric_col],
 )
 
 
@@ -108,9 +111,9 @@ def test_rank_scorer_pct_ties_win():
         (0.0, 0.0),
         (0.8, 0.0),
         (1.0, 0.0),
-        (1.5, 1/3),
-        (2.0, 1/3),
-        (3.0, 2/3),
+        (1.5, 1 / 3),
+        (2.0, 1 / 3),
+        (3.0, 2 / 3),
         (4.0, 1.0),
         (8.0, 1.0),
     ]
@@ -156,11 +159,11 @@ def test_rank_scorer_pct_not_partial():
     query_expected = [
         (0.0, 0.0),
         (0.8, 0.0),
-        (1.0, 1/6),
-        (1.5, 1/3),
-        (2.0, 1/2),
-        (2.5, 2/3),
-        (3.0, 5/6),
+        (1.0, 1 / 6),
+        (1.5, 1 / 3),
+        (2.0, 1 / 2),
+        (2.5, 2 / 3),
+        (3.0, 5 / 6),
         (4.0, 1.0),
         (8.0, 1.0),
     ]

--- a/tst/test_repository.py
+++ b/tst/test_repository.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import copy
 import shutil
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 from tabarena import EvaluationRepository, EvaluationRepositoryCollection
 from tabarena.contexts.context_artificial import load_repo_artificial
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def verify_equivalent_repository(
@@ -50,27 +55,39 @@ def verify_equivalent_repository(
                         assert np.isclose(repo1_val, repo2_val).all()
                 if configs:
                     if exact:
-                        assert np.array_equal(repo1.labels_test(dataset=dataset, fold=f), repo2.labels_test(dataset=dataset, fold=f))
-                        assert np.array_equal(repo1.labels_val(dataset=dataset, fold=f), repo2.labels_val(dataset=dataset, fold=f))
+                        assert np.array_equal(
+                            repo1.labels_test(dataset=dataset, fold=f), repo2.labels_test(dataset=dataset, fold=f)
+                        )
+                        assert np.array_equal(
+                            repo1.labels_val(dataset=dataset, fold=f), repo2.labels_val(dataset=dataset, fold=f)
+                        )
                     else:
-                        assert np.isclose(repo1.labels_test(dataset=dataset, fold=f), repo2.labels_test(dataset=dataset, fold=f)).all()
-                        assert np.isclose(repo1.labels_val(dataset=dataset, fold=f), repo2.labels_val(dataset=dataset, fold=f)).all()
+                        assert np.isclose(
+                            repo1.labels_test(dataset=dataset, fold=f), repo2.labels_test(dataset=dataset, fold=f)
+                        ).all()
+                        assert np.isclose(
+                            repo1.labels_val(dataset=dataset, fold=f), repo2.labels_val(dataset=dataset, fold=f)
+                        ).all()
     if verify_ensemble:
         datasets1 = [d for d in repo1.datasets() if len(repo1.configs(datasets=[d])) > 0]
         datasets2 = [d for d in repo2.datasets() if len(repo2.configs(datasets=[d])) > 0]
         if len(datasets1) == 0 and len(datasets2) == 0:
             pass
         else:
-            df_out_1, df_ensemble_weights_1 = repo1.evaluate_ensembles(datasets=datasets1, ensemble_size=10, backend=backend)
-            df_out_2, df_ensemble_weights_2 = repo2.evaluate_ensembles(datasets=datasets2, ensemble_size=10, backend=backend)
+            df_out_1, df_ensemble_weights_1 = repo1.evaluate_ensembles(
+                datasets=datasets1, ensemble_size=10, backend=backend
+            )
+            df_out_2, df_ensemble_weights_2 = repo2.evaluate_ensembles(
+                datasets=datasets2, ensemble_size=10, backend=backend
+            )
             assert df_out_1.equals(df_out_2)
             assert df_ensemble_weights_1.equals(df_ensemble_weights_2)
     if verify_baselines:
         baselines1 = repo1._zeroshot_context.df_baselines
         baselines2 = repo2._zeroshot_context.df_baselines
         if baselines1 is not None:
-            columns1 = sorted(list(baselines1.columns))
-            columns2 = sorted(list(baselines2.columns))
+            columns1 = sorted(baselines1.columns)
+            columns2 = sorted(baselines2.columns)
             assert columns1 == columns2
             baselines1 = baselines1[columns1].sort_values(by=columns1, ignore_index=True)
             baselines2 = baselines2[columns1].sort_values(by=columns1, ignore_index=True)
@@ -83,8 +100,8 @@ def verify_equivalent_repository(
         if metadata1 is None:
             assert metadata1 == metadata2
         else:
-            columns1 = sorted(list(metadata1.columns))
-            columns2 = sorted(list(metadata2.columns))
+            columns1 = sorted(metadata1.columns)
+            columns2 = sorted(metadata2.columns)
             assert columns1 == columns2
             metadata1 = metadata1[columns1].sort_values(by=columns1, ignore_index=True)
             metadata2 = metadata2[columns1].sort_values(by=columns1, ignore_index=True)
@@ -95,17 +112,17 @@ def verify_equivalent_repository(
 
 def test_repository():
     repo = load_repo_artificial()
-    dataset = 'abalone'
+    dataset = "abalone"
     tid = repo.dataset_to_tid(dataset)
     assert tid == 359946
     config = "NeuralNetFastAI_r1"  # TODO accessor
 
-    assert repo.datasets() == ['abalone', 'ada']
+    assert repo.datasets() == ["abalone", "ada"]
     assert repo.tids() == [359946, 359944]
     assert repo.n_folds() == 3
     assert repo.folds == [0, 1, 2]
     assert repo.dataset_to_tid(dataset) == 359946
-    assert repo.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
     # TODO check values, something like [{'framework': 'NeuralNetFastAI_r1', 'time_train_s': 0.1965823616800535, 'metric_error': 0.9764594650133958, 'time_infer_s': 0.3687251706609641, 'bestdiff': 0.8209932298479351, 'loss_rescaled': 0.09710127579306127, 'time_train_s_rescaled': 0.8379449074988039, 'time_infer_s_rescaled': 0.09609840789396307, 'rank': 2.345816964276348, 'score_val': 0.4686512016477016}]
     print(repo.metrics(datasets=[dataset], configs=[config], folds=[2]))
     assert repo.predict_val(dataset=dataset, config=config, fold=2).shape == (123, 25)
@@ -114,8 +131,13 @@ def test_repository():
     assert repo.predict_test_multi(dataset=dataset, fold=2, configs=[config]).shape == (1, 13, 25)
     assert repo.labels_val(dataset=dataset, fold=2).shape == (123,)
     assert repo.labels_test(dataset=dataset, fold=2).shape == (13,)
-    assert repo.dataset_metadata(dataset=dataset) == {'dataset': dataset, 'task_type': 'TaskType.SUPERVISED_CLASSIFICATION'}
-    result_errors, result_ensemble_weights = repo.evaluate_ensembles(datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native")
+    assert repo.dataset_metadata(dataset=dataset) == {
+        "dataset": dataset,
+        "task_type": "TaskType.SUPERVISED_CLASSIFICATION",
+    }
+    result_errors, result_ensemble_weights = repo.evaluate_ensembles(
+        datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native"
+    )
     assert result_errors.shape == (3, 8)
     assert len(result_ensemble_weights) == 3
 
@@ -124,46 +146,65 @@ def test_repository():
     assert dataset_info["problem_type"] == "regression"
 
     # Test ensemble weights are as expected
-    task_0 = repo.task_name(dataset=dataset, fold=0)
+    repo.task_name(dataset=dataset, fold=0)
     assert np.allclose(result_ensemble_weights.loc[(dataset, 0)], [1.0, 0.0])
 
     # Test `max_models_per_type`
     result_errors_w_max_models, result_ensemble_weights_w_max_models = repo.evaluate_ensembles(
-        datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native", ensemble_kwargs={"max_models_per_type": 1}
+        datasets=[dataset],
+        configs=[config, config],
+        ensemble_size=5,
+        backend="native",
+        ensemble_kwargs={"max_models_per_type": 1},
     )
     assert result_errors_w_max_models.shape == (3, 8)
     assert len(result_ensemble_weights_w_max_models) == 3
     assert np.allclose(result_ensemble_weights_w_max_models.loc[(dataset, 0)], [1.0, 0.0])
 
-    assert repo.evaluate_ensembles(datasets=[dataset], configs=[config, config],
-                                  ensemble_size=5, folds=[2], backend="native")[0].shape == (1, 8)
+    assert repo.evaluate_ensembles(
+        datasets=[dataset], configs=[config, config], ensemble_size=5, folds=[2], backend="native"
+    )[0].shape == (1, 8)
 
     repo: EvaluationRepository = repo.subset(folds=[0, 2])
-    assert repo.datasets() == ['abalone', 'ada']
+    assert repo.datasets() == ["abalone", "ada"]
     assert repo.n_folds() == 2
     assert repo.folds == [0, 2]
     assert repo.tids() == [359946, 359944]
-    assert repo.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
     assert repo.predict_val(dataset=dataset, config=config, fold=2).shape == (123, 25)
     assert repo.predict_test(dataset=dataset, config=config, fold=2).shape == (13, 25)
-    assert repo.dataset_metadata(dataset=dataset) == {'dataset': dataset, 'task_type': 'TaskType.SUPERVISED_CLASSIFICATION'}
+    assert repo.dataset_metadata(dataset=dataset) == {
+        "dataset": dataset,
+        "task_type": "TaskType.SUPERVISED_CLASSIFICATION",
+    }
     # result_errors, result_ensemble_weights = repo.evaluate_ensemble(datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native")[0],
-    assert repo.evaluate_ensembles(datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native")[0].shape == (2, 8)
-    assert repo.evaluate_ensembles(datasets=[dataset], configs=[config, config], ensemble_size=5, folds=[2], backend="native")[0].shape == (1, 8)
+    assert repo.evaluate_ensembles(datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native")[
+        0
+    ].shape == (2, 8)
+    assert repo.evaluate_ensembles(
+        datasets=[dataset], configs=[config, config], ensemble_size=5, folds=[2], backend="native"
+    )[0].shape == (1, 8)
     assert repo.evaluate_ensemble(dataset=dataset, fold=2, configs=[config, config], ensemble_size=5)[0].shape == (1, 8)
 
     repo: EvaluationRepository = repo.subset(folds=[2], datasets=[dataset], configs=[config])
-    assert repo.datasets() == ['abalone']
+    assert repo.datasets() == ["abalone"]
     assert repo.n_folds() == 1
     assert repo.folds == [2]
     assert repo.tids() == [359946]
     assert repo.configs() == [config]
     assert repo.predict_val(dataset=dataset, config=config, fold=2).shape == (123, 25)
     assert repo.predict_test(dataset=dataset, config=config, fold=2).shape == (13, 25)
-    assert repo.dataset_metadata(dataset=dataset) == {'dataset': dataset, 'task_type': 'TaskType.SUPERVISED_CLASSIFICATION'}
-    assert repo.evaluate_ensembles(datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native")[0].shape == (1, 8)
+    assert repo.dataset_metadata(dataset=dataset) == {
+        "dataset": dataset,
+        "task_type": "TaskType.SUPERVISED_CLASSIFICATION",
+    }
+    assert repo.evaluate_ensembles(datasets=[dataset], configs=[config, config], ensemble_size=5, backend="native")[
+        0
+    ].shape == (1, 8)
 
-    assert repo.evaluate_ensembles(datasets=[dataset], configs=[config, config], ensemble_size=5, folds=[2], backend="native")[0].shape == (1, 8)
+    assert repo.evaluate_ensembles(
+        datasets=[dataset], configs=[config, config], ensemble_size=5, folds=[2], backend="native"
+    )[0].shape == (1, 8)
 
 
 def test_repository_force_to_dense():
@@ -194,29 +235,30 @@ def test_repository_force_to_dense():
 
 
 def test_repository_predict_binary_as_multiclass():
-    """
-    Test to verify that binary_as_multiclass logic works for binary problem_type
-    """
-    dataset = 'abalone'
-    configs = ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    """Test to verify that binary_as_multiclass logic works for binary problem_type."""
+    dataset = "abalone"
+    configs = ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
 
     for problem_type in ["binary", "multiclass", "regression"]:
-        if problem_type == "multiclass":
-            n_classes = 3
-        else:
-            n_classes = 2
+        n_classes = 3 if problem_type == "multiclass" else 2
         repo = load_repo_artificial(n_classes=n_classes, problem_type=problem_type)
         assert repo.dataset_info(dataset)["problem_type"] == problem_type
-        _assert_predict_multi_binary_as_multiclass(repo=repo, fun=repo.predict_val_multi, dataset=dataset, configs=configs, n_rows=123, n_classes=n_classes)
-        _assert_predict_multi_binary_as_multiclass(repo=repo, fun=repo.predict_test_multi, dataset=dataset, configs=configs, n_rows=13, n_classes=n_classes)
-        _assert_predict_binary_as_multiclass(repo=repo, fun=repo.predict_val, dataset=dataset, config=configs[0], n_rows=123, n_classes=n_classes)
-        _assert_predict_binary_as_multiclass(repo=repo, fun=repo.predict_test, dataset=dataset, config=configs[0], n_rows=13, n_classes=n_classes)
+        _assert_predict_multi_binary_as_multiclass(
+            repo=repo, fun=repo.predict_val_multi, dataset=dataset, configs=configs, n_rows=123, n_classes=n_classes
+        )
+        _assert_predict_multi_binary_as_multiclass(
+            repo=repo, fun=repo.predict_test_multi, dataset=dataset, configs=configs, n_rows=13, n_classes=n_classes
+        )
+        _assert_predict_binary_as_multiclass(
+            repo=repo, fun=repo.predict_val, dataset=dataset, config=configs[0], n_rows=123, n_classes=n_classes
+        )
+        _assert_predict_binary_as_multiclass(
+            repo=repo, fun=repo.predict_test, dataset=dataset, config=configs[0], n_rows=13, n_classes=n_classes
+        )
 
 
 def test_repository_subset():
-    """
-    Verify repo.subset() works as intended and `inplace` argument works as intended.
-    """
+    """Verify repo.subset() works as intended and `inplace` argument works as intended."""
     repo = load_repo_artificial()
     assert repo.datasets() == ["abalone", "ada"]
 
@@ -245,7 +287,7 @@ def test_repository_configs_hyperparameters():
     with pytest.raises(AssertionError):
         verify_equivalent_repository(repo1, repo2, verify_configs_hyperparameters=True)
 
-    configs = ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    configs = ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
 
     configs_type_1 = repo1.configs_type()
     for c in configs:
@@ -271,36 +313,46 @@ def test_repository_configs_hyperparameters():
     assert configs_hyperparameters_2["NeuralNetFastAI_r2"] == {"foo": 15, "x": "y"}
 
     autogluon_hyperparameters_dict = repo2.autogluon_hyperparameters_dict(configs=configs)
-    assert autogluon_hyperparameters_dict == {'FASTAI': [
-        {'ag_args': {'priority': -1}, 'bar': 'hello', 'foo': 10},
-        {'ag_args': {'priority': -2}, 'foo': 15, 'x': 'y'}
-    ]}
+    assert autogluon_hyperparameters_dict == {
+        "FASTAI": [
+            {"ag_args": {"priority": -1}, "bar": "hello", "foo": 10},
+            {"ag_args": {"priority": -2}, "foo": 15, "x": "y"},
+        ]
+    }
 
     # reverse order
-    autogluon_hyperparameters_dict = repo2.autogluon_hyperparameters_dict(configs=['NeuralNetFastAI_r2', 'NeuralNetFastAI_r1'])
-    assert autogluon_hyperparameters_dict == {'FASTAI': [
-        {'ag_args': {'priority': -1}, 'foo': 15, 'x': 'y'},
-        {'ag_args': {'priority': -2}, 'bar': 'hello', 'foo': 10}
-    ]}
+    autogluon_hyperparameters_dict = repo2.autogluon_hyperparameters_dict(
+        configs=["NeuralNetFastAI_r2", "NeuralNetFastAI_r1"]
+    )
+    assert autogluon_hyperparameters_dict == {
+        "FASTAI": [
+            {"ag_args": {"priority": -1}, "foo": 15, "x": "y"},
+            {"ag_args": {"priority": -2}, "bar": "hello", "foo": 10},
+        ]
+    }
 
     # no priority
     autogluon_hyperparameters_dict = repo2.autogluon_hyperparameters_dict(configs=configs, ordered=False)
-    assert autogluon_hyperparameters_dict == {'FASTAI': [
-        {'bar': 'hello', 'foo': 10},
-        {'foo': 15, 'x': 'y'}
-    ]}
+    assert autogluon_hyperparameters_dict == {
+        "FASTAI": [
+            {"bar": "hello", "foo": 10},
+            {"foo": 15, "x": "y"},
+        ]
+    }
 
-    repo2_subset = repo2.subset(configs=['NeuralNetFastAI_r2'])
+    repo2_subset = repo2.subset(configs=["NeuralNetFastAI_r2"])
     with pytest.raises(ValueError):
         repo2_subset.autogluon_hyperparameters_dict(configs=configs, ordered=False)
-    autogluon_hyperparameters_dict = repo2_subset.autogluon_hyperparameters_dict(configs=['NeuralNetFastAI_r2'])
-    assert autogluon_hyperparameters_dict == {'FASTAI': [
-        {'ag_args': {'priority': -1}, 'foo': 15, 'x': 'y'}
-    ]}
+    autogluon_hyperparameters_dict = repo2_subset.autogluon_hyperparameters_dict(configs=["NeuralNetFastAI_r2"])
+    assert autogluon_hyperparameters_dict == {
+        "FASTAI": [
+            {"ag_args": {"priority": -1}, "foo": 15, "x": "y"},
+        ]
+    }
 
 
 def test_repository_save_load():
-    """test repo save and load work"""
+    """Test repo save and load work."""
     repo = load_repo_artificial(include_hyperparameters=True)
     save_path = "tmp_repo"
     repo.to_dir(path=save_path)
@@ -316,8 +368,7 @@ def test_repository_save_load():
 
 
 def test_repository_save_load_with_moving_files():
-    """test repo save and load work when moving files to different directories"""
-
+    """Test repo save and load work when moving files to different directories."""
     save_path = "tmp_repo"
     copy_path = "tmp_repo_copy"
     shutil.rmtree(save_path, ignore_errors=True)
@@ -353,7 +404,9 @@ def test_repository_save_load_with_moving_files():
     repo_loaded_mem.predict_test(dataset="abalone", fold=0, config=repo_loaded.configs()[0])
     repo_loaded_memopt.predict_test(dataset="abalone", fold=0, config=repo_loaded.configs()[0])
 
-    verify_equivalent_repository(repo1=repo, repo2=repo_loaded, verify_ensemble=True, exact=True, verify_config_fallback=False)
+    verify_equivalent_repository(
+        repo1=repo, repo2=repo_loaded, verify_ensemble=True, exact=True, verify_config_fallback=False
+    )
     verify_equivalent_repository(repo1=repo, repo2=repo_loaded_mem, verify_ensemble=True, exact=True)
     verify_equivalent_repository(repo1=repo, repo2=repo_loaded_memopt, verify_ensemble=True, exact=True)
 
@@ -373,7 +426,9 @@ def test_repository_save_load_with_moving_files():
     verify_equivalent_repository(repo1=repo, repo2=repo_loaded_memopt, verify_ensemble=True, exact=True)
 
     # verify that the copy works even after deleting the original files
-    verify_equivalent_repository(repo1=repo, repo2=repo_loaded_copy, verify_ensemble=True, exact=True, verify_config_fallback=False)
+    verify_equivalent_repository(
+        repo1=repo, repo2=repo_loaded_copy, verify_ensemble=True, exact=True, verify_config_fallback=False
+    )
 
     # verify that the copy stops working after deleting the copied files
     repo_loaded_copy.predict_test(dataset="abalone", fold=0, config=repo_loaded_copy.configs()[0])
@@ -383,28 +438,27 @@ def test_repository_save_load_with_moving_files():
 
 
 def test_repository_baselines_differ():
-    """
-    Test when baselines exist for datasets without configs.
+    """Test when baselines exist for datasets without configs.
     Test that folds are properly automatically filtered upon filtering out all tasks using a given fold.
     """
     repo = load_repo_artificial(add_baselines_extra=True)
-    dataset = 'abalone'
+    dataset = "abalone"
     config = "NeuralNetFastAI_r1"
 
-    assert repo.datasets() == ['a', 'abalone', 'ada', 'b']
+    assert repo.datasets() == ["a", "abalone", "ada", "b"]
     assert repo.tids() == [5, 359946, 359944, 6]
     assert repo.folds == [0, 1, 2]
-    assert repo.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
     assert repo.baselines() == ["b1", "b2", "b_e1"]
 
     repo: EvaluationRepository = repo.subset(folds=[0, 2])
-    assert repo.datasets() == ["a", 'abalone', 'ada', "b"]
+    assert repo.datasets() == ["a", "abalone", "ada", "b"]
     assert repo.folds == [0, 2]
-    assert repo.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
     assert repo.baselines() == ["b1", "b2", "b_e1"]
 
     repo_subset1: EvaluationRepository = repo.subset(folds=[2], datasets=[dataset], configs=[config])
-    assert repo_subset1.datasets() == ['abalone']
+    assert repo_subset1.datasets() == ["abalone"]
     assert repo_subset1.folds == [2]
     assert repo_subset1.configs() == [config]
     assert repo_subset1.baselines() == ["b1", "b2"]
@@ -417,9 +471,7 @@ def test_repository_baselines_differ():
 
 
 def test_repository_only_baselines():
-    """
-    Test when only baselines exist and no configs exist.
-    """
+    """Test when only baselines exist and no configs exist."""
     repo = load_repo_artificial(add_baselines_extra=True, include_configs=False)
 
     assert repo.datasets() == ["a", "abalone", "ada", "b"]

--- a/tst/test_repository_collection.py
+++ b/tst/test_repository_collection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -10,17 +12,17 @@ from .test_repository import verify_equivalent_repository
 def test_repository_collection():
     repo = load_repo_artificial()
 
-    assert repo.datasets() == ['abalone', 'ada']
+    assert repo.datasets() == ["abalone", "ada"]
     assert repo.tids() == [359946, 359944]
     assert repo.n_folds() == 3
     assert repo.folds == [0, 1, 2]
-    assert repo.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
 
     datasets = repo.datasets()
     folds = repo.folds
     configs = repo.configs()
 
-    repo_1 = repo.subset(configs=['NeuralNetFastAI_r2'])
+    repo_1 = repo.subset(configs=["NeuralNetFastAI_r2"])
     repo_2 = repo.subset(configs=["NeuralNetFastAI_r1"])
 
     repo_collection = EvaluationRepositoryCollection(repos=[repo_1, repo_2])
@@ -40,7 +42,7 @@ def test_repository_collection():
             predict_val_collection = repo_collection.predict_val_multi(dataset=dataset, fold=fold, configs=configs)
             assert np.array_equal(predict_val, predict_val_collection)
 
-    repo_1 = repo.subset(datasets=['abalone'])
+    repo_1 = repo.subset(datasets=["abalone"])
     repo_2 = repo.subset(datasets=["ada"])
     repo_collection = EvaluationRepositoryCollection(repos=[repo_1, repo_2])
     verify_equivalent_repository(repo1=repo, repo2=repo_collection, verify_ensemble=True)
@@ -61,9 +63,7 @@ def test_repository_collection():
 
 
 def test_repository_collection_concat_only_configs_with_only_baselines():
-    """
-    Verifies that merging repos with only baselines and only configs works as intended.
-    """
+    """Verifies that merging repos with only baselines and only configs works as intended."""
     repo_configs = load_repo_artificial(include_baselines=False)
     repo_baselines = load_repo_artificial(include_configs=False, add_baselines_extra=True)
 
@@ -73,7 +73,7 @@ def test_repository_collection_concat_only_configs_with_only_baselines():
     assert repo_configs.tids() == [359946, 359944]
     assert repo_configs.n_folds() == 3
     assert repo_configs.folds == [0, 1, 2]
-    assert repo_configs.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo_configs.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
     assert repo_configs.baselines() == []
 
     assert repo_baselines.datasets() == ["a", "abalone", "ada", "b"]
@@ -88,9 +88,7 @@ def test_repository_collection_concat_only_configs_with_only_baselines():
 
 
 def test_repository_collection_concat_only_configs():
-    """
-    Verifies that merging repos with only configs works as intended.
-    """
+    """Verifies that merging repos with only configs works as intended."""
     repo_configs = load_repo_artificial(include_baselines=False)
     repo_configs_1 = repo_configs.subset(datasets=["abalone"])
     repo_configs_2 = repo_configs.subset(datasets=["ada"])
@@ -99,14 +97,14 @@ def test_repository_collection_concat_only_configs():
     assert repo_configs_1.tids() == [359946]
     assert repo_configs_1.n_folds() == 3
     assert repo_configs_1.folds == [0, 1, 2]
-    assert repo_configs_1.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo_configs_1.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
     assert repo_configs_1.baselines() == []
 
     assert repo_configs_2.datasets() == ["ada"]
     assert repo_configs_2.tids() == [359944]
     assert repo_configs_2.n_folds() == 3
     assert repo_configs_2.folds == [0, 1, 2]
-    assert repo_configs_2.configs() == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert repo_configs_2.configs() == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
     assert repo_configs_2.baselines() == []
 
     repo_collection = EvaluationRepositoryCollection(repos=[repo_configs_1, repo_configs_2])
@@ -114,9 +112,7 @@ def test_repository_collection_concat_only_configs():
 
 
 def test_repository_collection_concat_only_baselines():
-    """
-    Verifies that merging repos with only baselines works as intended.
-    """
+    """Verifies that merging repos with only baselines works as intended."""
     repo_baselines = load_repo_artificial(include_configs=False, add_baselines_extra=True)
     repo_baselines_1 = repo_baselines.subset(datasets=["abalone", "ada"])
     repo_baselines_2 = repo_baselines.subset(datasets=["a", "b"])

--- a/tst/test_repository_utils.py
+++ b/tst/test_repository_utils.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import numpy as np
 
 from tabarena.contexts.context_artificial import load_repo_artificial
-from tabarena.repository.time_utils import get_runtime, filter_configs_by_runtime, sort_by_runtime
+from tabarena.repository.time_utils import filter_configs_by_runtime, get_runtime, sort_by_runtime
 
 repo = load_repo_artificial()
 
@@ -25,7 +27,7 @@ def test_get_runtime_time_infer_s():
         dataset="ada",
         fold=1,
         config_names=config_names,
-        runtime_col='time_infer_s',
+        runtime_col="time_infer_s",
     )
     assert list(runtime_dict.keys()) == config_names
     assert np.allclose(list(runtime_dict.values()), [2.0, 4.0])
@@ -33,7 +35,7 @@ def test_get_runtime_time_infer_s():
 
 def test_sort_by_runtime():
     config_names = repo.configs()
-    assert sort_by_runtime(repo, config_names) == ['NeuralNetFastAI_r1', 'NeuralNetFastAI_r2']
+    assert sort_by_runtime(repo, config_names) == ["NeuralNetFastAI_r1", "NeuralNetFastAI_r2"]
 
 
 def test_filter_configs_by_runtime():
@@ -45,7 +47,7 @@ def test_filter_configs_by_runtime():
         (2.0, 1),
         (3.01, len(config_names)),
         (6.0, len(config_names)),
-        (np.inf, len(config_names))
+        (np.inf, len(config_names)),
     ]:
         selected_configs = filter_configs_by_runtime(
             repo,

--- a/tst/test_roc_auc_cpp.py
+++ b/tst/test_roc_auc_cpp.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import numpy as np
+
 from tabarena.metrics._roc_auc_cpp import CppAuc
 
 
@@ -15,5 +18,5 @@ def test_cpp_auc_compilation():
             y_true=np.array([i % 2 == 0 for i in range(n_samples)]),
             y_score=np.arange(n_samples) / n_samples + 1,
         ),
-        0.5
+        0.5,
     )

--- a/tst/test_tabular_predictions.py
+++ b/tst/test_tabular_predictions.py
@@ -1,14 +1,22 @@
+from __future__ import annotations
+
 import copy
-import os
 import tempfile
-from typing import List
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
-from tabarena.predictions import TabularModelPredictions, TabularPredictionsMemmap, TabularPredictionsInMemory, TabularPredictionsInMemoryOpt
-from tabarena.predictions.tabular_predictions import TabularPredictionsDict
+from tabarena.predictions import (
+    TabularModelPredictions,
+    TabularPredictionsInMemory,
+    TabularPredictionsInMemoryOpt,
+    TabularPredictionsMemmap,
+)
 from tabarena.utils.test_utils import generate_artificial_dict, generate_dummy
+
+if TYPE_CHECKING:
+    from tabarena.predictions.tabular_predictions import TabularPredictionsDict
 
 num_models = 13
 num_folds = 3
@@ -23,13 +31,15 @@ pred_dict = generate_artificial_dict(num_folds, models, dataset_shapes)
 
 def _assert_equivalent_pred_dict(pred_dict_1: TabularPredictionsDict, pred_dict_2: TabularPredictionsDict):
     assert sorted(pred_dict_1.keys()) == sorted(pred_dict_2.keys())
-    for dataset in pred_dict_1.keys():
+    for dataset in pred_dict_1:
         assert sorted(pred_dict_1[dataset].keys()) == sorted(pred_dict_2[dataset].keys())
         for fold, fold_dict in pred_dict_1[dataset].items():
             assert sorted(pred_dict_1[dataset][fold].keys()) == sorted(pred_dict_2[dataset][fold].keys())
             for split, model_dict in fold_dict.items():
-                for model, model_value in model_dict.items():
-                    assert np.allclose(pred_dict_1[dataset][fold][split][model], pred_dict_2[dataset][fold][split][model])
+                for model, _model_value in model_dict.items():
+                    assert np.allclose(
+                        pred_dict_1[dataset][fold][split][model], pred_dict_2[dataset][fold][split][model]
+                    )
 
 
 def _assert_equivalent_preds(preds_1: TabularModelPredictions, preds_2: TabularModelPredictions):
@@ -68,11 +78,14 @@ def _assert_equivalent_preds(preds_1: TabularModelPredictions, preds_2: TabularM
     _assert_equivalent_pred_dict(preds_1.to_dict(), preds_2.to_dict())
 
 
-@pytest.mark.parametrize("cls", [
-    TabularPredictionsMemmap,
-    TabularPredictionsInMemory,
-    TabularPredictionsInMemoryOpt,
-])
+@pytest.mark.parametrize(
+    "cls",
+    [
+        TabularPredictionsMemmap,
+        TabularPredictionsInMemory,
+        TabularPredictionsInMemoryOpt,
+    ],
+)
 def test_predictions_shape(cls):
     with tempfile.TemporaryDirectory() as tmpdirname:
         preds: TabularModelPredictions = cls.from_dict(pred_dict, output_dir=tmpdirname)
@@ -86,18 +99,21 @@ def test_predictions_shape(cls):
             for dataset, (val_shape, test_shape) in dataset_shapes.items():
                 val_pred_proba = preds.predict_val(dataset=dataset, fold=2, models=test_models)
                 test_pred_proba = preds.predict_test(dataset=dataset, fold=2, models=test_models)
-                assert val_pred_proba.shape == tuple([len(test_models)] + list(val_shape))
-                assert test_pred_proba.shape == tuple([len(test_models)] + list(test_shape))
+                assert val_pred_proba.shape == (len(test_models), *list(val_shape))
+                assert test_pred_proba.shape == (len(test_models), *list(test_shape))
                 for i, model in enumerate(test_models):
                     assert np.allclose(val_pred_proba[i], generate_dummy(val_shape, test_models)[model])
                     assert np.allclose(test_pred_proba[i], generate_dummy(test_shape, test_models)[model])
 
 
-@pytest.mark.parametrize("cls", [
-    TabularPredictionsMemmap,
-    TabularPredictionsInMemory,
-    TabularPredictionsInMemoryOpt
-])
+@pytest.mark.parametrize(
+    "cls",
+    [
+        TabularPredictionsMemmap,
+        TabularPredictionsInMemory,
+        TabularPredictionsInMemoryOpt,
+    ],
+)
 def test_restrict_datasets(cls):
     with tempfile.TemporaryDirectory() as tmpdirname:
         preds: TabularModelPredictions = cls.from_dict(pred_dict, output_dir=tmpdirname)
@@ -110,11 +126,14 @@ def test_restrict_datasets(cls):
         assert sorted(preds.folds) == []
 
 
-@pytest.mark.parametrize("cls", [
-    TabularPredictionsMemmap,
-    TabularPredictionsInMemory,
-    TabularPredictionsInMemoryOpt,
-])
+@pytest.mark.parametrize(
+    "cls",
+    [
+        TabularPredictionsMemmap,
+        TabularPredictionsInMemory,
+        TabularPredictionsInMemoryOpt,
+    ],
+)
 def test_restrict_models(cls):
     with tempfile.TemporaryDirectory() as tmpdirname:
         preds: TabularModelPredictions = cls.from_dict(pred_dict, output_dir=tmpdirname)
@@ -127,11 +146,14 @@ def test_restrict_models(cls):
         assert sorted(preds.folds) == []
 
 
-@pytest.mark.parametrize("cls", [
-    TabularPredictionsMemmap,
-    TabularPredictionsInMemory,
-    TabularPredictionsInMemoryOpt,
-])
+@pytest.mark.parametrize(
+    "cls",
+    [
+        TabularPredictionsMemmap,
+        TabularPredictionsInMemory,
+        TabularPredictionsInMemoryOpt,
+    ],
+)
 def test_restrict_folds(cls):
     with tempfile.TemporaryDirectory() as tmpdirname:
         preds: TabularModelPredictions = cls.from_dict(pred_dict, output_dir=tmpdirname)
@@ -144,11 +166,14 @@ def test_restrict_folds(cls):
         assert sorted(preds.folds) == []
 
 
-@pytest.mark.parametrize("cls", [
-    TabularPredictionsMemmap,
-    TabularPredictionsInMemory,
-    TabularPredictionsInMemoryOpt,
-])
+@pytest.mark.parametrize(
+    "cls",
+    [
+        TabularPredictionsMemmap,
+        TabularPredictionsInMemory,
+        TabularPredictionsInMemoryOpt,
+    ],
+)
 def test_to_dict(cls):
     # Checks that to_dict returns the same dictionary as the original input
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -156,11 +181,14 @@ def test_to_dict(cls):
         _assert_equivalent_pred_dict(pred_dict_1=pred_dict, pred_dict_2=preds.to_dict())
 
 
-@pytest.mark.parametrize("cls", [
-    TabularPredictionsMemmap,
-    TabularPredictionsInMemory,
-    TabularPredictionsInMemoryOpt,
-])
+@pytest.mark.parametrize(
+    "cls",
+    [
+        TabularPredictionsMemmap,
+        TabularPredictionsInMemory,
+        TabularPredictionsInMemoryOpt,
+    ],
+)
 def test_to_data_dir(cls):
     # Checks that to_dict returns the same dictionary as the original input
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -169,13 +197,15 @@ def test_to_data_dir(cls):
             preds.to_data_dir(data_dir=new_data_dir)
             pred_dict2 = cls.from_data_dir(data_dir=new_data_dir).to_dict()
             assert sorted(pred_dict.keys()) == sorted(pred_dict2.keys())
-            for dataset in pred_dict.keys():
+            for dataset in pred_dict:
                 assert sorted(pred_dict[dataset].keys()) == sorted(pred_dict2[dataset].keys())
                 for fold, fold_dict in pred_dict[dataset].items():
                     assert sorted(pred_dict[dataset][fold].keys()) == sorted(pred_dict2[dataset][fold].keys())
                     for split, model_dict in fold_dict.items():
-                        for model, model_value in model_dict.items():
-                            assert np.allclose(pred_dict[dataset][fold][split][model], pred_dict2[dataset][fold][split][model])
+                        for model, _model_value in model_dict.items():
+                            assert np.allclose(
+                                pred_dict[dataset][fold][split][model], pred_dict2[dataset][fold][split][model]
+                            )
 
 
 def test_predictions_after_restrict():
@@ -187,7 +217,9 @@ def test_predictions_after_restrict():
     ]
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        preds_list: List[TabularModelPredictions] = [c.from_dict(pred_dict, output_dir=tmpdirname) for c in preds_cls_list]
+        preds_list: list[TabularModelPredictions] = [
+            c.from_dict(pred_dict, output_dir=tmpdirname) for c in preds_cls_list
+        ]
 
         cur_datasets = copy.deepcopy(preds_list[0].datasets)
         cur_models = copy.deepcopy(preds_list[0].models)

--- a/tst/test_zeroshot_configs.py
+++ b/tst/test_zeroshot_configs.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import numpy as np
 
 from tabarena.portfolio.zeroshot_selection import zeroshot_configs
 
 
 def test_zeroshot_configs():
-    val_scores = np.array([
-        [0.1, 0.2, 0.0, 1.0, 0.2],
-        [0.0, 0.2, 1.0, 1.0, 0.2],
-        [0.1, 0.2, 1.0, 0.0, 0.2],
-    ])
+    val_scores = np.array(
+        [
+            [0.1, 0.2, 0.0, 1.0, 0.2],
+            [0.0, 0.2, 1.0, 1.0, 0.2],
+            [0.1, 0.2, 1.0, 0.0, 0.2],
+        ]
+    )
     assert zeroshot_configs(val_scores, 3) == [0, 2, 3]
     assert zeroshot_configs(val_scores, 4) == [0, 2, 3]


### PR DESCRIPTION
Bring all first-party code into compliance with the existing ruff.toml rule set, then wire ruff into CI and pre-commit so it stays clean.

Config (ruff.toml):
- Fix a latent bug: `exclude` lived under [lint] (lint-only, did not prune discovery) and only "worked" because its entries duplicated ruff's built-in defaults. Move exclusions to a top-level `extend-exclude`.
- Exclude vendored upstream (limix/_vendor, tabm/_internal, modernnca/_internal) and archived examples; lint everything else first-party.
- target-version py311; extend `src` to all package src dirs; TCH -> TC.
- Relax high-volume non-auto-fixable stylistic rules (docstrings, complexity, unused-args, pandas opinions, E501, PTH, ...); per-file-ignores for tests and __init__.py re-exports. Correctness/safety rules stay enabled.

Code:
- Apply `ruff check --fix` (safe fixes) and `ruff format` repo-wide.
- Fix genuine issues surfaced: bare except, missing `raise ... from`, a dead shadowed import, self-assignments, and a `requests.get` without timeout.
- Targeted `# noqa` for pre-existing / false-positive instances of rules kept enabled (F821, B023, security S-rules) so they still guard new code.

Enforcement:
- CI: add `ruff check .` + `ruff format --check .` (drop the unused flake8).
- Add a pinned .pre-commit-config.yaml; pin ruff==0.14.0 across CI, pre-commit, and the lint dependency group.
- Document the workflow in AGENTS.md / CLAUDE.md.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
