### PR TITLE
Add TabArenaContext.make_experiment_batch_runner with subset/datasets/split selection

### DIFF
--- a/examples/benchmarking/run_quickstart_tabarena.py
+++ b/examples/benchmarking/run_quickstart_tabarena.py
@@ -31,7 +31,6 @@ if __name__ == "__main__":
         AGModelBagExperiment(  # Wrapper for fitting a single bagged model via AutoGluon
             # The name you want the config to have
             name="LightGBM_c1_BAG_L1_Reproduced",
-            # The class of the model. Can also be a string if AutoGluon recognizes it, such as `"GBM"`
             # Supports any model that inherits from `autogluon.core.models.AbstractModel`
             model_cls=LGBModel,
             model_hyperparameters={
@@ -40,13 +39,6 @@ if __name__ == "__main__":
             num_bag_folds=8,  # num_bag_folds=8 was used in the TabArena 2025 paper
             time_limit=3600,  # time_limit=3600 was used in the TabArena 2025 paper
         ),
-        # AGModelBagExperiment(
-        #     name="TA-RealMLP_c1_BAG_L1_Reproduced",
-        #     model_cls=RealMLPModel,
-        #     model_hyperparameters={},
-        #     num_bag_folds=8,
-        #     time_limit=3600,
-        # ),
     ]
 
     # Build a runner scoped to the demo tasks via the TabArenaContext factory: the 3

--- a/examples/benchmarking/run_quickstart_tabarena.py
+++ b/examples/benchmarking/run_quickstart_tabarena.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pandas as pd
 
-from tabarena.benchmark.experiment import AGModelBagExperiment, ExperimentBatchRunner
+from tabarena.benchmark.experiment import AGModelBagExperiment
 from tabarena.nips2025_utils.end_to_end import EndToEnd
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 
@@ -21,12 +21,9 @@ if __name__ == "__main__":
 
     # Sample for a quick demo
     datasets = ["anneal", "credit-g", "diabetes"]  # datasets = list(task_metadata["name"])
-    folds = [0]
 
     # import your model classes
     from autogluon.tabular.models import LGBModel
-
-    from tabarena.models import RealMLPModel
 
     # This list of methods will be fit sequentially on each task (dataset x fold)
     methods = [
@@ -43,28 +40,29 @@ if __name__ == "__main__":
             num_bag_folds=8,  # num_bag_folds=8 was used in the TabArena 2025 paper
             time_limit=3600,  # time_limit=3600 was used in the TabArena 2025 paper
         ),
-        AGModelBagExperiment(
-            name="TA-RealMLP_c1_BAG_L1_Reproduced",
-            model_cls=RealMLPModel,
-            model_hyperparameters={},
-            num_bag_folds=8,
-            time_limit=3600,
-        ),
+        # AGModelBagExperiment(
+        #     name="TA-RealMLP_c1_BAG_L1_Reproduced",
+        #     model_cls=RealMLPModel,
+        #     model_hyperparameters={},
+        #     num_bag_folds=8,
+        #     time_limit=3600,
+        # ),
     ]
 
-    exp_batch_runner = ExperimentBatchRunner(
+    # Build a runner scoped to the demo tasks via the TabArenaContext factory: the 3
+    # datasets above at fold 0 / repeat 0. The "lite" subset keeps split 0
+    # (== fold 0, repeat 0; split = n_folds * repeat + fold), and `datasets` restricts to
+    # the demo datasets. `make_experiment_batch_runner` resolves these into the exact
+    # (dataset, fold, repeat) triplets that `run_all` executes.
+    exp_batch_runner = tabarena_context.make_experiment_batch_runner(
         expname=expname,
-        task_metadata=task_metadata,
+        datasets=datasets,
+        subset="lite",
         cache_mode="ignore" if ignore_cache else "default",
     )
 
-    # Get the run artifacts.
-    # Fits each method on each task (datasets * folds)
-    results_lst: list[dict[str, Any]] = exp_batch_runner.run(
-        datasets=datasets,
-        folds=folds,
-        methods=methods,
-    )
+    # Get the run artifacts. Fits each method on each configured task.
+    results_lst: list[dict[str, Any]] = exp_batch_runner.run_all(methods=methods)
 
     # compute results
     end_to_end = EndToEnd.from_raw(results_lst=results_lst, task_metadata=task_metadata, cache=False, cache_raw=False)

--- a/examples/benchmarking/run_quickstart_tabarena_tabiclv2.py
+++ b/examples/benchmarking/run_quickstart_tabarena_tabiclv2.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from tabarena.benchmark.experiment import AGModelOuterExperiment
+from tabarena.nips2025_utils.end_to_end import EndToEnd
+from tabarena.nips2025_utils.tabarena_context import TabArenaContext
+
+if __name__ == "__main__":
+    expname = str(
+        Path(__file__).parent / "experiments" / "quickstart"
+    )  # folder location to save all experiment artifacts
+    eval_dir = Path(__file__).parent / "eval" / "quickstart"
+
+    context = TabArenaContext()
+
+    # import your model classes
+    from tabarena.models import TabICLv2Model
+
+    # This list of methods will be fit sequentially on each task
+    methods = [
+        AGModelOuterExperiment(
+            name="TabICLv2",
+            model_cls=TabICLv2Model,
+            model_hyperparameters={},
+        ),
+        AGModelOuterExperiment(
+            name="TabICLv2_n1",
+            model_cls=TabICLv2Model,
+            model_hyperparameters={"n_estimators": 1},
+        ),
+    ]
+
+    experiment_batch_runner = context.make_experiment_batch_runner(
+        expname=expname,
+        subset=["small", "lite"],
+    )
+
+    # Get the run artifacts. Fits each method on each configured task.
+    results_lst: list[dict[str, Any]] = experiment_batch_runner.run_all(methods=methods)
+
+    # compute results
+    end_to_end = EndToEnd.from_raw(
+        results_lst=results_lst,
+        task_metadata=context.task_metadata,
+        cache=False,
+        cache_raw=False,
+    )
+    end_to_end_results = end_to_end.to_results()
+
+    print(f"New Configs Hyperparameters: {end_to_end.configs_hyperparameters()}")
+    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+        print(f"Results:\n{end_to_end_results.model_results.head(100)}")
+
+    new_results: pd.DataFrame = end_to_end_results.get_results(
+        new_result_prefix="Demo_",
+        use_model_results=True,  # If False: Will instead use the ensemble/HPO results
+    )
+    leaderboard: pd.DataFrame = context.compare(
+        output_dir=eval_dir,
+        only_valid_tasks=new_results["method"].unique(),  # only compare on tasks ran in `results_lst`
+        new_results=new_results,
+        verbose=False,
+    )
+    leaderboard_website = context.leaderboard_to_website_format(leaderboard)
+    print(leaderboard_website.to_markdown(index=False))

--- a/examples/benchmarking/run_quickstart_tabarena_tabiclv2.py
+++ b/examples/benchmarking/run_quickstart_tabarena_tabiclv2.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     expname = str(
         Path(__file__).parent / "experiments" / "quickstart"
     )  # folder location to save all experiment artifacts
-    eval_dir = Path(__file__).parent / "eval" / "quickstart"
+    eval_dir = Path(__file__).parent / "eval" / "quickstart_tabiclv2"
 
     context = TabArenaContext()
 

--- a/packages/bencheval/src/bencheval/tabarena.py
+++ b/packages/bencheval/src/bencheval/tabarena.py
@@ -262,8 +262,6 @@ class TabArena:
                 f"\n\tUnused columns ({len(unused_columns)}): {unused_columns}"
                 f"\n\tIndex names ({len(index_names)}): {index_names}",
             )
-        if unused_columns:
-            print(f"Unused columns: {unused_columns}")
 
         for c in self.groupby_columns:
             assert data[c].isnull().sum() == 0, f"groupby column {c!r} contains NaN!"

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
@@ -18,6 +18,7 @@ class ExperimentBatchRunner:
         self,
         expname: str,
         task_metadata: pd.DataFrame,
+        dataset_fold_repeats: list[tuple[str, int, int]] | None = None,
         cache_cls: type[AbstractCacheFunction] | None = CacheFunctionPickle,
         cache_cls_kwargs: dict | None = None,
         cache_mode: Literal["default", "ignore", "only", "only_strict"] = "default",
@@ -27,6 +28,11 @@ class ExperimentBatchRunner:
         """Parameters
         ----------
         expname
+        dataset_fold_repeats: list[tuple[str, int, int]] | None, default None
+            The allowed (dataset, fold, repeat) triplets that `run_all` executes. If
+            None, `run_all` uses the full grid implied by the `n_folds` and `n_repeats`
+            columns of `task_metadata`. Each triplet is validated against `task_metadata`
+            (dataset must be present; fold < n_folds; repeat < n_repeats).
         cache_cls
         cache_cls_kwargs
         cache_mode: {"default", "ignore", "only", "only_strict"}, default "default"
@@ -65,6 +71,9 @@ class ExperimentBatchRunner:
         )
         self.debug_mode = debug_mode
         self.raise_on_failure = raise_on_failure
+        if dataset_fold_repeats is not None:
+            self._validate_dataset_fold_repeats(dataset_fold_repeats)
+        self._dataset_fold_repeats = dataset_fold_repeats
 
     @property
     def datasets(self) -> list[str]:
@@ -161,9 +170,10 @@ class ExperimentBatchRunner:
         self,
         methods: list[Experiment],
     ) -> list[dict[str, Any]]:
-        """Run every (dataset, fold, repeat) dictated by `task_metadata`.
+        """Run the configured (dataset, fold, repeat) triplets.
 
-        For each dataset, runs all folds in `range(n_folds)` x repeats in
+        If `dataset_fold_repeats` was passed at init, runs exactly those triplets.
+        Otherwise, for each dataset runs all folds in `range(n_folds)` x repeats in
         `range(n_repeats)`, taken from the `n_folds` and `n_repeats` columns of
         `task_metadata`. Delegates to `run_dataset_fold_repeats`.
 
@@ -179,18 +189,20 @@ class ExperimentBatchRunner:
             Can pass into `exp_bach_runner.repo_from_results(results_lst=results_lst)` to generate an EvaluationRepository.
 
         """
-        for col in ("dataset", "n_folds", "n_repeats"):
-            if col not in self.task_metadata.columns:
-                raise AssertionError(f"`task_metadata` must contain the column '{col}' to use `run_all`.")
+        dataset_fold_repeats = self._dataset_fold_repeats
+        if dataset_fold_repeats is None:
+            for col in ("dataset", "n_folds", "n_repeats"):
+                if col not in self.task_metadata.columns:
+                    raise AssertionError(f"`task_metadata` must contain the column '{col}' to use `run_all`.")
 
-        metadata = self.task_metadata.drop_duplicates(subset="dataset")
-        dataset_fold_repeats: list[tuple[str, int, int]] = []
-        for dataset, n_folds, n_repeats in zip(
-            metadata["dataset"], metadata["n_folds"], metadata["n_repeats"], strict=False
-        ):
-            for repeat in range(int(n_repeats)):
-                for fold in range(int(n_folds)):
-                    dataset_fold_repeats.append((dataset, fold, repeat))
+            metadata = self.task_metadata.drop_duplicates(subset="dataset")
+            dataset_fold_repeats = []
+            for dataset, n_folds, n_repeats in zip(
+                metadata["dataset"], metadata["n_folds"], metadata["n_repeats"], strict=False
+            ):
+                for repeat in range(int(n_repeats)):
+                    for fold in range(int(n_folds)):
+                        dataset_fold_repeats.append((dataset, fold, repeat))
 
         return self.run_dataset_fold_repeats(
             methods=methods,
@@ -256,6 +268,36 @@ class ExperimentBatchRunner:
             return
         if len(repeats) != len(set(repeats)):
             raise AssertionError("Duplicate repeats present! Ensure all repeats are unique.")
+
+    def _validate_dataset_fold_repeats(self, dataset_fold_repeats: list[tuple[str, int, int]]):
+        """Verify each (dataset, fold, repeat) is possible according to `task_metadata`.
+
+        Checks the dataset is present, and (when the `n_folds`/`n_repeats` columns exist)
+        that `0 <= fold < n_folds` and `0 <= repeat < n_repeats` for that dataset.
+        """
+        has_counts = {"n_folds", "n_repeats"}.issubset(self.task_metadata.columns)
+        counts: dict[str, tuple[int, int]] = {}
+        if has_counts:
+            metadata = self.task_metadata.drop_duplicates(subset="dataset")
+            counts = {
+                dataset: (int(n_folds), int(n_repeats))
+                for dataset, n_folds, n_repeats in zip(
+                    metadata["dataset"], metadata["n_folds"], metadata["n_repeats"], strict=False
+                )
+            }
+        invalid = []
+        for dataset, fold, repeat in dataset_fold_repeats:
+            if dataset not in self._dataset_to_tid_dict:
+                invalid.append((dataset, fold, repeat, "unknown dataset"))
+            elif has_counts:
+                n_folds, n_repeats = counts[dataset]
+                if not (0 <= fold < n_folds) or not (0 <= repeat < n_repeats):
+                    invalid.append((dataset, fold, repeat, f"out of range (n_folds={n_folds}, n_repeats={n_repeats})"))
+        if invalid:
+            invalid_str = "\n\t".join(str(x) for x in invalid)
+            raise AssertionError(
+                f"`dataset_fold_repeats` contains {len(invalid)} entry(ies) not valid for `task_metadata`:\n\t{invalid_str}",
+            )
 
 
 def check_cache_hit(

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -58,7 +58,9 @@ def compare_on_tabarena(
     df_results = pd.concat([ta_results, new_results], ignore_index=True) if new_results is not None else ta_results
 
     kwargs = kwargs.copy()
-    if isinstance(only_valid_tasks, (str, list)):
+    if isinstance(only_valid_tasks, set):
+        only_valid_tasks = list(only_valid_tasks)
+    if isinstance(only_valid_tasks, (str, list, tuple, np.ndarray)):
         kwargs["only_valid_tasks"] = only_valid_tasks
     elif only_valid_tasks and new_results is not None:
         df_results = filter_to_valid_tasks(
@@ -196,23 +198,6 @@ def prepare_data(
 ) -> pd.DataFrame:
     df_results = df_results.copy()
 
-    if isinstance(only_valid_tasks, str):
-        only_valid_tasks = [only_valid_tasks]
-    if isinstance(only_valid_tasks, list):
-        for filter_method in only_valid_tasks:
-            # Filter to tasks present in a specific method
-            df_filter = df_results[df_results["method"] == filter_method]
-            if "imputed" in df_filter.columns:
-                df_filter = df_filter[not df_filter["imputed"]]
-            assert len(df_filter) != 0, (
-                f"No method named '{filter_method}' remains to filter to!\n"
-                f"Available tasks: {list(df_results['method'].unique())}"
-            )
-            df_results = filter_to_valid_tasks(
-                df_to_filter=df_results,
-                df_filter=df_filter,
-            )
-
     if "method_type" not in df_results.columns:
         df_results["method_type"] = "baseline"
     if "method_subtype" not in df_results.columns:
@@ -221,6 +206,25 @@ def prepare_data(
         df_results["config_type"] = np.nan
     if "imputed" not in df_results.columns:
         df_results["imputed"] = False
+
+    df_results["imputed"] = df_results["imputed"].fillna(0).astype(bool)
+
+    if isinstance(only_valid_tasks, str):
+        only_valid_tasks = [only_valid_tasks]
+    if isinstance(only_valid_tasks, list):
+        for filter_method in only_valid_tasks:
+            # Filter to tasks present in a specific method
+            df_filter = df_results[df_results["method"] == filter_method]
+            if "imputed" in df_filter.columns:
+                df_filter = df_filter[~df_filter["imputed"]]
+            assert len(df_filter) != 0, (
+                f"No method named '{filter_method}' remains to filter to!\n"
+                f"Available tasks: {list(df_results['method'].unique())}"
+            )
+            df_results = filter_to_valid_tasks(
+                df_to_filter=df_results,
+                df_filter=df_filter,
+            )
 
     if isinstance(fillna, str):
         fillna = df_results[df_results["method"] == fillna]

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -58,9 +58,9 @@ def compare_on_tabarena(
     df_results = pd.concat([ta_results, new_results], ignore_index=True) if new_results is not None else ta_results
 
     kwargs = kwargs.copy()
-    if isinstance(only_valid_tasks, set):
+    if isinstance(only_valid_tasks, (tuple, np.ndarray)):
         only_valid_tasks = list(only_valid_tasks)
-    if isinstance(only_valid_tasks, (str, list, tuple, np.ndarray)):
+    if isinstance(only_valid_tasks, (str, list)):
         kwargs["only_valid_tasks"] = only_valid_tasks
     elif only_valid_tasks and new_results is not None:
         df_results = filter_to_valid_tasks(

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -23,6 +23,7 @@ from tabarena.website.website_format import format_leaderboard
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from tabarena.benchmark.experiment import ExperimentBatchRunner
     from tabarena.benchmark.result import BaselineResult
     from tabarena.repository.abstract_repository import AbstractRepository
 
@@ -876,6 +877,72 @@ class TabArenaContext:
                 predicates=self.subset_predicates,
             )
         return df_results
+
+    def make_experiment_batch_runner(
+        self,
+        expname: str,
+        *,
+        subset: str | list[str] | None = None,
+        **kwargs,
+    ) -> ExperimentBatchRunner:
+        """Create an `ExperimentBatchRunner` over this context's `task_metadata`.
+
+        If `subset` is provided, restrict the (dataset, fold, repeat) triplets that the
+        runner's `run_all` executes to those whose split (``n_folds * repeat + fold``)
+        passes the subset predicate expressions — the same predicates used by `compare`
+        (e.g. ``"lite"``, ``"small"``, ``"binary"``, ``"!tiny"``). If None, `run_all`
+        runs the full ``n_folds`` x ``n_repeats`` grid from `task_metadata`.
+
+        Extra keyword arguments (``cache_mode``, ``debug_mode``, ...) are forwarded to
+        `ExperimentBatchRunner`.
+        """
+        from tabarena.benchmark.experiment import ExperimentBatchRunner
+
+        dataset_fold_repeats = None
+        if subset is not None:
+            dataset_fold_repeats = self._subset_dataset_fold_repeats(subset=subset)
+        return ExperimentBatchRunner(
+            expname=expname,
+            task_metadata=self.task_metadata,
+            dataset_fold_repeats=dataset_fold_repeats,
+            **kwargs,
+        )
+
+    def _subset_dataset_fold_repeats(self, subset: str | list[str]) -> list[tuple[str, int, int]]:
+        """Expand `task_metadata` into (dataset, fold, repeat) triplets kept by `subset`.
+
+        Builds the full per-dataset grid (``split = n_folds * repeat + fold``), then
+        filters it with the same predicate machinery as `compare`. The subset predicates
+        treat the split index as the ``fold`` column, so e.g. ``"lite"`` keeps
+        ``split == 0`` (i.e. ``(fold 0, repeat 0)``).
+        """
+        from tabarena.nips2025_utils.compare import subset_tasks
+
+        if isinstance(subset, str):
+            subset = [subset]
+
+        metadata = self.task_metadata.drop_duplicates(subset="dataset")
+        rows = []
+        for dataset, n_folds, n_repeats in zip(
+            metadata["dataset"], metadata["n_folds"], metadata["n_repeats"], strict=False
+        ):
+            n_folds, n_repeats = int(n_folds), int(n_repeats)
+            for repeat in range(n_repeats):
+                for fold in range(n_folds):
+                    # `subset_tasks` treats the "fold" column as the split index.
+                    rows.append((dataset, fold, repeat, n_folds * repeat + fold))
+        grid = pd.DataFrame(rows, columns=["dataset", "_fold", "_repeat", "fold"])
+
+        filtered = subset_tasks(
+            df_results=grid,
+            subset=subset,
+            task_metadata_og=self.task_metadata,
+            predicates=self.subset_predicates,
+        )
+        return [
+            (dataset, int(fold), int(repeat))
+            for dataset, fold, repeat in zip(filtered["dataset"], filtered["_fold"], filtered["_repeat"], strict=False)
+        ]
 
     def load_configs_hyperparameters(
         self,

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -883,24 +883,42 @@ class TabArenaContext:
         expname: str,
         *,
         subset: str | list[str] | None = None,
+        datasets: list[str] | None = None,
+        dataset_fold_repeats: list[tuple[str, int, int]] | None = None,
         **kwargs,
     ) -> ExperimentBatchRunner:
         """Create an `ExperimentBatchRunner` over this context's `task_metadata`.
 
-        If `subset` is provided, restrict the (dataset, fold, repeat) triplets that the
-        runner's `run_all` executes to those whose split (``n_folds * repeat + fold``)
-        passes the subset predicate expressions — the same predicates used by `compare`
-        (e.g. ``"lite"``, ``"small"``, ``"binary"``, ``"!tiny"``). If None, `run_all`
-        runs the full ``n_folds`` x ``n_repeats`` grid from `task_metadata`.
+        The (dataset, fold, repeat) triplets the runner's `run_all` executes are
+        determined by `subset`, `datasets`, and `dataset_fold_repeats`:
 
-        Extra keyword arguments (``cache_mode``, ``debug_mode``, ...) are forwarded to
-        `ExperimentBatchRunner`.
+        - `subset`: predicate expressions (the same as `compare`, e.g. ``"lite"``,
+          ``"small"``, ``"binary"``, ``"!tiny"``) applied to the full per-dataset grid,
+          where the predicates treat the split (``n_folds * repeat + fold``) as the
+          ``fold`` column (so ``"lite"`` keeps ``split == 0`` == ``(fold 0, repeat 0)``).
+        - `datasets`: restrict to these dataset names.
+        - `dataset_fold_repeats`: an explicit list of triplets. When given, the result is
+          the **intersection** of these and the triplets derived from `subset`/`datasets`
+          (so user triplets that fall outside the subset/datasets selection are dropped).
+
+        If none of the three are given, `run_all` runs the full ``n_folds`` x
+        ``n_repeats`` grid from `task_metadata`. Extra keyword arguments (``cache_mode``,
+        ``debug_mode``, ...) are forwarded to `ExperimentBatchRunner`.
         """
         from tabarena.benchmark.experiment import ExperimentBatchRunner
 
-        dataset_fold_repeats = None
-        if subset is not None:
-            dataset_fold_repeats = self._subset_dataset_fold_repeats(subset=subset)
+        derived = None
+        if subset is not None or datasets is not None:
+            derived = self._subset_dataset_fold_repeats(subset=subset, datasets=datasets)
+
+        if dataset_fold_repeats is not None:
+            if derived is not None:
+                allowed = set(derived)
+                dataset_fold_repeats = [t for t in dataset_fold_repeats if t in allowed]
+            # else: no subset/datasets constraint -> use the user's triplets as-is.
+        else:
+            dataset_fold_repeats = derived
+
         return ExperimentBatchRunner(
             expname=expname,
             task_metadata=self.task_metadata,
@@ -908,13 +926,18 @@ class TabArenaContext:
             **kwargs,
         )
 
-    def _subset_dataset_fold_repeats(self, subset: str | list[str]) -> list[tuple[str, int, int]]:
-        """Expand `task_metadata` into (dataset, fold, repeat) triplets kept by `subset`.
+    def _subset_dataset_fold_repeats(
+        self,
+        subset: str | list[str] | None = None,
+        datasets: list[str] | None = None,
+    ) -> list[tuple[str, int, int]]:
+        """Expand `task_metadata` into (dataset, fold, repeat) triplets kept by the filters.
 
         Builds the full per-dataset grid (``split = n_folds * repeat + fold``), then
-        filters it with the same predicate machinery as `compare`. The subset predicates
-        treat the split index as the ``fold`` column, so e.g. ``"lite"`` keeps
-        ``split == 0`` (i.e. ``(fold 0, repeat 0)``).
+        filters it with the same machinery as `compare` (`subset` predicate expressions
+        and/or an explicit `datasets` list). The subset predicates treat the split index
+        as the ``fold`` column, so e.g. ``"lite"`` keeps ``split == 0`` (i.e.
+        ``(fold 0, repeat 0)``).
         """
         from tabarena.nips2025_utils.compare import subset_tasks
 
@@ -936,6 +959,7 @@ class TabArenaContext:
         filtered = subset_tasks(
             df_results=grid,
             subset=subset,
+            datasets=datasets,
             task_metadata_og=self.task_metadata,
             predicates=self.subset_predicates,
         )

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -884,32 +884,52 @@ class TabArenaContext:
         *,
         subset: str | list[str] | None = None,
         datasets: list[str] | None = None,
+        splits: list[int] | None = None,
+        folds: list[int] | None = None,
+        repeats: list[int] | None = None,
         dataset_fold_repeats: list[tuple[str, int, int]] | None = None,
         **kwargs,
     ) -> ExperimentBatchRunner:
         """Create an `ExperimentBatchRunner` over this context's `task_metadata`.
 
         The (dataset, fold, repeat) triplets the runner's `run_all` executes are
-        determined by `subset`, `datasets`, and `dataset_fold_repeats`:
+        determined by the following filters (all default None):
 
         - `subset`: predicate expressions (the same as `compare`, e.g. ``"lite"``,
           ``"small"``, ``"binary"``, ``"!tiny"``) applied to the full per-dataset grid,
           where the predicates treat the split (``n_folds * repeat + fold``) as the
           ``fold`` column (so ``"lite"`` keeps ``split == 0`` == ``(fold 0, repeat 0)``).
         - `datasets`: restrict to these dataset names.
+        - `splits`: restrict to these split indices (``n_folds * repeat + fold``).
+        - `folds` / `repeats`: restrict to these fold / repeat indices.
         - `dataset_fold_repeats`: an explicit list of triplets. When given, the result is
           the **intersection** of these and the triplets derived from `subset`/`datasets`
           (so user triplets that fall outside the subset/datasets selection are dropped).
 
-        If none of the three are given, `run_all` runs the full ``n_folds`` x
-        ``n_repeats`` grid from `task_metadata`. Extra keyword arguments (``cache_mode``,
-        ``debug_mode``, ...) are forwarded to `ExperimentBatchRunner`.
+        `subset`, `datasets`, and the split/fold/repeat filters compose (AND). Two
+        combinations are disallowed: `splits` together with `folds`/`repeats`, and
+        `dataset_fold_repeats` together with any of `splits`/`folds`/`repeats`.
+
+        If no filters are given, `run_all` runs the full ``n_folds`` x ``n_repeats`` grid
+        from `task_metadata`. Extra keyword arguments (``cache_mode``, ``debug_mode``, ...)
+        are forwarded to `ExperimentBatchRunner`.
         """
         from tabarena.benchmark.experiment import ExperimentBatchRunner
 
+        if splits is not None and (folds is not None or repeats is not None):
+            raise ValueError("Cannot specify `splits` together with `folds`/`repeats`.")
+        if dataset_fold_repeats is not None and any(x is not None for x in (splits, folds, repeats)):
+            raise ValueError("Cannot specify `dataset_fold_repeats` together with `splits`/`folds`/`repeats`.")
+
         derived = None
-        if subset is not None or datasets is not None:
-            derived = self._subset_dataset_fold_repeats(subset=subset, datasets=datasets)
+        if any(x is not None for x in (subset, datasets, splits, folds, repeats)):
+            derived = self._subset_dataset_fold_repeats(
+                subset=subset,
+                datasets=datasets,
+                splits=splits,
+                folds=folds,
+                repeats=repeats,
+            )
 
         if dataset_fold_repeats is not None:
             if derived is not None:
@@ -930,13 +950,17 @@ class TabArenaContext:
         self,
         subset: str | list[str] | None = None,
         datasets: list[str] | None = None,
+        splits: list[int] | None = None,
+        folds: list[int] | None = None,
+        repeats: list[int] | None = None,
     ) -> list[tuple[str, int, int]]:
         """Expand `task_metadata` into (dataset, fold, repeat) triplets kept by the filters.
 
         Builds the full per-dataset grid (``split = n_folds * repeat + fold``), then
-        filters it with the same machinery as `compare` (`subset` predicate expressions
-        and/or an explicit `datasets` list). The subset predicates treat the split index
-        as the ``fold`` column, so e.g. ``"lite"`` keeps ``split == 0`` (i.e.
+        filters it (AND) by: the `subset` predicate expressions and/or an explicit
+        `datasets` list (via the same machinery as `compare`), and then by the
+        `splits`/`folds`/`repeats` index lists. The subset predicates treat the split
+        index as the ``fold`` column, so e.g. ``"lite"`` keeps ``split == 0`` (i.e.
         ``(fold 0, repeat 0)``).
         """
         from tabarena.nips2025_utils.compare import subset_tasks
@@ -963,6 +987,12 @@ class TabArenaContext:
             task_metadata_og=self.task_metadata,
             predicates=self.subset_predicates,
         )
+        if splits is not None:
+            filtered = filtered[filtered["fold"].isin(splits)]  # "fold" column holds the split index
+        if folds is not None:
+            filtered = filtered[filtered["_fold"].isin(folds)]
+        if repeats is not None:
+            filtered = filtered[filtered["_repeat"].isin(repeats)]
         return [
             (dataset, int(fold), int(repeat))
             for dataset, fold, repeat in zip(filtered["dataset"], filtered["_fold"], filtered["_repeat"], strict=False)

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -1365,8 +1365,7 @@ class TabArenaEvaluator:
         # remove suffix
         imputed_names = [n.split(" (")[0] for n in imputed_names]
         imputed_names = [method_rename_map.get(n, n) for n in imputed_names]
-        imputed_names = list(set(imputed_names))
-        return imputed_names
+        return list(set(imputed_names))
 
     def plot_portfolio_ensemble_weights_barplot(self, df_ensemble_weights: pd.DataFrame):
         from pathlib import Path

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -654,6 +654,8 @@ class TabArenaEvaluator:
 
         if imputed_names is None:
             imputed_names = self.get_imputed_names(df_results=df_results)
+        if verbose:
+            print(f"Model for which results were imputed: {imputed_names}")
 
         self.assert_no_duplicates(df_results=df_results)
         self.assert_no_nan_methods(df_results=df_results)
@@ -1364,7 +1366,6 @@ class TabArenaEvaluator:
         imputed_names = [n.split(" (")[0] for n in imputed_names]
         imputed_names = [method_rename_map.get(n, n) for n in imputed_names]
         imputed_names = list(set(imputed_names))
-        print(f"Model for which results were imputed: {imputed_names}")
         return imputed_names
 
     def plot_portfolio_ensemble_weights_barplot(self, df_ensemble_weights: pd.DataFrame):

--- a/tst/benchmark/experiment/test_experiment_utils.py
+++ b/tst/benchmark/experiment/test_experiment_utils.py
@@ -510,6 +510,26 @@ class TestExperimentBatchRunnerRunAll:
         with pytest.raises(AssertionError, match="only_strict"):
             runner.run_all(methods=[_make_minimal_experiment()])
 
+    def test_run_all_uses_dataset_fold_repeats_init_arg(self, tmp_path):
+        # When dataset_fold_repeats is set at init, run_all runs exactly those triplets
+        # (not the full n_folds x n_repeats grid).
+        _RecordingCache.instances.clear()
+        runner = self._runner(
+            tmp_path,
+            cache_mode="only",
+            cache_cls=_RecordingCache,
+            dataset_fold_repeats=[("d0", 0, 0), ("d1", 2, 1)],
+        )
+        result = runner.run_all(methods=[_make_minimal_experiment("m")])
+        assert result == []
+        assert self._cache_suffixes() == ["m/0/0_0", "m/1/1_2"]
+
+    def test_invalid_dataset_fold_repeats_raises(self, tmp_path):
+        # repeat=5 is out of range for n_repeats=1 -> rejected at construction.
+        task_metadata = pd.DataFrame({"tid": [0], "dataset": ["d0"], "n_folds": [2], "n_repeats": [1]})
+        with pytest.raises(AssertionError, match="not valid for"):
+            self._runner(tmp_path, task_metadata=task_metadata, dataset_fold_repeats=[("d0", 0, 5)])
+
 
 class TestRunExperimentsNewCacheCls:
     def test_custom_cache_cls_used(self, tmp_path):

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -46,3 +46,32 @@ class TestMakeExperimentBatchRunner:
     def test_no_subset_leaves_full_grid(self, tmp_path):
         runner = _ctx().make_experiment_batch_runner(expname=str(tmp_path))
         assert runner._dataset_fold_repeats is None
+
+    def test_datasets_filter(self, tmp_path):
+        runner = _ctx().make_experiment_batch_runner(expname=str(tmp_path), datasets=["small_ds"])
+        assert runner._dataset_fold_repeats == [("small_ds", 0, 0), ("small_ds", 1, 0)]
+
+    def test_dataset_fold_repeats_used_as_is_without_subset(self, tmp_path):
+        runner = _ctx().make_experiment_batch_runner(
+            expname=str(tmp_path),
+            dataset_fold_repeats=[("big_ds", 1, 0)],
+        )
+        assert runner._dataset_fold_repeats == [("big_ds", 1, 0)]
+
+    def test_dataset_fold_repeats_intersected_with_subset(self, tmp_path):
+        # "lite" keeps split 0 only -> (small_ds,1,0) is dropped.
+        runner = _ctx().make_experiment_batch_runner(
+            expname=str(tmp_path),
+            subset="lite",
+            dataset_fold_repeats=[("small_ds", 0, 0), ("small_ds", 1, 0), ("big_ds", 0, 0)],
+        )
+        assert runner._dataset_fold_repeats == [("small_ds", 0, 0), ("big_ds", 0, 0)]
+
+    def test_dataset_fold_repeats_intersected_with_datasets(self, tmp_path):
+        # datasets=["small_ds"] -> (big_ds,0,0) is dropped.
+        runner = _ctx().make_experiment_batch_runner(
+            expname=str(tmp_path),
+            datasets=["small_ds"],
+            dataset_fold_repeats=[("small_ds", 1, 0), ("big_ds", 0, 0)],
+        )
+        assert runner._dataset_fold_repeats == [("small_ds", 1, 0)]

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from tabarena.nips2025_utils.tabarena_context import TabArenaContext
+
+
+def _ctx() -> TabArenaContext:
+    # methods=[] keeps construction light (no method-metadata collection load).
+    task_metadata = pd.DataFrame(
+        {
+            "tid": [0, 1],
+            "dataset": ["small_ds", "big_ds"],
+            "n_folds": [2, 2],
+            "n_repeats": [1, 1],
+            "n_samples_train_per_fold": [100, 50_000],
+            "problem_type": ["binary", "regression"],
+            "n_features": [10, 10],
+            "n_classes": [2, 0],
+        },
+    )
+    return TabArenaContext(methods=[], task_metadata=task_metadata)
+
+
+class TestSubsetDatasetFoldRepeats:
+    """subset -> (dataset, fold, repeat) triplets, where split = n_folds*repeat + fold."""
+
+    def test_lite_keeps_split_zero_per_dataset(self):
+        # "lite" == split 0 == (fold 0, repeat 0) for every dataset.
+        assert _ctx()._subset_dataset_fold_repeats("lite") == [("small_ds", 0, 0), ("big_ds", 0, 0)]
+
+    def test_dataset_predicate_keeps_full_grid_of_matching_datasets(self):
+        # "small" == max_train_rows <= 10000 -> only small_ds, all (fold, repeat).
+        assert _ctx()._subset_dataset_fold_repeats("small") == [("small_ds", 0, 0), ("small_ds", 1, 0)]
+
+    def test_predicates_are_anded(self):
+        assert _ctx()._subset_dataset_fold_repeats(["small", "lite"]) == [("small_ds", 0, 0)]
+
+
+class TestMakeExperimentBatchRunner:
+    def test_subset_forwarded_as_dataset_fold_repeats(self, tmp_path):
+        runner = _ctx().make_experiment_batch_runner(expname=str(tmp_path), subset="lite", cache_mode="only")
+        assert runner._dataset_fold_repeats == [("small_ds", 0, 0), ("big_ds", 0, 0)]
+        assert runner.cache_mode == "only"  # extra kwargs forwarded
+
+    def test_no_subset_leaves_full_grid(self, tmp_path):
+        runner = _ctx().make_experiment_batch_runner(expname=str(tmp_path))
+        assert runner._dataset_fold_repeats is None

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 
@@ -75,3 +76,59 @@ class TestMakeExperimentBatchRunner:
             dataset_fold_repeats=[("small_ds", 1, 0), ("big_ds", 0, 0)],
         )
         assert runner._dataset_fold_repeats == [("small_ds", 1, 0)]
+
+
+def _ctx_multi() -> TabArenaContext:
+    # "a": 3 folds x 2 repeats -> splits 0..5; "b": 2 folds x 1 repeat -> splits 0..1.
+    task_metadata = pd.DataFrame(
+        {
+            "tid": [0, 1],
+            "dataset": ["a", "b"],
+            "n_folds": [3, 2],
+            "n_repeats": [2, 1],
+            "n_samples_train_per_fold": [100, 100],
+            "problem_type": ["binary", "binary"],
+            "n_features": [10, 10],
+            "n_classes": [2, 2],
+        },
+    )
+    return TabArenaContext(methods=[], task_metadata=task_metadata)
+
+
+class TestSplitsFoldsRepeats:
+    def _dfr(self, tmp_path, **kwargs):
+        return _ctx_multi().make_experiment_batch_runner(expname=str(tmp_path), **kwargs)._dataset_fold_repeats
+
+    def test_folds_filter(self, tmp_path):
+        # fold 0 across all repeats: a(0,0),(0,1); b(0,0).
+        assert self._dfr(tmp_path, folds=[0]) == [("a", 0, 0), ("a", 0, 1), ("b", 0, 0)]
+
+    def test_repeats_filter(self, tmp_path):
+        # repeat 1 only exists for "a" (b has a single repeat).
+        assert self._dfr(tmp_path, repeats=[1]) == [("a", 0, 1), ("a", 1, 1), ("a", 2, 1)]
+
+    def test_folds_and_repeats_compose(self, tmp_path):
+        assert self._dfr(tmp_path, folds=[0], repeats=[0]) == [("a", 0, 0), ("b", 0, 0)]
+
+    def test_splits_filter(self, tmp_path):
+        # split 3 for "a" (n_folds=3) == (fold 0, repeat 1); "b" has no split 3.
+        assert self._dfr(tmp_path, splits=[3]) == [("a", 0, 1)]
+
+    def test_splits_compose_with_datasets(self, tmp_path):
+        assert self._dfr(tmp_path, datasets=["a"], splits=[0]) == [("a", 0, 0)]
+
+    def test_splits_with_folds_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="`splits` together with `folds`"):
+            self._dfr(tmp_path, splits=[0], folds=[0])
+
+    def test_splits_with_repeats_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="`splits` together with `folds`"):
+            self._dfr(tmp_path, splits=[0], repeats=[0])
+
+    def test_dataset_fold_repeats_with_folds_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="`dataset_fold_repeats` together"):
+            self._dfr(tmp_path, dataset_fold_repeats=[("a", 0, 0)], folds=[0])
+
+    def test_dataset_fold_repeats_with_splits_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="`dataset_fold_repeats` together"):
+            self._dfr(tmp_path, dataset_fold_repeats=[("a", 0, 0)], splits=[0])


### PR DESCRIPTION
## Summary

Adds a `TabArenaContext` factory that builds an `ExperimentBatchRunner` scoped to a
selected set of `(dataset, fold, repeat)` triplets, reusing the same subset machinery
as `compare`. Lets you launch experiment runs for a slice of the benchmark (a size
bucket, specific datasets, `lite`, specific folds/repeats/splits, …) without manually
enumerating tasks.

## Changes

**`ExperimentBatchRunner`**
- New `dataset_fold_repeats` init arg: the allowed `(dataset, fold, repeat)` triplets
  that `run_all()` executes. If `None`, `run_all()` uses the full `n_folds × n_repeats`
  grid from `task_metadata` (unchanged behavior). Triplets are validated against
  `task_metadata` (dataset present; `fold < n_folds`; `repeat < n_repeats`).

**`TabArenaContext.make_experiment_batch_runner(expname, *, subset, datasets, splits, folds, repeats, dataset_fold_repeats, **kwargs)`**
- `subset`: `compare`-style predicate expressions (`"lite"`, `"small"`, `"binary"`,
  `"!tiny"`, …). Predicates treat the split index (`split = n_folds*repeat + fold`) as
  the `fold` column, so `"lite"` keeps `split == 0` == `(fold 0, repeat 0)`.
- `datasets`: restrict to dataset names.
- `splits` / `folds` / `repeats`: restrict by split / fold / repeat index. Compose (AND)
  with `subset`/`datasets`.
- `dataset_fold_repeats`: explicit triplets; the result is the **intersection** of these
  with the subset/datasets-derived set.
- Disallowed combinations (raise `ValueError`): `splits` with `folds`/`repeats`; and
  `dataset_fold_repeats` with any of `splits`/`folds`/`repeats`.
- Extra kwargs (`cache_mode`, `debug_mode`, …) are forwarded to `ExperimentBatchRunner`.

**Example**
- `run_quickstart_tabarena.py` now builds the runner via
  `tabarena_context.make_experiment_batch_runner(datasets=…, subset="lite")` and calls
  `run_all()`, reproducing the original `run(datasets, folds=[0])`.

## Testing

- New `tst/nips2025_utils/test_tabarena_context.py`: subset / datasets / splits / folds /
  repeats filtering, the `dataset_fold_repeats` intersection, and all mutual-exclusion
  errors.
- `ExperimentBatchRunner` arg + validation tests in `tst/benchmark/experiment`.
- `ruff check .` / `ruff format --check .` pass; `tst/nips2025_utils` +
  `tst/benchmark/experiment` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
