### PR TITLE
Make matplotlib/seaborn imports lazy

### DIFF
--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import functools
 import itertools
 import json
 import math
@@ -9,17 +10,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import matplotlib
-import matplotlib.colors as mcolors
-import matplotlib.patheffects as PathEffects
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import seaborn as sns
 from autogluon.common.savers import save_pd
-from matplotlib import ticker
-from matplotlib.patches import Patch
-from tueplots import bundles, fonts, fontsizes
 
 from bencheval.tabarena import TabArena
 from tabarena.nips2025_utils.fetch_metadata import load_task_metadata
@@ -59,15 +52,28 @@ class TuneMethodOverride:
     promote_from_baselines: bool = False  # move `methods` out of `baselines` into `framework_types`
 
 
-matplotlib.rcParams.update(fontsizes.neurips2024())
-matplotlib.rcParams.update(
-    {
-        "text.latex.preamble": r"\usepackage{times} \usepackage{amsmath} \usepackage{amsfonts} \usepackage{amssymb} \usepackage{xcolor}",
-    }
-)
+@functools.cache
+def _init_global_rcparams() -> None:
+    """Apply TabArena's global matplotlib style (once).
+
+    Cached + lazy so that importing this module does not import ``matplotlib``/``tueplots``
+    — this keeps the plotting stack off the ``TabArenaContext`` import path. Called from
+    ``TabArenaEvaluator.__init__`` (previously ran at module import time).
+    """
+    import matplotlib
+    from tueplots import fontsizes
+
+    matplotlib.rcParams.update(fontsizes.neurips2024())
+    matplotlib.rcParams.update(
+        {
+            "text.latex.preamble": r"\usepackage{times} \usepackage{amsmath} \usepackage{amsfonts} \usepackage{amssymb} \usepackage{xcolor}",
+        }
+    )
 
 
 def darken_color(color_str, amount=0.5):
+    import matplotlib.colors as mcolors
+
     # Convert color string to RGB tuple (values between 0 and 1)
     rgb = mcolors.to_rgb(color_str)
     # Interpolate with black (0, 0, 0)
@@ -138,8 +144,12 @@ class TabArenaEvaluator:
         self.banned_model_types = banned_model_types
         self.keep_best = keep_best
 
+        _init_global_rcparams()
         self.use_latex = use_latex
         if self.use_latex:
+            import matplotlib
+            from tueplots import bundles, fonts, fontsizes
+
             matplotlib.rcParams.update(bundles.neurips2024())
             matplotlib.rcParams.update(fonts.neurips2024_tex())
             self.rc_context_params = {
@@ -1591,6 +1601,11 @@ class TabArenaEvaluator:
         title: str | None = None,
         tune_method_overrides: list[TuneMethodOverride] | None = None,
     ):
+        import matplotlib.patheffects as PathEffects
+        import matplotlib.pyplot as plt
+        import seaborn as sns
+        from matplotlib.patches import Patch
+
         if method_style_map is None:
             method_style_map = {}
         if default_method_style is None:
@@ -2219,6 +2234,10 @@ class TabArenaEvaluator:
                 plt.close()
 
     def plot_tabarena_times(self, df: pd.DataFrame, output_dir: Path | str, show: bool = True):
+        import matplotlib.pyplot as plt
+        import seaborn as sns
+        from matplotlib import ticker
+
         df = df.copy()
 
         datasets_impute_freq = df.groupby("dataset")["imputed"].mean()

--- a/packages/tabarena/src/tabarena/plot/dataset_analysis.py
+++ b/packages/tabarena/src/tabarena/plot/dataset_analysis.py
@@ -5,10 +5,7 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import matplotlib
-import matplotlib.pyplot as plt
 import pandas as pd
-import seaborn as sns
 
 from tabarena.plot.plot_utils import figure_path, save_latex_table
 
@@ -17,6 +14,9 @@ if TYPE_CHECKING:
 
 
 def order_clustermap(df, allow_nan=True):
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     # TODO we could just call scipy
     if allow_nan:
         df = df.fillna(1)
@@ -106,6 +106,10 @@ def generate_dataset_info_latex(repo: EvaluationRepository, expname_outdir: str)
 
 
 def generate_dataset_analysis(repo, expname_outdir: str):
+    import matplotlib
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     num_models_to_plot = 20
     title_size = 20
     figsize = (20, 7)
@@ -233,6 +237,9 @@ def plot_train_time_deep_dive(
     time_limit_soft: float = 2800,
     time_limit_hard: float = 3600,
 ):
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     df = df.copy(deep=True)
     title_size = 20
     if only_per_method:

--- a/packages/tabarena/src/tabarena/plot/plot_ens_weights.py
+++ b/packages/tabarena/src/tabarena/plot/plot_ens_weights.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import matplotlib.pyplot as plt
 import pandas as pd
-import seaborn as sns
 
 
 # TODO: NaN color as black?
@@ -37,6 +35,9 @@ def create_heatmap(
     plt
 
     """
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     plt.figure(figsize=figsize)
 
     if include_mean:

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_frontier.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_frontier.py
@@ -4,20 +4,9 @@ import io
 import os
 from contextlib import redirect_stdout
 
-import matplotlib.patheffects as PathEffects
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import seaborn as sns
-from matplotlib.lines import Line2D
 from pandas.api.types import is_numeric_dtype
-
-try:
-    from adjustText import adjust_text
-
-    HAS_ADJUST_TEXT = True
-except ImportError:
-    HAS_ADJUST_TEXT = False
 
 
 def aggregate_stats(df, on: str, groupby="method", method=None):
@@ -142,6 +131,18 @@ def plot_pareto(
     y_percent_format: bool = False,
     legend_first: list[str] | None = None,
 ):
+    import matplotlib.patheffects as PathEffects
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    from matplotlib.lines import Line2D
+
+    try:
+        from adjustText import adjust_text
+
+        HAS_ADJUST_TEXT = True
+    except ImportError:
+        HAS_ADJUST_TEXT = False
+
     fig_size_ratio = 0.45
     fig_height = 10 * fig_size_ratio
 

--- a/packages/tabarena/src/tabarena/simulation/sim_runner.py
+++ b/packages/tabarena/src/tabarena/simulation/sim_runner.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import boto3
-import matplotlib.pyplot as plt
 from autogluon.common.savers import save_pkl
 
 from tabarena.utils import catchtime
@@ -98,6 +97,8 @@ def plot_results_multi(
     save_to_s3: bool = True,
     x_axis_col: str = "step",
 ):
+    import matplotlib.pyplot as plt
+
     if title is None:
         title = "Overfitting Delta"
     fig = plt.figure(dpi=300)


### PR DESCRIPTION
Defer the plotting stack (matplotlib, seaborn, tueplots, adjustText) into the functions that use it, so importing TabArenaContext no longer loads it.

- Move module-scope matplotlib/seaborn imports into the plotting functions/methods in tabarena_evaluator.py, dataset_analysis.py, plot_pareto_frontier.py, plot_ens_weights.py, and sim_runner.py.
- Relocate tabarena_evaluator's module-scope `matplotlib.rcParams.update(...)` into a cached `_init_global_rcparams()` called from `TabArenaEvaluator.__init__`, and make `darken_color`/`adjustText` import lazily.

Together with the earlier torch/huggingface_hub deferrals, TabArenaContext now imports free of torch/matplotlib/seaborn (~7.5s -> ~4.9s warm). No behavior change: the global rcParams are applied when an evaluator is created instead of at module import.