### PR TITLE
compare: forward compute_fold_similarity + fold_similarity_kwargs

### DIFF
--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -318,6 +318,8 @@ class AbstractArenaContext:
         remove_imputed: bool = False,
         leaderboard_kwargs: dict | None = None,
         figure_file_type: str = "pdf",
+        compute_fold_similarity: bool = False,
+        fold_similarity_kwargs: dict | None = None,
         **kwargs,
     ) -> pd.DataFrame:
         """Compute the leaderboard comparing ``new_results`` against this arena's baselines.
@@ -325,6 +327,13 @@ class AbstractArenaContext:
         ``ta_results`` defaults to :meth:`load_results`; ``new_results`` (if given)
         are concatenated to them. ``fillna`` / ``calibration_method`` resolve ``"auto"`` to
         the context's settings.
+
+        ``compute_fold_similarity`` ranks datasets by how consistently their folds/seeds agree
+        (and estimates folds-needed-for-stability), writing ``fold_similarity.csv`` to
+        ``output_dir``. ``fold_similarity_kwargs`` is forwarded to
+        :meth:`bencheval.tabarena.TabArena.rank_datasets_by_fold_similarity` (e.g.
+        ``{"similarity": "pearson", "target_reliability": 0.95}``); ignored unless
+        ``compute_fold_similarity`` is True.
         """
         # Deferred import: tabarena.nips2025_utils.compare imports TabArenaContext at module
         # level, which would be circular at import time.
@@ -386,6 +395,8 @@ class AbstractArenaContext:
             leaderboard_kwargs=leaderboard_kwargs,
             method_rename_map=method_rename_map,
             figure_file_type=figure_file_type,
+            compute_fold_similarity=compute_fold_similarity,
+            fold_similarity_kwargs=fold_similarity_kwargs,
             **kwargs,
         )
 

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -609,6 +609,7 @@ class TabArenaEvaluator:
         plot_pareto: bool = True,
         compute_fold_stability_curves: bool = False,
         compute_fold_similarity: bool = False,
+        fold_similarity_kwargs: dict | None = None,
         calibration_framework: str | None = "auto",
         average_seeds: bool = False,
         leaderboard_kwargs: dict | None = None,
@@ -893,7 +894,10 @@ class TabArenaEvaluator:
             save_pd.save(path=f"{self.output_dir}/fold_stability_curves.csv", df=fold_stability_curves)
 
         if compute_fold_similarity:
-            fold_similarity = tabarena.rank_datasets_by_fold_similarity(results_per_task=results_per_split)
+            fold_similarity = tabarena.rank_datasets_by_fold_similarity(
+                results_per_task=results_per_split,
+                **(fold_similarity_kwargs or {}),
+            )
             df_jitter, _ = tabarena.jitter_all_datasets(results_per_split)
             df_jitter = df_jitter.set_index("dataset")
             fold_similarity_df = fold_similarity["dataset_ranking"]

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -265,3 +265,40 @@ class TestAbstractArenaContextStandalone:
             AbstractArenaContext(methods="tabarena", task_metadata=_ctx().task_metadata_collection)
         with pytest.raises(ValueError, match="defines no presets"):
             AbstractArenaContext(methods=[], task_metadata="tabarena")
+
+
+class TestCompareFoldSimilarityForwarding:
+    """compare(compute_fold_similarity=, fold_similarity_kwargs=) reaches the lower-level compare."""
+
+    @staticmethod
+    def _base_ctx() -> AbstractArenaContext:
+        return AbstractArenaContext(methods=[], task_metadata=_ctx().task_metadata_collection)
+
+    @staticmethod
+    def _capture(monkeypatch) -> dict:
+        import tabarena.nips2025_utils.compare as compare_mod
+
+        captured: dict = {}
+
+        def fake_compare(**kwargs):
+            captured.update(kwargs)
+            return pd.DataFrame()
+
+        monkeypatch.setattr(compare_mod, "compare", fake_compare)
+        return captured
+
+    def test_forwards_flag_and_kwargs(self, monkeypatch, tmp_path):
+        captured = self._capture(monkeypatch)
+        self._base_ctx().compare(
+            output_dir=tmp_path,
+            compute_fold_similarity=True,
+            fold_similarity_kwargs={"similarity": "pearson", "target_reliability": 0.95},
+        )
+        assert captured["compute_fold_similarity"] is True
+        assert captured["fold_similarity_kwargs"] == {"similarity": "pearson", "target_reliability": 0.95}
+
+    def test_defaults_are_off(self, monkeypatch, tmp_path):
+        captured = self._capture(monkeypatch)
+        self._base_ctx().compare(output_dir=tmp_path)
+        assert captured["compute_fold_similarity"] is False
+        assert captured["fold_similarity_kwargs"] is None


### PR DESCRIPTION
## Summary

`AbstractArenaContext.compare` gains two explicit arguments:

- **`compute_fold_similarity: bool = False`** — when True, the evaluator ranks datasets by how consistently their folds/seeds agree (and estimates folds-needed-for-stability), writing `fold_similarity.csv` to `output_dir`.
- **`fold_similarity_kwargs: dict | None = None`** — forwarded into [`TabArena.rank_datasets_by_fold_similarity`](../blob/main/packages/bencheval/src/bencheval/tabarena.py) (e.g. `similarity`, `agg_fold_score`, `min_folds`, `target_reliability`, ...).

`compute_fold_similarity` already reached `TabArenaEvaluator.eval` via `**kwargs`, but `eval` hardcoded `rank_datasets_by_fold_similarity(results_per_task=...)` with no way to pass its tuning knobs. This adds a `fold_similarity_kwargs` param to `eval` and threads it through from `compare`, so the function's parameters are reachable from the public API.

## Usage

```python
ctx.compare(
    output_dir=eval_dir,
    compute_fold_similarity=True,
    fold_similarity_kwargs={"similarity": "pearson", "target_reliability": 0.95},
)
```

## Verification

- New unit tests (`tst/nips2025_utils/test_tabarena_context.py::TestCompareFoldSimilarityForwarding`): `compare` forwards both the flag and the kwargs to the lower-level compare, and they default off.
- Bounded integration run (cached `LightGBM`, 3 datasets):
  - a bogus `fold_similarity_kwargs` raises `TabArena.rank_datasets_by_fold_similarity() got an unexpected keyword argument ...` — confirming the kwargs reach that function;
  - valid kwargs write `fold_similarity.csv`, and `target_reliability=0.95` is honored (column `folds_needed_for_stability@0.95`, not the `@0.9` default);
  - `compute_fold_similarity=False` writes no csv.
- `ruff check`/`format` clean; `tst/nips2025_utils/test_tabarena_context.py` passes (29 tests).

Independent of #354; branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)