### PR TITLE
Replace ExperimentBatchRunner.load_results with cache_mode="only_strict"

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner_api.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_runner_api.py
@@ -186,7 +186,7 @@ def run_experiments_new(
     repetitions_mode: Literal["TabArena-Lite", "TabArena", "matrix", "individual"],
     tasks_metadata: pd.DataFrame | None = None,
     repetitions_mode_args: tuple | list | None = None,
-    cache_mode: Literal["default", "ignore", "only"] = "default",
+    cache_mode: Literal["default", "ignore", "only", "only_strict"] = "default",
     cache_cls: type[AbstractCacheFunction] = CacheFunctionPickle,
     cache_cls_kwargs: dict | None = None,
     raise_on_failure: bool = True,
@@ -275,13 +275,15 @@ def run_experiments_new(
                 above format, that specifies the repeat and fold pairs to run for
                 each task. We assume the list is ordered the same as the tasks, so the
                 first tuple corresponds to the first task, and so on.
-    cache_mode: Literal["default", "ignore", "only"], default "default"
+    cache_mode: Literal["default", "ignore", "only", "only_strict"], default "default"
         Determines how to handle the cache:
             - "default": Skip experiment if cache exists, otherwise run the experiment.
             - "ignore": Ignore the cache and always run the experiment. This will
                 overwrite the cache file upon completion.
             - "only": Only load results from cache. This does not run the experiment
-                if cache does not exist.
+                if cache does not exist; missing experiments are silently skipped.
+            - "only_strict": Like "only", but raise if any requested experiment is
+                missing from the cache (after listing all of the missing experiments).
     cache_cls: type[AbstractCacheFunction], default CacheFunctionPickle
         The cache class used to read/write each experiment's `results`. Must accept
         `cache_name` and `cache_path` constructor arguments (e.g. `CacheFunctionPickle`
@@ -347,6 +349,9 @@ def run_experiments_new(
     result_lst = []
     cur_experiment_idx, experiment_success_count, experiment_fail_count = -1, 0, 0
     experiment_missing_count, experiment_cache_exists_count = 0, 0
+    # (method, task, fold, repeat) tuples that were requested but absent from the cache,
+    # collected only for `cache_mode="only_strict"` to raise after the full sweep.
+    missing_cached_experiments: list[tuple] = []
     experiment_count_total = n_splits * len(model_experiments)
     for dataset_index, task_id_or_object in enumerate(tasks):
         task, eval_metric_name = None, None
@@ -395,15 +400,18 @@ def run_experiments_new(
                     **{"include_self_in_call": False, **(cache_cls_kwargs or {})},
                 )
                 cache_exists = cacher.exists
+                load_only = cache_mode in ("only", "only_strict")
 
                 # Check cache state
                 if cache_exists and (cache_mode != "ignore"):
                     experiment_cache_exists_count += 1
-                elif (not cache_exists) and (cache_mode == "only"):
+                elif (not cache_exists) and load_only:
                     experiment_missing_count += 1
+                    if cache_mode == "only_strict":
+                        missing_cached_experiments.append((model_experiment.name, cache_task_key, fold, repeat))
                     continue
 
-                if cache_mode == "only":
+                if load_only:
                     out = cacher.load_cache()
                 else:
                     if (task is None) and ((cache_mode == "ignore") or (not cache_exists)):
@@ -512,5 +520,13 @@ def run_experiments_new(
                     result_lst.append(out)
                 else:
                     experiment_fail_count += 1
+
+    if cache_mode == "only_strict" and missing_cached_experiments:
+        missing_str = "\n\t".join(str(m) for m in missing_cached_experiments)
+        raise AssertionError(
+            f"cache_mode='only_strict': missing cached results for "
+            f"{len(missing_cached_experiments)}/{experiment_count_total} experiment(s).\n"
+            f"Missing (method, task, fold, repeat):\n\t{missing_str}",
+        )
 
     return result_lst

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from tabarena.benchmark.experiment.experiment_constructor import Experiment
 from tabarena.utils.cache import AbstractCacheFunction, CacheFunctionDummy, CacheFunctionPickle
 
 if TYPE_CHECKING:
     import pandas as pd
+
+    from tabarena.benchmark.experiment.experiment_constructor import Experiment
 
 
 # TODO: Inspect artifact folder to load all results without needing to specify them explicitly
@@ -19,7 +20,7 @@ class ExperimentBatchRunner:
         task_metadata: pd.DataFrame,
         cache_cls: type[AbstractCacheFunction] | None = CacheFunctionPickle,
         cache_cls_kwargs: dict | None = None,
-        cache_mode: Literal["default", "ignore", "only"] = "default",
+        cache_mode: Literal["default", "ignore", "only", "only_strict"] = "default",
         debug_mode: bool = True,
         raise_on_failure: bool = True,
     ):
@@ -28,11 +29,14 @@ class ExperimentBatchRunner:
         expname
         cache_cls
         cache_cls_kwargs
-        cache_mode: {"default", "ignore", "only"}, default "default"
+        cache_mode: {"default", "ignore", "only", "only_strict"}, default "default"
             How to handle the experiment cache:
                 - "default": skip an experiment if its cache exists, otherwise run it.
                 - "ignore": always run the experiment, overwriting any existing cache.
-                - "only": only load results from cache; never run an experiment.
+                - "only": only load results from cache; never run an experiment, and
+                    silently skip experiments whose cache is missing.
+                - "only_strict": like "only", but raise if any requested experiment is
+                    missing from the cache.
         debug_mode: bool, default True
             If True, will operate in a manner best suited for local model development.
             This mode will be friendly to local debuggers and will avoid subprocesses/threads
@@ -225,86 +229,9 @@ class ExperimentBatchRunner:
             debug_mode=self.debug_mode,
         )
 
-    def load_results(
-        self,
-        methods: list[Experiment | str],
-        datasets: list[str],
-        folds: list[int],
-        repeats: list[int] | None = None,
-        require_all: bool = True,
-    ) -> list[dict[str, Any]]:
-        """Load results from the cache.
-
-        Parameters
-        ----------
-
-        Methods:
-        datasets
-        folds
-        repeats
-        require_all: bool, default True
-            If True, will raise an exception if not all methods x datasets x folds have a cached result to load.
-            If False, will return only the list of results with a cached result. This can be an empty list if no cached results exist.
-
-        Returns:
-        -------
-        results_lst
-            The same output format returned by `self.run`
-
-        """
-        results_lst = []
-        results_lst_exists = []
-        results_lst_missing = []
-        if repeats is not None:
-            repeat_fold_pairs = [(r, f) for r in repeats for f in folds]
-        else:
-            repeat_fold_pairs = [(None, f) for f in folds]
-        for method in methods:
-            method_name = method.name if isinstance(method, Experiment) else method
-            for dataset in datasets:
-                for repeat, fold in repeat_fold_pairs:
-                    cache_exists = self._cache_exists(method_name=method_name, dataset=dataset, fold=fold)
-                    cache_args = (method_name, dataset, fold, repeat)
-                    if cache_exists:
-                        results_lst_exists.append(cache_args)
-                        print(method.name, dataset, fold)
-                        print(f"\t{cache_exists}")
-                    else:
-                        results_lst_missing.append(cache_args)
-        if require_all and results_lst_missing:
-            raise AssertionError(
-                f"Missing cached results for {len(results_lst_missing)}/{len(results_lst_exists) + len(results_lst_missing)} experiments! "
-                f"\nTo load only the {len(results_lst_exists)} existing experiments, set `require_all=False`, "
-                f"or call `exp_batch_runner.run(methods=methods, datasets=datasets, folds=folds)` to run the missing experiments."
-                f"\nMissing experiments:\n\t{results_lst_missing}",
-            )
-        for method_name, dataset, fold, repeat in results_lst_exists:
-            results_lst.append(self._load_result(method_name=method_name, dataset=dataset, fold=fold, repeat=repeat))
-        return results_lst
-
     @classmethod
     def _subtask_name(cls, fold: int, repeat: int | None = None) -> str:
         return f"{fold}" if repeat is None else f"{repeat}_{fold}"
-
-    def _cache_name(self, method_name: str, dataset: str, fold: int, repeat: int | None = None) -> str:
-        subtask_name = self._subtask_name(fold=fold, repeat=repeat)
-        # TODO: Windows? Use Path?
-        tid = self._dataset_to_tid_dict[dataset]
-        return f"data/{method_name}/{tid}/{subtask_name}/results"
-
-    def _cache_exists(self, method_name: str, dataset: str, fold: int, repeat: int | None = None) -> bool:
-        cacher = self._get_cacher(method_name=method_name, dataset=dataset, fold=fold, repeat=repeat)
-        return cacher.exists
-
-    def _load_result(self, method_name: str, dataset: str, fold: int, repeat: int | None = None) -> dict[str, Any]:
-        cacher = self._get_cacher(method_name=method_name, dataset=dataset, fold=fold, repeat=repeat)
-        return cacher.load_cache()
-
-    def _get_cacher(
-        self, method_name: str, dataset: str, fold: int, repeat: int | None = None
-    ) -> AbstractCacheFunction:
-        cache_name = self._cache_name(method_name=method_name, dataset=dataset, fold=fold, repeat=repeat)
-        return self.cache_cls(cache_name=cache_name, cache_path=self.expname, **self.cache_cls_kwargs)
 
     def _validate_datasets(self, datasets: list[str]):
         unknown_datasets = []

--- a/tst/benchmark/experiment/test_experiment_utils.py
+++ b/tst/benchmark/experiment/test_experiment_utils.py
@@ -494,6 +494,22 @@ class TestExperimentBatchRunnerRunAll:
         with pytest.raises(AssertionError, match="n_folds"):
             runner.run_all(methods=[_make_minimal_experiment()])
 
+    def test_only_strict_raises_on_missing_cache(self, tmp_path):
+        # cache_mode="only_strict": no cache exists, so every requested experiment is
+        # missing and the run raises (rather than silently returning []).
+        runner = self._runner(tmp_path, cache_mode="only_strict")
+        with pytest.raises(AssertionError, match="only_strict"):
+            runner.run(methods=[_make_minimal_experiment()], datasets=["d0", "d1"], folds=[0])
+
+    def test_only_strict_generalizes_to_run_all(self, tmp_path):
+        # only_strict works through run_all too (same canonical cache path).
+        task_metadata = pd.DataFrame(
+            {"tid": [0, 1], "dataset": ["d0", "d1"], "n_folds": [1, 1], "n_repeats": [1, 1]},
+        )
+        runner = self._runner(tmp_path, task_metadata=task_metadata, cache_mode="only_strict")
+        with pytest.raises(AssertionError, match="only_strict"):
+            runner.run_all(methods=[_make_minimal_experiment()])
+
 
 class TestRunExperimentsNewCacheCls:
     def test_custom_cache_cls_used(self, tmp_path):


### PR DESCRIPTION
`load_results` (and its private `_cache_name`/`_cache_exists`/`_load_result`/ `_get_cacher` helpers) was unused, duplicated the canonical cache-path logic, and had drifted out of sync with the always-`{repeat}_{fold}` layout (its existence check dropped `repeat`). Remove all of it.

Its one useful feature — "load from cache, but error if anything is missing" — is reintroduced on the canonical path as a new `cache_mode="only_strict"` in `run_experiments_new`: it behaves like "only" (load, never run) but, after the sweep, raises listing every requested (method, task, fold, repeat) absent from the cache. Because all run methods funnel through `run_experiments_new`, this works for `run`, `run_dataset_fold_repeats`, and `run_all` alike. `ExperimentBatchRunner` exposes it via its `cache_mode` argument.
