### PR TITLE
Fix merge_metadata_frames: join on dataset identity, not all shared columns

### DIFF
--- a/packages/tabarena/src/tabarena/repository/evaluation_repository_collection.py
+++ b/packages/tabarena/src/tabarena/repository/evaluation_repository_collection.py
@@ -418,12 +418,23 @@ def merge_metadata_frames(df_list: list[pd.DataFrame]) -> pd.DataFrame:
     if not df_list:
         return pd.DataFrame()
 
-    # Decide your instance keys here.
-    # This is often something like ['dataset', 'task', 'seed'] or similar.
-    # For now, we use columns shared by all frames:
-    join_cols = list(set.intersection(*(set(df.columns) for df in df_list)))
-    if not join_cols:
+    # Join only on the instance-identity key; every other shared column is descriptive
+    # metadata to coalesce (NaN-vs-value), NOT a join key. Using *all* shared columns as keys
+    # is wrong: a descriptive column such as `class_consistency_over_splits` is all-NaN
+    # (inferred float64) in a frame whose datasets are all regression, but populated (object)
+    # in another, and pandas refuses to merge on keys with mismatched float64/object dtypes.
+    # df_metadata is one row per dataset, so `dataset` is its identity (fall back to name/tid).
+    shared_cols = set.intersection(*(set(df.columns) for df in df_list))
+    if not shared_cols:
         raise ValueError("No common columns found to use as join keys.")
+    identity_priority = ("dataset", "name", "tid")
+    join_key = next((c for c in identity_priority if c in shared_cols), None)
+    if join_key is None:
+        raise ValueError(
+            f"No instance-identity key {identity_priority} found to merge metadata frames on "
+            f"(shared columns: {sorted(shared_cols)}).",
+        )
+    join_cols = [join_key]
 
     def merge_pair(left: pd.DataFrame, right: pd.DataFrame) -> pd.DataFrame:
         overlapping_non_keys = (set(left.columns) & set(right.columns)) - set(join_cols)
@@ -464,12 +475,11 @@ def merge_metadata_frames(df_list: list[pd.DataFrame]) -> pd.DataFrame:
                         f"Conflict detected in column '{col}' for some instances.\nExamples:\n{conflict_examples}",
                     )
 
-                # 2) coalesce WITHOUT combine_first to avoid FutureWarning
-                s_out = s_l.copy()
-                mask_na = s_out.isna()
-                # where left is NaN, take right
-                s_out[mask_na] = s_r[mask_na]
-                merged[col] = s_out
+                # 2) coalesce: keep left where present, else take right. `.where` upcasts to a
+                #    common dtype (e.g. filling an all-NaN float64 column from an object column
+                #    yields object) instead of tripping pandas' "incompatible dtype" assignment
+                #    warning that a masked item-assignment would.
+                merged[col] = s_l.where(s_l.notna(), s_r)
 
                 merged = merged.drop(columns=[col_l, col_r])
 

--- a/tst/repository/test_evaluation_repository_collection.py
+++ b/tst/repository/test_evaluation_repository_collection.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from tabarena.repository.evaluation_repository_collection import merge_metadata_frames
+
+
+class TestMergeMetadataFrames:
+    """merge_metadata_frames joins per-dataset metadata on the dataset identity only."""
+
+    def test_disjoint_datasets_with_mismatched_descriptive_dtype_merge(self):
+        # Regression test: a descriptive column is object in one frame (a classification
+        # dataset) and all-NaN -> float64 in another (a regression dataset). It must NOT be
+        # used as a join key (pandas refuses to merge object vs float64 keys); joining on
+        # `dataset` only lets the frames merge and coalesces the descriptive column.
+        clf = pd.DataFrame(
+            {"dataset": ["ds_clf"], "tid": [1], "problem_type": ["binary"], "class_consistency": ["consistent"]},
+        )
+        reg = pd.DataFrame(
+            {"dataset": ["ds_reg"], "tid": [2], "problem_type": ["regression"], "class_consistency": [float("nan")]},
+        )
+        assert clf["class_consistency"].dtype == object
+        assert reg["class_consistency"].dtype == "float64"
+
+        merged = merge_metadata_frames([clf, reg]).set_index("dataset")
+        assert sorted(merged.index) == ["ds_clf", "ds_reg"]
+        assert merged.loc["ds_clf", "class_consistency"] == "consistent"
+        assert pd.isna(merged.loc["ds_reg", "class_consistency"])
+
+    def test_overlapping_dataset_coalesces_nan_with_value(self):
+        # Same dataset across frames: NaN on one side, a value on the other -> one row, value kept.
+        nan_side = pd.DataFrame({"dataset": ["ds"], "class_consistency": [float("nan")]})
+        val_side = pd.DataFrame({"dataset": ["ds"], "class_consistency": ["consistent"]})
+        merged = merge_metadata_frames([nan_side, val_side])
+        assert len(merged) == 1
+        assert merged.loc[0, "class_consistency"] == "consistent"
+
+    def test_does_not_emit_incompatible_dtype_future_warning(self):
+        clf = pd.DataFrame({"dataset": ["ds_clf"], "class_consistency": ["consistent"]})
+        reg = pd.DataFrame({"dataset": ["ds_reg"], "class_consistency": [float("nan")]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            merge_metadata_frames([clf, reg])
+
+    def test_genuine_conflict_still_raises(self):
+        a = pd.DataFrame({"dataset": ["ds"], "problem_type": ["binary"]})
+        b = pd.DataFrame({"dataset": ["ds"], "problem_type": ["multiclass"]})
+        with pytest.raises(ValueError, match="Conflict detected"):
+            merge_metadata_frames([a, b])
+
+    def test_no_identity_key_raises(self):
+        a = pd.DataFrame({"foo": [1]})
+        b = pd.DataFrame({"foo": [2]})
+        with pytest.raises(ValueError, match="identity key"):
+            merge_metadata_frames([a, b])


### PR DESCRIPTION
## Problem

`EvaluationRepositoryCollection(...)` (e.g. via `context.load_repo(...)`) fails when merging per-dataset metadata across method-repos:

```
ValueError: You are trying to merge on float64 and object columns for key 'class_consistency_over_splits'.
```

`merge_metadata_frames` used **every column shared by all frames** as a join key:

```python
join_cols = list(set.intersection(*(set(df.columns) for df in df_list)))
```

So descriptive (non-identity) columns become join keys. `class_consistency_over_splits` is a BeyondArena classification field that's `NaN` for regression datasets, so its inferred dtype differs per repo — `float64` (all-NaN) in one, `object` (populated) in another. `pd.merge` refuses to merge on a key whose dtype is `float64` on one side and `object` on the other, so the collection fails to build (after the full, slow per-repo load). The function's own docstring already says it should join on *"well-defined instance key columns"* — the implementation had regressed to "all shared columns".

## Fix

- Join only on the **instance-identity key** (`dataset`, falling back to `name`/`tid`); `df_metadata` is one row per dataset. Every other shared column flows through the existing coalesce path (`NaN`→value, conflict→raise), so descriptive-column dtype mismatches are irrelevant.
- Make the coalesce **dtype-safe** with `Series.where(...)`: filling an all-NaN `float64` column from an `object` column now upcasts, instead of tripping pandas' *"Setting an item of incompatible dtype … will raise an error in a future version"* `FutureWarning` (which the first change would otherwise surface).

## Tests

Adds `tst/repository/test_evaluation_repository_collection.py` (5 cases): the mismatched-dtype merge that previously raised, NaN↔value coalescing for a shared dataset (no duplicate rows), genuine-conflict detection still raising, the no-identity-key error, and a no-`FutureWarning` assertion. Reproduced the original `ValueError` and validated the fix on synthetic frames (no multi-minute repo load needed). `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)