### PR TITLE
Single-hub registration workflow for arena contexts (from_new_methods, run_experiments, register)

### DIFF
--- a/examples/benchmarking/run_register_new_methods.py
+++ b/examples/benchmarking/run_register_new_methods.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         subset="lite",
         datasets=DATASETS,
         register=False,
-        debug_mode=True,
+        # debug_mode=True,  # <-- For local debugger
     )
 
     # 3: register the run as InMemoryMethodMetadata, pre-filtering the context's task_metadata to

--- a/examples/benchmarking/run_register_new_methods.py
+++ b/examples/benchmarking/run_register_new_methods.py
@@ -1,17 +1,14 @@
 """Register locally-run models with an arena context (instead of passing ``new_results=``).
 
 The counterpart to run_quickstart_tabarena.py: rather than threading a results DataFrame into
-``compare(new_results=...)``, this converts the run into ``InMemoryMethodMetadata`` objects
-(``EndToEnd.from_raw_to_methods``) and registers them at context init via
-``TabArenaContext.from_new_methods(...)``. The new methods are then first-class — picked up
-automatically by ``compare`` (through ``load_results``), restricted to their own tasks (the
-factory pre-filters ``task_metadata`` to the tasks they ran, so ``compare`` scopes to them with
-nothing extra), and carried (with their metadata: hardware, verified, ...) into
-``leaderboard_to_website_format``.
+``compare(new_results=...)``, the arena context is the single hub — ``run_experiments`` runs the
+models scoped to the chosen tasks and ``register`` turns the run into ``InMemoryMethodMetadata``
+and pre-filters ``task_metadata`` to the tasks they ran. The new methods are then first-class —
+picked up automatically by ``compare`` (through ``load_results``), restricted to their own tasks
+(so ``compare`` scopes to them with nothing extra), and carried (with their metadata: hardware,
+verified, ...) into ``leaderboard_to_website_format``.
 
-Bounded for a fast, self-contained run: 3 small datasets, and the cached ``LightGBM`` as the
-only baseline (so no ~30-method S3 download). fillna/calibration are disabled so no separate
-RandomForest baseline is needed.
+Bounded for a fast, self-contained run: 3 small datasets, first split only.
 """
 
 from __future__ import annotations
@@ -23,13 +20,7 @@ import numpy as np
 from autogluon.core.models import AbstractModel
 from autogluon.features import LabelEncoderFeatureGenerator
 
-from tabarena.benchmark.experiment import (
-    ExperimentBatchRunner,
-    TabArenaV0pt1ExperimentBundle,
-    build_jobs,
-)
-from tabarena.benchmark.task.metadata import TabArenaTaskMetadataCollection
-from tabarena.nips2025_utils.end_to_end import EndToEnd
+from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
 from tabarena.nips2025_utils.tabarena_context import TabArenaContext
 
 if TYPE_CHECKING:
@@ -104,33 +95,32 @@ if __name__ == "__main__":
     results_dir = str(here / "experiments" / run_name)
     eval_dir = here / "eval" / run_name
 
-    # 1: 3 small datasets, first split only (r0f0).
-    task_collection = TabArenaTaskMetadataCollection().subset_tasks(
-        split_indices="lite",
-        dataset_names=DATASETS,
-    )
-    task_collection = task_collection.materialize()
-
-    # 2: same two models as the quickstart.
-    bundle = TabArenaV0pt1ExperimentBundle(
+    # 1: the models to run: a registry model at its default config,
+    #    and a custom model with one extra random HPO config.
+    experiments = TabArenaV0pt1ExperimentBundle(
         models=[
             ("Linear", 0),
             (CustomRandomForestModel.config_generator(), 1),
         ],
-    )
-    experiments = bundle.build_experiments()
-    jobs = build_jobs(experiments, task_collection)
+    ).build_experiments()
 
-    # 3: run locally (in-process native backend).
-    runner = ExperimentBatchRunner(expname=results_dir, task_metadata=task_collection, debug_mode=True)
-    results_lst = runner.run_jobs(jobs)
-
-    # 4: convert the run into registerable InMemoryMethodMetadata objects.
-    new_methods = EndToEnd.from_raw_to_methods(
-        results_lst=results_lst,
-        task_metadata=task_collection,
-        new_result_prefix="[New] ",
+    # 2: the context is the hub. run_experiments builds a runner scoped to 3 small datasets'
+    #    first split (r0f0), runs it locally (debug_mode -> in-process native backend), and hands
+    #    back the raw results. register=False here so we can register them explicitly below (and
+    #    inspect the registered methods); pass register=True to do it in a single call.
+    ta_context = TabArenaContext()
+    results_lst = ta_context.run_experiments(
+        experiments,
+        expname=results_dir,
+        subset="lite",
+        datasets=DATASETS,
+        register=False,
+        debug_mode=True,
     )
+
+    # 3: register the run as InMemoryMethodMetadata, pre-filtering the context's task_metadata to
+    #    the tasks just run — so `compare` scopes to them with nothing extra.
+    new_methods = ta_context.register(results_lst, new_result_prefix="[New] ")
     print("\n=== registered in-memory methods ===")
     for m in new_methods:
         print(
@@ -138,16 +128,8 @@ if __name__ == "__main__":
             f"config_type={m.config_type!r}  display_name={m.display_name!r}  type={type(m).__name__}",
         )
 
-    # from_new_methods registers the new methods AND pre-filters the context's task_metadata to
-    # the tasks they ran, so `compare` (which scopes results to task_metadata) is already
-    # restricted to them — no only_valid_tasks=True needed at the compare call. It is shorthand
-    # for TabArenaContext(extra_methods=new_methods, only_valid_tasks=True).
-    ta_context = TabArenaContext.from_new_methods(new_methods)
-
+    # 4: compare against the cached baselines.
     leaderboard = ta_context.compare(output_dir=eval_dir)
-    print("\n=== leaderboard (raw) ===")
-    print(leaderboard.to_string())
-
     leaderboard_website = ta_context.leaderboard_to_website_format(leaderboard=leaderboard)
     print("\n=== TabArena leaderboard (website format) ===")
     print(leaderboard_website.to_markdown(index=False))

--- a/examples/benchmarking/run_register_new_methods.py
+++ b/examples/benchmarking/run_register_new_methods.py
@@ -2,10 +2,10 @@
 
 The counterpart to run_quickstart_tabarena.py: rather than threading a results DataFrame into
 ``compare(new_results=...)``, this converts the run into ``InMemoryMethodMetadata`` objects
-(``EndToEnd.from_raw_to_methods``) and registers them at context init via ``extra_methods=``.
-The new methods are then first-class — picked up automatically by ``compare`` (through
-``load_results``), restricted to their own tasks via ``only_valid_tasks=True`` at context init
-(which pre-filters ``task_metadata`` to the tasks they ran, so ``compare`` scopes to them with
+(``EndToEnd.from_raw_to_methods``) and registers them at context init via
+``TabArenaContext.from_new_methods(...)``. The new methods are then first-class — picked up
+automatically by ``compare`` (through ``load_results``), restricted to their own tasks (the
+factory pre-filters ``task_metadata`` to the tasks they ran, so ``compare`` scopes to them with
 nothing extra), and carried (with their metadata: hardware, verified, ...) into
 ``leaderboard_to_website_format``.
 
@@ -138,10 +138,11 @@ if __name__ == "__main__":
             f"config_type={m.config_type!r}  display_name={m.display_name!r}  type={type(m).__name__}",
         )
 
-    # only_valid_tasks=True pre-filters the context's task_metadata to the tasks the new
-    # methods ran, so `compare` (which scopes results to task_metadata) is already restricted
-    # to them — no need to repeat only_valid_tasks=True at the compare call.
-    ta_context = TabArenaContext(extra_methods=new_methods, only_valid_tasks=True)
+    # from_new_methods registers the new methods AND pre-filters the context's task_metadata to
+    # the tasks they ran, so `compare` (which scopes results to task_metadata) is already
+    # restricted to them — no only_valid_tasks=True needed at the compare call. It is shorthand
+    # for TabArenaContext(extra_methods=new_methods, only_valid_tasks=True).
+    ta_context = TabArenaContext.from_new_methods(new_methods)
 
     leaderboard = ta_context.compare(output_dir=eval_dir)
     print("\n=== leaderboard (raw) ===")

--- a/examples/benchmarking/run_register_new_methods_beyondarena.py
+++ b/examples/benchmarking/run_register_new_methods_beyondarena.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tabarena.benchmark.experiment import BeyondArenaExperimentBundle
+from tabarena.benchmark.task.metadata import BeyondArenaTaskMetadataCollection
+from tabarena.evaluation.context.beyond_arena import BeyondArenaContext
+
+DATASETS = [
+    "hepatitis_survival_prediction",
+    "cirrhosis_patient_survival_prediction",
+    "clock_protein_toxicity",
+]
+
+if __name__ == "__main__":
+    here = Path(__file__).parent
+    run_name = "register_new_methods_beyondarena"
+    results_dir = str(here / "experiments" / run_name)
+    eval_dir = here / "eval" / run_name
+
+    task_collection = BeyondArenaTaskMetadataCollection().subset_tasks(
+        split_indices="lite",
+        dataset_names=DATASETS,
+    )
+
+    experiments = BeyondArenaExperimentBundle(
+        models=[("Linear", 0)],
+    ).build_experiments()
+
+    context = BeyondArenaContext(task_metadata=task_collection)
+    context.run_experiments(
+        experiments,
+        expname=results_dir,
+        new_result_prefix="[New] ",
+        # debug_mode=True,  # <-- For local debugger
+    )
+    leaderboard = context.compare(output_dir=eval_dir)
+    print(leaderboard.to_markdown())

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_utils.py
@@ -23,7 +23,7 @@ class ExperimentBatchRunner:
         cache_cls: type[AbstractCacheFunction] | None = CacheFunctionPickle,
         cache_cls_kwargs: dict | None = None,
         cache_mode: Literal["default", "ignore", "only", "only_strict"] = "default",
-        debug_mode: bool = True,
+        debug_mode: bool = False,
         raise_on_failure: bool = True,
         user_tasks: list[UserTask] | None = None,
     ):
@@ -64,7 +64,7 @@ class ExperimentBatchRunner:
                     silently skip experiments whose cache is missing.
                 - "only_strict": like "only", but raise if any requested experiment is
                     missing from the cache.
-        debug_mode: bool, default True
+        debug_mode: bool, default False
             If True, will operate in a manner best suited for local model development.
             This mode is friendly to local debuggers: it skips the failure-artifact capture
             (so a fit exception propagates cleanly instead of being recorded), and it defaults

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import copy
 import functools
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Self
 
 import numpy as np
 import pandas as pd
@@ -98,6 +98,11 @@ class AbstractArenaContext:
             method_metadata_lst = list(methods)
         method_names = {m.method for m in method_metadata_lst}
 
+        # The "new" methods registered on top of the baselines via `extra_methods=`. These
+        # define the valid-task scope for `only_valid_tasks` (whether their results live in
+        # memory or are loaded from disk); `methods=` baselines are the comparison set, not the
+        # scope. Tracked by name (method names are unique — asserted below).
+        self._new_method_names: set[str] = {m.method for m in extra_methods} if extra_methods else set()
         if extra_methods:
             for method_metadata in extra_methods:
                 assert method_metadata.method not in method_names, f"{method_metadata.method} already in methods..."
@@ -107,16 +112,35 @@ class AbstractArenaContext:
         self.method_metadata_collection: MethodMetadataCollection = MethodMetadataCollection(method_metadata_lst)
 
         # When True, pre-filter the context's task_metadata down to the tasks the registered
-        # in-memory ("new") methods actually ran, so it becomes the single source of truth for
-        # what is in scope — `compare` (which scopes results to `task_metadata` by default),
-        # the runner, plotting, and per-dataset tables all inherit the restriction without the
-        # caller repeating `only_valid_tasks=True` at each call site. (The counterpart to
+        # "new" methods actually ran, so it becomes the single source of truth for what is in
+        # scope — `compare` (which scopes results to `task_metadata` by default), the runner,
+        # plotting, and per-dataset tables all inherit the restriction without the caller
+        # repeating `only_valid_tasks=True` at each call site. (The counterpart to
         # `compare(only_valid_tasks=True)`; see `run_register_new_methods.py`.)
         self.only_valid_tasks = only_valid_tasks
         if only_valid_tasks:
             self.task_metadata_collection = self.task_metadata_collection.subset(
                 self._registered_valid_task_triplets(),
             )
+
+    @classmethod
+    def from_new_methods(cls, new_methods: list[MethodMetadata], **kwargs) -> Self:
+        """Build a context with ``new_methods`` registered and scoped to the tasks they ran.
+
+        The intent-revealing shorthand for the registration-first workflow (see
+        ``examples/benchmarking/run_register_new_methods.py``): equivalent to
+        ``cls(extra_methods=new_methods, only_valid_tasks=True, **kwargs)``, but pairs the two
+        co-dependent arguments in one call so neither can be forgotten — ``only_valid_tasks=True``
+        needs registered new methods to define the valid tasks, and registering new methods is
+        almost always meant to be evaluated only on their own tasks.
+
+        ``new_methods`` are the methods to register, typically the (in-memory) ones returned by
+        :meth:`~tabarena.nips2025_utils.end_to_end.EndToEnd.from_raw_to_methods`, though any
+        ``MethodMetadata`` works (in-memory or disk-backed). The baselines / task-metadata preset
+        and any other settings (``backend``, ``fillna_method``, ...) come from ``**kwargs`` (and
+        the concrete arena's constructor defaults).
+        """
+        return cls(extra_methods=new_methods, only_valid_tasks=True, **kwargs)
 
     # ------------------------------------------------------------------ arena-specific hooks
     def _resolve_task_metadata_preset(self, name: str) -> TaskMetadataCollection:
@@ -315,22 +339,23 @@ class AbstractArenaContext:
 
     # ------------------------------------------------------------------ comparison / runner
     def _registered_new_results(self) -> pd.DataFrame | None:
-        """Concatenated results of the registered in-memory (locally-produced) methods, or None.
+        """Concatenated results of the registered "new" methods, or None.
 
-        These are the methods registered via ``methods=`` / ``extra_methods=`` whose results
-        live in memory (``is_in_memory``). ``compare`` treats them as the "new" results, so
-        ``only_valid_tasks=True`` can restrict the leaderboard to the tasks they ran without
-        the caller having to pass ``new_results`` (or list out method names) again.
+        The "new" methods are those registered on top of the baselines via ``extra_methods=``,
+        regardless of whether their results live in memory or are loaded from disk. ``methods=``
+        baselines are the comparison set, not the scope. ``compare`` treats these as the "new"
+        results, so ``only_valid_tasks=True`` can restrict the leaderboard to the tasks they ran
+        without the caller having to pass ``new_results`` (or list out method names) again.
         """
         frames = [
             m.load_results()
             for m in self.method_metadata_collection.method_metadata_lst
-            if getattr(m, "is_in_memory", False)
+            if m.method in self._new_method_names
         ]
         return pd.concat(frames, ignore_index=True) if frames else None
 
     def _registered_valid_task_triplets(self) -> list[tuple[str, int, int]]:
-        """``(dataset, fold, repeat)`` triplets the registered in-memory methods ran.
+        """``(dataset, fold, repeat)`` triplets the registered new methods ran.
 
         The valid-task scope used by ``__init__(only_valid_tasks=True)`` to pre-filter
         :attr:`task_metadata_collection`. A results frame's ``fold`` column is the *split*
@@ -342,7 +367,7 @@ class AbstractArenaContext:
         df_filter = self._registered_new_results()
         if df_filter is None:
             raise ValueError(
-                "only_valid_tasks=True needs registered in-memory methods "
+                "only_valid_tasks=True needs new methods registered via extra_methods= "
                 "(e.g. extra_methods=EndToEnd.from_raw_to_methods(...)) to define the valid tasks.",
             )
         grid = self.task_metadata_collection.task_grid()
@@ -363,7 +388,7 @@ class AbstractArenaContext:
             triplets.append((dataset, fold, repeat))
         if not triplets:
             raise ValueError(
-                "only_valid_tasks=True: the registered in-memory methods share no (dataset, split) "
+                "only_valid_tasks=True: the registered new methods share no (dataset, split) "
                 "with this context's task_metadata, so there is nothing to scope to.",
             )
         return triplets
@@ -408,8 +433,9 @@ class AbstractArenaContext:
             df_filter = new_results if new_results is not None else self._registered_new_results()
             if df_filter is None:
                 raise ValueError(
-                    "only_valid_tasks=True needs new_results or registered in-memory methods "
-                    "(e.g. extra_methods=EndToEnd.from_raw_to_methods(...)) to define the valid tasks.",
+                    "only_valid_tasks=True needs new_results or new methods registered via "
+                    "extra_methods= (e.g. extra_methods=EndToEnd.from_raw_to_methods(...)) "
+                    "to define the valid tasks.",
                 )
             return df_filter, None
         return None, None  # False / None -> no restriction
@@ -439,7 +465,7 @@ class AbstractArenaContext:
         """Compute the leaderboard comparing ``new_results`` against this arena's baselines.
 
         ``ta_results`` defaults to :meth:`load_results` (which includes any registered
-        in-memory methods); ``new_results`` (if given) are concatenated to them.
+        methods); ``new_results`` (if given) are concatenated to them.
         ``fillna`` / ``calibration_method`` resolve ``"auto"`` to the context's settings.
 
         ``filter_to_task_metadata`` (default ``True``) scopes the results to this context's
@@ -447,7 +473,7 @@ class AbstractArenaContext:
         collection are dropped before scoring. For a full-suite context this is a no-op (the
         results are already within the suite); for a context constructed with
         ``only_valid_tasks=True`` (whose ``task_metadata`` was pre-filtered to the registered
-        in-memory methods' tasks) it is what restricts the leaderboard to those tasks — so the
+        new methods' tasks) it is what restricts the leaderboard to those tasks — so the
         pre-filtered context needs nothing more here. Pass ``False`` to evaluate ``ta_results``
         / ``new_results`` exactly as given (the historical behaviour).
 
@@ -455,7 +481,7 @@ class AbstractArenaContext:
 
         * ``False`` (default) — no restriction.
         * ``True`` — restrict to the tasks the "new" results ran: ``new_results`` if given,
-          else the registered in-memory methods (so a context built with
+          else the methods registered via ``extra_methods=`` (so a context built with
           ``extra_methods=EndToEnd.from_raw_to_methods(...)`` needs nothing more here).
         * a ``MethodMetadata`` (or list) — restrict to the tasks those registered methods ran.
         * a method-column name (or list) — passed through to the lower-level compare, which

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -183,12 +183,13 @@ class AbstractArenaContext:
 
         The single-hub entry point for the registration-first workflow (see
         ``examples/benchmarking/run_register_new_methods.py``): builds a runner scoped to the
-        selected ``(dataset, fold, repeat)`` triplets (via :meth:`make_experiment_batch_runner` —
-        ``subset`` / ``datasets`` / ``splits`` / ``folds`` / ``repeats`` have the same semantics
-        there), runs every selected split (``ExperimentBatchRunner.run_all``), and — when
-        ``register`` (the default) — registers the raw results back into this context via
-        :meth:`register` (pre-filtering ``task_metadata`` to the tasks just run, so a subsequent
-        :meth:`compare` is scoped to them with nothing extra).
+        selected ``(dataset, fold, repeat)`` triplets and materialized so it is runnable (via
+        :meth:`make_experiment_batch_runner` with ``materialize=True`` — ``subset`` / ``datasets``
+        / ``splits`` / ``folds`` / ``repeats`` have the same semantics there), runs every selected
+        split (``ExperimentBatchRunner.run_all``), and — when ``register`` (the default) —
+        registers the raw results back into this context via :meth:`register` (pre-filtering
+        ``task_metadata`` to the tasks just run, so a subsequent :meth:`compare` is scoped to them
+        with nothing extra).
 
         ``expname`` is the runner's results-cache directory. Extra ``**runner_kwargs`` (e.g.
         ``debug_mode``, ``cache_mode``) reach :class:`ExperimentBatchRunner`. Returns the raw
@@ -201,6 +202,7 @@ class AbstractArenaContext:
             splits=splits,
             folds=folds,
             repeats=repeats,
+            materialize=True,
             **runner_kwargs,
         )
         results = runner.run_all(experiments)
@@ -730,6 +732,7 @@ class AbstractArenaContext:
         folds: list[int] | None = None,
         repeats: list[int] | None = None,
         dataset_fold_repeats: list[tuple[str, int, int]] | None = None,
+        materialize: bool = False,
         **kwargs,
     ) -> ExperimentBatchRunner:
         """Create an `ExperimentBatchRunner` over this context's `task_metadata`.
@@ -754,10 +757,17 @@ class AbstractArenaContext:
 
         If no filters are given, `run_all` runs every split in `task_metadata`. Extra keyword
         arguments (``cache_mode``, ``debug_mode``, ...) are forwarded to `ExperimentBatchRunner`.
-        Omitting ``debug_mode`` inherits its default (``True``): a debugger-friendly local mode
-        that, for bagged AutoGluon models, fits folds in-process ("sequential_local") rather than
-        in parallel Ray workers. Pass ``debug_mode=False`` for large-scale benchmarking (parallel
-        fold fitting + recorded failure artifacts).
+        Omitting ``debug_mode`` inherits its default (``False``): large-scale benchmarking mode
+        (parallel fold fitting + recorded failure artifacts). Pass ``debug_mode=True`` for a
+        debugger-friendly local mode that, for bagged AutoGluon models, fits folds in-process
+        ("sequential_local") rather than in parallel Ray workers.
+
+        `materialize` (default False) makes the (already-scoped) collection runnable before the
+        runner is built — downloading + converting only the selected tasks for remote-backed
+        sources (e.g. BeyondArena / Data Foundry), whose per-task cache files the runner loads at
+        fit time. A no-op for already-local sources (e.g. TabArena v0.1, which downloads its
+        OpenML data on demand). Pass True whenever the runner will actually be run against a
+        remote-backed suite (`run_experiments` does this automatically).
         """
         from tabarena.benchmark.experiment import ExperimentBatchRunner
 
@@ -790,6 +800,11 @@ class AbstractArenaContext:
         collection = self.task_metadata_collection
         if dataset_fold_repeats is not None:
             collection = collection.subset(dataset_fold_repeats)
+        # Materialize (download + convert the selected tasks) before constructing the runner —
+        # the runner resolves each task's spec from `task_id_str` in __init__, which materialize
+        # updates for remote-backed sources.
+        if materialize:
+            collection = collection.materialize()
         return ExperimentBatchRunner(
             expname=expname,
             task_metadata=collection,

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -42,7 +42,7 @@ from tabarena.repository import EvaluationRepository, EvaluationRepositoryCollec
 from tabarena.website.website_format import format_leaderboard
 
 if TYPE_CHECKING:
-    from tabarena.benchmark.experiment import ExperimentBatchRunner
+    from tabarena.benchmark.experiment import Experiment, ExperimentBatchRunner
     from tabarena.benchmark.result import BaselineResult
     from tabarena.repository.abstract_repository import AbstractRepository
 
@@ -96,32 +96,26 @@ class AbstractArenaContext:
             method_metadata_lst = self._resolve_methods_preset(methods)
         else:
             method_metadata_lst = list(methods)
-        method_names = {m.method for m in method_metadata_lst}
-
-        # The "new" methods registered on top of the baselines via `extra_methods=`. These
-        # define the valid-task scope for `only_valid_tasks` (whether their results live in
-        # memory or are loaded from disk); `methods=` baselines are the comparison set, not the
-        # scope. Tracked by name (method names are unique — asserted below).
-        self._new_method_names: set[str] = {m.method for m in extra_methods} if extra_methods else set()
-        if extra_methods:
-            for method_metadata in extra_methods:
-                assert method_metadata.method not in method_names, f"{method_metadata.method} already in methods..."
-                method_metadata_lst.append(method_metadata)
-                method_names.add(method_metadata.method)
-
         self.method_metadata_collection: MethodMetadataCollection = MethodMetadataCollection(method_metadata_lst)
 
-        # When True, pre-filter the context's task_metadata down to the tasks the registered
-        # "new" methods actually ran, so it becomes the single source of truth for what is in
-        # scope — `compare` (which scopes results to `task_metadata` by default), the runner,
-        # plotting, and per-dataset tables all inherit the restriction without the caller
+        # Names of the "new" methods registered on top of the baselines via `extra_methods=`
+        # (and :meth:`register`). These define the valid-task scope for `only_valid_tasks`
+        # (whether their results live in memory or are loaded from disk); `methods=` baselines
+        # are the comparison set, not the scope.
+        self._new_method_names: set[str] = set()
+
+        # `only_valid_tasks=True` pre-filters the context's task_metadata down to the tasks the
+        # registered "new" methods actually ran, so it becomes the single source of truth for
+        # what is in scope — `compare` (which scopes results to `task_metadata` by default), the
+        # runner, plotting, and per-dataset tables all inherit the restriction without the caller
         # repeating `only_valid_tasks=True` at each call site. (The counterpart to
         # `compare(only_valid_tasks=True)`; see `run_register_new_methods.py`.)
-        self.only_valid_tasks = only_valid_tasks
-        if only_valid_tasks:
-            self.task_metadata_collection = self.task_metadata_collection.subset(
-                self._registered_valid_task_triplets(),
-            )
+        self.only_valid_tasks = False
+        if extra_methods:
+            self._register_methods(list(extra_methods), scope_to_valid_tasks=only_valid_tasks)
+        elif only_valid_tasks:
+            # No new methods to define the scope — raise the standard, helpful error.
+            self._scope_to_valid_tasks()
 
     @classmethod
     def from_new_methods(cls, new_methods: list[MethodMetadata], **kwargs) -> Self:
@@ -141,6 +135,78 @@ class AbstractArenaContext:
         the concrete arena's constructor defaults).
         """
         return cls(extra_methods=new_methods, only_valid_tasks=True, **kwargs)
+
+    def register(
+        self,
+        results: list[BaselineResult | dict],
+        *,
+        new_result_prefix: str | None = None,
+        scope_to_valid_tasks: bool = True,
+    ) -> list[MethodMetadata]:
+        """Register externally-produced raw results into this context as new methods.
+
+        The post-construction counterpart to ``extra_methods=`` / :meth:`from_new_methods`:
+        converts ``results`` (e.g. from :meth:`run_experiments` or
+        ``ExperimentBatchRunner.run_all``) into in-memory methods via
+        :meth:`~tabarena.nips2025_utils.end_to_end.EndToEnd.from_raw_to_methods`, appends them as
+        "new" methods, and — when ``scope_to_valid_tasks`` (the default) — pre-filters
+        ``task_metadata`` to the tasks they ran so a subsequent :meth:`compare` is scoped to them
+        with nothing extra. Returns the registered methods.
+        """
+        # Deferred: tabarena.nips2025_utils.end_to_end imports TabArenaContext at module level,
+        # which would be circular at import time.
+        from tabarena.nips2025_utils.end_to_end import EndToEnd
+
+        new_methods = EndToEnd.from_raw_to_methods(
+            results_lst=results,
+            task_metadata=self.task_metadata_collection,
+            new_result_prefix=new_result_prefix,
+        )
+        self._register_methods(new_methods, scope_to_valid_tasks=scope_to_valid_tasks)
+        return new_methods
+
+    def run_experiments(
+        self,
+        experiments: list[Experiment],
+        *,
+        expname: str | Path,
+        subset: str | list[str] | None = None,
+        datasets: list[str] | None = None,
+        splits: list[int] | None = None,
+        folds: list[int] | None = None,
+        repeats: list[int] | None = None,
+        register: bool = True,
+        new_result_prefix: str | None = None,
+        **runner_kwargs,
+    ) -> list[BaselineResult]:
+        """Run ``experiments`` over this context's task_metadata and register the results.
+
+        The single-hub entry point for the registration-first workflow (see
+        ``examples/benchmarking/run_register_new_methods.py``): builds a runner scoped to the
+        selected ``(dataset, fold, repeat)`` triplets (via :meth:`make_experiment_batch_runner` —
+        ``subset`` / ``datasets`` / ``splits`` / ``folds`` / ``repeats`` have the same semantics
+        there), runs every selected split (``ExperimentBatchRunner.run_all``), and — when
+        ``register`` (the default) — registers the raw results back into this context via
+        :meth:`register` (pre-filtering ``task_metadata`` to the tasks just run, so a subsequent
+        :meth:`compare` is scoped to them with nothing extra).
+
+        ``expname`` is the runner's results-cache directory. Extra ``**runner_kwargs`` (e.g.
+        ``debug_mode``, ``cache_mode``) reach :class:`ExperimentBatchRunner`. Returns the raw
+        results list (also registered when ``register`` is True).
+        """
+        runner = self.make_experiment_batch_runner(
+            expname=str(expname),
+            subset=subset,
+            datasets=datasets,
+            splits=splits,
+            folds=folds,
+            repeats=repeats,
+            **runner_kwargs,
+        )
+        results = runner.run_all(experiments)
+        if register:
+            self.register(results, new_result_prefix=new_result_prefix)
+        return results
 
     # ------------------------------------------------------------------ arena-specific hooks
     def _resolve_task_metadata_preset(self, name: str) -> TaskMetadataCollection:
@@ -401,6 +467,39 @@ class AbstractArenaContext:
         """
         grid = self.task_metadata_collection.task_grid()
         return grid[["dataset", "split"]].rename(columns={"split": "fold"})
+
+    def _register_methods(self, new_methods: list[MethodMetadata], *, scope_to_valid_tasks: bool) -> None:
+        """Append ``new_methods`` as "new" methods (shared by ``__init__`` and :meth:`register`).
+
+        Validates name uniqueness, extends :attr:`method_metadata_collection` and
+        :attr:`_new_method_names`, and — when ``scope_to_valid_tasks`` — pre-filters
+        ``task_metadata`` to the tasks the registered new methods ran (see
+        :meth:`_scope_to_valid_tasks`).
+        """
+        existing = {m.method for m in self.method_metadata_collection.method_metadata_lst}
+        for m in new_methods:
+            assert m.method not in existing, f"{m.method} already in methods..."
+            existing.add(m.method)
+        self.method_metadata_collection = MethodMetadataCollection(
+            [*self.method_metadata_collection.method_metadata_lst, *new_methods],
+        )
+        self._new_method_names.update(m.method for m in new_methods)
+        if scope_to_valid_tasks:
+            self.only_valid_tasks = True
+            self._scope_to_valid_tasks()
+
+    def _scope_to_valid_tasks(self) -> None:
+        """Pre-filter :attr:`task_metadata_collection` to the registered new methods' tasks.
+
+        Subsets the collection to :meth:`_registered_valid_task_triplets` (raising if no new
+        methods define a scope) and invalidates the derived :attr:`task_metadata` cache.
+        """
+        self.task_metadata_collection = self.task_metadata_collection.subset(
+            self._registered_valid_task_triplets(),
+        )
+        # The legacy `task_metadata` DataFrame is a cached_property derived from the collection;
+        # drop it so it is recomputed from the now-filtered collection on next access.
+        self.__dict__.pop("task_metadata", None)
 
     def _resolve_only_valid_tasks(
         self,

--- a/tst/models/test_in_memory_method_metadata.py
+++ b/tst/models/test_in_memory_method_metadata.py
@@ -379,3 +379,92 @@ class TestFromNewMethodsFactory:
     def test_without_new_methods_raises(self):
         with pytest.raises(ValueError, match="only_valid_tasks=True needs"):
             AbstractArenaContext.from_new_methods([], methods=[], task_metadata=_task_metadata())
+
+
+class TestRegister:
+    """`register` adds run results post-construction and (by default) scopes task_metadata."""
+
+    def _im(self, method: str, datasets) -> InMemoryMethodMetadata:
+        return InMemoryMethodMetadata(
+            results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
+            method=method,
+            artifact_name=method,
+            method_type="config",
+            model_key=method,
+        )
+
+    def test_register_converts_and_scopes(self, monkeypatch):
+        # Stub the heavy raw->methods conversion; register's job is the wiring + scoping.
+        im = self._im("NewA", datasets=("d1",))
+        monkeypatch.setattr(
+            "tabarena.nips2025_utils.end_to_end.EndToEnd.from_raw_to_methods",
+            lambda **kwargs: [im],
+        )
+        ctx = AbstractArenaContext(methods=[], task_metadata=_task_metadata())
+        out = ctx.register(["raw"], new_result_prefix="[New] ")
+        assert out == [im]
+        assert "NewA" in ctx.methods
+        assert ctx.only_valid_tasks is True
+        assert ctx.task_metadata_collection.dataset_names() == ["d1"]  # d2 pruned
+
+    def test_register_without_scoping_keeps_full_task_metadata(self, monkeypatch):
+        im = self._im("NewA", datasets=("d1",))
+        monkeypatch.setattr(
+            "tabarena.nips2025_utils.end_to_end.EndToEnd.from_raw_to_methods",
+            lambda **kwargs: [im],
+        )
+        ctx = AbstractArenaContext(methods=[], task_metadata=_task_metadata())
+        ctx.register(["raw"], scope_to_valid_tasks=False)
+        assert "NewA" in ctx.methods
+        assert ctx.only_valid_tasks is False
+        assert set(ctx.task_metadata_collection.dataset_names()) == {"d1", "d2"}
+
+
+class TestRunExperiments:
+    """`run_experiments` orchestrates make_experiment_batch_runner -> run_all -> register."""
+
+    class _FakeRunner:
+        def __init__(self):
+            self.ran = None
+
+        def run_all(self, experiments):
+            self.ran = experiments
+            return ["raw-result"]
+
+    def test_scopes_runner_and_registers(self, monkeypatch):
+        ctx = AbstractArenaContext(methods=[], task_metadata=_task_metadata())
+        runner = self._FakeRunner()
+        captured: dict = {}
+        monkeypatch.setattr(
+            ctx,
+            "make_experiment_batch_runner",
+            lambda expname, **kwargs: captured.update(expname=expname, **kwargs) or runner,
+        )
+        monkeypatch.setattr(ctx, "register", lambda results, **kw: captured.update(registered=results, register_kw=kw))
+
+        out = ctx.run_experiments(
+            ["exp1"],
+            expname="run-dir",
+            subset="lite",
+            datasets=["d1"],
+            new_result_prefix="[New] ",
+            debug_mode=True,
+        )
+        assert out == ["raw-result"]
+        assert runner.ran == ["exp1"]  # experiments forwarded to run_all
+        assert captured["expname"] == "run-dir"
+        assert captured["subset"] == "lite"
+        assert captured["datasets"] == ["d1"]
+        assert captured["debug_mode"] is True  # runner_kwargs forwarded
+        assert captured["registered"] == ["raw-result"]
+        assert captured["register_kw"]["new_result_prefix"] == "[New] "
+
+    def test_register_false_skips_registration(self, monkeypatch):
+        ctx = AbstractArenaContext(methods=[], task_metadata=_task_metadata())
+        monkeypatch.setattr(ctx, "make_experiment_batch_runner", lambda expname, **kwargs: self._FakeRunner())
+        called = {"register": False}
+        monkeypatch.setattr(ctx, "register", lambda *a, **k: called.__setitem__("register", True))
+
+        out = ctx.run_experiments(["exp1"], expname="run-dir", register=False)
+        assert out == ["raw-result"]
+        assert called["register"] is False

--- a/tst/models/test_in_memory_method_metadata.py
+++ b/tst/models/test_in_memory_method_metadata.py
@@ -53,6 +53,21 @@ def _task_metadata() -> TaskMetadataCollection:
     return TaskMetadataCollection.from_legacy_df(legacy)
 
 
+class _DiskBackedMethod(MethodMetadata):
+    """A non-in-memory method whose results come from an in-test frame (stands in for disk).
+
+    ``is_in_memory`` stays False (inherited from ``MethodMetadata``), so this proves that
+    ``only_valid_tasks`` scopes by registration via ``extra_methods=`` — not by in-memory status.
+    """
+
+    def __init__(self, results: pd.DataFrame, **kwargs):
+        super().__init__(**kwargs)
+        self._results = results
+
+    def load_results(self) -> pd.DataFrame:
+        return self._results
+
+
 class TestInMemoryArtifacts:
     def test_is_in_memory_marker(self):
         assert MethodMetadata.is_in_memory is False
@@ -151,6 +166,15 @@ class TestContextRegistration:
             model_key=method,
         )
 
+    def _disk_backed(self, method: str, datasets) -> _DiskBackedMethod:
+        return _DiskBackedMethod(
+            results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
+            method=method,
+            artifact_name=method,
+            method_type="config",
+            model_key=method,
+        )
+
     def test_registered_method_is_listed_and_loadable(self):
         im = self._in_memory("NewA", datasets=("d1",))
         ctx = self._ctx(im)
@@ -158,14 +182,17 @@ class TestContextRegistration:
         loaded = ctx.load_results()
         assert set(loaded["method"]) == {"NewA (default)"}
 
-    def test_registered_new_results_concats_only_in_memory(self):
-        im_a = self._in_memory("NewA", datasets=("d1",))
-        im_b = self._in_memory("NewB", datasets=("d1", "d2"))
-        ctx = self._ctx(im_a, im_b)
+    def test_registered_new_results_concats_registered_new_methods(self):
+        # Both an in-memory and a disk-backed method registered via extra_methods= contribute;
+        # only_valid_tasks scopes by registration, not by in-memory status.
+        im = self._in_memory("NewA", datasets=("d1",))
+        disk = self._disk_backed("NewB", datasets=("d1", "d2"))
+        assert disk.is_in_memory is False
+        ctx = self._ctx(im, disk)
         new = ctx._registered_new_results()
         assert set(new["method"]) == {"NewA (default)", "NewB (default)"}
 
-    def test_registered_new_results_none_without_in_memory(self):
+    def test_registered_new_results_none_without_extra_methods(self):
         assert self._ctx()._registered_new_results() is None
 
 
@@ -263,6 +290,25 @@ class TestInitOnlyValidTasks:
         # The legacy DataFrame view derives from the (now filtered) collection.
         assert set(ctx.task_metadata["dataset"]) == {"d1"}
 
+    def test_prefilters_with_disk_backed_method(self):
+        # only_valid_tasks does not require in-memory methods: a disk-backed method registered
+        # via extra_methods= defines the valid tasks just the same.
+        disk = _DiskBackedMethod(
+            results=_results_frame("Disk (default)", datasets=("d1",), ta_name="Disk", ta_suite="Disk"),
+            method="Disk",
+            artifact_name="Disk",
+            method_type="config",
+            model_key="Disk",
+        )
+        assert disk.is_in_memory is False
+        ctx = AbstractArenaContext(
+            methods=[],
+            task_metadata=_task_metadata(),
+            extra_methods=[disk],
+            only_valid_tasks=True,
+        )
+        assert ctx.task_metadata_collection.dataset_names() == ["d1"]
+
     def test_results_filter_frame_tracks_prefilter(self):
         ctx = AbstractArenaContext(
             methods=[],
@@ -274,7 +320,7 @@ class TestInitOnlyValidTasks:
         df_filter = ctx._task_metadata_results_filter()
         assert set(zip(df_filter["dataset"], df_filter["fold"], strict=False)) == {("d1", 0)}
 
-    def test_without_in_memory_methods_raises(self):
+    def test_without_new_methods_raises(self):
         with pytest.raises(ValueError, match="only_valid_tasks=True needs"):
             AbstractArenaContext(methods=[], task_metadata=_task_metadata(), only_valid_tasks=True)
 
@@ -287,3 +333,49 @@ class TestInitOnlyValidTasks:
                 extra_methods=[self._im("Bad", datasets=("d3",))],
                 only_valid_tasks=True,
             )
+
+
+class TestFromNewMethodsFactory:
+    """`from_new_methods` pairs extra_methods + only_valid_tasks=True in one intent-revealing call."""
+
+    def _im(self, method: str, datasets) -> InMemoryMethodMetadata:
+        return InMemoryMethodMetadata(
+            results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
+            method=method,
+            artifact_name=method,
+            method_type="config",
+            model_key=method,
+        )
+
+    def test_registers_methods_and_prefilters_tasks(self):
+        ctx = AbstractArenaContext.from_new_methods(
+            [self._im("NewA", datasets=("d1",))],
+            methods=[],
+            task_metadata=_task_metadata(),
+        )
+        assert "NewA" in ctx.methods
+        assert ctx.only_valid_tasks is True
+        # d2 had no new-method results -> pruned (same as the explicit two-kwarg form).
+        assert ctx.task_metadata_collection.dataset_names() == ["d1"]
+
+    def test_returns_the_concrete_subclass(self):
+        ctx = AbstractArenaContext.from_new_methods(
+            [self._im("NewA", datasets=("d1",))],
+            methods=[],
+            task_metadata=_task_metadata(),
+        )
+        # Self return type: a factory on the base yields the base; subclasses yield themselves.
+        assert type(ctx) is AbstractArenaContext
+
+    def test_forwards_extra_kwargs(self):
+        ctx = AbstractArenaContext.from_new_methods(
+            [self._im("NewA", datasets=("d1",))],
+            methods=[],
+            task_metadata=_task_metadata(),
+            backend="native",
+        )
+        assert ctx.backend == "native"
+
+    def test_without_new_methods_raises(self):
+        with pytest.raises(ValueError, match="only_valid_tasks=True needs"):
+            AbstractArenaContext.from_new_methods([], methods=[], task_metadata=_task_metadata())

--- a/tst/models/test_in_memory_method_metadata.py
+++ b/tst/models/test_in_memory_method_metadata.py
@@ -448,16 +448,32 @@ class TestRunExperiments:
             subset="lite",
             datasets=["d1"],
             new_result_prefix="[New] ",
-            debug_mode=True,
+            debug_mode=True,  # an explicit runner_kwarg (overriding ExperimentBatchRunner's default)
         )
         assert out == ["raw-result"]
         assert runner.ran == ["exp1"]  # experiments forwarded to run_all
         assert captured["expname"] == "run-dir"
         assert captured["subset"] == "lite"
         assert captured["datasets"] == ["d1"]
+        assert captured["materialize"] is True  # runner is made runnable before run_all
         assert captured["debug_mode"] is True  # runner_kwargs forwarded
         assert captured["registered"] == ["raw-result"]
         assert captured["register_kw"]["new_result_prefix"] == "[New] "
+
+    def test_omitting_runner_kwargs_leaves_runner_defaults(self, monkeypatch):
+        # run_experiments forwards only what it is given; an unspecified debug_mode is not
+        # injected, so ExperimentBatchRunner keeps its own default (now False).
+        ctx = AbstractArenaContext(methods=[], task_metadata=_task_metadata())
+        captured: dict = {}
+        monkeypatch.setattr(
+            ctx,
+            "make_experiment_batch_runner",
+            lambda expname, **kwargs: captured.update(kwargs) or self._FakeRunner(),
+        )
+        monkeypatch.setattr(ctx, "register", lambda *a, **k: None)
+
+        ctx.run_experiments(["exp1"], expname="run-dir")
+        assert "debug_mode" not in captured  # not forwarded -> runner uses its own default
 
     def test_register_false_skips_registration(self, monkeypatch):
         ctx = AbstractArenaContext(methods=[], task_metadata=_task_metadata())

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -48,6 +48,23 @@ class TestMakeExperimentBatchRunner:
         assert runner.task_metadata_collection.dataset_fold_repeats() == [("small_ds", 0, 0), ("big_ds", 0, 0)]
         assert runner.cache_mode == "only"  # extra kwargs forwarded
 
+    def test_materialize_makes_the_scoped_collection_runnable(self, tmp_path, monkeypatch):
+        # materialize=True materializes the (scoped) collection before the runner is built.
+        from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection
+
+        calls: list[int] = []
+        orig = TaskMetadataCollection.materialize
+
+        def spy(self):
+            calls.append(len(self))
+            return orig(self)
+
+        monkeypatch.setattr(TaskMetadataCollection, "materialize", spy)
+        runner = _ctx().make_experiment_batch_runner(expname=str(tmp_path), subset="lite", materialize=True)
+        # Materialized exactly the scoped collection (2 lite tasks), and the runner still sees them.
+        assert calls == [2]
+        assert runner.task_metadata_collection.dataset_fold_repeats() == [("small_ds", 0, 0), ("big_ds", 0, 0)]
+
     def test_no_subset_leaves_full_grid(self, tmp_path):
         runner = _ctx().make_experiment_batch_runner(expname=str(tmp_path))
         # No filter -> the runner gets the full, unfiltered collection.


### PR DESCRIPTION
Makes the arena context the single hub for the registration-first workflow (run locally → register → compare), and fixes running new methods on BeyondArena. Built on top of #354 (`InMemoryMethodMetadata`).

## What's in here

**1. `AbstractArenaContext.from_new_methods(new_methods, **kwargs)`**
Intent-revealing factory — shorthand for `cls(extra_methods=new_methods, only_valid_tasks=True, **kwargs)`. Pairs the two co-dependent args in one call so neither is forgotten. Defined on the base, so `TabArenaContext`/`BeyondArenaContext` inherit it (`-> Self`).

**2. `only_valid_tasks` scopes by registration, not in-memory status**
The valid-task scope is now defined by the methods registered via `extra_methods=` (the "new" methods), whether their results live in memory or are loaded from disk. `methods=` baselines remain the comparison set, not the scope.

**3. `run_experiments` + `register` (the single hub)**
- `run_experiments(experiments, *, expname, subset/datasets/splits/folds/repeats, register=True, ...)` — builds a runner scoped to the selected triplets (via `make_experiment_batch_runner`), runs `run_all`, and registers the results back.
- `register(results, *, new_result_prefix=None, scope_to_valid_tasks=True)` — converts raw results to `InMemoryMethodMetadata`, appends them as new methods, and pre-filters `task_metadata` to the tasks they ran.

This collapses `run_register_new_methods.py` from ~5 manual steps to: build experiments → `run_experiments` → `register` → `compare`.

**4. `compare` scopes results to `task_metadata`**
`compare(filter_to_task_metadata=True)` (default) intersects `df_results` with the collection's `(dataset, split)` grid — no-op for a full-suite context, and what makes a pre-filtered (`only_valid_tasks=True`) context restrict the leaderboard. Previously `compare` never dropped result rows by `task_metadata`.

**5. BeyondArena: materialize before running + a minimal example**
`run_experiments`/`make_experiment_batch_runner` now materialize the (scoped) collection before building the runner (new `materialize=` flag). This downloads + converts only the selected tasks for remote-backed sources (BeyondArena / Data Foundry), whose per-task cache files the runner loads at fit time — fixing a `FileNotFoundError` when running new methods on BeyondArena. No-op for local sources (TabArena). Adds `examples/benchmarking/run_register_new_methods_beyondarena.py` (builds the context from the live `BeyondArenaTaskMetadataCollection`, pre-scoped by bare dataset names).

**6. `ExperimentBatchRunner` `debug_mode` default → `False`**
Aligns the `make_experiment_batch_runner` docstring and `run_experiments` tests with the new default.

## Verification
- New/updated tests for the factory, registration scoping (in-memory + disk-backed), `compare` filtering, `run_experiments`/`register` orchestration, `materialize`, and the `debug_mode` default.
- Ran the BeyondArena flow end-to-end locally: materialize downloads + writes the task cache, Linear fits, `register` produces `[New] LinearModel`, `task_metadata` scopes to the run tasks.
- `ruff check` + `ruff format --check` clean across changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)