### PR TITLE
Remove include_unverified logic (treat as always True)

### DIFF
--- a/examples/plots/run_generate_main_leaderboard.py
+++ b/examples/plots/run_generate_main_leaderboard.py
@@ -7,23 +7,10 @@ from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 if __name__ == "__main__":
     save_path = "output_leaderboard"  # folder to save all figures and tables
 
-    output_path_verified = Path(save_path) / "verified"
-    output_path_unverified = Path(save_path) / "unverified"
+    tabarena_context = TabArenaContext()
+    leaderboard = tabarena_context.compare(output_dir=Path(save_path))
+    leaderboard_website = tabarena_context.leaderboard_to_website_format(leaderboard=leaderboard)
 
-    tabarena_context = TabArenaContext(include_unverified=False)
-    leaderboard_verified = tabarena_context.compare(output_dir=output_path_verified)
-    leaderboard_website_verified = tabarena_context.leaderboard_to_website_format(leaderboard=leaderboard_verified)
-
-    tabarena_context_unverified = TabArenaContext(include_unverified=True)
-    leaderboard_unverified = tabarena_context_unverified.compare(output_dir=output_path_unverified)
-    leaderboard_website_unverified = tabarena_context_unverified.leaderboard_to_website_format(
-        leaderboard=leaderboard_unverified
-    )
-
-    print("Verified Leaderboard:")
-    print(leaderboard_website_verified.to_markdown(index=False))
-    print("")
-
-    print("Unverified Leaderboard:")
-    print(leaderboard_website_unverified.to_markdown(index=False))
+    print("Leaderboard:")
+    print(leaderboard_website.to_markdown(index=False))
     print("")

--- a/examples/plots/run_generate_website_artifacts.py
+++ b/examples/plots/run_generate_website_artifacts.py
@@ -20,7 +20,6 @@ def generate_website_artifacts(output_path: str | Path):
     use_latex: bool = False
     download_results = "auto"  # Set to False to avoid re-download
 
-    include_unverified = True
     run_ablations = False
     figure_file_type = "png"
 
@@ -29,7 +28,7 @@ def generate_website_artifacts(output_path: str | Path):
     # set to "sequential" to debug or "auto" to follow the TabArenaContext backend.
     engine = "ray"
 
-    tabarena_context = TabArenaContext(include_unverified=include_unverified)
+    tabarena_context = TabArenaContext()
     tabarena_context.load_results(download_results=download_results)
 
     evaluator_kwargs = {

--- a/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
@@ -65,8 +65,6 @@ class TabArenaEvalConfig:
     subsets: list[list[str]] | None = None
     """Each entry is a subset spec (e.g. ``["regression"]``); ``[]`` means the full
     benchmark. ``None`` is treated as ``[[]]`` (full only)."""
-    include_unverified: bool = True
-    """Passed to ``TabArenaContext`` so unverified baselines are included."""
     num_cpus: int | None = None
     """CPUs for raw-result post-processing (None = all available)."""
     tabarena_cache_path: str | None = None
@@ -103,7 +101,6 @@ def _compare_subset(results, subset: list[str], *, config: TabArenaEvalConfig, f
     return results.compare_on_tabarena(
         output_dir=figure_output_dir / "subsets" / subset_label(subset),
         subset=subset or None,
-        tabarena_context_kwargs={"include_unverified": config.include_unverified},
     )
 
 

--- a/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
@@ -220,7 +220,7 @@ def evaluate_beyond_subsets(
     # the BeyondArena subset filtering.
     task_metadata_collection = TaskMetadataCollection(InMemoryTaskMetadataSource(task_metadata).load())
     if method_rename_map is None:
-        method_rename_map = TabArenaContext(include_unverified=True).get_method_rename_map()
+        method_rename_map = TabArenaContext().get_method_rename_map()
         method_rename_map = {**method_rename_map, **DEFAULT_METHOD_RENAME_MAP, **(method_rename_map_extra or {})}
 
     df_results = _align_results_to_task_metadata(

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -76,7 +76,6 @@ class AbstractArenaContext:
         task_metadata: str | TaskMetadataCollection,
         *,
         extra_methods: list[MethodMetadata] | None = None,
-        include_unverified: bool = False,
         backend: Literal["ray", "native"] = "ray",
         fillna_method: str | None = None,
         calibration_method: str | None = None,
@@ -93,7 +92,7 @@ class AbstractArenaContext:
         # A string selects a named preset (resolved by the concrete arena); otherwise an
         # explicit list of MethodMetadata is used as-is.
         if isinstance(methods, str):
-            method_metadata_lst = self._resolve_methods_preset(methods, include_unverified=include_unverified)
+            method_metadata_lst = self._resolve_methods_preset(methods)
         else:
             method_metadata_lst = list(methods)
         method_names = {m.method for m in method_metadata_lst}
@@ -116,7 +115,7 @@ class AbstractArenaContext:
             f"Pass an explicit TaskMetadataCollection instead.",
         )
 
-    def _resolve_methods_preset(self, name: str, *, include_unverified: bool) -> list[MethodMetadata]:
+    def _resolve_methods_preset(self, name: str) -> list[MethodMetadata]:
         """Resolve a named methods preset to a ``list[MethodMetadata]``. The base arena defines
         no presets — pass an explicit list or override in a subclass.
         """

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -101,7 +101,6 @@ class TabArenaContext(AbstractArenaContext):
         task_metadata: str | TaskMetadataCollection = "tabarena",
         *,
         extra_methods: list[MethodMetadata] | None = None,
-        include_unverified: bool = False,
         backend: Literal["ray", "native"] = "ray",
         fillna_method: str | None = "RF (default)",
         calibration_method: str | None = "RF (default)",
@@ -110,7 +109,6 @@ class TabArenaContext(AbstractArenaContext):
             methods=methods,
             task_metadata=task_metadata,
             extra_methods=extra_methods,
-            include_unverified=include_unverified,
             backend=backend,
             fillna_method=fillna_method,
             calibration_method=calibration_method,
@@ -124,7 +122,7 @@ class TabArenaContext(AbstractArenaContext):
 
         return TaskMetadataCollection.from_preset("TabArena-v0.1")
 
-    def _resolve_methods_preset(self, name: str, *, include_unverified: bool) -> list[MethodMetadata]:
+    def _resolve_methods_preset(self, name: str) -> list[MethodMetadata]:
         if name != "tabarena":
             raise ValueError(f"Unknown methods preset '{name}'.")
         methods = copy.deepcopy(_methods_paper)
@@ -132,8 +130,6 @@ class TabArenaContext(AbstractArenaContext):
             tabarena_method_metadata_collection.method_metadata_lst,
         )
         method_metadata_lst = [m for m in method_metadata_lst if m.method in methods]
-        if not include_unverified:
-            method_metadata_lst = [m for m in method_metadata_lst if m.verified]
         method_metadata_name_set = {m.method for m in method_metadata_lst}
         methods = [m for m in methods if m in method_metadata_name_set]
         return [m for m in method_metadata_lst if m.method in set(methods)]

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -1332,9 +1332,7 @@ def plot_tuning_trajectories(
         subset_map = []
 
     if tabarena_context is None:
-        tabarena_context = TabArenaContext(
-            include_unverified=True,
-        )
+        tabarena_context = TabArenaContext()
     if isinstance(calibration_framework, str) and calibration_framework == "auto":
         calibration_framework = tabarena_context.calibration_method
     if isinstance(fillna_method, str) and fillna_method == "auto":

--- a/tst/evaluation/test_benchmark_eval.py
+++ b/tst/evaluation/test_benchmark_eval.py
@@ -110,7 +110,7 @@ def test_run_eval_orchestration(tmp_path, monkeypatch):
     figs = Path(cfg.figure_output_dir)
     assert [c[0] for c in compare_calls] == [figs / "subsets" / "full", figs / "subsets" / "regression"]
     assert [c[1] for c in compare_calls] == [None, ["regression"]]
-    assert compare_calls[0][2] == {"include_unverified": True}
+    assert compare_calls[0][2] is None
 
     # Leaderboards returned + saved as CSV.
     assert set(out) == {"full", "regression"}


### PR DESCRIPTION
## Summary

Removes the `include_unverified` filtering logic, treating the value as always True: the `"tabarena"` methods preset now always includes every method (previously unverified methods — e.g. LimiX, OrionMSP, SAP-RPT-OSS — were excluded by default; the default context now resolves 32 methods).

- `AbstractArenaContext.__init__` / `TabArenaContext.__init__` lose the `include_unverified` param; the `_resolve_methods_preset` hook loses it too, and the `verified` filter in `TabArenaContext._resolve_methods_preset` is removed.
- `TabArenaEvalConfig.include_unverified` is removed; `_compare_subset` no longer passes `tabarena_context_kwargs`.
- Internal `TabArenaContext(include_unverified=True)` call sites (`beyond_arena_eval`, `plot_pareto_over_tuning_time`) simplified to `TabArenaContext()`.
- Examples no longer mention verified/unverified: `run_generate_main_leaderboard.py` now produces a single leaderboard (previously separate `verified/` and `unverified/` outputs); `run_generate_website_artifacts.py` drops the flag.
- The `MethodMetadata.verified` field and the website's "Verified" column are intentionally kept — only the include/exclude filtering is removed.

Note: downstream `tabarena-slurm-setup` has two `include_unverified=True` call sites (`run_eval_example.py`, `tabarena_v0pt2/eval/run_eval.py`) that will need the kwarg dropped when it picks up this change.

## Testing

- `ruff check` / `ruff format --check` clean
- Verified `TabArenaContext.__init__` no longer accepts the param and the default preset resolves all 32 methods
- `tst/nips2025_utils/` + `tst/evaluation/`: 79 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)