### PR TITLE
Remove holdout artifact persistence (load/download/upload)

### DIFF
--- a/examples/plots/run_generate_paper_figures.py
+++ b/examples/plots/run_generate_paper_figures.py
@@ -15,9 +15,7 @@ if __name__ == "__main__":
     plot_n_configs = False
 
     tabarena_context = TabArenaContext()
-    df_results_holdout = None  # TODO: Mitra does not yet have holdout results saved in S3, need to add
     include_portfolio = False
-    # df_results_holdout = tabarena_context.load_baseline_results(download_results=download_results, holdout=True)
 
     df_results = tabarena_context.load_baseline_results(download_results=download_results)
 
@@ -40,7 +38,6 @@ if __name__ == "__main__":
 
     tabarena_context_all.evaluate_all(
         df_results=df_results,
-        df_results_holdout=df_results_holdout,
         configs_hyperparameters=configs_hyperparameters,
         save_path=save_path,
         elo_bootstrap_rounds=elo_bootstrap_rounds,

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_public_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_public_r2.py
@@ -122,13 +122,9 @@ class MethodDownloaderPublicR2:
             clear_dir=self.clear_dirs,
         )
 
-    def download_processed(self, holdout: bool = False):
-        if holdout:
-            dest_dir = Path(self.method_metadata.path_processed_holdout)
-            r2_key = (self.prefix / "processed_holdout.zip").as_posix()
-        else:
-            dest_dir = Path(self.method_metadata.path_processed)
-            r2_key = (self.prefix / "processed.zip").as_posix()
+    def download_processed(self):
+        dest_dir = Path(self.method_metadata.path_processed)
+        r2_key = (self.prefix / "processed.zip").as_posix()
 
         self._download_and_unzip_if_exists(
             r2_key=r2_key,
@@ -136,20 +132,20 @@ class MethodDownloaderPublicR2:
             clear_dir=self.clear_dirs,
         )
 
-    def download_configs_hyperparameters(self, holdout: bool = False):
-        path_local = Path(self.method_metadata.path_configs_hyperparameters(holdout=holdout))
+    def download_configs_hyperparameters(self):
+        path_local = Path(self.method_metadata.path_configs_hyperparameters())
         r2_key = self.local_to_r2_path(path_local=path_local)
         self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
 
-    def download_results(self, holdout: bool = False):
-        file_names: Iterable[Path | str] = self.method_metadata.path_results_files(holdout=holdout)
+    def download_results(self):
+        file_names: Iterable[Path | str] = self.method_metadata.path_results_files()
         for path_local in file_names:
             path_local = Path(path_local)
             r2_key = self.local_to_r2_path(path_local=path_local)
             self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
 
-    def download_results_hpo_trajectories(self, holdout: bool = False):
-        path_local = Path(self.method_metadata.path_results_hpo_trajectories(holdout=holdout))
+    def download_results_hpo_trajectories(self):
+        path_local = Path(self.method_metadata.path_results_hpo_trajectories())
         r2_key = self.local_to_r2_path(path_local=path_local)
         self._download_to_local_if_exists(r2_key=r2_key, path_local=Path(path_local))
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_r2.py
@@ -123,30 +123,26 @@ class MethodDownloaderR2:
         r2_key = (self.prefix / "raw.zip").as_posix()
         self._download_and_unzip_if_exists(r2_key=r2_key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
 
-    def download_processed(self, holdout: bool = False):
-        if holdout:
-            dest_dir = Path(self.method_metadata.path_processed_holdout)
-            r2_key = (self.prefix / "processed_holdout.zip").as_posix()
-        else:
-            dest_dir = Path(self.method_metadata.path_processed)
-            r2_key = (self.prefix / "processed.zip").as_posix()
+    def download_processed(self):
+        dest_dir = Path(self.method_metadata.path_processed)
+        r2_key = (self.prefix / "processed.zip").as_posix()
 
         self._download_and_unzip_if_exists(r2_key=r2_key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
 
-    def download_configs_hyperparameters(self, holdout: bool = False):
-        path_local = Path(self.method_metadata.path_configs_hyperparameters(holdout=holdout))
+    def download_configs_hyperparameters(self):
+        path_local = Path(self.method_metadata.path_configs_hyperparameters())
         r2_key = self.local_to_r2_path(path_local=path_local)
         self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
 
-    def download_results(self, holdout: bool = False):
-        file_names: Iterable[Path | str] = self.method_metadata.path_results_files(holdout=holdout)
+    def download_results(self):
+        file_names: Iterable[Path | str] = self.method_metadata.path_results_files()
         for path_local in file_names:
             path_local = Path(path_local)
             r2_key = self.local_to_r2_path(path_local=path_local)
             self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
 
-    def download_results_hpo_trajectories(self, holdout: bool = False):
-        path_local = self.method_metadata.path_results_hpo_trajectories(holdout=holdout)
+    def download_results_hpo_trajectories(self):
+        path_local = self.method_metadata.path_results_hpo_trajectories()
         r2_key = self.local_to_r2_path(path_local=path_local)
         self._download_to_local_if_exists(r2_key=r2_key, path_local=Path(path_local))
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
@@ -87,20 +87,20 @@ class MethodDownloaderS3:
         s3_key = (self.prefix / "processed.zip").as_posix()
         self._download_and_unzip_if_exists(s3_key=s3_key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
 
-    def download_configs_hyperparameters(self, holdout: bool = False):
-        path_local = Path(self.method_metadata.path_configs_hyperparameters(holdout=holdout))
+    def download_configs_hyperparameters(self):
+        path_local = Path(self.method_metadata.path_configs_hyperparameters())
         s3_key = self.local_to_s3_path(path_local=path_local)
         self._download_to_local_if_exists(s3_key=s3_key, path_local=path_local)
 
-    def download_results(self, holdout: bool = False):
-        file_names: Iterable[Path | str] = self.method_metadata.path_results_files(holdout=holdout)
+    def download_results(self):
+        file_names: Iterable[Path | str] = self.method_metadata.path_results_files()
         for path_local in file_names:
             path_local = Path(path_local)
             s3_key = self.local_to_s3_path(path_local=path_local)
             self._download_to_local_if_exists(s3_key=s3_key, path_local=path_local)
 
-    def download_results_hpo_trajectories(self, holdout: bool = False):
-        path_local = self.method_metadata.path_results_hpo_trajectories(holdout=holdout)
+    def download_results_hpo_trajectories(self):
+        path_local = self.method_metadata.path_results_hpo_trajectories()
         s3_key = self.local_to_s3_path(path_local=path_local)
         self._download_to_local_if_exists(s3_key=s3_key, path_local=path_local)
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader_r2.py
@@ -88,22 +88,17 @@ class MethodUploaderR2:
         print(f"Uploading raw zipped files to: {r2_key}")
         self._upload_fileobj(fileobj=fileobj, r2_key=r2_key)
 
-    def upload_processed(self, holdout: bool = False):
-        if holdout:
-            path_processed = self.method_metadata.path_processed_holdout
-            processed_zip_name = "processed_holdout.zip"
-        else:
-            path_processed = self.method_metadata.path_processed
-            processed_zip_name = "processed.zip"
+    def upload_processed(self):
+        path_processed = self.method_metadata.path_processed
 
         print(f"Zipping processed files into memory under: {path_processed}")
         fileobj = zip_in_memory(path=path_processed)
-        r2_key = self.prefix / processed_zip_name
+        r2_key = self.prefix / "processed.zip"
 
         print(f"Uploading processed zipped files to: {r2_key}")
         self._upload_fileobj(fileobj=fileobj, r2_key=r2_key)
 
-        self.upload_configs_hyperparameters(holdout=holdout)
+        self.upload_configs_hyperparameters()
 
     def _upload_fileobj(self, fileobj: io.BytesIO, r2_key: str | Path):
         if isinstance(r2_key, Path):
@@ -130,8 +125,8 @@ class MethodUploaderR2:
             Key=r2_key,
         )
 
-    def upload_configs_hyperparameters(self, holdout: bool = False):
-        path_local = self.method_metadata.path_configs_hyperparameters(holdout=holdout)
+    def upload_configs_hyperparameters(self):
+        path_local = self.method_metadata.path_configs_hyperparameters()
         self._upload_file(path_local=path_local)
 
     def local_to_r2_path(self, path_local: str | Path) -> str:
@@ -145,11 +140,11 @@ class MethodUploaderR2:
     def local_to_s3_path(self, path_local: str | Path) -> str:
         return self.local_to_r2_path(path_local=path_local)
 
-    def upload_results(self, holdout: bool = False):
-        file_names = self.method_metadata.path_results_files(holdout=holdout)
+    def upload_results(self):
+        file_names = self.method_metadata.path_results_files()
         for path_local in file_names:
             self._upload_file(path_local=path_local)
 
-    def upload_results_hpo_trajectories(self, holdout: bool = False):
-        path_local = self.method_metadata.path_results_hpo_trajectories(holdout=holdout)
+    def upload_results_hpo_trajectories(self):
+        path_local = self.method_metadata.path_results_hpo_trajectories()
         self._upload_file(path_local=path_local)

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader_s3.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader_s3.py
@@ -57,24 +57,19 @@ class MethodUploaderS3:
         print(f"Uploading raw zipped files to: {s3_key}")
         self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
 
-    def upload_processed(self, holdout: bool = False):
-        if holdout:
-            path_processed = self.method_metadata.path_processed_holdout
-            processed_zip_name = "processed_holdout.zip"
-        else:
-            path_processed = self.method_metadata.path_processed
-            processed_zip_name = "processed.zip"
+    def upload_processed(self):
+        path_processed = self.method_metadata.path_processed
 
         print(f"Zipping processed files into memory under: {path_processed}")
         fileobj = zip_in_memory(path=path_processed)
-        s3_key = self.prefix / processed_zip_name
+        s3_key = self.prefix / "processed.zip"
 
         # Upload to S3 directly from memory
         print(f"Uploading processed zipped files to: {s3_key}")
         self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
 
         # Upload configs_hyperparameters as a standalone file for fast access
-        self.upload_configs_hyperparameters(holdout=holdout)
+        self.upload_configs_hyperparameters()
 
     def _upload_fileobj(self, fileobj: io.BytesIO, s3_key: str | Path):
         import boto3
@@ -108,8 +103,8 @@ class MethodUploaderS3:
         s3_client = boto3.client("s3")
         s3_client.upload_file(Filename=path_local, Bucket=self.s3_bucket, Key=s3_key, **kwargs)
 
-    def upload_configs_hyperparameters(self, holdout: bool = False):
-        path_local = self.method_metadata.path_configs_hyperparameters(holdout=holdout)
+    def upload_configs_hyperparameters(self):
+        path_local = self.method_metadata.path_configs_hyperparameters()
         self._upload_file(path_local=path_local)
 
     def local_to_s3_path(self, path_local: str | Path) -> str:
@@ -117,11 +112,11 @@ class MethodUploaderS3:
         _, s3_key = s3_path_to_bucket_prefix(s3_path_loc)
         return s3_key
 
-    def upload_results(self, holdout: bool = False):
-        file_names = self.method_metadata.path_results_files(holdout=holdout)
+    def upload_results(self):
+        file_names = self.method_metadata.path_results_files()
         for path_local in file_names:
             self._upload_file(path_local=path_local)
 
-    def upload_results_hpo_trajectories(self, holdout: bool = False):
-        path_local = self.method_metadata.path_results_hpo_trajectories(holdout=holdout)
+    def upload_results_hpo_trajectories(self):
+        path_local = self.method_metadata.path_results_hpo_trajectories()
         self._upload_file(path_local=path_local)

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -345,16 +345,8 @@ class MethodMetadata:
         return self.path / "processed"
 
     @property
-    def path_processed_holdout(self) -> Path:
-        return self.path / "processed_holdout"
-
-    @property
     def path_results(self) -> Path:
         return self.path / "results"
-
-    @property
-    def path_results_holdout(self) -> Path:
-        return self.path_results / "holdout"
 
     @property
     def path_raw_exists(self) -> bool:
@@ -368,21 +360,17 @@ class MethodMetadata:
     def path_results_exists(self) -> bool:
         return self.path_results.is_dir()
 
-    def path_results_hpo(self, holdout: bool = False) -> Path:
-        path_prefix = self.path_results_holdout if holdout else self.path_results
-        return path_prefix / "hpo_results.parquet"
+    def path_results_hpo(self) -> Path:
+        return self.path_results / "hpo_results.parquet"
 
-    def path_results_model(self, holdout: bool = False) -> Path:
-        path_prefix = self.path_results_holdout if holdout else self.path_results
-        return path_prefix / "model_results.parquet"
+    def path_results_model(self) -> Path:
+        return self.path_results / "model_results.parquet"
 
-    def path_results_portfolio(self, holdout: bool = False) -> Path:
-        path_prefix = self.path_results_holdout if holdout else self.path_results
-        return path_prefix / "portfolio_results.parquet"
+    def path_results_portfolio(self) -> Path:
+        return self.path_results / "portfolio_results.parquet"
 
-    def path_results_hpo_trajectories(self, holdout: bool = False) -> Path:
-        path_prefix = self.path_results_holdout if holdout else self.path_results
-        return path_prefix / "hpo_trajectories.parquet"
+    def path_results_hpo_trajectories(self) -> Path:
+        return self.path_results / "hpo_trajectories.parquet"
 
     def relative_to_cache_root(self, path: Path) -> Path:
         return path.relative_to(self.path_cache_root)
@@ -489,50 +477,49 @@ class MethodMetadata:
             )
         raise ValueError(f"Invalid cache_type for uploads: {cache_type}")
 
-    def load_model_results(self, holdout: bool = False) -> pd.DataFrame:
-        return pd.read_parquet(path=self.path_results_model(holdout=holdout))
+    def load_model_results(self) -> pd.DataFrame:
+        return pd.read_parquet(path=self.path_results_model())
 
-    def load_hpo_results(self, holdout: bool = False) -> pd.DataFrame:
-        return pd.read_parquet(path=self.path_results_hpo(holdout=holdout))
+    def load_hpo_results(self) -> pd.DataFrame:
+        return pd.read_parquet(path=self.path_results_hpo())
 
-    def load_portfolio_results(self, holdout: bool = False) -> pd.DataFrame:
-        return pd.read_parquet(path=self.path_results_portfolio(holdout=holdout))
+    def load_portfolio_results(self) -> pd.DataFrame:
+        return pd.read_parquet(path=self.path_results_portfolio())
 
-    def load_results(self, holdout: bool = False) -> pd.DataFrame:
+    def load_results(self) -> pd.DataFrame:
         if self.method_type == "config":
-            df_results = self.load_hpo_results(holdout=holdout)
+            df_results = self.load_hpo_results()
         elif self.method_type == "baseline":
-            df_results = self.load_model_results(holdout=holdout)
+            df_results = self.load_model_results()
         elif self.method_type == "portfolio":
-            df_results = self.load_portfolio_results(holdout=holdout)
+            df_results = self.load_portfolio_results()
         else:
             raise ValueError(f"Unknown method_type: {self.method_type} for method {self.method}")
         return df_results
 
-    def path_configs_hyperparameters(self, holdout: bool = False) -> Path:
-        path_processed = self.path_processed_holdout if holdout else self.path_processed
-        return path_processed / "configs_hyperparameters.json"
+    def path_configs_hyperparameters(self) -> Path:
+        return self.path_processed / "configs_hyperparameters.json"
 
-    def load_configs_hyperparameters(self, holdout: bool = False, download: str | bool = "auto") -> dict[str, dict]:
+    def load_configs_hyperparameters(self, download: str | bool = "auto") -> dict[str, dict]:
         if download == "auto":
             try:
-                return self.load_configs_hyperparameters(holdout=holdout, download=False)
+                return self.load_configs_hyperparameters(download=False)
             except FileNotFoundError:
                 print(
                     f"Cache miss detected for configs_hyperparameters.json "
                     f"(method={self.method}), attempting download...",
                 )
-                out = self.load_configs_hyperparameters(holdout=holdout, download=True)
+                out = self.load_configs_hyperparameters(download=True)
                 print("\tDownload successful")
                 return out
         elif isinstance(download, bool) and download:
-            self.download_configs_hyperparameters(holdout=holdout)
-        with open(self.path_configs_hyperparameters(holdout=holdout)) as f:
+            self.download_configs_hyperparameters()
+        with open(self.path_configs_hyperparameters()) as f:
             return json.load(f)
 
-    def download_configs_hyperparameters(self, holdout: bool = False):
+    def download_configs_hyperparameters(self):
         method_downloader = self.method_downloader()
-        method_downloader.download_configs_hyperparameters(holdout=holdout)
+        method_downloader.download_configs_hyperparameters()
 
     def load_raw_file_paths(self, max_files: int | None = None) -> list[Path]:
         return fetch_all_pickles(dir_path=self.path_raw, suffix="results.pkl", max_files=max_files)
@@ -563,11 +550,10 @@ class MethodMetadata:
         self,
         path_processed: str | Path | None = None,
         prediction_format: Literal["memmap", "memopt", "mem"] = "memmap",
-        as_holdout: bool = False,
         verbose: bool = False,
     ) -> EvaluationRepository:
         if path_processed is None:
-            path_processed = self.path_processed_holdout if as_holdout else self.path_processed
+            path_processed = self.path_processed
         return EvaluationRepository.from_dir(
             path=path_processed,
             prediction_format=prediction_format,
@@ -617,33 +603,27 @@ class MethodMetadata:
         self,
         results_lst: list[BaselineResult] | None = None,
         task_metadata: pd.DataFrame | TaskMetadataCollection = None,
-        cache: bool = False,
         engine: str = "ray",
     ) -> EvaluationRepository:
         if results_lst is None:
             results_lst = self.load_raw(engine=engine)
         results_holdout_lst = results_to_holdout(result_lst=results_lst)
-        repo: EvaluationRepository = generate_repo_from_results_lst(
+        return generate_repo_from_results_lst(
             results_lst=results_holdout_lst,
             task_metadata=task_metadata,
             name_suffix=self.name_suffix,
         )
 
-        if cache:
-            repo.to_dir(self.path_processed_holdout)
-        return repo
-
     def generate_results(
         self,
         repo: EvaluationRepository | None = None,
-        as_holdout: bool = False,
         backend: Literal["ray", "native"] = "ray",
         cache: bool = False,
     ) -> tuple[pd.DataFrame | None, pd.DataFrame]:
-        save_file = str(self.path_results_hpo(holdout=as_holdout))
-        save_file_model = str(self.path_results_model(holdout=as_holdout))
+        save_file = str(self.path_results_hpo())
+        save_file_model = str(self.path_results_model())
         if repo is None:
-            repo = self.load_processed(as_holdout=as_holdout)
+            repo = self.load_processed()
 
         if self.method_type == "config":
             model_types = repo.config_types()
@@ -695,13 +675,12 @@ class MethodMetadata:
         fixed_configs: list[str] | None = None,
         fit_order: Literal["original", "random"] = "random",
         config_type: str | list[str] | None = None,
-        holdout: bool = False,
         backend: Literal["ray", "native"] = "ray",
         seed: int = 0,
         **kwargs,
     ) -> pd.DataFrame:
         if repo is None:
-            repo = self.load_processed(as_holdout=holdout)
+            repo = self.load_processed()
         if config_type is None:
             assert self.config_type is not None
             config_type = self.config_type
@@ -741,7 +720,6 @@ class MethodMetadata:
         fit_order: Literal["original", "random"] = "random",
         time_limit: float | None = None,
         backend: Literal["ray", "native"] = "ray",
-        holdout: bool = False,
         config_type: str | list[str] | None = None,
         repo: EvaluationRepository | None = None,
         cache: bool = False,
@@ -763,9 +741,8 @@ class MethodMetadata:
 
         df_results_hpo_lst = []
         if repo is None:
-            repo = self.load_processed(as_holdout=holdout)
+            repo = self.load_processed()
 
-        # FIXME: Breaks for holdout, need to find a way to get self.config_default(holdout=True)
         # FIXME: Needed for TabPFN-2.5
         repo.set_config_fallback(config_fallback=self.config_default)
 
@@ -801,7 +778,6 @@ class MethodMetadata:
                     fit_order=fit_order,
                     time_limit=time_limit,
                     backend=backend,
-                    holdout=holdout,
                     config_type=config_type,
                 )
                 df_results_hpo["always_include_default"] = always_include_default
@@ -809,18 +785,18 @@ class MethodMetadata:
         df_results_hpo_combined = pd.concat(df_results_hpo_lst, ignore_index=True)
 
         if cache:
-            save_pd.save(path=self.path_results_hpo_trajectories(holdout=holdout), df=df_results_hpo_combined)
+            save_pd.save(path=self.path_results_hpo_trajectories(), df=df_results_hpo_combined)
 
         return df_results_hpo_combined
 
-    def load_hpo_trajectories(self, holdout: bool = False, download: bool | str = "auto") -> pd.DataFrame:
-        path_local = self.path_results_hpo_trajectories(holdout=holdout)
+    def load_hpo_trajectories(self, download: bool | str = "auto") -> pd.DataFrame:
+        path_local = self.path_results_hpo_trajectories()
         if download == "auto":
             download = not path_local.exists()
             if download:
                 print(f"Downloading hpo trajectories for {self.method}...")
         if download:
-            self.method_downloader().download_results_hpo_trajectories(holdout=holdout)
+            self.method_downloader().download_results_hpo_trajectories()
         return pd.read_parquet(path=path_local)
 
     def generate_best(
@@ -829,12 +805,11 @@ class MethodMetadata:
         n_configs: int = 1,
         n_iterations: int = 40,
         backend: Literal["ray", "native"] = "ray",
-        holdout: bool = False,
         time_limit: float | None = None,
         **kwargs,
     ):
         if repo is None:
-            repo = self.load_processed(as_holdout=holdout)
+            repo = self.load_processed()
         from tabarena.paper.paper_runner_tabarena import PaperRunTabArena
 
         simulator = PaperRunTabArena(repo=repo, backend=backend)
@@ -962,16 +937,16 @@ class MethodMetadata:
     def cache_processed(self, repo: EvaluationRepository):
         repo.to_dir(self.path_processed)
 
-    def path_results_files(self, holdout: bool = False) -> list[Path]:
+    def path_results_files(self) -> list[Path]:
         if self.method_type == "portfolio":
             file_names = [
-                self.path_results_portfolio(holdout=holdout),
+                self.path_results_portfolio(),
             ]
         else:
             file_names = [
-                self.path_results_model(holdout=holdout),
+                self.path_results_model(),
             ]
 
         if self.method_type == "config":
-            file_names.append(self.path_results_hpo(holdout=holdout))
+            file_names.append(self.path_results_hpo())
         return file_names

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -109,7 +109,6 @@ class AbstractArenaContext(ABC):
     def load_baseline_results(
         self,
         methods: list[str] | None = None,
-        holdout: bool = False,
         download_results: str | bool = "auto",
         methods_drop: list[str] | None = None,
     ) -> pd.DataFrame:

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -160,7 +160,6 @@ class EndToEndSingle:
         task_metadata: TaskMetadataCollection | None = None,
         cache: bool = True,
         cache_raw: bool = True,
-        cache_holdout: bool = False,
         cache_hpo_trajectories: bool = False,
         name: str | None = None,
         name_prefix: str | None = None,
@@ -291,26 +290,8 @@ class EndToEndSingle:
         hpo_results, model_results = method_metadata.generate_results(
             repo=repo,
             cache=cache,
-            as_holdout=False,
             backend=backend,
         )
-
-        if cache_holdout and method_metadata.is_bag:
-            log("\tConverting raw (holdout) results into an EvaluationRepository...")
-            repo_holdout: EvaluationRepository = method_metadata.generate_repo_holdout(
-                results_lst=results_lst,
-                task_metadata=task_metadata,
-                cache=True,
-            )
-            repo_holdout = method_metadata.load_processed(as_holdout=True)
-
-            log("\tSimulating HPO (holdout)...")
-            _hpo_results_holdout, _model_results_holdout = method_metadata.generate_results(
-                repo=repo_holdout,
-                cache=cache,
-                as_holdout=True,
-                backend=backend,
-            )
 
         if cache_hpo_trajectories:
             if method_metadata.method_type == "config":
@@ -341,7 +322,6 @@ class EndToEndSingle:
         task_metadata: TaskMetadataCollection | None = None,
         cache: bool = True,
         cache_raw: bool = True,
-        cache_holdout: bool = False,
         cache_hpo_trajectories: bool = False,
         name: str | None = None,
         name_prefix: str | None = None,
@@ -394,7 +374,6 @@ class EndToEndSingle:
             task_metadata=task_metadata,
             cache=cache,
             cache_raw=cache_raw,
-            cache_holdout=cache_holdout,
             cache_hpo_trajectories=cache_hpo_trajectories,
             name=name,
             name_prefix=name_prefix,
@@ -608,18 +587,17 @@ class EndToEndResultsSingle:
         *,
         model_results: pd.DataFrame = None,
         hpo_results: pd.DataFrame = None,
-        holdout: bool = False,
     ):
         self.method_metadata = method_metadata
         if model_results is None:
-            model_results = self.method_metadata.load_model_results(holdout=holdout)
+            model_results = self.method_metadata.load_model_results()
         if hpo_results is None and self.method_metadata.method_type == "config":
-            hpo_results = self.method_metadata.load_hpo_results(holdout=holdout)
+            hpo_results = self.method_metadata.load_hpo_results()
         self.model_results = model_results
         self.hpo_results = hpo_results
 
     @classmethod
-    def from_cache(cls, method: str | MethodMetadata, artifact_name: str | None = None, holdout: bool = False) -> Self:
+    def from_cache(cls, method: str | MethodMetadata, artifact_name: str | None = None) -> Self:
         if isinstance(method, MethodMetadata):
             method_metadata = method
         else:
@@ -629,7 +607,7 @@ class EndToEndResultsSingle:
                 method=method,
                 artifact_name=artifact_name,
             )
-        return cls(method_metadata=method_metadata, holdout=holdout)
+        return cls(method_metadata=method_metadata)
 
     def compare_on_tabarena(
         self,

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -11,13 +11,11 @@ from tabarena.models._method_metadata import MethodMetadata
 from tabarena.nips2025_utils.abstract_arena_context import AbstractArenaContext
 from tabarena.nips2025_utils.artifacts import tabarena_method_metadata_collection
 from tabarena.nips2025_utils.eval_all import evaluate_all
-from tabarena.nips2025_utils.generate_repo import generate_repo_from_paths
 from tabarena.nips2025_utils.per_dataset_tables import get_per_dataset_tables
 from tabarena.nips2025_utils.subset_predicate import SubsetPredicate
 from tabarena.paper.paper_runner_tabarena import PaperRunTabArena
 from tabarena.paper.tabarena_evaluator import TabArenaEvaluator
 from tabarena.repository import EvaluationRepository, EvaluationRepositoryCollection
-from tabarena.utils.pickle_utils import fetch_all_pickles
 
 if TYPE_CHECKING:
     from tabarena.benchmark.result import BaselineResult
@@ -257,26 +255,6 @@ class TabArenaContext(AbstractArenaContext):
         )
         return metadata.path_processed
 
-    def generate_repo_holdout(self, method: str) -> Path:
-        metadata = self.method_metadata(method=method)
-
-        path_raw = metadata.path_raw
-        path_processed = metadata.path_processed_holdout
-
-        name_suffix = metadata.name_suffix
-
-        file_paths_method = fetch_all_pickles(dir_path=path_raw, suffix="results.pkl")
-        repo: EvaluationRepository = generate_repo_from_paths(
-            result_paths=file_paths_method,
-            task_metadata=self.task_metadata_collection,
-            engine=self.engine,
-            name_suffix=name_suffix,
-            as_holdout=True,
-        )
-
-        repo.to_dir(path_processed)
-        return path_processed
-
     # FIXME: This is a hacky approach, refactor
     def generate_hpo_trajectories(
         self,
@@ -342,7 +320,6 @@ class TabArenaContext(AbstractArenaContext):
         methods: str | None = None,
         repo: EvaluationRepository | None = None,
         folds: list[int] | None = None,
-        holdout: bool = False,
         name: str | None = None,
         ta_name: str | None = None,
         ta_suite: str | None = None,
@@ -684,30 +661,26 @@ class TabArenaContext(AbstractArenaContext):
             **kwargs,
         )
 
-    def load_hpo_results(self, method: str, holdout: bool = False) -> pd.DataFrame:
+    def load_hpo_results(self, method: str) -> pd.DataFrame:
         metadata = self.method_metadata(method=method)
-        return metadata.load_hpo_results(holdout=holdout)
+        return metadata.load_hpo_results()
 
-    def load_config_results(self, method: str, holdout: bool = False) -> pd.DataFrame:
+    def load_config_results(self, method: str) -> pd.DataFrame:
         metadata = self.method_metadata(method=method)
-        return metadata.load_model_results(holdout=holdout)
+        return metadata.load_model_results()
 
-    def load_portfolio_results(self, method: str, holdout: bool = False) -> pd.DataFrame:
+    def load_portfolio_results(self, method: str) -> pd.DataFrame:
         metadata = self.method_metadata(method=method)
-        return metadata.load_portfolio_results(holdout=holdout)
+        return metadata.load_portfolio_results()
 
     def load_baseline_results(
         self,
         methods: list[str] | None = None,
-        holdout: bool = False,
         download_results: str | bool = "auto",
         methods_drop: list[str] | None = None,
     ) -> pd.DataFrame:
         if methods is None:
             methods = self.methods
-            if holdout:
-                # only include methods that can have holdout
-                methods = [m for m in methods if self.method_metadata(m).is_bag]
         if methods_drop is not None:
             for method in methods_drop:
                 if method not in methods:
@@ -721,10 +694,10 @@ class TabArenaContext(AbstractArenaContext):
             method_metadata = self.method_metadata(method=method)
             if isinstance(download_results, bool) and download_results:
                 method_downloader = method_metadata.method_downloader()
-                method_downloader.download_results(holdout=holdout)
+                method_downloader.download_results()
 
             try:
-                df_results = method_metadata.load_results(holdout=holdout)
+                df_results = method_metadata.load_results()
             except FileNotFoundError as err:
                 if isinstance(download_results, str) and download_results == "auto":
                     print(
@@ -733,8 +706,8 @@ class TabArenaContext(AbstractArenaContext):
                         f'(download_results={download_results}, method="{method_metadata.method}")',
                     )
                     method_downloader = method_metadata.method_downloader()
-                    method_downloader.download_results(holdout=holdout)
-                    df_results = method_metadata.load_results(holdout=holdout)
+                    method_downloader.download_results()
+                    df_results = method_metadata.load_results()
                 else:
                     print(
                         f"Missing local results files for method {method_metadata.method}! "
@@ -748,19 +721,15 @@ class TabArenaContext(AbstractArenaContext):
     def load_configs_hyperparameters(
         self,
         methods: list[str] | None = None,
-        holdout: bool = False,
         download: bool | str = False,
     ) -> dict[str, dict]:
         if methods is None:
             methods = self.methods
             methods = [m for m in methods if self.method_metadata(m).method_type == "config"]
-            if holdout:
-                # only include methods that can have holdout
-                methods = [m for m in methods if self.method_metadata(m).is_bag]
         configs_hyperparameters_lst = []
         for method in methods:
             metadata = self.method_metadata(method=method)
-            configs_hyperparameters = metadata.load_configs_hyperparameters(holdout=holdout, download=download)
+            configs_hyperparameters = metadata.load_configs_hyperparameters(download=download)
             configs_hyperparameters_lst.append(configs_hyperparameters)
 
         def merge_dicts_no_duplicates(dicts: list[dict]) -> dict:
@@ -782,7 +751,6 @@ class TabArenaContext(AbstractArenaContext):
         self,
         save_path: str | Path,
         df_results: pd.DataFrame = None,
-        df_results_holdout: pd.DataFrame = None,
         df_results_cpu: pd.DataFrame = None,
         configs_hyperparameters: dict[str, dict] | None = None,
         include_portfolio: bool = False,
@@ -808,7 +776,6 @@ class TabArenaContext(AbstractArenaContext):
         evaluate_all(
             tabarena_context=self,  # FIXME: Don't do this in future, clean up
             df_results=df_results,
-            # df_results_holdout=df_results_holdout,  # TODO: Add back later
             # configs_hyperparameters=configs_hyperparameters,  # TODO: Add back later
             eval_save_path=save_path,
             elo_bootstrap_rounds=elo_bootstrap_rounds,
@@ -967,14 +934,13 @@ class TabArenaContext(AbstractArenaContext):
     def load_config_results_multi(
         self,
         method_metadata_lst: list[MethodMetadata] | None = None,
-        holdout: bool = False,
     ) -> pd.DataFrame:
         if method_metadata_lst is None:
             method_metadata_lst = self.method_metadata_collection.method_metadata_lst
         df_results_configs_lst = []
         for method_metadata in method_metadata_lst:
             if method_metadata.method_type == "config":
-                df_results_configs_lst.append(method_metadata.load_model_results(holdout=holdout))
+                df_results_configs_lst.append(method_metadata.load_model_results())
         return pd.concat(df_results_configs_lst, ignore_index=True)
 
     def find_missing(self, method: str):


### PR DESCRIPTION
## Summary

Removes all logic for loading, downloading, and uploading `holdout=True` variants of method artifacts and results. The `holdout=False` behavior is now the only code path.

- **`MethodMetadata`**: drops `path_processed_holdout` / `path_results_holdout` and the `holdout` param on all path/load/download methods (`path_results_*`, `load_*_results`, `load_results`, `load_configs_hyperparameters`, `download_configs_hyperparameters`, `load_processed`, `load_hpo_trajectories`, `generate_results`, `generate_hpo_result`, `generate_hpo_trajectories`, `generate_best`, `path_results_files`)
- **Uploaders/downloaders** (`uploader_s3`, `uploader_r2`, `downloader_s3`, `downloader_r2`, `downloader_public_r2`): drop `holdout` params and `processed_holdout.zip` handling
- **`TabArenaContext` / `AbstractArenaContext`**: drop `holdout` params on `load_hpo_results`, `load_config_results`, `load_portfolio_results`, `load_baseline_results`, `load_configs_hyperparameters`, `load_config_results_multi`; remove the `generate_repo_holdout` persistence method and the dead `df_results_holdout` param of `evaluate_all`
- **`EndToEndSingle` / `EndToEndResultsSingle`**: drop `cache_holdout` and the holdout results-loading params
- **`examples/plots/run_generate_paper_figures.py`**: drop the `df_results_holdout` placeholder

**Retained**: the ability to *generate* holdout artifacts from raw results — `AGBagResult.bag_artifacts`, `result_to_holdout` / `results_to_holdout`, the `as_holdout` / `convert_to_holdout` flags on raw loading, and `MethodMetadata.generate_repo_holdout` (now in-memory only; its `cache` param is removed along with the on-disk `processed_holdout/` location).

Note: existing holdout artifacts in S3/R2 (`processed_holdout.zip`, `results/holdout/*.parquet`) are not deleted; they simply become unreachable through this codebase.

## Testing

- `ruff check` / `ruff format --check` pass on touched files
- `import tabarena` verified
- `tst/benchmark/test_results.py`, `tst/nips2025_utils/`: all pass (the only observed failures were pre-existing environmental failures in `tst/models/`, reproduced on clean `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)