### PR TITLE
Promote _subset_dataset_fold_repeats to public dataset_fold_repeats

### DIFF
--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -769,7 +769,7 @@ class AbstractArenaContext:
 
         derived = None
         if any(x is not None for x in (subset, datasets, splits, folds, repeats)):
-            derived = self._subset_dataset_fold_repeats(
+            derived = self.dataset_fold_repeats(
                 subset=subset,
                 datasets=datasets,
                 splits=splits,
@@ -802,7 +802,7 @@ class AbstractArenaContext:
             **kwargs,
         )
 
-    def _subset_dataset_fold_repeats(
+    def dataset_fold_repeats(
         self,
         subset: str | list[str] | None = None,
         datasets: list[str] | None = None,
@@ -810,7 +810,13 @@ class AbstractArenaContext:
         folds: list[int] | None = None,
         repeats: list[int] | None = None,
     ) -> list[tuple[str, int, int]]:
-        """Expand the task grid into (dataset, fold, repeat) triplets kept by the filters.
+        """Expand the task grid into the (dataset, fold, repeat) work units kept by the filters.
+
+        The public work-unit enumeration: given the same ``subset`` / ``datasets`` /
+        ``splits`` / ``folds`` / ``repeats`` filters that :meth:`make_experiment_batch_runner`
+        and :meth:`run_experiments` accept, return the exact ``(dataset, fold, repeat)`` triplets
+        those would run — without building a runner — so callers can plan, shard, or cost the work
+        up front.
 
         Evaluates the `subset` predicate expressions on the native task grid
         (:meth:`TaskMetadataCollection.task_grid` — one row per ``(dataset, fold, repeat, split)``),
@@ -840,6 +846,23 @@ class AbstractArenaContext:
             (dataset, int(fold), int(repeat))
             for dataset, fold, repeat in zip(grid["dataset"], grid["fold"], grid["repeat"], strict=False)
         ]
+
+    def _subset_dataset_fold_repeats(
+        self,
+        subset: str | list[str] | None = None,
+        datasets: list[str] | None = None,
+        splits: list[int] | None = None,
+        folds: list[int] | None = None,
+        repeats: list[int] | None = None,
+    ) -> list[tuple[str, int, int]]:
+        """Deprecated private alias for :meth:`dataset_fold_repeats` (kept for back-compat)."""
+        return self.dataset_fold_repeats(
+            subset=subset,
+            datasets=datasets,
+            splits=splits,
+            folds=folds,
+            repeats=repeats,
+        )
 
     # ------------------------------------------------------------------ artifacts / simulation / plotting
     # FIXME: Finish this, it is WIP

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -46,6 +46,14 @@ class TestSubsetDatasetFoldRepeats:
         ctx = _ctx()
         assert ctx._subset_dataset_fold_repeats("lite") == ctx.dataset_fold_repeats("lite")
 
+    def test_no_filter_returns_full_grid(self):
+        assert set(_ctx().dataset_fold_repeats()) == {
+            ("small_ds", 0, 0),
+            ("small_ds", 1, 0),
+            ("big_ds", 0, 0),
+            ("big_ds", 1, 0),
+        }
+
 
 class TestMakeExperimentBatchRunner:
     def test_subset_forwarded_as_dataset_fold_repeats(self, tmp_path):

--- a/tst/nips2025_utils/test_tabarena_context.py
+++ b/tst/nips2025_utils/test_tabarena_context.py
@@ -32,14 +32,19 @@ class TestSubsetDatasetFoldRepeats:
 
     def test_lite_keeps_split_zero_per_dataset(self):
         # "lite" == split 0 == (fold 0, repeat 0) for every dataset.
-        assert _ctx()._subset_dataset_fold_repeats("lite") == [("small_ds", 0, 0), ("big_ds", 0, 0)]
+        assert _ctx().dataset_fold_repeats("lite") == [("small_ds", 0, 0), ("big_ds", 0, 0)]
 
     def test_dataset_predicate_keeps_full_grid_of_matching_datasets(self):
         # "small" == max_train_rows <= 10000 -> only small_ds, all (fold, repeat).
-        assert _ctx()._subset_dataset_fold_repeats("small") == [("small_ds", 0, 0), ("small_ds", 1, 0)]
+        assert _ctx().dataset_fold_repeats("small") == [("small_ds", 0, 0), ("small_ds", 1, 0)]
 
     def test_predicates_are_anded(self):
-        assert _ctx()._subset_dataset_fold_repeats(["small", "lite"]) == [("small_ds", 0, 0)]
+        assert _ctx().dataset_fold_repeats(["small", "lite"]) == [("small_ds", 0, 0)]
+
+    def test_private_alias_delegates_to_public(self):
+        # `_subset_dataset_fold_repeats` is a back-compat alias for the public method.
+        ctx = _ctx()
+        assert ctx._subset_dataset_fold_repeats("lite") == ctx.dataset_fold_repeats("lite")
 
 
 class TestMakeExperimentBatchRunner:
@@ -232,12 +237,12 @@ def _ctx_collection() -> TabArenaContext:
 
 
 class TestNativeGridSubset:
-    """`_subset_dataset_fold_repeats` builds the grid natively from the collection's splits."""
+    """`dataset_fold_repeats` builds the grid natively from the collection's splits."""
 
     def test_full_grid_from_collection(self):
         ctx = _ctx_collection()
         assert ctx.task_metadata_collection is not None
-        assert set(ctx._subset_dataset_fold_repeats()) == {
+        assert set(ctx.dataset_fold_repeats()) == {
             ("small_ds", 0, 0),
             ("small_ds", 1, 0),
             ("big_ds", 0, 0),
@@ -245,14 +250,14 @@ class TestNativeGridSubset:
         }
 
     def test_lite_keeps_split_zero(self):
-        assert set(_ctx_collection()._subset_dataset_fold_repeats("lite")) == {
+        assert set(_ctx_collection().dataset_fold_repeats("lite")) == {
             ("small_ds", 0, 0),
             ("big_ds", 0, 0),
         }
 
     def test_small_predicate_keeps_small_dataset_full_grid(self):
         # "small" == max_train_rows <= 10000 -> only small_ds (n_train=100), both folds.
-        assert set(_ctx_collection()._subset_dataset_fold_repeats("small")) == {
+        assert set(_ctx_collection().dataset_fold_repeats("small")) == {
             ("small_ds", 0, 0),
             ("small_ds", 1, 0),
         }


### PR DESCRIPTION
## What

Promotes the `(dataset, fold, repeat)` work-unit enumeration on `AbstractArenaContext` from a private method to a stable public one.

- Renames `_subset_dataset_fold_repeats(...)` → **`dataset_fold_repeats(...)`** (matching the existing `TaskMetadataCollection.dataset_fold_repeats()` naming).
- Keeps `_subset_dataset_fold_repeats` as a thin **back-compat alias** that delegates to the public method (no signature/behavior change), so existing callers — including `tst/evaluation/context/test_beyond_arena_context.py` — keep working.
- Points the internal caller in `make_experiment_batch_runner` at the public name.

## Why

The work-unit list was only reachable through the private method. The public entry points (`make_experiment_batch_runner` / `run_experiments`) accept the same `subset` / `datasets` / `splits` / `folds` / `repeats` filters but only return a *runner* — never the triplet list. Callers (e.g. external adapters) that want to plan, shard, or cost the work up front had to reach into a private API. This exposes it as a supported surface without changing behavior.

## Tests

- Migrated the canonical `TestSubsetDatasetFoldRepeats` / `TestNativeGridSubset` tests to the public method.
- Added `test_private_alias_delegates_to_public` asserting the alias still returns the same result.
- `pytest tst/nips2025_utils/test_tabarena_context.py` → **31 passed**.

## Follow-up (not in this PR)

A natural next step is to also return each unit's actual per-`(fold, repeat)` sample count (from `task_grid()`) so callers don't have to re-join the coarser per-dataset `n_samples_train_per_fold` off the legacy `task_metadata` DataFrame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)