### PR TITLE
Add InMemoryMethodMetadata: register locally-run results at context init

### DIFF
--- a/examples/advanced/run_generate_beyondarena_core_subset.py
+++ b/examples/advanced/run_generate_beyondarena_core_subset.py
@@ -38,7 +38,9 @@ if __name__ == "__main__":
     fold_similarity = pd.read_csv(save_path / "fold_similarity.csv")
     folds_needed_col = f"folds_needed_for_stability@{TARGET_RELIABILITY}"
     fold_similarity["folds_to_use"] = fold_similarity[[folds_needed_col, "num_folds"]].min(axis=1)
-    folds_to_use = {str(d): int(n) for d, n in zip(fold_similarity["dataset"], fold_similarity["folds_to_use"], strict=False)}
+    folds_to_use = {
+        str(d): int(n) for d, n in zip(fold_similarity["dataset"], fold_similarity["folds_to_use"], strict=False)
+    }
 
     # 3) expand to valid tasks: each dataset's first `folds_to_use` splits (lowest split indices).
     grid = tabarena_context.task_metadata_collection.task_grid()

--- a/examples/benchmarking/run_register_new_methods.py
+++ b/examples/benchmarking/run_register_new_methods.py
@@ -98,13 +98,6 @@ class CustomRandomForestModel(AbstractModel):
         )
 
 
-def lightgbm_baseline_metadata():
-    """The cached paper ``LightGBM`` MethodMetadata (the single baseline for this run)."""
-    metas = [m for m in tabarena_method_metadata_collection.method_metadata_lst if m.method == "LightGBM"]
-    assert len(metas) == 1, metas
-    return copy.deepcopy(metas[0])
-
-
 if __name__ == "__main__":
     here = Path(__file__).parent
     run_name = "register_new_methods"
@@ -132,7 +125,7 @@ if __name__ == "__main__":
     runner = ExperimentBatchRunner(expname=results_dir, task_metadata=task_collection, debug_mode=True)
     results_lst = runner.run_jobs(jobs)
 
-    # 4: NEW PATH — convert the run into registerable InMemoryMethodMetadata objects.
+    # 4: convert the run into registerable InMemoryMethodMetadata objects.
     new_methods = EndToEnd.from_raw_to_methods(
         results_lst=results_lst,
         task_metadata=task_collection,
@@ -145,17 +138,7 @@ if __name__ == "__main__":
             f"config_type={m.config_type!r}  display_name={m.display_name!r}  type={type(m).__name__}",
         )
 
-    # 5: register the new methods at init (alongside the cached LightGBM baseline). No
-    #    new_results= passed to compare; the methods are picked up via load_results(), and
-    #    only_valid_tasks=True restricts the leaderboard to the tasks they ran.
-    ta_context = TabArenaContext(
-        methods=[lightgbm_baseline_metadata()],
-        task_metadata=task_collection,
-        extra_methods=new_methods,
-        backend="native",
-        fillna_method=None,  # avoid needing the RandomForest fillna baseline
-        calibration_method=None,
-    )
+    ta_context = TabArenaContext(extra_methods=new_methods)
 
     leaderboard = ta_context.compare(
         output_dir=eval_dir,

--- a/examples/benchmarking/run_register_new_methods.py
+++ b/examples/benchmarking/run_register_new_methods.py
@@ -4,8 +4,10 @@ The counterpart to run_quickstart_tabarena.py: rather than threading a results D
 ``compare(new_results=...)``, this converts the run into ``InMemoryMethodMetadata`` objects
 (``EndToEnd.from_raw_to_methods``) and registers them at context init via ``extra_methods=``.
 The new methods are then first-class — picked up automatically by ``compare`` (through
-``load_results``), restricted to their own tasks via ``only_valid_tasks=True``, and carried
-(with their metadata: hardware, verified, ...) into ``leaderboard_to_website_format``.
+``load_results``), restricted to their own tasks via ``only_valid_tasks=True`` at context init
+(which pre-filters ``task_metadata`` to the tasks they ran, so ``compare`` scopes to them with
+nothing extra), and carried (with their metadata: hardware, verified, ...) into
+``leaderboard_to_website_format``.
 
 Bounded for a fast, self-contained run: 3 small datasets, and the cached ``LightGBM`` as the
 only baseline (so no ~30-method S3 download). fillna/calibration are disabled so no separate
@@ -14,7 +16,6 @@ RandomForest baseline is needed.
 
 from __future__ import annotations
 
-import copy
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,7 +29,6 @@ from tabarena.benchmark.experiment import (
     build_jobs,
 )
 from tabarena.benchmark.task.metadata import TabArenaTaskMetadataCollection
-from tabarena.nips2025_utils.artifacts import tabarena_method_metadata_collection
 from tabarena.nips2025_utils.end_to_end import EndToEnd
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 
@@ -138,12 +138,12 @@ if __name__ == "__main__":
             f"config_type={m.config_type!r}  display_name={m.display_name!r}  type={type(m).__name__}",
         )
 
-    ta_context = TabArenaContext(extra_methods=new_methods)
+    # only_valid_tasks=True pre-filters the context's task_metadata to the tasks the new
+    # methods ran, so `compare` (which scopes results to task_metadata) is already restricted
+    # to them — no need to repeat only_valid_tasks=True at the compare call.
+    ta_context = TabArenaContext(extra_methods=new_methods, only_valid_tasks=True)
 
-    leaderboard = ta_context.compare(
-        output_dir=eval_dir,
-        only_valid_tasks=True,
-    )
+    leaderboard = ta_context.compare(output_dir=eval_dir)
     print("\n=== leaderboard (raw) ===")
     print(leaderboard.to_string())
 

--- a/examples/benchmarking/run_register_new_methods.py
+++ b/examples/benchmarking/run_register_new_methods.py
@@ -1,0 +1,170 @@
+"""Register locally-run models with an arena context (instead of passing ``new_results=``).
+
+The counterpart to run_quickstart_tabarena.py: rather than threading a results DataFrame into
+``compare(new_results=...)``, this converts the run into ``InMemoryMethodMetadata`` objects
+(``EndToEnd.from_raw_to_methods``) and registers them at context init via ``extra_methods=``.
+The new methods are then first-class — picked up automatically by ``compare`` (through
+``load_results``), restricted to their own tasks via ``only_valid_tasks=True``, and carried
+(with their metadata: hardware, verified, ...) into ``leaderboard_to_website_format``.
+
+Bounded for a fast, self-contained run: 3 small datasets, and the cached ``LightGBM`` as the
+only baseline (so no ~30-method S3 download). fillna/calibration are disabled so no separate
+RandomForest baseline is needed.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from autogluon.core.models import AbstractModel
+from autogluon.features import LabelEncoderFeatureGenerator
+
+from tabarena.benchmark.experiment import (
+    ExperimentBatchRunner,
+    TabArenaV0pt1ExperimentBundle,
+    build_jobs,
+)
+from tabarena.benchmark.task.metadata import TabArenaTaskMetadataCollection
+from tabarena.nips2025_utils.artifacts import tabarena_method_metadata_collection
+from tabarena.nips2025_utils.end_to_end import EndToEnd
+from tabarena.nips2025_utils.tabarena_context import TabArenaContext
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from tabarena.utils.config_utils import ConfigGenerator
+
+DATASETS = ["blood-transfusion-service-center", "QSAR_fish_toxicity", "anneal"]
+
+
+class CustomRandomForestModel(AbstractModel):
+    ag_key = "CRF"
+    ag_name = "CustomRF"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._feature_generator = None
+
+    def _preprocess(self, X: pd.DataFrame, is_train: bool = False, **kwargs) -> np.ndarray:
+        X = super()._preprocess(X, **kwargs)
+        if is_train:
+            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
+            self._feature_generator.fit(X=X)
+        if self._feature_generator.features_in:
+            X = X.copy()
+            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+        return X.fillna(0).to_numpy(dtype=np.float32)
+
+    def _fit(self, X: pd.DataFrame, y: pd.Series, num_cpus: int = 1, **kwargs) -> None:
+        if self.problem_type == "regression":
+            from sklearn.ensemble import RandomForestRegressor
+
+            model_cls = RandomForestRegressor
+        else:
+            from sklearn.ensemble import RandomForestClassifier
+
+            model_cls = RandomForestClassifier
+
+        X = self.preprocess(X, y=y, is_train=True)
+        self.model = model_cls(**self._get_model_params())
+        self.model.fit(X, y)
+
+    def _set_default_params(self) -> None:
+        for param, val in {"n_estimators": 10, "n_jobs": -1, "random_state": 0}.items():
+            self._set_default_param_value(param, val)
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        default_auxiliary_params.update({"valid_raw_types": ["int", "float", "category"]})
+        return default_auxiliary_params
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str]:
+        return ["binary", "multiclass", "regression"]
+
+    @classmethod
+    def config_generator(cls) -> ConfigGenerator:
+        from autogluon.common.space import Int
+
+        from tabarena.utils.config_utils import ConfigGenerator
+
+        return ConfigGenerator(
+            model_cls=cls,
+            manual_configs=[{}],
+            search_space={"n_estimators": Int(4, 50)},
+        )
+
+
+def lightgbm_baseline_metadata():
+    """The cached paper ``LightGBM`` MethodMetadata (the single baseline for this run)."""
+    metas = [m for m in tabarena_method_metadata_collection.method_metadata_lst if m.method == "LightGBM"]
+    assert len(metas) == 1, metas
+    return copy.deepcopy(metas[0])
+
+
+if __name__ == "__main__":
+    here = Path(__file__).parent
+    run_name = "register_new_methods"
+    results_dir = str(here / "experiments" / run_name)
+    eval_dir = here / "eval" / run_name
+
+    # 1: 3 small datasets, first split only (r0f0).
+    task_collection = TabArenaTaskMetadataCollection().subset_tasks(
+        split_indices="lite",
+        dataset_names=DATASETS,
+    )
+    task_collection = task_collection.materialize()
+
+    # 2: same two models as the quickstart.
+    bundle = TabArenaV0pt1ExperimentBundle(
+        models=[
+            ("Linear", 0),
+            (CustomRandomForestModel.config_generator(), 1),
+        ],
+    )
+    experiments = bundle.build_experiments()
+    jobs = build_jobs(experiments, task_collection)
+
+    # 3: run locally (in-process native backend).
+    runner = ExperimentBatchRunner(expname=results_dir, task_metadata=task_collection, debug_mode=True)
+    results_lst = runner.run_jobs(jobs)
+
+    # 4: NEW PATH — convert the run into registerable InMemoryMethodMetadata objects.
+    new_methods = EndToEnd.from_raw_to_methods(
+        results_lst=results_lst,
+        task_metadata=task_collection,
+        new_result_prefix="[New] ",
+    )
+    print("\n=== registered in-memory methods ===")
+    for m in new_methods:
+        print(
+            f"  method={m.method!r}  artifact_name={m.artifact_name!r}  "
+            f"config_type={m.config_type!r}  display_name={m.display_name!r}  type={type(m).__name__}",
+        )
+
+    # 5: register the new methods at init (alongside the cached LightGBM baseline). No
+    #    new_results= passed to compare; the methods are picked up via load_results(), and
+    #    only_valid_tasks=True restricts the leaderboard to the tasks they ran.
+    ta_context = TabArenaContext(
+        methods=[lightgbm_baseline_metadata()],
+        task_metadata=task_collection,
+        extra_methods=new_methods,
+        backend="native",
+        fillna_method=None,  # avoid needing the RandomForest fillna baseline
+        calibration_method=None,
+    )
+
+    leaderboard = ta_context.compare(
+        output_dir=eval_dir,
+        only_valid_tasks=True,
+    )
+    print("\n=== leaderboard (raw) ===")
+    print(leaderboard.to_string())
+
+    leaderboard_website = ta_context.leaderboard_to_website_format(leaderboard=leaderboard)
+    print("\n=== TabArena leaderboard (website format) ===")
+    print(leaderboard_website.to_markdown(index=False))
+    print(f"\nView saved figures in {eval_dir}")

--- a/packages/tabarena/src/tabarena/evaluation/context/beyond_arena.py
+++ b/packages/tabarena/src/tabarena/evaluation/context/beyond_arena.py
@@ -101,6 +101,7 @@ class BeyondArenaContext(AbstractArenaContext):
         backend: str = "ray",
         fillna_method: str | None = "RF (default)",
         calibration_method: str | None = "XGB (default)",
+        only_valid_tasks: bool = False,
     ) -> None:
         """Build a BeyondArena context.
 
@@ -114,6 +115,8 @@ class BeyondArenaContext(AbstractArenaContext):
             backend: ``"ray"`` or ``"native"``, forwarded to :class:`AbstractArenaContext`.
             fillna_method: Imputed-method name forwarded to :class:`AbstractArenaContext`.
             calibration_method: Calibration-method name forwarded to :class:`AbstractArenaContext`.
+            only_valid_tasks: Forwarded to :class:`AbstractArenaContext`; when ``True``,
+                pre-filter ``task_metadata`` to the registered in-memory methods' tasks.
         """
         super().__init__(
             methods=methods,
@@ -122,6 +125,7 @@ class BeyondArenaContext(AbstractArenaContext):
             backend=backend,
             fillna_method=fillna_method,
             calibration_method=calibration_method,
+            only_valid_tasks=only_valid_tasks,
         )
 
     def _resolve_task_metadata_preset(self, name: str) -> TaskMetadataCollection:

--- a/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
@@ -1,0 +1,136 @@
+"""``InMemoryMethodMetadata`` — a :class:`MethodMetadata` backed by in-memory artifacts.
+
+PROTOTYPE. Lets locally-produced results be registered with an arena context at init time
+(via the existing ``methods=`` / ``extra_methods=`` arguments) so they flow through
+``compare`` and the leaderboard/website machinery exactly like cached baseline methods —
+without ever being written to disk or S3.
+
+Only the *results-loading* slice of the :class:`MethodMetadata` contract is served from
+memory (``load_results`` always; ``load_processed`` if a repo is supplied). The disk/S3-only
+operations (``load_raw``, ``generate_repo``, ``method_downloader`` / ``method_uploader``,
+``to_yaml``) are unsupported and raise, since there is no on-disk artifact behind them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Self
+
+from tabarena.models._method_metadata import MethodMetadata
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from tabarena.nips2025_utils.end_to_end_single import EndToEndResultsSingle
+    from tabarena.repository.evaluation_repository import EvaluationRepository
+
+
+class InMemoryMethodMetadata(MethodMetadata):
+    """A :class:`MethodMetadata` whose result artifacts live in memory rather than on disk.
+
+    The in-memory results frame and (optional) repo are held in private slots that are
+    excluded from the ``__dict__``-derived :meth:`to_info_dict`, so the metadata info table
+    (and any YAML serialization) never tries to embed a DataFrame.
+    """
+
+    is_in_memory: bool = True
+
+    #: Instance attributes holding in-memory artifacts — kept out of ``to_info_dict`` so a
+    #: DataFrame never lands in ``MethodMetadataCollection.info()`` (and thus the website
+    #: leaderboard merge).
+    _IN_MEMORY_SLOTS = ("_results", "_repo")
+
+    def __init__(
+        self,
+        *,
+        results: pd.DataFrame,
+        repo: EvaluationRepository | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._results = results
+        self._repo = repo
+
+    @classmethod
+    def from_results_single(
+        cls,
+        results_single: EndToEndResultsSingle,
+        *,
+        new_result_prefix: str | None = None,
+    ) -> Self:
+        """Build from an ``EndToEndResultsSingle`` (its ``method_metadata`` + in-memory results).
+
+        ``new_result_prefix`` is treated as part of the method's *identity*: it is applied
+        both to the results frame (via ``EndToEndResultsSingle.get_results``) and to the
+        metadata's name fields, so the website leaderboard merge on ``(ta_name, ta_suite)``
+        still matches.
+        """
+        base = results_single.method_metadata
+        results = results_single.get_results(new_result_prefix=new_result_prefix)
+
+        kwargs = base.to_info_dict()
+        if new_result_prefix:
+            # Bake the prefix into identity so it matches the (already-prefixed) frame:
+            #   * method/artifact_name -> ta_name/ta_suite (the website merge key)
+            #   * model_key            -> config_type (the rename-map / family key)
+            #   * display_name         -> rendered method name
+            for field in ("method", "artifact_name", "model_key", "display_name"):
+                value = kwargs.get(field)
+                if isinstance(value, str):
+                    kwargs[field] = new_result_prefix + value
+
+        return cls(results=results, repo=results_single_repo(results_single), **kwargs)
+
+    # ------------------------------------------------------------------ serialization
+    def to_info_dict(self) -> dict:
+        return {k: v for k, v in self.__dict__.items() if k not in self._IN_MEMORY_SLOTS}
+
+    # ------------------------------------------------------------------ in-memory artifacts
+    def load_results(self) -> pd.DataFrame:
+        return self._results.copy(deep=True)
+
+    def load_model_results(self) -> pd.DataFrame:
+        return self._results.copy(deep=True)
+
+    def load_hpo_results(self) -> pd.DataFrame:
+        return self._results.copy(deep=True)
+
+    def load_processed(self, *args, **kwargs) -> EvaluationRepository:
+        if self._repo is None:
+            raise NotImplementedError(
+                f"{type(self).__name__}(method={self.method!r}) has no in-memory repo; "
+                f"repo-backed operations (load_repo / simulation / HPO) are unavailable. "
+                f"Build it from an EndToEndSingle (which retains the repo) to enable these.",
+            )
+        return self._repo
+
+    # ------------------------------------------------------------------ disabled disk/S3 ops
+    def _unsupported(self, op: str):
+        return NotImplementedError(
+            f"{op} is unsupported for {type(self).__name__}(method={self.method!r}): "
+            f"its artifacts live in memory, with no on-disk/S3 backing.",
+        )
+
+    def to_yaml(self, *args, **kwargs):
+        raise self._unsupported("to_yaml")
+
+    def to_yaml_fileobj(self, *args, **kwargs):
+        raise self._unsupported("to_yaml_fileobj")
+
+    def load_raw(self, *args, **kwargs):
+        raise self._unsupported("load_raw")
+
+    def generate_repo(self, *args, **kwargs):
+        raise self._unsupported("generate_repo")
+
+    def method_downloader(self, *args, **kwargs):
+        raise self._unsupported("method_downloader")
+
+    def method_uploader(self, *args, **kwargs):
+        raise self._unsupported("method_uploader")
+
+
+def results_single_repo(results_single: EndToEndResultsSingle) -> EvaluationRepository | None:
+    """Return ``results_single.repo`` if it carries one (``EndToEndSingle.to_results`` does
+    not), else ``None`` — keeps the in-memory repo when available for simulation paths.
+    """
+    return getattr(results_single, "repo", None)

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -29,6 +29,13 @@ if TYPE_CHECKING:
 
 # FIXME: Implement `best` and `best-N`
 class MethodMetadata:
+    #: Whether this method's artifacts live in memory (no on-disk/S3 backing). False for the
+    #: disk-backed base class; True for :class:`InMemoryMethodMetadata`. Arena contexts treat
+    #: in-memory methods as the locally-produced "new" results (e.g. ``compare`` resolves
+    #: ``only_valid_tasks=True`` against them). A class attribute, so it stays out of
+    #: :meth:`to_info_dict` / the metadata info table.
+    is_in_memory: bool = False
+
     def __init__(
         self,
         method: str,
@@ -827,6 +834,14 @@ class MethodMetadata:
         df_results_best["ta_name"] = self.method
         df_results_best["ta_suite"] = self.artifact_name
         return df_results_best
+
+    def to_info_dict(self) -> dict:
+        """The flat field dict used to build the metadata info table / YAML.
+
+        Defaults to ``self.__dict__``; an overridable hook so subclasses that hold
+        non-serializable state (e.g. an in-memory results DataFrame) can exclude it.
+        """
+        return dict(self.__dict__)
 
     @property
     def path_metadata(self) -> Path:

--- a/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
@@ -117,7 +117,7 @@ class MethodMetadataCollection:
     def info(self) -> pd.DataFrame:
         info_lst = []
         for method_metadata in self.method_metadata_lst:
-            cur_info = method_metadata.__dict__
+            cur_info = method_metadata.to_info_dict()
             info_lst.append(cur_info)
 
         return pd.DataFrame(info_lst)

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -79,6 +79,7 @@ class AbstractArenaContext:
         backend: Literal["ray", "native"] = "ray",
         fillna_method: str | None = None,
         calibration_method: str | None = None,
+        only_valid_tasks: bool = False,
     ):
         # A TaskMetadataCollection is the single source of truth; the legacy `task_metadata`
         # DataFrame view is derived from it on demand (see the `task_metadata` cached_property).
@@ -104,6 +105,18 @@ class AbstractArenaContext:
                 method_names.add(method_metadata.method)
 
         self.method_metadata_collection: MethodMetadataCollection = MethodMetadataCollection(method_metadata_lst)
+
+        # When True, pre-filter the context's task_metadata down to the tasks the registered
+        # in-memory ("new") methods actually ran, so it becomes the single source of truth for
+        # what is in scope — `compare` (which scopes results to `task_metadata` by default),
+        # the runner, plotting, and per-dataset tables all inherit the restriction without the
+        # caller repeating `only_valid_tasks=True` at each call site. (The counterpart to
+        # `compare(only_valid_tasks=True)`; see `run_register_new_methods.py`.)
+        self.only_valid_tasks = only_valid_tasks
+        if only_valid_tasks:
+            self.task_metadata_collection = self.task_metadata_collection.subset(
+                self._registered_valid_task_triplets(),
+            )
 
     # ------------------------------------------------------------------ arena-specific hooks
     def _resolve_task_metadata_preset(self, name: str) -> TaskMetadataCollection:
@@ -316,6 +329,54 @@ class AbstractArenaContext:
         ]
         return pd.concat(frames, ignore_index=True) if frames else None
 
+    def _registered_valid_task_triplets(self) -> list[tuple[str, int, int]]:
+        """``(dataset, fold, repeat)`` triplets the registered in-memory methods ran.
+
+        The valid-task scope used by ``__init__(only_valid_tasks=True)`` to pre-filter
+        :attr:`task_metadata_collection`. A results frame's ``fold`` column is the *split*
+        index (``n_folds * repeat + fold``), which the task grid carries as ``split``; this
+        maps each ``(dataset, split)`` the methods ran onto the collection's ``(fold, repeat)``.
+        Pairs absent from the grid are dropped (a method that ran a task outside this context's
+        universe does not widen it).
+        """
+        df_filter = self._registered_new_results()
+        if df_filter is None:
+            raise ValueError(
+                "only_valid_tasks=True needs registered in-memory methods "
+                "(e.g. extra_methods=EndToEnd.from_raw_to_methods(...)) to define the valid tasks.",
+            )
+        grid = self.task_metadata_collection.task_grid()
+        split_to_fold_repeat = {
+            (dataset, int(split)): (int(fold), int(repeat))
+            for dataset, split, fold, repeat in zip(
+                grid["dataset"], grid["split"], grid["fold"], grid["repeat"], strict=False
+            )
+        }
+        triplets: list[tuple[str, int, int]] = []
+        seen: set[tuple[str, int]] = set()
+        for dataset, split in zip(df_filter["dataset"], df_filter["fold"], strict=False):
+            key = (dataset, int(split))
+            if key in seen or key not in split_to_fold_repeat:
+                continue
+            seen.add(key)
+            fold, repeat = split_to_fold_repeat[key]
+            triplets.append((dataset, fold, repeat))
+        if not triplets:
+            raise ValueError(
+                "only_valid_tasks=True: the registered in-memory methods share no (dataset, split) "
+                "with this context's task_metadata, so there is nothing to scope to.",
+            )
+        return triplets
+
+    def _task_metadata_results_filter(self) -> pd.DataFrame:
+        """A ``(dataset, fold)`` frame of this context's task grid for ``filter_to_valid_tasks``.
+
+        A results frame's ``fold`` column is the *split* index, carried by the grid as
+        ``split`` — so the grid's ``split`` is renamed to ``fold`` here to line the two up.
+        """
+        grid = self.task_metadata_collection.task_grid()
+        return grid[["dataset", "split"]].rename(columns={"split": "fold"})
+
     def _resolve_only_valid_tasks(
         self,
         only_valid_tasks: bool | str | list[str] | MethodMetadata | list[MethodMetadata],
@@ -359,6 +420,7 @@ class AbstractArenaContext:
         new_results: pd.DataFrame | None = None,
         ta_results: pd.DataFrame | None = None,
         only_valid_tasks: bool | str | list[str] | MethodMetadata | list[MethodMetadata] = False,
+        filter_to_task_metadata: bool = True,
         subset: str | list[str] | None = None,
         tasks: list[tuple[str, int]] | None = None,
         datasets: list[str] | None = None,
@@ -379,6 +441,15 @@ class AbstractArenaContext:
         ``ta_results`` defaults to :meth:`load_results` (which includes any registered
         in-memory methods); ``new_results`` (if given) are concatenated to them.
         ``fillna`` / ``calibration_method`` resolve ``"auto"`` to the context's settings.
+
+        ``filter_to_task_metadata`` (default ``True``) scopes the results to this context's
+        :attr:`task_metadata_collection`: rows whose ``(dataset, fold)`` is not a task of the
+        collection are dropped before scoring. For a full-suite context this is a no-op (the
+        results are already within the suite); for a context constructed with
+        ``only_valid_tasks=True`` (whose ``task_metadata`` was pre-filtered to the registered
+        in-memory methods' tasks) it is what restricts the leaderboard to those tasks — so the
+        pre-filtered context needs nothing more here. Pass ``False`` to evaluate ``ta_results``
+        / ``new_results`` exactly as given (the historical behaviour).
 
         ``only_valid_tasks`` restricts the leaderboard to a subset of tasks:
 
@@ -417,6 +488,17 @@ class AbstractArenaContext:
                 new_results["method_subtype"] = np.nan
 
         df_results = pd.concat([ta_results, new_results], ignore_index=True) if new_results is not None else ta_results
+
+        # Scope to the context's task_metadata (the single source of truth): the lower-level
+        # `compare` builds the leaderboard from `df_results` alone and never drops rows by
+        # task_metadata, so without this a pre-filtered task_metadata would not restrict the
+        # leaderboard. No-op for a full-suite context (results already ⊆ the grid). Skipped for
+        # an empty frame (no methods / new_results), which carries no dataset/fold columns.
+        if filter_to_task_metadata and not df_results.empty:
+            df_results = filter_to_valid_tasks(
+                df_to_filter=df_results,
+                df_filter=self._task_metadata_results_filter(),
+            )
 
         kwargs = kwargs.copy()
         df_filter, passthrough_names = self._resolve_only_valid_tasks(only_valid_tasks, new_results)

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -301,12 +301,64 @@ class AbstractArenaContext:
         )
 
     # ------------------------------------------------------------------ comparison / runner
+    def _registered_new_results(self) -> pd.DataFrame | None:
+        """Concatenated results of the registered in-memory (locally-produced) methods, or None.
+
+        These are the methods registered via ``methods=`` / ``extra_methods=`` whose results
+        live in memory (``is_in_memory``). ``compare`` treats them as the "new" results, so
+        ``only_valid_tasks=True`` can restrict the leaderboard to the tasks they ran without
+        the caller having to pass ``new_results`` (or list out method names) again.
+        """
+        frames = [
+            m.load_results()
+            for m in self.method_metadata_collection.method_metadata_lst
+            if getattr(m, "is_in_memory", False)
+        ]
+        return pd.concat(frames, ignore_index=True) if frames else None
+
+    def _resolve_only_valid_tasks(
+        self,
+        only_valid_tasks: bool | str | list[str] | MethodMetadata | list[MethodMetadata],
+        new_results: pd.DataFrame | None,
+    ) -> tuple[pd.DataFrame | None, str | list[str] | None]:
+        """Resolve ``only_valid_tasks`` (see :meth:`compare`) to a ``(df_filter, names)`` pair.
+
+        Exactly one of the two is non-``None`` (or both ``None`` for "no restriction"):
+
+        * ``df_filter`` — a results frame whose ``(dataset, fold)`` pairs are the valid tasks
+          (applied here via ``filter_to_valid_tasks``). Used for ``True`` and ``MethodMetadata``.
+        * ``names`` — a method-column name / list handed to the lower-level compare, which
+          restricts to the tasks where each named method has results.
+        """
+        if isinstance(only_valid_tasks, (tuple, np.ndarray)):
+            only_valid_tasks = list(only_valid_tasks)
+        if isinstance(only_valid_tasks, MethodMetadata):
+            only_valid_tasks = [only_valid_tasks]
+
+        if isinstance(only_valid_tasks, list) and any(isinstance(m, MethodMetadata) for m in only_valid_tasks):
+            if not all(isinstance(m, MethodMetadata) for m in only_valid_tasks):
+                raise TypeError(
+                    "only_valid_tasks list must be all method-column names or all MethodMetadata, not mixed.",
+                )
+            return pd.concat([m.load_results() for m in only_valid_tasks], ignore_index=True), None
+        if isinstance(only_valid_tasks, (str, list)):
+            return None, only_valid_tasks
+        if only_valid_tasks is True:
+            df_filter = new_results if new_results is not None else self._registered_new_results()
+            if df_filter is None:
+                raise ValueError(
+                    "only_valid_tasks=True needs new_results or registered in-memory methods "
+                    "(e.g. extra_methods=EndToEnd.from_raw_to_methods(...)) to define the valid tasks.",
+                )
+            return df_filter, None
+        return None, None  # False / None -> no restriction
+
     def compare(
         self,
         output_dir: str | Path,
         new_results: pd.DataFrame | None = None,
         ta_results: pd.DataFrame | None = None,
-        only_valid_tasks: bool | str | list[str] = False,
+        only_valid_tasks: bool | str | list[str] | MethodMetadata | list[MethodMetadata] = False,
         subset: str | list[str] | None = None,
         tasks: list[tuple[str, int]] | None = None,
         datasets: list[str] | None = None,
@@ -324,9 +376,19 @@ class AbstractArenaContext:
     ) -> pd.DataFrame:
         """Compute the leaderboard comparing ``new_results`` against this arena's baselines.
 
-        ``ta_results`` defaults to :meth:`load_results`; ``new_results`` (if given)
-        are concatenated to them. ``fillna`` / ``calibration_method`` resolve ``"auto"`` to
-        the context's settings.
+        ``ta_results`` defaults to :meth:`load_results` (which includes any registered
+        in-memory methods); ``new_results`` (if given) are concatenated to them.
+        ``fillna`` / ``calibration_method`` resolve ``"auto"`` to the context's settings.
+
+        ``only_valid_tasks`` restricts the leaderboard to a subset of tasks:
+
+        * ``False`` (default) — no restriction.
+        * ``True`` — restrict to the tasks the "new" results ran: ``new_results`` if given,
+          else the registered in-memory methods (so a context built with
+          ``extra_methods=EndToEnd.from_raw_to_methods(...)`` needs nothing more here).
+        * a ``MethodMetadata`` (or list) — restrict to the tasks those registered methods ran.
+        * a method-column name (or list) — passed through to the lower-level compare, which
+          restricts to the tasks where each named method has results.
 
         ``compute_fold_similarity`` ranks datasets by how consistently their folds/seeds agree
         (and estimates folds-needed-for-stability), writing ``fold_similarity.csv`` to
@@ -357,15 +419,11 @@ class AbstractArenaContext:
         df_results = pd.concat([ta_results, new_results], ignore_index=True) if new_results is not None else ta_results
 
         kwargs = kwargs.copy()
-        if isinstance(only_valid_tasks, (tuple, np.ndarray)):
-            only_valid_tasks = list(only_valid_tasks)
-        if isinstance(only_valid_tasks, (str, list)):
-            kwargs["only_valid_tasks"] = only_valid_tasks
-        elif only_valid_tasks and new_results is not None:
-            df_results = filter_to_valid_tasks(
-                df_to_filter=df_results,
-                df_filter=new_results,
-            )
+        df_filter, passthrough_names = self._resolve_only_valid_tasks(only_valid_tasks, new_results)
+        if passthrough_names is not None:
+            kwargs["only_valid_tasks"] = passthrough_names
+        if df_filter is not None:
+            df_results = filter_to_valid_tasks(df_to_filter=df_results, df_filter=df_filter)
 
         # Subset to the requested tasks here (with this context's subset predicates) — the
         # lower-level `compare` evaluates the results frame as-is.

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -542,8 +542,7 @@ class EndToEndResults:
     def to_method_metadata_lst(self, *, new_result_prefix: str | None = None) -> list:
         """Vend each method as an :class:`InMemoryMethodMetadata` for context registration."""
         return [
-            result.to_method_metadata(new_result_prefix=new_result_prefix)
-            for result in self.end_to_end_results_lst
+            result.to_method_metadata(new_result_prefix=new_result_prefix) for result in self.end_to_end_results_lst
         ]
 
     def get_results(

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -305,6 +305,35 @@ class EndToEnd:
         )
 
     @classmethod
+    def from_raw_to_methods(
+        cls,
+        results_lst: list[BaselineResult | dict],
+        task_metadata: TaskMetadataCollection | None = None,
+        *,
+        new_result_prefix: str | None = None,
+        debug_mode: bool = True,
+        verbose: bool = True,
+    ) -> list:
+        """Turn raw experiment results into a list of ``InMemoryMethodMetadata`` (one per method).
+
+        The registration-first sibling of :meth:`from_raw_to_results_df`: instead of a tidy
+        results DataFrame you must thread into ``compare(new_results=...)``, this returns
+        method objects to register at context init via ``extra_methods=`` so they flow
+        through every context operation, not just ``compare``.
+        """
+        cache = not debug_mode
+        backend: Literal["ray", "native"] = "native" if debug_mode else "ray"
+        end_to_end = cls.from_raw(
+            results_lst=results_lst,
+            task_metadata=task_metadata,
+            cache=cache,
+            cache_raw=cache,
+            backend=backend,
+            verbose=verbose,
+        )
+        return end_to_end.to_results().to_method_metadata_lst(new_result_prefix=new_result_prefix)
+
+    @classmethod
     def from_raw_to_results_df(
         cls,
         results_lst: list[BaselineResult | dict],
@@ -509,6 +538,13 @@ class EndToEndResults:
             remove_imputed=remove_imputed,
             **kwargs,
         )
+
+    def to_method_metadata_lst(self, *, new_result_prefix: str | None = None) -> list:
+        """Vend each method as an :class:`InMemoryMethodMetadata` for context registration."""
+        return [
+            result.to_method_metadata(new_result_prefix=new_result_prefix)
+            for result in self.end_to_end_results_lst
+        ]
 
     def get_results(
         self,

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -649,6 +649,17 @@ class EndToEndResultsSingle:
             remove_imputed=remove_imputed,
         )
 
+    def to_method_metadata(self, *, new_result_prefix: str | None = None):
+        """Vend this method as an :class:`InMemoryMethodMetadata` (metadata + in-memory results).
+
+        The returned object can be passed to an arena context's ``methods=`` /
+        ``extra_methods=`` so the method is registered at init and flows through
+        ``compare`` and the leaderboard/website machinery like a cached baseline.
+        """
+        from tabarena.models._in_memory_method_metadata import InMemoryMethodMetadata
+
+        return InMemoryMethodMetadata.from_results_single(self, new_result_prefix=new_result_prefix)
+
     def get_results(
         self,
         new_result_prefix: str | None = None,

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -103,6 +103,7 @@ class TabArenaContext(AbstractArenaContext):
         backend: Literal["ray", "native"] = "ray",
         fillna_method: str | None = "RF (default)",
         calibration_method: str | None = "RF (default)",
+        only_valid_tasks: bool = False,
     ):
         super().__init__(
             methods=methods,
@@ -111,6 +112,7 @@ class TabArenaContext(AbstractArenaContext):
             backend=backend,
             fillna_method=fillna_method,
             calibration_method=calibration_method,
+            only_valid_tasks=only_valid_tasks,
         )
 
     def _resolve_task_metadata_preset(self, name: str) -> TaskMetadataCollection:

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -842,7 +842,7 @@ class TabArenaEvaluator:
 
         if verbose:
             print(
-                f"Evaluating with {len(df_results_rank_compare[tabarena.task_col].unique())} datasets... ({n_tasks} tasks)| problem_types={self.problem_types}, folds={self.folds}"
+                f"Evaluating with {len(df_results_rank_compare[tabarena.task_col].unique())} datasets... ({n_tasks} tasks)"
             )
             with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
                 print(leaderboard)

--- a/tst/evaluation/test_beyond_metadata.py
+++ b/tst/evaluation/test_beyond_metadata.py
@@ -46,9 +46,12 @@ def test_max_train_rows_is_per_task_max_over_splits():
 def test_every_subset_predicate_is_usable_on_per_dataset_frame():
     frame = load_beyond_task_metadata_collection("BeyondArena").per_dataset_frame()
     for name, predicate in BeyondArenaContext.SUBSET_PREDICATES.items():
-        if name == "lite":
-            continue  # "lite" needs a per-fold "fold" column (only on df_results)
-        mask = predicate(frame)  # must not KeyError -> column present
+        # Split-level predicates (e.g. "lite", "core") declare a per-split "split" column that
+        # only a task grid / results frame carries — they are not applicable to a one-row-per-
+        # dataset frame, so skip them via their self-described required columns.
+        if any(col not in frame.columns for col in predicate.required_columns):
+            continue
+        mask = predicate.evaluate(frame, name=name)  # must not KeyError -> column present
         assert mask.dtype == bool
         assert len(mask) == len(frame)
 

--- a/tst/models/test_in_memory_method_metadata.py
+++ b/tst/models/test_in_memory_method_metadata.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tabarena.benchmark.task.metadata import TaskMetadataCollection
+from tabarena.models._in_memory_method_metadata import InMemoryMethodMetadata
+from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models._method_metadata_collection import MethodMetadataCollection
+from tabarena.nips2025_utils.abstract_arena_context import AbstractArenaContext
+from tabarena.nips2025_utils.end_to_end_single import EndToEndResultsSingle
+
+
+def _results_frame(method: str, *, datasets=("d1",), folds=(0,), config_type="MM", ta_name="M", ta_suite="M"):
+    rows = [
+        {
+            "method": method,
+            "dataset": dataset,
+            "fold": fold,
+            "metric_error": 0.1,
+            "metric": "roc_auc",
+            "problem_type": "binary",
+            "method_type": "config",
+            "method_subtype": "default",
+            "config_type": config_type,
+            "ta_name": ta_name,
+            "ta_suite": ta_suite,
+        }
+        for dataset in datasets
+        for fold in folds
+    ]
+    return pd.DataFrame(rows)
+
+
+def _task_metadata() -> TaskMetadataCollection:
+    legacy = pd.DataFrame(
+        {
+            "tid": [0, 1],
+            "dataset": ["d1", "d2"],
+            "name": ["d1", "d2"],
+            "n_folds": [1, 1],
+            "n_repeats": [1, 1],
+            "n_samples_train_per_fold": [100, 100],
+            "n_samples_test_per_fold": [50, 50],
+            "NumberOfInstances": [150, 150],
+            "problem_type": ["binary", "binary"],
+            "n_features": [10, 10],
+            "n_classes": [2, 2],
+            "target_feature": ["t", "t"],
+        },
+    )
+    return TaskMetadataCollection.from_legacy_df(legacy)
+
+
+class TestInMemoryArtifacts:
+    def test_is_in_memory_marker(self):
+        assert MethodMetadata.is_in_memory is False
+        assert InMemoryMethodMetadata.is_in_memory is True
+
+    def test_load_results_returns_a_copy(self):
+        df = _results_frame("MM (default)")
+        im = InMemoryMethodMetadata(results=df, method="M", method_type="config", model_key="MM")
+        out = im.load_results()
+        assert out.equals(df)
+        out.loc[0, "metric_error"] = 999.0
+        assert im.load_results().loc[0, "metric_error"] == 0.1  # original untouched
+
+    def test_to_info_dict_excludes_in_memory_slots(self):
+        im = InMemoryMethodMetadata(results=_results_frame("MM (default)"), method="M", method_type="baseline")
+        info = im.to_info_dict()
+        assert "_results" not in info and "_repo" not in info
+        assert info["method"] == "M"
+
+    def test_disabled_disk_ops_raise(self):
+        im = InMemoryMethodMetadata(results=_results_frame("MM (default)"), method="M", method_type="baseline")
+        for op in ("to_yaml", "to_yaml_fileobj", "load_raw", "generate_repo", "method_downloader", "method_uploader"):
+            with pytest.raises(NotImplementedError):
+                getattr(im, op)()
+
+    def test_load_processed_requires_repo(self):
+        im = InMemoryMethodMetadata(results=_results_frame("MM (default)"), method="M", method_type="config")
+        with pytest.raises(NotImplementedError, match="no in-memory repo"):
+            im.load_processed()
+        sentinel = object()
+        im_with_repo = InMemoryMethodMetadata(
+            results=_results_frame("MM (default)"),
+            repo=sentinel,
+            method="M",
+            method_type="config",
+        )
+        assert im_with_repo.load_processed() is sentinel
+
+
+class TestCollectionInfo:
+    def test_info_does_not_embed_dataframe(self):
+        im = InMemoryMethodMetadata(results=_results_frame("MM (default)"), method="M", method_type="baseline")
+        info = MethodMetadataCollection([im]).info()
+        assert "_results" not in info.columns
+        assert "_repo" not in info.columns
+        assert info.loc[0, "method"] == "M"
+
+
+class TestFromResultsSinglePrefixIdentity:
+    """new_result_prefix must be baked into identity so the website merge key still matches."""
+
+    def _results_single(self) -> EndToEndResultsSingle:
+        base = MethodMetadata(
+            method="MyModel",
+            artifact_name="MyModel",
+            method_type="config",
+            ag_key="MM",
+            model_key="MM",
+            display_name="MyModel",
+        )
+        hpo = _results_frame("MM (default)", config_type="MM", ta_name="MyModel", ta_suite="MyModel")
+        return EndToEndResultsSingle(method_metadata=base, model_results=hpo, hpo_results=hpo)
+
+    def test_prefix_applied_to_identity_fields(self):
+        im = self._results_single().to_method_metadata(new_result_prefix="[New] ")
+        assert im.method == "[New] MyModel"
+        assert im.artifact_name == "[New] MyModel"
+        assert im.display_name == "[New] MyModel"
+        assert im.config_type == "[New] MM"  # model_key was prefixed too
+
+    def test_frame_and_identity_share_the_website_merge_key(self):
+        # leaderboard_to_website_format merges leaderboard <-> info on (ta_name, ta_suite),
+        # where info's ta_name/ta_suite == method/artifact_name. They must equal the frame's.
+        im = self._results_single().to_method_metadata(new_result_prefix="[New] ")
+        frame = im.load_results()
+        assert list(frame["ta_name"].unique()) == [im.method]
+        assert list(frame["ta_suite"].unique()) == [im.artifact_name]
+        assert list(frame["method"].unique()) == ["[New] MM (default)"]
+
+    def test_no_prefix_is_identity(self):
+        im = self._results_single().to_method_metadata()
+        assert im.method == "MyModel"
+        assert im.config_type == "MM"
+
+
+class TestContextRegistration:
+    def _ctx(self, *extra) -> AbstractArenaContext:
+        return AbstractArenaContext(methods=[], task_metadata=_task_metadata(), extra_methods=list(extra))
+
+    def _in_memory(self, method: str, datasets) -> InMemoryMethodMetadata:
+        return InMemoryMethodMetadata(
+            results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
+            method=method,
+            artifact_name=method,
+            method_type="config",
+            model_key=method,
+        )
+
+    def test_registered_method_is_listed_and_loadable(self):
+        im = self._in_memory("NewA", datasets=("d1",))
+        ctx = self._ctx(im)
+        assert "NewA" in ctx.methods
+        loaded = ctx.load_results()
+        assert set(loaded["method"]) == {"NewA (default)"}
+
+    def test_registered_new_results_concats_only_in_memory(self):
+        im_a = self._in_memory("NewA", datasets=("d1",))
+        im_b = self._in_memory("NewB", datasets=("d1", "d2"))
+        ctx = self._ctx(im_a, im_b)
+        new = ctx._registered_new_results()
+        assert set(new["method"]) == {"NewA (default)", "NewB (default)"}
+
+    def test_registered_new_results_none_without_in_memory(self):
+        assert self._ctx()._registered_new_results() is None
+
+
+class TestResolveOnlyValidTasks:
+    def _ctx_with(self, im) -> AbstractArenaContext:
+        return AbstractArenaContext(methods=[], task_metadata=_task_metadata(), extra_methods=[im])
+
+    def _im(self) -> InMemoryMethodMetadata:
+        return InMemoryMethodMetadata(
+            results=_results_frame("NewA (default)", datasets=("d1",), ta_name="NewA", ta_suite="NewA"),
+            method="NewA",
+            artifact_name="NewA",
+            method_type="config",
+            model_key="NewA",
+        )
+
+    def test_false_is_no_restriction(self):
+        ctx = self._ctx_with(self._im())
+        assert ctx._resolve_only_valid_tasks(False, None) == (None, None)
+
+    def test_true_uses_registered_in_memory_methods(self):
+        ctx = self._ctx_with(self._im())
+        df_filter, names = ctx._resolve_only_valid_tasks(True, None)
+        assert names is None
+        assert set(df_filter["dataset"]) == {"d1"}  # only the task NewA ran
+
+    def test_true_prefers_explicit_new_results(self):
+        ctx = self._ctx_with(self._im())
+        new_results = _results_frame("X (default)", datasets=("d2",))
+        df_filter, _ = ctx._resolve_only_valid_tasks(True, new_results)
+        assert set(df_filter["dataset"]) == {"d2"}
+
+    def test_true_without_any_source_raises(self):
+        ctx = AbstractArenaContext(methods=[], task_metadata=_task_metadata())
+        with pytest.raises(ValueError, match="only_valid_tasks=True needs"):
+            ctx._resolve_only_valid_tasks(True, None)
+
+    def test_method_metadata_object_resolves_to_its_tasks(self):
+        im = self._im()
+        ctx = self._ctx_with(im)
+        df_filter, names = ctx._resolve_only_valid_tasks(im, None)
+        assert names is None
+        assert set(df_filter["dataset"]) == {"d1"}
+
+    def test_string_names_pass_through(self):
+        ctx = self._ctx_with(self._im())
+        df_filter, names = ctx._resolve_only_valid_tasks(["NewA (default)"], None)
+        assert df_filter is None
+        assert names == ["NewA (default)"]
+
+    def test_numpy_array_of_names_passes_through_as_list(self):
+        ctx = self._ctx_with(self._im())
+        df_filter, names = ctx._resolve_only_valid_tasks(np.array(["NewA (default)"]), None)
+        assert df_filter is None
+        assert names == ["NewA (default)"]
+
+    def test_mixed_list_raises(self):
+        im = self._im()
+        ctx = self._ctx_with(im)
+        with pytest.raises(TypeError, match="not mixed"):
+            ctx._resolve_only_valid_tasks([im, "NewA (default)"], None)

--- a/tst/models/test_in_memory_method_metadata.py
+++ b/tst/models/test_in_memory_method_metadata.py
@@ -227,3 +227,63 @@ class TestResolveOnlyValidTasks:
         ctx = self._ctx_with(im)
         with pytest.raises(TypeError, match="not mixed"):
             ctx._resolve_only_valid_tasks([im, "NewA (default)"], None)
+
+
+class TestInitOnlyValidTasks:
+    """`only_valid_tasks=True` at init pre-filters task_metadata to the new methods' tasks."""
+
+    def _im(self, method: str, datasets) -> InMemoryMethodMetadata:
+        return InMemoryMethodMetadata(
+            results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
+            method=method,
+            artifact_name=method,
+            method_type="config",
+            model_key=method,
+        )
+
+    def test_default_keeps_full_task_metadata(self):
+        ctx = AbstractArenaContext(
+            methods=[],
+            task_metadata=_task_metadata(),
+            extra_methods=[self._im("NewA", datasets=("d1",))],
+        )
+        assert ctx.only_valid_tasks is False
+        assert set(ctx.task_metadata_collection.dataset_names()) == {"d1", "d2"}
+
+    def test_prefilters_to_registered_method_tasks(self):
+        ctx = AbstractArenaContext(
+            methods=[],
+            task_metadata=_task_metadata(),
+            extra_methods=[self._im("NewA", datasets=("d1",))],
+            only_valid_tasks=True,
+        )
+        assert ctx.only_valid_tasks is True
+        # d2 had no new-method results, so it is pruned from the context's task_metadata.
+        assert ctx.task_metadata_collection.dataset_names() == ["d1"]
+        # The legacy DataFrame view derives from the (now filtered) collection.
+        assert set(ctx.task_metadata["dataset"]) == {"d1"}
+
+    def test_results_filter_frame_tracks_prefilter(self):
+        ctx = AbstractArenaContext(
+            methods=[],
+            task_metadata=_task_metadata(),
+            extra_methods=[self._im("NewA", datasets=("d1",))],
+            only_valid_tasks=True,
+        )
+        # The (dataset, fold) frame compare uses to scope results matches the kept tasks.
+        df_filter = ctx._task_metadata_results_filter()
+        assert set(zip(df_filter["dataset"], df_filter["fold"], strict=False)) == {("d1", 0)}
+
+    def test_without_in_memory_methods_raises(self):
+        with pytest.raises(ValueError, match="only_valid_tasks=True needs"):
+            AbstractArenaContext(methods=[], task_metadata=_task_metadata(), only_valid_tasks=True)
+
+    def test_no_overlap_with_task_metadata_raises(self):
+        # A method that ran a task outside the context's universe must not widen it.
+        with pytest.raises(ValueError, match="share no"):
+            AbstractArenaContext(
+                methods=[],
+                task_metadata=_task_metadata(),
+                extra_methods=[self._im("Bad", datasets=("d3",))],
+                only_valid_tasks=True,
+            )


### PR DESCRIPTION
## Problem

New (locally-run) results reach an arena context only as a DataFrame passed to `compare(new_results=...)`. The method's `MethodMetadata` object never reaches the context, so:

- **Website leaderboard** (`leaderboard_to_website_format`) builds its per-method info from `method_metadata_collection.info()` and merges on `(ta_name, ta_suite)`. A new method has no row there, so it renders with `Verified=Unknown`, `Hardware=Unknown`, and loses reference-URL / model-family typing.
- **Context operations with no `new_results` channel** (per-dataset tables, runtime plots, tuning trajectories, rename maps) don't see the new method at all.

So a new method is a second-class citizen: rows in one DataFrame handed to one method, rather than a method the context knows about.

## Change

Make locally-produced results first-class by registering them at init via the existing `methods=` / `extra_methods=` plumbing.

- **`InMemoryMethodMetadata(MethodMetadata)`** — serves `load_results` (and `load_processed`, if a repo is supplied) from memory; the disk/S3-only operations (`load_raw`, `generate_repo`, `method_downloader`/`method_uploader`, `to_yaml`) raise with a clear message. The results frame / repo are held in slots excluded from serialization, so a DataFrame never lands in the metadata info table (and thus the website merge).
- **`MethodMetadata.to_info_dict()`** hook (now used by `MethodMetadataCollection.info()`), plus an `is_in_memory` marker.
- **Vending from the end-to-end pipeline**: `EndToEndResultsSingle.to_method_metadata`, `EndToEndResults.to_method_metadata_lst`, and `EndToEnd.from_raw_to_methods` (the registration-first sibling of `from_raw_to_results_df`). `new_result_prefix` is treated as part of identity — applied to both the results frame and the metadata's `method`/`artifact_name`/`model_key`/`display_name` — so the website merge key `(ta_name, ta_suite)` still matches.
- **`AbstractArenaContext.compare`**: `only_valid_tasks` now also accepts `True` (restrict to the registered in-memory / new methods' tasks — no `new_results` needed) and `MethodMetadata` object(s), in addition to the existing method-name string/list forms. Resolution factored into a unit-tested `_resolve_only_valid_tasks` helper.

## Usage

```python
new_methods = EndToEnd.from_raw_to_methods(results_lst, task_metadata=tc, new_result_prefix="[New] ")
ctx = TabArenaContext(extra_methods=new_methods)
leaderboard = ctx.compare(output_dir=eval_dir, only_valid_tasks=True)
website = ctx.leaderboard_to_website_format(leaderboard=leaderboard)
```

See `examples/benchmarking/run_register_new_methods.py` for a complete, fast, self-contained run.

## Verification

- `examples/benchmarking/run_register_new_methods.py` run end-to-end (2 models × 3 small datasets, cached `LightGBM` baseline). New methods are picked up by `compare` via `load_results` (no `new_results=`), `only_valid_tasks=True` restricts to their 3 tasks, and the website leaderboard carries their metadata — `Hardware=CPU`, `Verified=➖` — where the current `new_results=` path shows `Unknown`.
- New unit test `tst/models/test_in_memory_method_metadata.py` (20 cases): in-memory artifact access, `to_info_dict`/`info()` excludes the DataFrame, disabled disk ops raise, prefix-as-identity coherence with the website merge key, context registration, and all `only_valid_tasks` forms. `ruff check`/`format` clean; affected `nips2025_utils` tests pass.

## Notes / limitations

- `from_raw_to_methods` goes through `EndToEndSingle.to_results()`, which drops the repo, so the in-memory methods support compare / website / per-dataset but **not** `load_repo` / simulation (they raise the clear error). Retaining the repo would mean vending from `EndToEndSingle`.
- Display names render from the base config behavior (e.g. `[New] LR`, `[New] CRF`), since `MethodMetadata.from_raw` sets a config's `display_name` to its `config_type`.
- The existing `compare(new_results=...)` path is unchanged and still valid for ad-hoc/iterative comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)