### PR TITLE
Rename AbstractArenaContext.load_baseline_results to load_results

### DIFF
--- a/examples/!old/run_quickstart_tabarena_custom_autogluon.py
+++ b/examples/!old/run_quickstart_tabarena_custom_autogluon.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 
     # load the TabArena paper results
     tabarena_context = TabArenaContext()
-    tabarena_results = tabarena_context.load_baseline_results(download_results="auto")
+    tabarena_results = tabarena_context.load_results(download_results="auto")
     tabarena_results = tabarena_results[[c for c in tabarena_results.columns if c in metrics.columns]]
 
     dataset_fold_map = metrics.groupby("dataset")["fold"].apply(set)

--- a/examples/benchmarking/run_custom_datasets_via_experiment_batch_runner.py
+++ b/examples/benchmarking/run_custom_datasets_via_experiment_batch_runner.py
@@ -9,7 +9,7 @@ download), and showcases each of these steps:
 4. Run them on two models, using ``run_jobs`` for a *non-rectangular* sweep (the
    classification task has 3 folds, the regression task has 1).
 5. Aggregate the raw results with ``EndToEnd``.
-6. Compute a leaderboard via a subclassed ``TabArenaContext.compare`` call.
+6. Compute a leaderboard via a ``TabArenaContext.compare`` call (with no baseline methods).
 
 Run with::
 
@@ -137,19 +137,6 @@ def _metadata_row(
     }
 
 
-class CustomBenchmarkContext(TabArenaContext):
-    """A ``TabArenaContext`` for a self-contained custom benchmark (no paper baselines).
-
-    The base ``compare`` pulls the official TabArena paper results to compare against (via
-    ``load_baseline_results``). A custom benchmark has no such baselines, so we override it to
-    contribute nothing — the leaderboard is then computed purely from the results we pass as
-    ``new_results``, against the custom task metadata the context was constructed with.
-    """
-
-    def load_baseline_results(self, *args, **kwargs) -> pd.DataFrame:
-        return pd.DataFrame()
-
-
 if __name__ == "__main__":
     here = Path(__file__).parent
     results_dir = str(here / "experiments" / "custom_ebr")
@@ -205,8 +192,11 @@ if __name__ == "__main__":
     print("\n=== raw per-fold results ===")
     print(df_results[["method", "dataset", "fold", "metric", "metric_error"]].to_string(index=False))
 
-    # 6: leaderboard via the subclassed context's `compare`, on the custom task metadata.
-    context = CustomBenchmarkContext(
+    # 6: leaderboard via the context's `compare`, on the custom task metadata. With
+    # `methods=[]` the context contributes no baseline results (`load_results` returns an
+    # empty frame), so the leaderboard is computed purely from the results passed as
+    # `new_results`.
+    context = TabArenaContext(
         task_metadata=task_collection,
         methods=[],
         fillna_method=None,

--- a/examples/plots/run_generate_paper_figures.py
+++ b/examples/plots/run_generate_paper_figures.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     tabarena_context = TabArenaContext()
     include_portfolio = False
 
-    df_results = tabarena_context.load_baseline_results(download_results=download_results)
+    df_results = tabarena_context.load_results(download_results=download_results)
 
     configs_hyperparameters = tabarena_context.load_configs_hyperparameters(download=download_results)
 

--- a/examples/plots/run_generate_website_artifacts.py
+++ b/examples/plots/run_generate_website_artifacts.py
@@ -30,7 +30,7 @@ def generate_website_artifacts(output_path: str | Path):
     engine = "ray"
 
     tabarena_context = TabArenaContext(include_unverified=include_unverified)
-    tabarena_context.load_baseline_results(download_results=download_results)
+    tabarena_context.load_results(download_results=download_results)
 
     evaluator_kwargs = {
         "figure_file_type": figure_file_type,

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -6,13 +6,11 @@ leaderboard via ``compare``, subsetting results, and rendering a website leaderb
 that is specific to TabArena — it works for any benchmark whose tasks/methods are described by
 a :class:`TaskMetadataCollection` / :class:`MethodMetadataCollection`.
 
-Each concrete arena fills in three hooks:
+Each concrete arena fills in two hooks:
 
 * :meth:`_resolve_task_metadata_preset` — turn a named preset (e.g. ``"tabarena"``) into a
   :class:`TaskMetadataCollection`.
 * :meth:`_resolve_methods_preset` — turn a named methods preset into a ``list[MethodMetadata]``.
-* :meth:`load_baseline_results` — the baseline/reference results ``compare`` compares against
-  (none by default; override to supply them).
 
 and may override the class-level :attr:`SUBSET_PREDICATES` and :attr:`_default_subsets` to
 declare arena-specific subset filters. :class:`~tabarena.nips2025_utils.tabarena_context.TabArenaContext`
@@ -107,18 +105,58 @@ class AbstractArenaContext(ABC):
     def _resolve_methods_preset(self, name: str, *, include_unverified: bool) -> list[MethodMetadata]:
         """Resolve a named methods preset (e.g. ``"tabarena"``) to a ``list[MethodMetadata]``."""
 
-    def load_baseline_results(
+    def load_results(
         self,
         methods: list[str] | None = None,
         download_results: str | bool = "auto",
         methods_drop: list[str] | None = None,
     ) -> pd.DataFrame:
-        """Baseline/reference results to compare new results against.
+        """Load the cached results of this arena's methods (downloading on cache miss).
 
-        Empty by default — a self-contained arena has no external baselines. Override to load
-        them (see ``TabArenaContext`` for the paper-results downloader).
+        These are the baseline/reference results ``compare`` compares new results against.
+        A context constructed with no methods contributes none (empty DataFrame), so a
+        self-contained arena's leaderboard is computed purely from ``new_results``.
         """
-        return pd.DataFrame()
+        if methods is None:
+            methods = self.methods
+        if methods_drop is not None:
+            for method in methods_drop:
+                if method not in methods:
+                    raise AssertionError(
+                        f"Specified '{method}' in `methods_drop`, but '{method}' is not present in methods: {methods}",
+                    )
+            methods = [method for method in methods if method not in methods_drop]
+        if not methods:
+            return pd.DataFrame()
+
+        df_results_lst = []
+        for method in methods:
+            method_metadata = self.method_metadata(method=method)
+            if isinstance(download_results, bool) and download_results:
+                method_downloader = method_metadata.method_downloader()
+                method_downloader.download_results()
+
+            try:
+                df_results = method_metadata.load_results()
+            except FileNotFoundError as err:
+                if isinstance(download_results, str) and download_results == "auto":
+                    print(
+                        f"Missing local results files for method! "
+                        f"Attempting to download from s3 and retry... "
+                        f'(download_results={download_results}, method="{method_metadata.method}")',
+                    )
+                    method_downloader = method_metadata.method_downloader()
+                    method_downloader.download_results()
+                    df_results = method_metadata.load_results()
+                else:
+                    print(
+                        f"Missing local results files for method {method_metadata.method}! "
+                        f"Try setting `download_results=True` to get the required files.",
+                    )
+                    raise err
+            df_results_lst.append(df_results)
+
+        return pd.concat(df_results_lst, ignore_index=True)
 
     # ------------------------------------------------------------------ metadata views
     def _resolve_task_metadata_collection(
@@ -266,7 +304,7 @@ class AbstractArenaContext(ABC):
     ) -> pd.DataFrame:
         """Compute the leaderboard comparing ``new_results`` against this arena's baselines.
 
-        ``ta_results`` defaults to :meth:`load_baseline_results`; ``new_results`` (if given)
+        ``ta_results`` defaults to :meth:`load_results`; ``new_results`` (if given)
         are concatenated to them. ``fillna`` / ``calibration_method`` resolve ``"auto"`` to
         the context's settings.
         """
@@ -280,7 +318,7 @@ class AbstractArenaContext(ABC):
             calibration_method = self.calibration_method
 
         if ta_results is None:
-            ta_results = self.load_baseline_results(
+            ta_results = self.load_results(
                 download_results="auto",
             )
 
@@ -336,7 +374,7 @@ class AbstractArenaContext(ABC):
     ) -> dict[str, pd.DataFrame]:
         output_dir = Path(output_dir)
         if ta_results is None:
-            ta_results = self.load_baseline_results(
+            ta_results = self.load_results(
                 download_results="auto",
             )
         datasets = sorted(ta_results["dataset"].unique())

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -716,7 +716,7 @@ class EndToEndResultsSingle:
         fillna_method = "RF (default)"
         fillna_method_name = "RandomForest"
 
-        df_fillna = tabarena_context.load_baseline_results(methods=[fillna_method_name])
+        df_fillna = tabarena_context.load_results(methods=[fillna_method_name])
         df_fillna = df_fillna[df_fillna["method"] == fillna_method]
         assert not df_fillna.empty
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -68,9 +68,9 @@ class TabArenaContext(AbstractArenaContext):
     """Reference arena context: TabArena v0.1 task/method presets + the paper workflow.
 
     Implements the :class:`AbstractArenaContext` hooks against the committed TabArena v0.1
-    suite and the paper's method metadata, overrides :meth:`load_baseline_results` to load the
-    paper baseline results, and adds the full reproduction workflow (HPO / portfolio
-    simulation, plotting, repo generation). ``BeyondArenaContext`` subclasses this.
+    suite and the paper's method metadata (so :meth:`load_results` loads the paper baseline
+    results), and adds the full reproduction workflow (HPO / portfolio simulation, plotting,
+    repo generation). ``BeyondArenaContext`` subclasses this.
     """
 
     SUBSET_PREDICATES: dict[str, SubsetPredicate] = {
@@ -673,51 +673,6 @@ class TabArenaContext(AbstractArenaContext):
         metadata = self.method_metadata(method=method)
         return metadata.load_portfolio_results()
 
-    def load_baseline_results(
-        self,
-        methods: list[str] | None = None,
-        download_results: str | bool = "auto",
-        methods_drop: list[str] | None = None,
-    ) -> pd.DataFrame:
-        if methods is None:
-            methods = self.methods
-        if methods_drop is not None:
-            for method in methods_drop:
-                if method not in methods:
-                    raise AssertionError(
-                        f"Specified '{method}' in `methods_drop`, but '{method}' is not present in methods: {methods}",
-                    )
-            methods = [method for method in methods if method not in methods_drop]
-
-        df_results_lst = []
-        for method in methods:
-            method_metadata = self.method_metadata(method=method)
-            if isinstance(download_results, bool) and download_results:
-                method_downloader = method_metadata.method_downloader()
-                method_downloader.download_results()
-
-            try:
-                df_results = method_metadata.load_results()
-            except FileNotFoundError as err:
-                if isinstance(download_results, str) and download_results == "auto":
-                    print(
-                        f"Missing local results files for method! "
-                        f"Attempting to download from s3 and retry... "
-                        f'(download_results={download_results}, method="{method_metadata.method}")',
-                    )
-                    method_downloader = method_metadata.method_downloader()
-                    method_downloader.download_results()
-                    df_results = method_metadata.load_results()
-                else:
-                    print(
-                        f"Missing local results files for method {method_metadata.method}! "
-                        f"Try setting `download_results=True` to get the required files.",
-                    )
-                    raise err
-            df_results_lst.append(df_results)
-
-        return pd.concat(df_results_lst, ignore_index=True)
-
     def load_configs_hyperparameters(
         self,
         methods: list[str] | None = None,
@@ -763,7 +718,7 @@ class TabArenaContext(AbstractArenaContext):
         progress_bar: bool = True,
     ):
         if df_results is None:
-            df_results = self.load_baseline_results(download_results="auto")
+            df_results = self.load_results(download_results="auto")
 
         if fillna_method == "auto":
             fillna_method = self.fillna_method
@@ -907,7 +862,7 @@ class TabArenaContext(AbstractArenaContext):
         if fillna_method == "auto":
             fillna_method = self.fillna_method
         if df_results is None:
-            df_results = self.load_baseline_results(download_results="auto")
+            df_results = self.load_results(download_results="auto")
 
         if use_display_names:
             rename_map = self._method_rename_map_to_display_names()

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -1084,7 +1084,7 @@ def _prepare_tuning_trajectories_data(
     results_hpo = pd.concat(results_hpo_lst, ignore_index=True)
     results_hpo["display_name"] = results_hpo["display_name"].fillna(results_hpo["config_type"])
 
-    result_baselines = tabarena_context.load_baseline_results()
+    result_baselines = tabarena_context.load_results()
 
     results_hpo_mean = (
         results_hpo.copy()

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -261,7 +261,7 @@ class TestAbstractArenaContextStandalone:
     def test_defaults_are_arena_agnostic(self):
         ctx = self._ctx()
         assert ctx.methods == []
-        assert ctx.load_baseline_results().empty  # no baselines by default
+        assert ctx.load_results().empty  # no methods -> no baseline results
         # Base ships only the universal predicates (no TabArena size/foundation buckets).
         assert set(ctx.subset_predicates) == {"all", "binary", "multiclass", "classification", "regression", "lite"}
 


### PR DESCRIPTION
## Summary

Renames `AbstractArenaContext.load_baseline_results` to `load_results`, and the base method adopts `TabArenaContext`'s real implementation (load each method's cached results, downloading from the method's cache on a miss) instead of returning an empty DataFrame. `TabArenaContext`'s override is removed — it now inherits the base method, which loads the paper baseline results because of the context's method metadata.

- A context constructed with no methods returns an empty frame from `load_results`, preserving the self-contained-arena semantics (the leaderboard is computed purely from `new_results`). This makes the `CustomBenchmarkContext` subclass in `examples/benchmarking/run_custom_datasets_via_experiment_batch_runner.py` unnecessary — the example now uses `TabArenaContext(methods=[])` directly.
- All callers renamed: `compare` / `compare_per_dataset`, `EndToEndResultsSingle.fillna_results_on_tabarena`, `evaluate_all` / `generate_per_dataset_tables`, `plot_pareto_over_tuning_time`, the plotting/website examples, and the standalone-context test.
- Docstrings updated (the base module now describes two arena hooks; `load_results` is a concrete method).

No downstream usage of `load_baseline_results` exists outside this repo (checked the surrounding workspace, including the BeyondArena / slurm-setup extensions).

## Testing

- `ruff check` / `ruff format --check` pass on touched files
- Verified `AbstractArenaContext` no longer has `load_baseline_results` and `TabArenaContext.load_results` is the inherited base method
- `tst/nips2025_utils/` + `tst/evaluation/`: 79 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)