### PR TITLE
Make compare() generic; move task subsetting into AbstractArenaContext

### DIFF
--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -358,6 +358,18 @@ class AbstractArenaContext:
                 df_filter=new_results,
             )
 
+        # Subset to the requested tasks here (with this context's subset predicates) — the
+        # lower-level `compare` evaluates the results frame as-is.
+        if isinstance(subset, str):
+            subset = [subset]
+        df_results = self.subset_results(
+            df_results=df_results,
+            subset=subset,
+            tasks=tasks,
+            datasets=datasets,
+            folds=folds,
+        )
+
         # TODO: only methods that exist in runs
         #  Pair with (method, artifact_name)
         method_rename_map = self.get_method_rename_map()
@@ -366,11 +378,6 @@ class AbstractArenaContext:
             df_results=df_results,
             output_dir=Path(output_dir),
             task_metadata=self.task_metadata_collection,
-            subset=subset,
-            tasks=tasks,
-            datasets=datasets,
-            folds=folds,
-            tabarena_context=self,
             fillna=fillna,
             calibration_framework=calibration_method,
             score_on_val=score_on_val,

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
-from tabarena.benchmark.task.metadata import default_task_metadata_collection
 from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection
 from tabarena.nips2025_utils.subset_predicate import SubsetPredicate
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
@@ -19,10 +18,8 @@ if TYPE_CHECKING:
 def compare(
     df_results: pd.DataFrame,
     output_dir: str | Path,
-    task_metadata: TaskMetadataCollection | None = None,
+    task_metadata: TaskMetadataCollection,
     only_valid_tasks: str | list[str] | None = None,
-    tasks: list[tuple[str, int]] | None = None,
-    datasets: list[str] | None = None,
     calibration_framework: str | None = None,
     fillna: str | pd.DataFrame | None = None,
     score_on_val: bool = False,
@@ -32,41 +29,20 @@ def compare(
     method_rename_map: dict | None = None,
     figure_file_type: str = "pdf",
     add_dataset_count: bool = False,
-    subset: list[str] | None = None,
-    folds: list[int] | None = None,
     elo_ymin: float | None = None,
-    tabarena_context: TabArenaContext | None = None,
     **kwargs,
 ):
-    if task_metadata is None:
-        task_metadata = default_task_metadata_collection()
-    if subset is not None or folds is not None or datasets is not None or tasks is not None:
-        if subset is None:
-            subset = []
-        if isinstance(subset, str):
-            subset = [subset]
-        df_results = subset_tasks(
-            df_results=df_results,
-            subset=subset,
-            tasks=tasks,
-            datasets=datasets,
-            folds=folds,
-            task_metadata_og=task_metadata,
-            # Thread the context's predicates so subclass-specific subsets (e.g.
-            # BeyondArena's "random"/"temporal"/"grouped") take effect; without this
-            # subset_tasks silently falls back to TabArenaContext.SUBSET_PREDICATES.
-            predicates=tabarena_context.subset_predicates if tabarena_context is not None else None,
-        )
+    """Evaluate ``df_results`` (already subset to the tasks of interest) into a leaderboard.
 
+    Generic over the supplied ``task_metadata``; task subsetting is the caller's job
+    (see :meth:`AbstractArenaContext.compare`, which subsets via ``subset_results`` first).
+    """
     df_results = prepare_data(
         df_results=df_results,
         only_valid_tasks=only_valid_tasks,
         fillna=fillna,
         remove_imputed=remove_imputed,
     )
-
-    if datasets is not None:
-        df_results = df_results[df_results["dataset"].isin(datasets)]
 
     if score_on_val:
         error_col = "metric_error_val"

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -392,6 +392,13 @@ class EndToEndResults:
             fillna=False,
         )
 
+        # The lower-level `compare` requires explicit task metadata; default to the
+        # TabArena-v0.1 suite here, matching the TabArena results this class manages.
+        if task_metadata is None:
+            from tabarena.benchmark.task.metadata import default_task_metadata_collection
+
+            task_metadata = default_task_metadata_collection()
+
         return compare(
             df_results=results,
             output_dir=output_dir,


### PR DESCRIPTION
## Summary

Removes the non-generic logic from `tabarena.nips2025_utils.compare.compare` and moves the task-subsetting step into `AbstractArenaContext`:

- **`compare()`** loses the `tabarena_context` param, the `task_metadata = default_task_metadata_collection()` fallback (`task_metadata` is now a required `TaskMetadataCollection`), and the `subset`/`tasks`/`datasets`/`folds` params together with the `subset_tasks` block (including the now-redundant post-`prepare_data` `datasets` filter). It now just prepares and evaluates the results frame it's given — generic over the supplied task metadata.
- **`AbstractArenaContext.compare`** subsets the combined results itself via the existing `subset_results` (which threads `self.subset_predicates`, so subclass-specific subsets like BeyondArena's still take effect) before delegating to `compare()`. The subset → `prepare_data` ordering is unchanged.
- **`EndToEndResults.compare`** keeps its `task_metadata=None` convenience by resolving the TabArena-v0.1 default at its own call site — the TabArena-specific fallback moved to the caller that wants it, out of the generic function.

Other direct `compare()` callers (`beyond_arena_eval`, the custom-datasets quickstart example) already pass an explicit `task_metadata` and none of the removed params. Downstream note: `tabarena-slurm-setup/tabarena_v0pt2/eval/run_eval.py` imports `compare` — if it relies on the implicit v0.1 metadata default or the subset params, it will need a small update when bumping tabarena.

## Testing

- `ruff check` / `ruff format --check` clean
- `tst/nips2025_utils/` + `tst/evaluation/`: 79 passed
- Ran `examples/benchmarking/run_quickstart_tabarena_custom_datasets.py` end-to-end (direct `compare()` caller) — leaderboard produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)