### PR TITLE
Rename bencheval `TabArena` → `BenchmarkEvaluator` + restructure (registry, module split, tests)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Raw predictions → EvaluationRepository → Simulation/Portfolio → Results Da
 - **`AbstractExecModel`** (`packages/tabarena/src/tabarena/benchmark/exec_models/base.py`) — Base for the benchmark *execution* wrappers (the AutoGluon wrappers live in `benchmark/exec_models/autogluon.py`). New benchmarked models live in one folder per model at `packages/tabarena/src/tabarena/models/<model>/` (`model.py` = AutoGluon wrapper subclassing AG's `AbstractModel`/`AbstractTorchModel`, `hpo.py` = search-space generator, `info.py` = `ModelInfo`/`MethodMetadata` registry entry), auto-discovered by `packages/tabarena/src/tabarena/models/_registry.py::discover_models()` (which `packages/tabarena/src/tabarena/benchmark/exec_models/registry.py` then derives the AG registry from). Use the **`add-model` skill** — there is no `benchmark/models/ag/<model>/` layout for new models.
 - **`ExperimentRunner` / `ExperimentBatchRunner`** (`packages/tabarena/src/tabarena/benchmark/experiment/`) — Execute model fitting across tasks. Configured via YAML (`experiment_constructor.py`).
 - **`ZeroshotSimulatorContext`** (`packages/tabarena/src/tabarena/simulation/`) — Manages config rankings for HPO simulation and portfolio generation.
-- **`TabArena`** (`packages/bencheval/src/bencheval/tabarena.py`) — Leaderboard computation from results DataFrames. Independent of the core `tabarena` package.
+- **`BenchmarkEvaluator`** (`packages/bencheval/src/bencheval/evaluator.py`) — Leaderboard computation from results DataFrames. Independent of the core `tabarena` package.
 
 ### Data caching
 
@@ -104,4 +104,4 @@ Artifacts download to `~/.cache/tabarena/` by default; override with `TABARENA_C
 - Do not add `tests/` — use `tst/`.
 - Do not import optional model dependencies at the top of shared modules; lazy-import inside the wrapper.
 - Do not skip `from __future__ import annotations` — ruff will fail CI.
-- Do not change the public API of `EvaluationRepository`, `TabularModelPredictions`, or `bencheval.tabarena.TabArena` without explicit user direction; they are consumed by external scripts and artifacts.
+- Do not change the public API of `EvaluationRepository`, `TabularModelPredictions`, or `bencheval.evaluator.BenchmarkEvaluator` without explicit user direction; they are consumed by external scripts and artifacts.

--- a/examples/!old/run_quickstart_tabarena_custom_autogluon.py
+++ b/examples/!old/run_quickstart_tabarena_custom_autogluon.py
@@ -133,9 +133,9 @@ if __name__ == "__main__":
 
     calibration_framework = "RF (default)"
 
-    from bencheval.tabarena import TabArena
+    from bencheval.evaluator import BenchmarkEvaluator
 
-    tabarena = TabArena(
+    tabarena = BenchmarkEvaluator(
         method_col="method",
         task_col="dataset",
         seed_column="fold",

--- a/examples/plots/run_generate_synthetic_leaderboard.py
+++ b/examples/plots/run_generate_synthetic_leaderboard.py
@@ -3,7 +3,7 @@
 This script:
 1) Creates synthetic long-form results with columns:
    method, task, seed, metric_error, time_train_s, time_infer_s
-2) Runs TabArena.leaderboard() with average_seeds=True and False
+2) Runs BenchmarkEvaluator.leaderboard() with average_seeds=True and False
 3) Computes and (optionally) plots a win-rate matrix
 
 Notes:
@@ -17,7 +17,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from bencheval.tabarena import TabArena
+from bencheval.evaluator import BenchmarkEvaluator
 
 
 def make_synthetic_results(
@@ -33,7 +33,7 @@ def make_synthetic_results(
     - Each seed adds small noise.
     - Includes time_train_s and time_infer_s.
 
-    Returns a long-form DataFrame suitable for TabArena.
+    Returns a long-form DataFrame suitable for BenchmarkEvaluator.
     """
     rng = np.random.default_rng(rng_seed)
 
@@ -58,7 +58,7 @@ def make_synthetic_results(
                 base = 0.20  # baseline error floor
                 error = base * task_difficulty[task] * method_skill[method]
                 error *= float(1.0 + shared_noise + rng.normal(0.0, 0.06))
-                error = max(0.0, error)  # must be >= 0 per TabArena.verify_error
+                error = max(0.0, error)  # must be >= 0 per BenchmarkEvaluator.verify_error
 
                 # times: better methods might be slower (arbitrary example)
                 time_train_s = float(
@@ -107,7 +107,7 @@ def main() -> None:
     # Provide seed_column to enable average_seeds=True/False behavior.
     # Keep defaults for:
     #   method_col="method", task_col="task", error_col="metric_error"
-    arena = TabArena(seed_column="seed")
+    arena = BenchmarkEvaluator(seed_column="seed")
 
     # ----------------------------
     # 3) Compute leaderboard

--- a/packages/bencheval/src/bencheval/_analysis.py
+++ b/packages/bencheval/src/bencheval/_analysis.py
@@ -1,0 +1,1076 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ._common import RANK
+
+
+class DatasetAnalysisMixin:
+    """Dataset / fold similarity, representativeness and jitter analytics (mixed into BenchmarkEvaluator)."""
+
+    def dataset_representativeness(
+        self,
+        results_per_task: pd.DataFrame,
+        value_col: str = RANK,
+        *,
+        similarity: str = "spearman",  # {"spearman", "pearson"}
+        population_mode: str = "loo_mean",  # {"loo_mean", "global_mean"}
+        score_mode: str = "to_population",  # {"to_population", "mean_pairwise"}
+        min_methods: int | None = None,
+    ) -> dict:
+        """Quantify how similar each dataset is to the others based on model performance,
+        then identify the most- and least-representative datasets.
+
+        Intuition
+        ---------
+        Each dataset defines a vector over methods (e.g., ranks or errors).
+        Two datasets are "similar" if these vectors are correlated across methods.
+        Representativeness is measured by how well a dataset aligns with the population.
+
+        Parameters
+        ----------
+        results_per_task : pd.DataFrame
+            Output of `self.compute_results_per_task(data=data)` (may include seed col).
+        value_col : str, default "rank"
+            Column used to compare method performance. Common:
+            - RANK (lower is better)
+            - self.error_col (lower is better)
+            - IMPROVABILITY (higher is better) [still fine; correlation handles direction]
+            - LOSS_RESCALED (lower is better)
+        similarity : {"spearman","pearson"}, default "spearman"
+            Similarity metric for comparing datasets via correlation across methods.
+            Spearman is recommended (rank-based; robust to scale).
+        population_mode : {"loo_mean","global_mean"}, default "loo_mean"
+            How to define the population reference vector:
+            - "loo_mean": reference for dataset d is mean vector over all datasets except d
+            - "global_mean": reference is mean vector over all datasets (includes d)
+        score_mode : {"to_population","mean_pairwise"}, default "to_population"
+            How to assign a single representativeness score per dataset:
+            - "to_population": correlation(dataset_vector, population_reference_vector)
+            - "mean_pairwise": average correlation to all other datasets
+        min_methods : int | None
+            If set, require at least this many methods to compute correlations.
+
+        Returns:
+        -------
+        out : dict with keys
+            - "representativeness": pd.DataFrame indexed by dataset with columns:
+                ["score", "num_methods", "num_obs"]
+            - "most_representative": str
+            - "least_representative": str
+            - "dataset_similarity_matrix": pd.DataFrame (dataset x dataset)
+            - "method_matrix": pd.DataFrame (dataset x method), values = value_col (after seed-avg)
+        """
+        if similarity not in {"spearman", "pearson"}:
+            raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
+        if population_mode not in {"loo_mean", "global_mean"}:
+            raise ValueError(f"population_mode must be 'loo_mean' or 'global_mean', got {population_mode!r}")
+        if score_mode not in {"to_population", "mean_pairwise"}:
+            raise ValueError(f"score_mode must be 'to_population' or 'mean_pairwise', got {score_mode!r}")
+
+        required = {self.task_col, self.method_col, value_col}
+        missing = [c for c in required if c not in results_per_task.columns]
+        if missing:
+            raise ValueError(
+                f"results_per_task is missing required columns: {missing}\n"
+                f"Available columns: {list(results_per_task.columns)}",
+            )
+
+        df = results_per_task.copy()
+
+        # If seed column exists, average within (task, method) so each dataset has one value per method.
+        group_cols = [self.task_col, self.method_col]
+        if self.seed_column is not None and self.seed_column in df.columns:
+            df = df.groupby(group_cols, as_index=False)[value_col].mean()
+
+        # Pivot to dataset x method matrix
+        M = df.pivot(index=self.task_col, columns=self.method_col, values=value_col)
+
+        # Optional sanity: require sufficient overlap
+        num_methods_per_dataset = M.notna().sum(axis=1)
+        if min_methods is not None:
+            keep = num_methods_per_dataset >= min_methods
+            M = M.loc[keep]
+            num_methods_per_dataset = num_methods_per_dataset.loc[keep]
+            if M.shape[0] == 0:
+                raise ValueError(f"No datasets have >= {min_methods} methods after filtering.")
+
+        # If you're using BenchmarkEvaluator's verify_data_is_dense, M should be fully dense.
+        # But we handle missingness by using pairwise corr + aligning vectors where needed.
+
+        # 1) Dataset↔dataset similarity matrix (correlation across methods)
+        # corr over rows => easiest via transpose (methods as rows, datasets as cols)
+        dataset_sim = M.T.corr(method=similarity)
+
+        # 2) Representativeness score per dataset
+        if score_mode == "mean_pairwise":
+            # Mean similarity to all other datasets (exclude self)
+            score = (
+                (dataset_sim.sum(axis=1) - 1.0) / (dataset_sim.shape[0] - 1)
+                if dataset_sim.shape[0] > 1
+                else dataset_sim.iloc[:, 0]
+            )
+        # Similarity to a "population reference vector"
+        # Reference vector is mean performance across datasets (optionally leave-one-out).
+        elif population_mode == "global_mean":
+            ref = M.mean(axis=0)
+            score = M.apply(lambda row: row.corr(ref, method=similarity), axis=1)
+        else:
+            # Leave-one-out mean reference: ref_d = mean of all datasets except d
+            # Compute efficiently: total_sum - row, then divide by (n-1)
+            n = M.shape[0]
+            if n <= 1:
+                score = pd.Series(index=M.index, data=np.nan, dtype=float)
+            else:
+                total = M.sum(axis=0)
+
+                def loo_corr(row: pd.Series) -> float:
+                    ref_d = (total - row) / (n - 1)
+                    return row.corr(ref_d, method=similarity)
+
+                score = M.apply(loo_corr, axis=1)
+
+        rep = pd.DataFrame(
+            {
+                "score": score,
+                "num_methods": num_methods_per_dataset,
+                "num_obs": df.groupby(self.task_col).size().reindex(M.index).astype(int),
+            }
+        ).sort_values("score", ascending=False)
+
+        most_rep = rep.index[0]
+        least_rep = rep.index[-1]
+
+        return {
+            "representativeness": rep,
+            "most_representative": most_rep,
+            "least_representative": least_rep,
+            "dataset_similarity_matrix": dataset_sim.loc[M.index, M.index],
+            "method_matrix": M,
+        }
+
+    def dataset_fold_similarity(
+        self,
+        results_per_task: pd.DataFrame,
+        dataset: str,
+        value_col: str = RANK,
+        *,
+        similarity: str = "spearman",  # {"spearman", "pearson"}
+        agg_across_methods: str = "mean",  # {"mean", "median"}
+        min_methods: int | None = None,
+        return_pairwise: bool = True,
+    ) -> dict:
+        """Quantify how similar a dataset's folds/seeds are, based on how methods perform.
+
+        Assumes `results_per_task` was produced with `include_seed_col=True`, so that
+        each row corresponds to (task, seed, method) with a metric like rank/error.
+
+        Approach
+        --------
+        For the chosen dataset, build a matrix:
+            rows = fold/seed
+            cols = method
+            values = value_col (e.g., rank or metric_error)
+
+        Then compute fold↔fold similarity as correlation across methods.
+
+        Parameters
+        ----------
+        results_per_task : pd.DataFrame
+            Output of `self.compute_results_per_task(..., include_seed_col=True)`.
+            Must include `self.seed_column` and `value_col`.
+        dataset : str
+            Task/dataset name (value from `self.task_col`) to analyze.
+        value_col : str, default RANK
+            Performance column to compare across folds. Good defaults:
+            - RANK (ranking alignment)
+            - self.error_col (raw metric error)
+            - IMPROVABILITY, LOSS_RESCALED, etc.
+        similarity : {"spearman","pearson"}, default "spearman"
+            Correlation type for fold similarity.
+        agg_across_methods : {"mean","median"}, default "mean"
+            How to aggregate a per-fold similarity score from its similarities to other folds.
+        min_methods : int | None
+            If set, require each fold have at least this many methods present
+            (after pivot) to be included.
+        return_pairwise : bool, default True
+            If True, also return a tidy dataframe of fold-pair similarities.
+
+        Returns:
+        -------
+        out : dict
+            - "fold_similarity_matrix": pd.DataFrame (fold x fold)
+            - "fold_scores": pd.DataFrame indexed by fold with columns:
+                ["score", "num_methods"]
+            - "most_similar_pair": tuple | None  (fold_i, fold_j, sim)
+            - "least_similar_pair": tuple | None (fold_i, fold_j, sim)
+            - "fold_method_matrix": pd.DataFrame (fold x method)
+            - "pairwise": pd.DataFrame (optional) columns [seed_i, seed_j, similarity]
+        """
+        if self.seed_column is None:
+            raise ValueError("BenchmarkEvaluator.seed_column is None, but fold similarity requires a seed/fold column.")
+        if self.seed_column not in results_per_task.columns:
+            raise ValueError(
+                f"results_per_task must include seed column {self.seed_column!r}. "
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
+            )
+        if similarity not in {"spearman", "pearson"}:
+            raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
+        if agg_across_methods not in {"mean", "median"}:
+            raise ValueError(f"agg_across_methods must be 'mean' or 'median', got {agg_across_methods!r}")
+
+        required = {self.task_col, self.method_col, self.seed_column, value_col}
+        missing = [c for c in required if c not in results_per_task.columns]
+        if missing:
+            raise ValueError(
+                f"results_per_task is missing required columns: {missing}\n"
+                f"Available columns: {list(results_per_task.columns)}",
+            )
+
+        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
+        if df.empty:
+            raise ValueError(
+                f"No rows found for {self.task_col} == {dataset!r}.\n"
+                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}",
+            )
+
+        # If duplicates exist for (task, seed, method), average them.
+        df = df.groupby([self.task_col, self.seed_column, self.method_col], as_index=False)[value_col].mean()
+
+        # Pivot -> folds x methods
+        M = df.pivot(index=self.seed_column, columns=self.method_col, values=value_col)
+
+        # Optionally filter folds with insufficient method coverage
+        num_methods_per_fold = M.notna().sum(axis=1)
+        if min_methods is not None:
+            keep = num_methods_per_fold >= min_methods
+            M = M.loc[keep]
+            num_methods_per_fold = num_methods_per_fold.loc[keep]
+            if M.shape[0] == 0:
+                raise ValueError(f"No folds have >= {min_methods} methods after filtering.")
+
+        # Correlation across methods between folds
+        # corr over rows => transpose to make folds columns
+        fold_sim = M.T.corr(method=similarity)
+
+        # Per-fold "representativeness among folds": average similarity to other folds
+        if fold_sim.shape[0] <= 1:
+            scores = pd.Series(index=fold_sim.index, data=np.nan, dtype=float)
+        else:
+            off_diag = fold_sim.copy()
+            np.fill_diagonal(off_diag.values, np.nan)
+            if agg_across_methods == "mean":
+                scores = off_diag.mean(axis=1, skipna=True)
+            else:
+                scores = off_diag.median(axis=1, skipna=True)
+
+        fold_scores = pd.DataFrame(
+            {
+                "score": scores,
+                "num_methods": num_methods_per_fold.reindex(fold_sim.index).astype(int),
+            }
+        ).sort_values("score", ascending=False)
+
+        # Identify most/least similar fold pairs
+        most_pair = None
+        least_pair = None
+        if fold_sim.shape[0] >= 2:
+            # consider only upper triangle (excluding diagonal)
+            sim_vals = fold_sim.where(np.triu(np.ones(fold_sim.shape), k=1).astype(bool))
+            stacked = sim_vals.stack(future_stack=True)  # MultiIndex (seed_i, seed_j) -> similarity
+            if len(stacked) > 0:
+                (i_max, j_max), v_max = stacked.idxmax(), float(stacked.max())
+                (i_min, j_min), v_min = stacked.idxmin(), float(stacked.min())
+                most_pair = (i_max, j_max, v_max)
+                least_pair = (i_min, j_min, v_min)
+
+        out = {
+            "fold_similarity_matrix": fold_sim,
+            "fold_scores": fold_scores,
+            "most_similar_pair": most_pair,
+            "least_similar_pair": least_pair,
+            "fold_method_matrix": M,
+        }
+
+        if return_pairwise and fold_sim.shape[0] >= 2:
+            sim_vals = fold_sim.where(np.triu(np.ones(fold_sim.shape), k=1).astype(bool))
+
+            # Ensure the row/col index level names are unique before stacking,
+            # otherwise reset_index can try to insert a column that already exists.
+            idx_name = fold_sim.index.name or self.seed_column or "fold"
+            col_name = fold_sim.columns.name or self.seed_column or "fold"
+
+            # Use internal unique names for stack/reset_index
+            sim_vals_safe = sim_vals.copy()
+            sim_vals_safe.index = sim_vals_safe.index.rename(f"__{idx_name}_i")
+            sim_vals_safe.columns = sim_vals_safe.columns.rename(f"__{col_name}_j")
+
+            # pandas >= 2.1: support future_stack=True (silences FutureWarning)
+            try:
+                s = sim_vals_safe.stack(future_stack=True)
+            except TypeError:
+                s = sim_vals_safe.stack(dropna=True)
+            s = s.dropna()
+
+            pairwise = s.rename("similarity").reset_index()
+
+            # Rename back to desired output names (avoid collisions on rename too)
+            col_i = f"{self.seed_column}_i"
+            col_j = f"{self.seed_column}_j"
+            pairwise = pairwise.rename(
+                columns={
+                    f"__{idx_name}_i": col_i,
+                    f"__{col_name}_j": col_j,
+                }
+            )
+
+            pairwise = pairwise.sort_values("similarity", ascending=False).reset_index(drop=True)
+            out["pairwise"] = pairwise
+        return out
+
+    def rank_datasets_by_fold_similarity(
+        self,
+        results_per_task: pd.DataFrame,
+        value_col: str = RANK,
+        *,
+        similarity: str = "spearman",  # {"spearman", "pearson"}
+        agg_fold_score: str = "mean_pairwise",  # {"mean_pairwise", "median_pairwise"}
+        min_folds: int = 2,
+        min_methods: int | None = None,
+        include_pairwise_extremes: bool = True,
+        # --- new: stability estimation controls ---
+        target_reliability: float = 0.90,
+        stability_cap_folds: int = 100,
+        stability_conservative: bool = True,
+        stability_rho_floor: float = 0.01,
+    ) -> dict:
+        """Rank datasets by how consistently their folds/seeds agree with each other,
+        and estimate how many folds are needed to get a stable global ordering.
+
+        Assumes `results_per_task` was computed with `include_seed_col=True` so that
+        each row corresponds to (task, seed, method) with a metric like rank/error.
+
+        For each dataset:
+          1) build fold x method matrix
+          2) compute fold-fold similarity matrix (correlation across methods)
+          3) summarize it into a single "fold agreement" score
+          4) estimate stability/reliability of the k-fold aggregate and folds needed
+             to hit `target_reliability`, using Spearman–Brown style extrapolation:
+                Rel(k) = (k*rho) / (1 + (k-1)*rho)
+             where rho ~= fold_agreement.
+
+        Parameters
+        ----------
+        results_per_task : pd.DataFrame
+            Output of `self.compute_results_per_task(..., include_seed_col=True)`.
+            Must include `self.seed_column`.
+        value_col : str, default RANK
+            Column used to compare method performance across folds.
+        similarity : {"spearman","pearson"}, default "spearman"
+            Similarity metric for fold-fold correlation across methods.
+        agg_fold_score : {"mean_pairwise","median_pairwise"}, default "mean_pairwise"
+            How to aggregate fold-fold similarities into a dataset score.
+        min_folds : int, default 2
+            Require at least this many folds/seeds for a dataset to be scored.
+        min_methods : int | None
+            If set, require each fold have at least this many methods present.
+            Passed through to `dataset_fold_similarity`.
+        include_pairwise_extremes : bool, default True
+            If True, include the most/least similar fold pair per dataset.
+        target_reliability : float, default 0.90
+            Stability threshold τ in (0,1). Higher = stricter stability requirement.
+        stability_cap_folds : int, default 100
+            Maximum folds to return for `folds_needed_for_stability@τ`.
+        stability_conservative : bool, default True
+            If True, treat rho<=0 as "not stably orderable" and return cap (with rho floored).
+        stability_rho_floor : float, default 0.01
+            Minimum rho used when conservative and rho is extremely small/negative.
+
+        Returns:
+        -------
+        out : dict
+            - "dataset_ranking": pd.DataFrame indexed by dataset with columns:
+                ["fold_agreement", "num_folds", "num_methods_min", "num_methods_mean",
+                 "rho_used", "stability_at_num_folds@{τ}", "folds_needed_for_stability@{τ}",
+                 "most_similar_pair", "least_similar_pair" (optional), "error" (optional)]
+              sorted descending by fold_agreement.
+            - "per_dataset": dict[str, dict]
+              Lightweight per-dataset summary.
+            - "stability_params": dict
+              Echo of stability configuration.
+        """
+        if self.seed_column is None:
+            raise ValueError(
+                "BenchmarkEvaluator.seed_column is None, but fold similarity ranking requires a seed/fold column."
+            )
+        if self.seed_column not in results_per_task.columns:
+            raise ValueError(
+                f"results_per_task must include seed column {self.seed_column!r}. "
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
+            )
+        if agg_fold_score not in {"mean_pairwise", "median_pairwise"}:
+            raise ValueError(
+                f"agg_fold_score must be 'mean_pairwise' or 'median_pairwise', got {agg_fold_score!r}",
+            )
+        if similarity not in {"spearman", "pearson"}:
+            raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
+        if not (0 < float(target_reliability) < 1):
+            raise ValueError(f"target_reliability must be in (0,1), got {target_reliability!r}")
+
+        tau = float(target_reliability)
+        tau_tag = f"{tau:.2f}".rstrip("0").rstrip(".")  # e.g. "0.9" or "0.95"
+        col_stability_at_k = "stability_at_num_folds"
+        col_folds_needed = f"folds_needed_for_stability@{tau_tag}"
+
+        def _rel(k: int, rho: float) -> float:
+            if k <= 0 or not np.isfinite(rho) or rho <= 0:
+                return 0.0
+            return (k * rho) / (1.0 + (k - 1) * rho)
+
+        def _folds_needed(rho: float) -> int:
+            # k >= tau(1-rho)/(rho(1-tau))
+            if not np.isfinite(rho) or rho <= 0:
+                return int(stability_cap_folds)
+            k_float = (tau * (1.0 - rho)) / (rho * (1.0 - tau))
+            k_req = int(np.ceil(k_float))
+            return max(1, min(int(stability_cap_folds), k_req))
+
+        datasets = list(pd.Index(results_per_task[self.task_col].unique()).sort_values())
+
+        rows: list[dict] = []
+        per_dataset: dict[str, dict] = {}
+
+        for ds in datasets:
+            try:
+                out_ds = self.dataset_fold_similarity(
+                    results_per_task=results_per_task,
+                    dataset=ds,
+                    value_col=value_col,
+                    similarity=similarity,
+                    agg_across_methods="mean",  # not used for dataset score
+                    min_methods=min_methods,
+                    return_pairwise=False,
+                )
+            except Exception as e:
+                rows.append(
+                    {
+                        self.task_col: ds,
+                        "fold_agreement": np.nan,
+                        "num_folds": 0,
+                        "num_methods_min": np.nan,
+                        "num_methods_mean": np.nan,
+                        "rho_used": np.nan,
+                        col_stability_at_k: np.nan,
+                        col_folds_needed: np.nan,
+                        "error": repr(e),
+                    }
+                )
+                continue
+
+            fold_sim = out_ds["fold_similarity_matrix"]
+            fold_method = out_ds["fold_method_matrix"]
+
+            num_folds = int(fold_sim.shape[0])
+            methods_per_fold = fold_method.notna().sum(axis=1)
+            num_methods_min = int(methods_per_fold.min()) if len(methods_per_fold) else np.nan
+            num_methods_mean = float(methods_per_fold.mean()) if len(methods_per_fold) else np.nan
+
+            if num_folds < min_folds:
+                rows.append(
+                    {
+                        self.task_col: ds,
+                        "fold_agreement": np.nan,
+                        "num_folds": num_folds,
+                        "num_methods_min": num_methods_min,
+                        "num_methods_mean": num_methods_mean,
+                        "rho_used": np.nan,
+                        col_stability_at_k: np.nan,
+                        col_folds_needed: np.nan,
+                        "error": f"Too few folds (min_folds={min_folds})",
+                    }
+                )
+                continue
+
+            # Aggregate off-diagonal similarities into dataset agreement score (rho estimate)
+            sim_vals = fold_sim.to_numpy(copy=True)
+            np.fill_diagonal(sim_vals, np.nan)
+
+            rho = float(np.nanmean(sim_vals)) if agg_fold_score == "mean_pairwise" else float(np.nanmedian(sim_vals))
+
+            rho_used = rho
+            notes = None
+            if stability_conservative:
+                # clamp to [-1,1]
+                if rho_used > 1:
+                    rho_used = 1.0
+                if rho_used < -1:
+                    rho_used = -1.0
+                if rho_used <= 0:
+                    # treat as not reliably aggregatable; use floor for rel(k) curve but folds_needed -> cap
+                    notes = "rho<=0; stability may not be achievable by averaging folds alone"
+                    rho_used = max(float(stability_rho_floor), 0.0)
+
+            stability_at_k = float(_rel(num_folds, rho_used))
+            folds_needed = int(_folds_needed(rho_used))
+
+            row = {
+                self.task_col: ds,
+                "fold_agreement": rho,  # raw estimate from observed fold similarities
+                "num_folds": num_folds,
+                "num_methods_min": num_methods_min,
+                "num_methods_mean": num_methods_mean,
+                "rho_used": rho_used,  # what we used for stability extrapolation
+                col_stability_at_k: stability_at_k,
+                col_folds_needed: folds_needed,
+            }
+            if notes is not None:
+                row["stability_note"] = notes
+
+            if include_pairwise_extremes and num_folds >= 2:
+                tri = np.triu(np.ones_like(sim_vals, dtype=bool), k=1)
+                vals = sim_vals[tri]
+                if np.isfinite(vals).any():
+                    fold_labels = list(fold_sim.index)
+                    ij = np.argwhere(tri)
+                    k_max = int(np.nanargmax(vals))
+                    i_max, j_max = map(int, ij[k_max])
+                    row["most_similar_pair"] = (fold_labels[i_max], fold_labels[j_max], float(vals[k_max]))
+
+                    k_min = int(np.nanargmin(vals))
+                    i_min, j_min = map(int, ij[k_min])
+                    row["least_similar_pair"] = (fold_labels[i_min], fold_labels[j_min], float(vals[k_min]))
+                else:
+                    row["most_similar_pair"] = None
+                    row["least_similar_pair"] = None
+
+            rows.append(row)
+
+            per_dataset[ds] = {
+                "fold_agreement": rho,
+                "num_folds": num_folds,
+                "num_methods_min": num_methods_min,
+                "num_methods_mean": num_methods_mean,
+                "rho_used": rho_used,
+                col_stability_at_k: stability_at_k,
+                col_folds_needed: folds_needed,
+            }
+            if notes is not None:
+                per_dataset[ds]["stability_note"] = notes
+            if include_pairwise_extremes:
+                per_dataset[ds]["most_similar_pair"] = row.get("most_similar_pair")
+                per_dataset[ds]["least_similar_pair"] = row.get("least_similar_pair")
+
+        ranking = pd.DataFrame(rows).set_index(self.task_col)
+        ranking = ranking.sort_values(by="fold_agreement", ascending=False)
+
+        return {
+            "dataset_ranking": ranking,
+            "per_dataset": per_dataset,
+            "stability_params": {
+                "target_reliability": tau,
+                "cap_folds": stability_cap_folds,
+                "conservative": stability_conservative,
+                "rho_floor": stability_rho_floor,
+                "similarity": similarity,
+                "agg_fold_score": agg_fold_score,
+            },
+        }
+
+    def jitter_all_datasets(
+        self,
+        results_per_task: pd.DataFrame,
+        *,
+        rank_col: str = RANK,
+        metric: str = "winrate",
+        datasets: list[str] | None = None,
+        return_per_method: bool = False,
+        sort_by: str = "jitter_mean",
+        ascending: bool = True,
+    ) -> tuple[pd.DataFrame, dict[str, dict] | None]:
+        """Compute fold jitter metrics for each dataset.
+
+        This is a wrapper around `self.dataset_jitter(...)`.
+
+        Parameters
+        ----------
+        results_per_task : pd.DataFrame
+            Output of `self.compute_results_per_task(..., include_seed_col=True)`.
+        rank_col : str, default RANK
+            Column read for per-fold ranks (rescaled to winrate when metric="winrate").
+        metric : {"winrate", "rank"}, default "winrate"
+            Per-method per-fold score used to compute jitter. ``"winrate"`` rescales the
+            rank to ``1 - (rank - 1)/(M - 1)`` so jitter values are in [0, 1] and
+            comparable across benchmarks with different method counts.
+        datasets : list[str] | None
+            If specified, only compute for these datasets. Otherwise uses all unique datasets.
+        return_per_method : bool, default False
+            If True, also return a dict keyed by dataset with per-method jitter outputs.
+        sort_by : str, default "jitter_mean"
+            Column name to sort the returned DataFrame by.
+        ascending : bool, default True
+            Sort direction.
+
+        Returns:
+        -------
+        df : pd.DataFrame
+            One row per dataset with:
+            ["dataset", "metric", "num_folds", "num_methods", "jitter_mean", "pairwise_jitter_mean"]
+            plus "error" if a dataset fails.
+        per_method : dict[str, dict] | None
+            If return_per_method=True, a dict of per-dataset detailed outputs; else None.
+        """
+        if self.seed_column is None:
+            raise ValueError("seed_column must be set to compute fold jitter.")
+        if self.seed_column not in results_per_task.columns:
+            raise ValueError(
+                f"results_per_task must include seed column {self.seed_column!r}. "
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
+            )
+
+        if datasets is None:
+            datasets = list(pd.Index(results_per_task[self.task_col].unique()).sort_values())
+
+        rows: list[dict] = []
+        per_method: dict[str, dict] | None = {} if return_per_method else None
+
+        for ds in datasets:
+            try:
+                out = self.dataset_jitter(
+                    results_per_task=results_per_task,
+                    dataset=ds,
+                    rank_col=rank_col,
+                    metric=metric,
+                    return_per_method=return_per_method,
+                )
+                # ensure consistent row schema
+                rows.append(
+                    {
+                        "dataset": out["dataset"],
+                        "metric": out["metric"],
+                        "num_folds": out["num_folds"],
+                        "num_methods": out["num_methods"],
+                        "jitter_mean": out["jitter_mean"],
+                        "pairwise_jitter_mean": out["pairwise_jitter_mean"],
+                    }
+                )
+
+                if return_per_method:
+                    assert per_method is not None
+                    # Keep only the per-method parts to avoid duplication
+                    per_method[ds] = {
+                        "per_method_jitter_mean": out.get("per_method_jitter_mean", None),
+                        "per_method_pairwise_jitter_mean": out.get("per_method_pairwise_jitter_mean", None),
+                    }
+
+            except Exception as e:
+                rows.append(
+                    {
+                        "dataset": ds,
+                        "metric": metric,
+                        "num_folds": np.nan,
+                        "num_methods": np.nan,
+                        "jitter_mean": np.nan,
+                        "pairwise_jitter_mean": np.nan,
+                        "error": repr(e),
+                    }
+                )
+                if return_per_method:
+                    assert per_method is not None
+                    per_method[ds] = {"error": repr(e)}
+
+        df = pd.DataFrame(rows)
+
+        if sort_by is not None and sort_by in df.columns:
+            df = df.sort_values(by=sort_by, ascending=ascending, na_position="last").reset_index(drop=True)
+
+        return df, per_method
+
+    def dataset_jitter(
+        self,
+        results_per_task: pd.DataFrame,
+        dataset: str,
+        *,
+        rank_col: str = RANK,
+        metric: str = "winrate",
+        return_per_method: bool = False,
+    ) -> dict:
+        """Compute fold-instability metrics for a dataset.
+
+        ``metric`` selects the per-fold per-method score:
+          - ``"winrate"`` (default): per-fold winrate ``1 - (rank - 1) / (M - 1)``,
+            in [0, 1] regardless of M. Comparable across benchmarks with different
+            method counts.
+          - ``"rank"``: raw per-fold rank from ``rank_col``, scale depends on M.
+
+        Metrics returned:
+          - jitter_mean:
+                E_{fold, method}[ |score_fold - score_global| ]
+          - pairwise_jitter_mean:
+                E_{fold1<fold2, method}[ |score_f1 - score_f2| ]
+
+        Assumes results_per_task was computed with include_seed_col=True.
+
+        Parameters
+        ----------
+        results_per_task : pd.DataFrame
+        dataset : str
+        rank_col : str
+            Source rank column (default: RANK).
+        metric : {"winrate", "rank"}, default "winrate"
+        return_per_method : bool
+            If True, also return per-method jitter statistics.
+
+        Returns:
+        -------
+        dict
+        """
+        if metric not in ("winrate", "rank"):
+            raise ValueError(f"metric must be 'winrate' or 'rank', got {metric!r}")
+        if self.seed_column is None:
+            raise ValueError("seed_column must be set to compute fold jitter.")
+        if self.seed_column not in results_per_task.columns:
+            raise ValueError(
+                "results_per_task must include seed column. Call compute_results_per_task(..., include_seed_col=True)",
+            )
+
+        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
+
+        if df.empty:
+            raise ValueError(f"No rows found for dataset {dataset!r}")
+
+        # Pivot: folds x methods (values are ranks; rescaled to winrate below if requested)
+        M = df.pivot(
+            index=self.seed_column,
+            columns=self.method_col,
+            values=rank_col,
+        )
+
+        # Drop methods with any missing folds
+        M = M.dropna(axis=1)
+
+        folds = M.index.tolist()
+        methods = M.columns.tolist()
+
+        num_folds = len(folds)
+        num_methods = len(methods)
+
+        if num_folds < 2:
+            raise ValueError("Need at least 2 folds to compute jitter.")
+        if num_methods < 2:
+            raise ValueError("Need at least 2 methods to compute jitter.")
+
+        if metric == "winrate":
+            # winrate = 1 - (rank - 1) / (M - 1); in [0, 1] regardless of M.
+            M = 1.0 - (M - 1.0) / (num_methods - 1)
+
+        # ---------------------------------------------------------
+        # 1) Expected jitter: deviation of per-fold score from the global mean
+        # ---------------------------------------------------------
+
+        global_score = M.mean(axis=0)
+
+        abs_dev = (M - global_score).abs()
+
+        jitter_mean = abs_dev.values.mean()
+
+        # ---------------------------------------------------------
+        # 2) Pairwise jitter: average absolute change between folds
+        # ---------------------------------------------------------
+
+        pairwise_changes = []
+
+        for i in range(num_folds):
+            for j in range(i + 1, num_folds):
+                diff = (M.iloc[i] - M.iloc[j]).abs()
+                pairwise_changes.append(diff.values.mean())
+
+        pairwise_jitter_mean = float(np.mean(pairwise_changes))
+
+        result = {
+            "dataset": dataset,
+            "metric": metric,
+            "num_folds": num_folds,
+            "num_methods": num_methods,
+            "jitter_mean": float(jitter_mean),
+            "pairwise_jitter_mean": pairwise_jitter_mean,
+        }
+
+        if return_per_method:
+            result["per_method_jitter_mean"] = abs_dev.mean(axis=0)
+            result["per_method_pairwise_jitter_mean"] = pd.concat(
+                [(M.iloc[i] - M.iloc[j]).abs() for i in range(num_folds) for j in range(i + 1, num_folds)],
+                axis=1,
+            ).mean(axis=1)
+
+        return result
+
+    def dataset_jitter_bootstrap_curve(
+        self,
+        results_per_task: pd.DataFrame,
+        dataset: str,
+        *,
+        rank_col: str = RANK,
+        metric: str = "winrate",
+        k_values: list[int] | None = None,
+        n_bootstrap: int = 500,
+        seed: int = 0,
+        drop_methods_with_any_missing: bool = True,
+    ) -> pd.DataFrame:
+        """Bootstrap how the k-fold *mean per-method score* converges to the global mean.
+
+        For each bootstrap replicate:
+          - sample k folds WITH replacement
+          - compute per-method mean score across those k folds  (mu_hat_k)
+          - compare to per-method global mean score across ALL folds (mu_global)
+          - jitter_k = mean_m |mu_hat_k[m] - mu_global[m]|
+
+        ``metric`` selects the per-fold per-method score:
+          - ``"winrate"`` (default): per-fold winrate ``1 - (rank - 1) / (M - 1)``,
+            in [0, 1] regardless of M. Comparable across datasets/benchmarks with
+            different method counts.
+          - ``"rank"``: raw per-fold rank from ``rank_col``, scale depends on M.
+
+        Returns a DataFrame with mean/median/95% CI of jitter_k vs k, plus a
+        ``metric`` column identifying which score was used.
+        """
+        if metric not in ("winrate", "rank"):
+            raise ValueError(f"metric must be 'winrate' or 'rank', got {metric!r}")
+        if self.seed_column is None:
+            raise ValueError("seed_column must be set to compute fold jitter.")
+        if self.seed_column not in results_per_task.columns:
+            raise ValueError(
+                f"results_per_task must include seed column {self.seed_column!r}. "
+                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
+            )
+
+        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
+        if df.empty:
+            raise ValueError(f"No rows found for dataset {dataset!r}")
+
+        # folds x methods matrix of ranks (the canonical per-fold score; winrate is a
+        # per-fold linear rescale of rank, see below)
+        M_df = df.pivot(index=self.seed_column, columns=self.method_col, values=rank_col)
+
+        if drop_methods_with_any_missing:
+            M_df = M_df.dropna(axis=1)
+        elif M_df.isna().any().any():
+            raise ValueError(
+                "Found NaNs in fold×method matrix. Set drop_methods_with_any_missing=True "
+                "or impute missing values before bootstrapping.",
+            )
+
+        M_full = M_df.to_numpy(dtype=float)  # shape (F, M), values are ranks
+        F, M = M_full.shape
+        if F < 1:
+            raise ValueError("No folds available after filtering.")
+        if M < 2:
+            raise ValueError("Need at least 2 methods after filtering.")
+
+        if metric == "winrate":
+            # winrate = 1 - (rank - 1) / (M - 1); in [0, 1] regardless of M.
+            # Equivalent to the pairwise winrate convention with average-rank tie handling.
+            M_full = 1.0 - (M_full - 1.0) / (M - 1.0)
+
+        # Global per-method mean score across ALL folds (fixed reference)
+        mu_global = M_full.mean(axis=0)  # shape (M,)
+
+        if k_values is None:
+            k_values = list(range(1, F + 1))
+        else:
+            k_values = [int(k) for k in k_values]
+            if any(k < 1 for k in k_values):
+                raise ValueError("All k_values must be >= 1.")
+            if any(k > F for k in k_values):
+                raise ValueError(f"All k_values must be <= number of available folds ({F}).")
+
+        rng = np.random.default_rng(seed)
+
+        def _summ(x: np.ndarray) -> dict:
+            return dict(
+                mean=float(np.mean(x)),
+                p50=float(np.quantile(x, 0.50)),
+                p025=float(np.quantile(x, 0.025)),
+                p975=float(np.quantile(x, 0.975)),
+            )
+
+        rows: list[dict] = []
+
+        for k in k_values:
+            jit = np.empty(n_bootstrap, dtype=float)
+
+            for b in range(n_bootstrap):
+                # Sample folds WITH replacement: classical bootstrap of the k-fold
+                # mean against the all-folds reference. At k=F this still produces
+                # non-zero jitter (Monte-Carlo resampling noise of the all-folds
+                # mean estimate) — without that, Φ=1 collapses to 0 in the strip.
+                idx = rng.choice(F, size=k, replace=True)
+                M_sel = M_full[idx, :]  # (k, M)
+
+                mu_hat = M_sel.mean(axis=0)  # per-method mean score across sampled folds
+                jit[b] = float(np.abs(mu_hat - mu_global).mean())
+
+            s = _summ(jit)
+            rows.append(
+                {
+                    "dataset": dataset,
+                    "metric": metric,
+                    "k": k,
+                    "n_bootstrap": n_bootstrap,
+                    "n_folds_available": F,
+                    "n_methods": M,
+                    "jitter_mean": s["mean"],
+                    "jitter_p50": s["p50"],
+                    "jitter_p025": s["p025"],
+                    "jitter_p975": s["p975"],
+                }
+            )
+
+        return pd.DataFrame(rows).sort_values("k").reset_index(drop=True)
+
+    def jitter_bootstrap_curve_all_datasets(
+        self,
+        results_per_task: pd.DataFrame,
+        *,
+        rank_col: str = RANK,
+        metric: str = "winrate",
+        k_values: list[int] | None = None,
+        n_bootstrap: int = 300,
+        seed: int = 0,
+        drop_methods_with_any_missing: bool = True,
+    ) -> pd.DataFrame:
+        datasets = list(pd.Index(results_per_task[self.task_col].unique()).sort_values())
+        dfs: list[pd.DataFrame] = []
+
+        for ds in datasets:
+            try:
+                d = self.dataset_jitter_bootstrap_curve(
+                    results_per_task=results_per_task,
+                    dataset=ds,
+                    rank_col=rank_col,
+                    metric=metric,
+                    k_values=k_values,
+                    n_bootstrap=n_bootstrap,
+                    seed=seed,
+                    drop_methods_with_any_missing=drop_methods_with_any_missing,
+                )
+                dfs.append(d)
+            except Exception as e:
+                dfs.append(
+                    pd.DataFrame(
+                        [
+                            {
+                                "dataset": ds,
+                                "metric": metric,
+                                "k": np.nan,
+                                "n_bootstrap": n_bootstrap,
+                                "error": repr(e),
+                            }
+                        ]
+                    )
+                )
+
+        return pd.concat(dfs, axis=0, ignore_index=True)
+
+    @staticmethod
+    def estimate_folds_for_stable_ordering(
+        fold_agreement: float,
+        num_folds: int,
+        *,
+        target_reliability: float = 0.90,  # "stable ordering" threshold
+        cap: int = 100,  # safety cap
+        conservative: bool = True,
+        rho_floor: float = 0.01,
+    ) -> dict:
+        """Estimate how many folds are needed to get a stable global ordering on a dataset,
+        based on observed inter-fold agreement.
+
+        Uses Spearman–Brown style extrapolation:
+            Rel(k) = (k*rho) / (1 + (k-1)*rho)
+        where rho ~ mean pairwise fold correlation ("fold_agreement").
+
+        Parameters
+        ----------
+        fold_agreement : float
+            Mean pairwise fold similarity (e.g., Spearman correlation across methods).
+        num_folds : int
+            Number of folds used to estimate fold_agreement.
+            Used mainly for reporting; the extrapolation itself uses fold_agreement.
+        target_reliability : float, default 0.90
+            Target reliability for considering the ordering "stable".
+        cap : int, default 100
+            Maximum folds to return (avoid absurd numbers).
+        conservative : bool, default True
+            If True, clamp rho into a plausible range and warn on edge cases.
+        rho_floor : float, default 0.01
+            Minimum rho to use when conservative and rho is extremely small/negative.
+
+        Returns:
+        -------
+        dict with:
+            - "rho": used rho
+            - "target_reliability": tau
+            - "k_required": estimated folds needed (int, capped)
+            - "rel_at_num_folds": estimated reliability at the observed num_folds
+            - "rel_curve": optional small table (k, Rel(k)) for k in [1..min(cap, 20)]
+            - "notes": list[str]
+        """
+        notes = []
+        rho = float(fold_agreement)
+
+        if not np.isfinite(rho):
+            raise ValueError("fold_agreement must be finite.")
+
+        # Correlation should be in [-1, 1]; we only have meaningful fold-averaging reliability for rho > 0
+        if conservative:
+            if rho > 1:
+                notes.append("rho > 1 encountered; clamping to 1.")
+                rho = 1.0
+            if rho < -1:
+                notes.append("rho < -1 encountered; clamping to -1.")
+                rho = -1.0
+
+            if rho <= 0:
+                notes.append(
+                    "fold_agreement <= 0 suggests folds disagree or are unrelated; "
+                    "a stable global ordering may not be achievable by averaging folds alone. "
+                    "Returning cap.",
+                )
+                rho = max(rho_floor, 0.0)
+
+        tau = float(target_reliability)
+        if not (0 < tau < 1):
+            raise ValueError("target_reliability must be in (0, 1).")
+
+        def rel(k: int) -> float:
+            if k <= 0:
+                return np.nan
+            if rho <= 0:
+                return 0.0
+            return (k * rho) / (1.0 + (k - 1) * rho)
+
+        rel_at_num = rel(int(num_folds))
+
+        # Solve k >= tau(1-rho)/(rho(1-tau))
+        if rho <= 0:
+            k_req = cap
+        else:
+            k_float = (tau * (1.0 - rho)) / (rho * (1.0 - tau))
+            k_req = int(np.ceil(k_float))
+            k_req = max(1, k_req)
+
+        if k_req > cap:
+            notes.append(f"Estimated folds ({k_req}) exceed cap ({cap}); returning cap.")
+            k_req = cap
+
+        rel_curve = [(k, rel(k)) for k in range(1, min(cap, 20) + 1)]
+        rel_curve_df = pd.DataFrame(rel_curve, columns=["k", "reliability"])
+
+        return {
+            "rho": rho,
+            "target_reliability": tau,
+            "k_required": k_req,
+            "rel_at_num_folds": rel_at_num,
+            "rel_curve": rel_curve_df,
+            "notes": notes,
+        }

--- a/packages/bencheval/src/bencheval/_common.py
+++ b/packages/bencheval/src/bencheval/_common.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+# Column names produced by the evaluator and shared across its concern modules
+# (validation, analysis, plotting). Defined here to avoid an evaluator <-> mixin
+# import cycle. Re-exported from ``bencheval.evaluator`` for backward compatibility.
+RANK = "rank"
+IMPROVABILITY = "improvability"
+LOSS_RESCALED = "loss_rescaled"
+FRONTIER_ADVANTAGE = "frontier_advantage"

--- a/packages/bencheval/src/bencheval/_plotting.py
+++ b/packages/bencheval/src/bencheval/_plotting.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pandas as pd
+
+
+class PlottingMixin:
+    """Leaderboard / results plotting helpers (mixed into BenchmarkEvaluator)."""
+
+    @staticmethod
+    def plot_winrate_matrix(
+        winrate_matrix: pd.DataFrame,
+        save_path: str | None,
+        title: str | None = None,
+    ):
+        import matplotlib.pyplot as plt
+
+        z = winrate_matrix.copy()
+        z = (z * 100).round().astype("Int64")
+
+        n_rows, n_cols = z.shape
+
+        # Scale figure size with matrix size, while keeping a sensible minimum
+        fig_w = max(11.1, 0.55 * n_cols + 3)
+        fig_h = max(9.0, 0.45 * n_rows + 2)
+
+        fig, ax = plt.subplots(figsize=(fig_w, fig_h), constrained_layout=True)
+
+        # PRGn-like colormap
+        im = ax.imshow(z.astype(float).to_numpy(), cmap="PRGn", vmin=0, vmax=100)
+
+        # Ticks / labels
+        ax.set_xticks(range(n_cols))
+        ax.set_yticks(range(n_rows))
+        ax.set_xticklabels(
+            z.columns,
+            fontsize=16,
+            rotation=330,
+            ha="right",
+            va="bottom",
+            rotation_mode="anchor",
+        )
+        ax.set_yticklabels(z.index, fontsize=16)
+        ax.tick_params(axis="x", pad=-2)
+        ax.tick_params(axis="x", which="both", length=0)
+        ax.tick_params(axis="y", which="both", length=0)
+
+        ax.xaxis.tick_top()
+        ax.xaxis.set_label_position("top")
+        ax.set_xlabel("Model B: Loser", fontsize=18)
+        ax.set_ylabel("Model A: Winner", fontsize=18)
+
+        cmap = plt.get_cmap("PRGn")
+        norm = plt.Normalize(vmin=0, vmax=100)
+
+        values = z.to_numpy()
+        for i in range(n_rows):
+            for j in range(n_cols):
+                val = values[i, j]
+                if pd.isna(val):
+                    text = ""
+                    text_color = "black"
+                else:
+                    text = f"{int(val)}"
+                    r, g, b, _ = cmap(norm(float(val)))
+                    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                    text_color = "black" if luminance > 0.5 else "white"
+
+                ax.text(
+                    j,
+                    i,
+                    text,
+                    ha="center",
+                    va="center",
+                    fontsize=16,
+                    color=text_color,
+                )
+
+        # Colorbar
+        from matplotlib.ticker import FuncFormatter
+
+        cbar = fig.colorbar(im, ax=ax)
+        cbar.ax.set_title("Win Rate", fontsize=18, pad=12, loc="left")
+        cbar.ax.tick_params(labelsize=16)
+        cbar.ax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: f"{int(x)}%"))
+
+        # Clean look
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+
+        ax.set_facecolor("white")
+        fig.patch.set_facecolor("white")
+
+        # Match imshow orientation expectations
+        ax.set_ylim(n_rows - 0.5, -0.5)
+
+        if title is not None:
+            # Center horizontally on the *grid* (i.e. the imshow axes), the
+            # same way ``ax.set_xlabel("Model B: Loser", ...)`` is centered.
+            # ``ax.get_position()`` returns the axes bounding box in figure
+            # coordinates, so the midpoint of its x-range is the matrix
+            # grid's horizontal center — independent of the colorbar that
+            # sits to the right.
+            fig.canvas.draw()
+            ax_bbox = ax.get_position()
+            x_axes_center = (ax_bbox.x0 + ax_bbox.x1) / 2
+            fig.suptitle(
+                title,
+                fontsize=20,
+                fontweight="bold",
+                x=x_axes_center,
+            )
+
+        if save_path is not None:
+            if os.path.dirname(save_path):
+                os.makedirs(os.path.dirname(save_path), exist_ok=True)
+            fig.savefig(save_path, bbox_inches="tight")
+        plt.close(fig)
+
+    def plot_critical_diagrams(
+        self, results_per_task, save_path: str | None = None, show: bool = False, reverse: bool = False
+    ):
+        import matplotlib.pyplot as plt
+
+        with plt.rc_context({"text.usetex": False}):
+            from autorank import autorank
+            from autorank._util import cd_diagram
+
+            plt.rcParams.update({"font.size": 12})
+
+            fig = plt.figure(figsize=(10, 4))
+            ax = fig.add_subplot(1, 1, 1)
+
+            data = results_per_task.pivot_table(index=self.task_col, columns=self.method_col, values="rank")
+            result = autorank(data, alpha=0.05, verbose=False, order="ascending", force_mode="nonparametric")
+
+            try:
+                _ = cd_diagram(result, reverse=reverse, ax=ax, width=6)
+            except KeyError:
+                print("Not enough methods to generate cd_diagram, skipping...")
+                return
+
+            # plt.tight_layout()  # cuts off text
+            if save_path is not None:
+                parent_dir = str(Path(save_path).parent)
+                os.makedirs(parent_dir, exist_ok=True)
+                plt.savefig(save_path, bbox_inches="tight", pad_inches=0.1)
+            if show:
+                plt.show()
+
+    def plot_dataset_metric_distribution(
+        self,
+        results_per_task: pd.DataFrame,
+        dataset: str,
+        metric_col: str | None = None,
+        *,
+        sort_by: str = "median",  # {"median", "mean"}
+        ascending: bool = True,  # lower is better for error-like metrics
+        kind: str = "violin",  # {"violin", "box", "bar"}
+        show_points: str | bool = "outliers",  # plotly: True, False, "all", "outliers"
+        log_y: bool = False,
+        max_methods: int | None = 50,  # cap for readability
+        save_path: str | None = None,
+        title: str | None = None,
+    ):
+        """Plot a single dataset's metric distribution across methods.
+
+        Parameters
+        ----------
+        results_per_task : pd.DataFrame
+            Output of `self.compute_results_per_task(data=data)` (possibly with seeds).
+            Must contain at least: [self.task_col, self.method_col, metric_col].
+        dataset : str
+            Dataset/task name to filter on (value from `self.task_col`).
+        metric_col : str | None, default None
+            Column to plot. If None, defaults to `self.error_col`.
+            Common choices: self.error_col, "rank", "improvability", "loss_rescaled".
+        sort_by : {"median","mean"}, default "median"
+            How to sort methods on the x-axis.
+        ascending : bool, default True
+            Whether to sort ascending (typical for error-like metrics).
+        kind : {"violin","box","bar"}, default "violin"
+            Plot type. If the dataset has only one value per method, it will fall back to "bar".
+        show_points : str | bool, default "outliers"
+            Whether to show individual points for violin/box.
+        log_y : bool, default False
+            Whether to log-scale the y-axis.
+        max_methods : int | None, default 50
+            If set, keep only the top-N methods by the chosen sorter (post-sort).
+        save_path : str | None, default None
+            If provided, writes the figure to this path (format inferred by extension).
+        title : str | None, default None
+            Optional plot title.
+
+        Returns:
+        -------
+        fig : plotly.graph_objects.Figure
+        df_plot : pd.DataFrame
+            Filtered dataframe used for plotting (one row per observation).
+        """
+        import plotly.express as px
+
+        if metric_col is None:
+            metric_col = self.error_col
+
+        required = {self.task_col, self.method_col, metric_col}
+        missing = [c for c in required if c not in results_per_task.columns]
+        if missing:
+            raise ValueError(
+                f"results_per_task is missing required columns: {missing}\n"
+                f"Available columns: {list(results_per_task.columns)}",
+            )
+
+        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
+        if df.empty:
+            raise ValueError(
+                f"No rows found for {self.task_col} == {dataset!r}.\n"
+                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}",
+            )
+
+        # Drop NaNs in the plotted metric (shouldn’t normally exist, but be safe)
+        df = df.dropna(subset=[metric_col])
+
+        # Determine whether we actually have a distribution per method (e.g. seeds)
+        # If each method has a single value, violin/box isn't very informative.
+        per_method_counts = df.groupby(self.method_col)[metric_col].size()
+        has_distribution = bool((per_method_counts > 1).any())
+
+        # Sort methods by mean/median for consistent x-axis ordering
+        if sort_by not in {"median", "mean"}:
+            raise ValueError(f"Invalid sort_by={sort_by!r}. Expected 'median' or 'mean'.")
+
+        if sort_by == "median":
+            sorter = df.groupby(self.method_col)[metric_col].median()
+        else:
+            sorter = df.groupby(self.method_col)[metric_col].mean()
+
+        sorter = sorter.sort_values(ascending=ascending)
+
+        if max_methods is not None and len(sorter) > max_methods:
+            sorter = sorter.iloc[:max_methods]
+            df = df[df[self.method_col].isin(sorter.index)].copy()
+
+        method_order = list(sorter.index)
+
+        # Pick plot type (force bar if no distribution)
+        plot_kind = kind
+        if plot_kind in {"violin", "box"} and not has_distribution:
+            plot_kind = "bar"
+
+        if title is None:
+            title = f"{dataset}: {metric_col} across methods"
+
+        if plot_kind == "violin":
+            fig = px.violin(
+                df,
+                x=self.method_col,
+                y=metric_col,
+                category_orders={self.method_col: method_order},
+                box=True,
+                points=show_points,
+                title=title,
+            )
+        elif plot_kind == "box":
+            fig = px.box(
+                df,
+                x=self.method_col,
+                y=metric_col,
+                category_orders={self.method_col: method_order},
+                points=show_points,
+                title=title,
+            )
+        elif plot_kind == "bar":
+            # One value per method (or user forced bar): use median/mean as height
+            agg = sorter.rename(metric_col).reset_index()
+            fig = px.bar(
+                agg,
+                x=self.method_col,
+                y=metric_col,
+                category_orders={self.method_col: method_order},
+                title=title,
+            )
+        else:
+            raise ValueError(f"Invalid kind={kind!r}. Expected 'violin', 'box', or 'bar'.")
+
+        fig.update_layout(
+            xaxis_title="Method",
+            yaxis_title=metric_col,
+            xaxis_tickangle=45,
+            margin=dict(l=10, r=10, t=40, b=10),
+            plot_bgcolor="white",
+        )
+        fig.update_xaxes(showgrid=False)
+        fig.update_yaxes(showgrid=True)
+
+        if log_y:
+            fig.update_yaxes(type="log")
+
+        if save_path is not None:
+            if os.path.dirname(save_path):
+                os.makedirs(os.path.dirname(save_path), exist_ok=True)
+            fig.write_image(save_path)
+
+        return fig, df

--- a/packages/bencheval/src/bencheval/_validation.py
+++ b/packages/bencheval/src/bencheval/_validation.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_numeric_dtype
+
+
+class ResultsValidationMixin:
+    """Data validation, cleaning and fill-in for results frames (mixed into BenchmarkEvaluator)."""
+
+    def verify_data(self, data: pd.DataFrame):
+        assert isinstance(data, pd.DataFrame)
+        data_columns = list(data.columns)
+        data_columns_set = set(data_columns)
+        assert len(data_columns) == len(data_columns_set)
+
+        missing_columns = []
+        present_columns = []
+        for c in self.columns_to_agg:
+            if c not in data_columns_set:
+                missing_columns.append(c)
+            else:
+                present_columns.append(c)
+        for c in self.groupby_columns:
+            if c not in data_columns_set:
+                missing_columns.append(c)
+            else:
+                present_columns.append(c)
+        if self.seed_column is not None:
+            if self.seed_column not in data_columns_set:
+                missing_columns.append(self.seed_column)
+            else:
+                present_columns.append(self.seed_column)
+
+        required_columns = self.groupby_columns + self.columns_to_agg
+        if self.seed_column is not None:
+            required_columns.append(self.seed_column)
+        unused_columns = [d for d in data_columns if d not in required_columns]
+
+        if missing_columns:
+            index_names = data.index.names
+            missing_in_index = []
+            for index_name in index_names:
+                if index_name in missing_columns:
+                    missing_in_index.append(index_name)
+            if missing_in_index:
+                msg_extra = (
+                    "Columns exist in the index that are required to be columns! "
+                    "\n\tEnsure you reset your index to make these columns available: `data = data.reset_index()`\n"
+                )
+            else:
+                msg_extra = ""
+            raise ValueError(
+                f"{msg_extra}"
+                f"Missing required columns:"
+                f"\n\tMissing columns ({len(missing_columns)}): {missing_columns}"
+                f"\n\tExisting columns ({len(present_columns)}): {present_columns}"
+                f"\n\tUnused columns ({len(unused_columns)}): {unused_columns}"
+                f"\n\tIndex names ({len(index_names)}): {index_names}",
+            )
+
+        for c in self.groupby_columns:
+            assert data[c].isnull().sum() == 0, f"groupby column {c!r} contains NaN!"
+        for c in self.columns_to_agg:
+            assert is_numeric_dtype(data[c]), "aggregation columns must be numeric!"
+        for c in self.columns_to_agg:
+            if data[c].isnull().sum() != 0:
+                invalid_samples = data[data[c].isnull()]
+
+                raise AssertionError(
+                    f"Column {c} should not contain null values. "
+                    f"Found {data[c].isnull().sum()}/{len(data)} null values! "
+                    f"Invalid samples:\n{invalid_samples.head(100).to_markdown()}",
+                )
+
+        # TODO: Check no duplicates
+        len_data = len(data)
+        unique_val_columns = [self.task_col, self.method_col]
+        if self.seed_column is not None:
+            unique_val_columns.append(self.seed_column)
+        len_data_dedupe = len(data.drop_duplicates(unique_val_columns))
+        assert len_data == len_data_dedupe
+
+        self.verify_data_is_dense(data=data)
+        self.verify_error(data=data)
+
+    def verify_data_is_dense(self, data: pd.DataFrame):
+        methods = list(data[self.method_col].unique())
+        num_methods = len(methods)
+        # FIXME: seed_column
+        datasets = list(data[self.task_col].unique())
+        num_datasets = len(datasets)
+
+        task_cols = self.get_task_groupby_cols(include_seed_col=True)
+        unique_tasks = data[task_cols].drop_duplicates().reset_index(drop=True)
+
+        unique_seeds_per_dataset = unique_tasks[self.task_col].value_counts()
+        num_tasks = unique_seeds_per_dataset.sum()
+        valid_tasks_per_method = data[self.method_col].value_counts()
+        valid_methods_per_dataset = data[self.task_col].value_counts()
+        valid_methods_per_task = data[task_cols].value_counts()
+        invalid_tasks_per_method = (-valid_tasks_per_method + num_tasks).sort_values(ascending=False)
+        invalid_methods_per_dataset = (
+            -valid_methods_per_dataset + valid_methods_per_dataset.index.map(unique_seeds_per_dataset) * num_methods
+        ).sort_values(ascending=False)
+        invalid_methods_per_task = (-valid_methods_per_task + num_methods).sort_values(ascending=False)
+
+        if (invalid_tasks_per_method != 0).any():
+            invalid_tasks_per_method_filtered = invalid_tasks_per_method[invalid_tasks_per_method != 0]
+            invalid_methods_per_dataset_filtered = invalid_methods_per_dataset[invalid_methods_per_dataset != 0]
+            invalid_methods_per_task_filtered = invalid_methods_per_task[invalid_methods_per_task != 0]
+            num_invalid_results = invalid_tasks_per_method.sum()
+            # num_invalid_tasks = invalid_methods_per_task_filtered.sum()
+
+            df_experiments_dense = unique_tasks.merge(
+                pd.Series(data=methods, name=self.method_col),
+                how="cross",
+            )
+            experiment_cols = [*task_cols, self.method_col]
+            overlap = pd.merge(
+                df_experiments_dense, data[experiment_cols], on=experiment_cols, how="left", indicator="exist"
+            )
+            df_missing_experiments = (
+                overlap[overlap["exist"] == "left_only"][experiment_cols]
+                .sort_values(by=experiment_cols)
+                .reset_index(drop=True)
+            )
+
+            with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+                if len(df_missing_experiments) <= 500:
+                    print(f"\nFailed Experiments ({len(df_missing_experiments)}):")
+                    print(df_missing_experiments)
+                print("\nMethods sorted by failure count:")
+                print(invalid_tasks_per_method_filtered)
+                print("\nDatasets sorted by failure count:")
+                print(invalid_methods_per_dataset_filtered)
+            # missing results
+            raise AssertionError(
+                f"Missing results for some methods. Ensure that all methods have results for all tasks.\n"
+                f"If failures exist, fill missing values before passing into this method.\n"
+                f"{len(invalid_tasks_per_method_filtered)}/{num_methods} methods with missing tasks. {num_invalid_results} missing results.\n"
+                f"{len(invalid_methods_per_dataset_filtered)}/{num_datasets} datasets with missing methods.\n"
+                f"{len(invalid_methods_per_task_filtered)}/{num_tasks} tasks with missing methods.\n"
+                f"Methods sorted by failure count:\n"
+                f"{invalid_tasks_per_method_filtered}",
+            )
+
+    def verify_error(self, data: pd.DataFrame):
+        min_error = data[self.error_col].min()
+        if min_error < 0:
+            data_invalid = data[data[self.error_col] < 0]
+            num_invalid = len(data_invalid)
+            raise ValueError(
+                f"Found {num_invalid} rows where {self.error_col} is less than 0! Error can never be less than 0. "
+                f"Ensure your error is computed correctly."
+                f"\nMinimum value found: {min_error}"
+                f"\nSometimes floating point precision can result in a tiny negative value. "
+                f"You can fix this by doing: data['{self.error_col}'] = data['{self.error_col}'].clip(lower=0)",
+            )
+
+    def clean_data(
+        self,
+        data: pd.DataFrame,
+    ) -> pd.DataFrame:
+        data = copy.deepcopy(data)
+        min_error = data[self.error_col].min()
+        if min_error < 0:
+            if min_error >= self.negative_error_threshold:
+                data[self.error_col] = data[self.error_col].clip(0)
+            else:
+                self.verify_error(data=data)
+        return data
+
+    def fillna_data(
+        self,
+        data: pd.DataFrame,
+        df_fillna: pd.DataFrame | None = None,
+        fillna_method: str = "worst",
+    ) -> pd.DataFrame:
+        """Fills missing (task, seed, method) rows in data with the (task, seed) row in df_fillna.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            The data to fill.
+        df_fillna : pd.DataFrame | None, default None
+            If specified, will fill methods with missing results in `data` with the results in `df_fillna`.
+            If specified, `fillna_method` is ignored.
+        fillna_method : str, default "worst"
+            Either "worst" or the name of a method in self.method_col.
+            If "worst", will fill with the result of the method with the worst error on a given task.
+            Ignored if `df_fillna` is specified.
+
+        Returns:
+        -------
+        pd.DataFrame
+            The filled data.
+
+        """
+        task_columns = [self.task_col, self.seed_column] if self.seed_column else [self.task_col]
+
+        unique_methods = list(data[self.method_col].unique())
+
+        if df_fillna is None:
+            if fillna_method == "worst":
+                assert df_fillna is None, "df_fillna must be None if fillna_method='worst'"
+                idx_worst = data.groupby(task_columns)[self.error_col].idxmax()
+                df_fillna = data.loc[idx_worst]
+            elif isinstance(fillna_method, str) and fillna_method in data[self.method_col].unique():
+                df_fillna = data.loc[data[self.method_col] == fillna_method]
+            else:
+                raise AssertionError(
+                    f"df_fillna is None and fillna_method {fillna_method!r} is not present in data."
+                    f"\n\tValid methods: {list(data[self.method_col].unique())}",
+                )
+        if self.method_col in df_fillna.columns:
+            df_fillna = df_fillna.drop(columns=[self.method_col])
+
+        data = data.set_index([*task_columns, self.method_col], drop=True)
+
+        df_filled = df_fillna[task_columns].merge(
+            pd.Series(data=unique_methods, name=self.method_col),
+            how="cross",
+        )
+        df_filled = df_filled.set_index(keys=list(df_filled.columns))
+
+        # missing results
+        nan_vals = df_filled.index.difference(data.index)
+
+        # fill valid values
+        fill_cols = list(data.columns)
+        df_filled[fill_cols] = np.nan
+        df_filled[fill_cols] = df_filled[fill_cols].astype(data.dtypes)
+        df_filled.loc[data.index] = data
+
+        df_fillna = df_fillna.set_index(task_columns, drop=True)
+        a = df_fillna.loc[nan_vals.droplevel(level=self.method_col)]
+        a.index = nan_vals
+        df_filled.loc[nan_vals] = a
+        data = df_filled
+
+        return data.reset_index(drop=False)

--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -42,8 +42,8 @@ class MetricSpec:
     name: str
     direction: MetricDirection
     alignment: MetricAlignment
-    compute: Callable[[TabArena, pd.DataFrame], pd.Series]
-    score: Callable[[TabArena, pd.DataFrame, pd.Series, str], float]
+    compute: Callable[[BenchmarkEvaluator, pd.DataFrame], pd.Series]
+    score: Callable[[BenchmarkEvaluator, pd.DataFrame, pd.Series, str], float]
     # Methods that must be present in any subset (e.g., Elo calibration framework)
     required_methods: frozenset[str] = frozenset()
     # What to do if required methods are missing from a subset
@@ -51,7 +51,7 @@ class MetricSpec:
 
 
 # TODO: Should "data" be an init arg? Probably not.
-class TabArena:
+class BenchmarkEvaluator:
     def __init__(
         self,
         method_col: str = "method",
@@ -1192,7 +1192,7 @@ class TabArena:
         sort_asc: bool,
     ) -> pd.Series:
         """Returns a per-method Series of weighted means using the same equal-task weighting
-        logic as other parts of TabArena.
+        logic as other parts of BenchmarkEvaluator.
         """
         seed_col = self._seed_col_if_present(df)
         return compute_weighted_mean_by_task(
@@ -1356,11 +1356,11 @@ class TabArena:
     def metric_spec_error(self) -> MetricSpec:
         """Lower is better. Score = weighted mean error (equal task weighting)."""
 
-        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
+        def compute(self: BenchmarkEvaluator, df: pd.DataFrame) -> pd.Series:
             # row-aligned; no recomputation needed
             return df[self.error_col]
 
-        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: BenchmarkEvaluator, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             groupby_columns = self._get_groupby_cols(df)
             tmp = df[groupby_columns].copy()
             tmp[self.error_col] = values.to_numpy()
@@ -1378,11 +1378,11 @@ class TabArena:
     def metric_spec_rank(self) -> MetricSpec:
         """Lower is better. Score = weighted mean rank."""
 
-        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
+        def compute(self: BenchmarkEvaluator, df: pd.DataFrame) -> pd.Series:
             task_groupby_cols = self._get_task_groupby_cols(results=df)
             return self.compare_rank_per(df=df, task_groupby_cols=task_groupby_cols)
 
-        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: BenchmarkEvaluator, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             groupby_columns = self._get_groupby_cols(df)
             tmp = df[groupby_columns].copy()
             tmp[RANK] = values.to_numpy()
@@ -1400,11 +1400,11 @@ class TabArena:
     def metric_spec_improvability(self) -> MetricSpec:
         """Lower is better (0 is ideal). Score = weighted mean improvability."""
 
-        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
+        def compute(self: BenchmarkEvaluator, df: pd.DataFrame) -> pd.Series:
             task_groupby_cols = self._get_task_groupby_cols(results=df)
             return self.compute_improvability_per(results_per_task=df, task_groupby_cols=task_groupby_cols)
 
-        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: BenchmarkEvaluator, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             groupby_columns = self._get_groupby_cols(df)
             tmp = df[groupby_columns].copy()
             tmp[IMPROVABILITY] = values.to_numpy()
@@ -1424,7 +1424,7 @@ class TabArena:
         calibration_framework = elo_kwargs.get("calibration_framework")
         required = frozenset([calibration_framework]) if calibration_framework else frozenset()
 
-        def compute(self: TabArena, df: pd.DataFrame) -> pd.Series:
+        def compute(self: BenchmarkEvaluator, df: pd.DataFrame) -> pd.Series:
             bars = self.compute_elo(
                 results_per_task=df,
                 include_quantiles=False,
@@ -1434,7 +1434,7 @@ class TabArena:
             # method-aligned Series
             return bars["elo"]
 
-        def score(self: TabArena, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
+        def score(self: BenchmarkEvaluator, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
             return float(values.get(method_1, float("nan")))
 
         return MetricSpec(
@@ -1709,7 +1709,7 @@ class TabArena:
             if M.shape[0] == 0:
                 raise ValueError(f"No datasets have >= {min_methods} methods after filtering.")
 
-        # If you're using TabArena's verify_data_is_dense, M should be fully dense.
+        # If you're using BenchmarkEvaluator's verify_data_is_dense, M should be fully dense.
         # But we handle missingness by using pairwise corr + aligning vectors where needed.
 
         # 1) Dataset↔dataset similarity matrix (correlation across methods)
@@ -1822,7 +1822,7 @@ class TabArena:
             - "pairwise": pd.DataFrame (optional) columns [seed_i, seed_j, similarity]
         """
         if self.seed_column is None:
-            raise ValueError("TabArena.seed_column is None, but fold similarity requires a seed/fold column.")
+            raise ValueError("BenchmarkEvaluator.seed_column is None, but fold similarity requires a seed/fold column.")
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
                 f"results_per_task must include seed column {self.seed_column!r}. "
@@ -2017,7 +2017,7 @@ class TabArena:
         import pandas as pd
 
         if self.seed_column is None:
-            raise ValueError("TabArena.seed_column is None, but fold similarity ranking requires a seed/fold column.")
+            raise ValueError("BenchmarkEvaluator.seed_column is None, but fold similarity ranking requires a seed/fold column.")
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
                 f"results_per_task must include seed column {self.seed_column!r}. "

--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -1,27 +1,22 @@
 from __future__ import annotations
 
-import copy
-import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
 from scipy.stats import gmean
 
+from ._analysis import DatasetAnalysisMixin
+from ._common import FRONTIER_ADVANTAGE, IMPROVABILITY, LOSS_RESCALED, RANK
+from ._plotting import PlottingMixin
+from ._validation import ResultsValidationMixin
 from .elo_utils import EloHelper
 from .mean_utils import compute_weighted_mean_by_task
 from .winrate_utils import compute_winrate, compute_winrate_matrix
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
-
-RANK = "rank"
-IMPROVABILITY = "improvability"
-LOSS_RESCALED = "loss_rescaled"
-FRONTIER_ADVANTAGE = "frontier_advantage"
+    from collections.abc import Callable, Iterable, Sequence
 
 MetricDirection = Literal["min", "max"]
 MetricAlignment = Literal["row", "method"]
@@ -50,8 +45,135 @@ class MetricSpec:
     invalid_subset_policy: InvalidSubsetPolicy = "raise"
 
 
+@dataclass
+class _LeaderboardContext:
+    """Mutable state threaded through the leaderboard metric producers.
+
+    ``results_agg`` may be replaced by a producer (e.g. ``improvability`` pops its own
+    column out of the aggregate and re-emits it with bootstrap CI bars), so the trailing
+    aggregate block is read from the context *after* every producer has run.
+    """
+
+    evaluator: BenchmarkEvaluator
+    results_per_task: pd.DataFrame
+    results_agg: pd.DataFrame
+    baseline_method: str | None
+    elo_kwargs: dict
+    relative_error_kwargs: dict
+
+
+@dataclass(frozen=True)
+class _LeaderboardMetric:
+    """One column-group of a leaderboard, produced from a ``_LeaderboardContext``.
+
+    ``produce`` returns the list of Series/DataFrames to concatenate (in order) for this
+    metric. Adding a leaderboard column is a single registry entry plus a selector key —
+    no new ``leaderboard()`` parameter or ``if`` branch.
+    """
+
+    key: str
+    produce: Callable[[_LeaderboardContext], list]
+    requires_baseline: bool = False
+    always_on: bool = False
+
+
+def _lb_elo(ctx: _LeaderboardContext) -> list:
+    return [ctx.evaluator.compute_elo(results_per_task=ctx.results_per_task, **ctx.elo_kwargs)]
+
+
+def _lb_rank(ctx: _LeaderboardContext) -> list:
+    return [ctx.results_agg[RANK]]
+
+
+def _lb_winrate(ctx: _LeaderboardContext) -> list:
+    return [ctx.evaluator.compute_winrate(results_per_task=ctx.results_per_task).to_frame()]
+
+
+def _lb_improvability(ctx: _LeaderboardContext) -> list:
+    ev = ctx.evaluator
+    tasks = list(ctx.results_per_task[ev.task_col].unique())
+    results_per_task_avg = ctx.results_per_task.groupby(ev.groupby_columns)[IMPROVABILITY].mean().reset_index()
+    improvability_bootstrap = get_bootstrap_result_lst(
+        data=tasks,
+        func_=ev._weighted_groupby_mean,
+        func_kwargs={"data": results_per_task_avg, "agg_column": IMPROVABILITY},
+        num_round=100,
+    )
+    improvability = ctx.results_agg[IMPROVABILITY]
+    ctx.results_agg = ctx.results_agg.drop(columns=[IMPROVABILITY])
+    improvability_quantiles = pd.DataFrame(
+        {
+            f"{IMPROVABILITY}+": improvability_bootstrap.quantile(0.975) - improvability,
+            f"{IMPROVABILITY}-": improvability - improvability_bootstrap.quantile(0.025),
+        }
+    )
+    return [improvability, improvability_quantiles]
+
+
+def _lb_baseline_advantage(ctx: _LeaderboardContext) -> list:
+    return [ctx.evaluator.compute_baseline_advantage(ctx.results_per_task, baseline_method=ctx.baseline_method)]
+
+
+def _lb_frontier_advantage(ctx: _LeaderboardContext) -> list:
+    return [ctx.evaluator.compute_frontier_advantage(results_per_task=ctx.results_per_task)]
+
+
+def _lb_mrr(ctx: _LeaderboardContext) -> list:
+    return [ctx.evaluator.compute_mrr(results_per_task=ctx.results_per_task).to_frame()]
+
+
+def _lb_relative_error(ctx: _LeaderboardContext) -> list:
+    return [
+        ctx.evaluator.compute_relative_error(
+            results_per_task=ctx.results_per_task,
+            baseline_method=ctx.baseline_method,
+            **ctx.relative_error_kwargs,
+        ).to_frame()
+    ]
+
+
+def _lb_skill_score(ctx: _LeaderboardContext) -> list:
+    return [
+        ctx.evaluator.compute_skill_score(results_per_task=ctx.results_per_task, baseline_method=ctx.baseline_method)
+    ]
+
+
+def _lb_rank_counts(ctx: _LeaderboardContext) -> list:
+    return [ctx.evaluator.compute_rank_counts(results_per_task=ctx.results_per_task)]
+
+
+# Ordered registry: the leaderboard emits these column-groups in this order. ``always_on``
+# metrics are always emitted; the rest are selected via ``leaderboard(metrics=...)`` (or the
+# legacy ``include_*`` flags). ``requires_baseline`` metrics are skipped when no baseline is set.
+_LEADERBOARD_METRICS: tuple[_LeaderboardMetric, ...] = (
+    _LeaderboardMetric("elo", _lb_elo),
+    _LeaderboardMetric("rank", _lb_rank, always_on=True),
+    _LeaderboardMetric("winrate", _lb_winrate),
+    _LeaderboardMetric("improvability", _lb_improvability),
+    _LeaderboardMetric("baseline_advantage", _lb_baseline_advantage, requires_baseline=True),
+    _LeaderboardMetric("frontier_advantage", _lb_frontier_advantage),
+    _LeaderboardMetric("mrr", _lb_mrr),
+    _LeaderboardMetric("relative_error", _lb_relative_error, requires_baseline=True),
+    _LeaderboardMetric("skill_score", _lb_skill_score, requires_baseline=True),
+    _LeaderboardMetric("rank_counts", _lb_rank_counts),
+)
+
+# Maps the legacy ``include_*`` flags onto registry keys (back-compat selector layer).
+_LEADERBOARD_FLAG_TO_KEY = {
+    "include_elo": "elo",
+    "include_winrate": "winrate",
+    "include_improvability": "improvability",
+    "include_mrr": "mrr",
+    "include_rank_counts": "rank_counts",
+    "include_relative_error": "relative_error",
+    "include_skill_score": "skill_score",
+    "include_baseline_advantage": "baseline_advantage",
+    "include_frontier_advantage": "frontier_advantage",
+}
+
+
 # TODO: Should "data" be an init arg? Probably not.
-class BenchmarkEvaluator:
+class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingMixin):
     def __init__(
         self,
         method_col: str = "method",
@@ -122,7 +244,19 @@ class BenchmarkEvaluator:
         relative_error_kwargs: dict | None = None,
         elo_kwargs: dict | None = None,
         sort_by: str | list[str] | None = "rank",
+        metrics: Sequence[str] | None = None,
     ):
+        """Build a per-method leaderboard.
+
+        Metric columns are produced by the ordered registry ``_LEADERBOARD_METRICS``.
+        Select them either with the legacy ``include_*`` flags or, equivalently, by passing
+        ``metrics`` — an iterable of metric keys (e.g. ``["elo", "winrate", "mrr"]``) which,
+        when given, overrides the flags. ``rank`` is always included. ``baseline_method`` is
+        required for ``baseline_advantage`` / ``relative_error`` / ``skill_score`` (they are
+        silently skipped without it). ``include_error`` / ``include_rescaled_loss`` toggle
+        columns carried over from the aggregate, and ``average_seeds`` controls per-seed
+        handling.
+        """
         if elo_kwargs is None:
             elo_kwargs = {}
         if relative_error_kwargs is None:
@@ -130,74 +264,49 @@ class BenchmarkEvaluator:
         if baseline_method is None:
             baseline_method = elo_kwargs.get("calibration_framework")
 
+        enabled = self._resolve_leaderboard_metrics(
+            metrics,
+            {
+                "include_elo": include_elo,
+                "include_winrate": include_winrate,
+                "include_improvability": include_improvability,
+                "include_mrr": include_mrr,
+                "include_rank_counts": include_rank_counts,
+                "include_relative_error": include_relative_error,
+                "include_skill_score": include_skill_score,
+                "include_baseline_advantage": include_baseline_advantage,
+                "include_frontier_advantage": include_frontier_advantage,
+            },
+        )
+
         self.verify_data(data=data)
 
-        if average_seeds:
-            # average each method's task error across the seeds
-            # Calculate all metrics on the averaged error for the task.
-            results_per_task = self.compute_results_per_task(data=data)
-        else:
-            # Keep each method's task error for each seed, don't average the error.
-            # Calculate all metrics on each seed, then average across seeds to get the metric value for the task.
-            results_per_task = self.compute_results_per_task(data=data, include_seed_col=True)
+        # average_seeds=True averages each method's per-task error across seeds first;
+        # otherwise metrics are computed per seed and averaged afterwards.
+        results_per_task = self.compute_results_per_task(data=data, include_seed_col=not average_seeds)
 
-        results_agg = self.aggregate(results_by_dataset=results_per_task)
+        ctx = _LeaderboardContext(
+            evaluator=self,
+            results_per_task=results_per_task,
+            results_agg=self.aggregate(results_by_dataset=results_per_task),
+            baseline_method=baseline_method,
+            elo_kwargs=elo_kwargs,
+            relative_error_kwargs=relative_error_kwargs,
+        )
+
         results_lst = []
+        for metric in _LEADERBOARD_METRICS:
+            if not metric.always_on and metric.key not in enabled:
+                continue
+            if metric.requires_baseline and baseline_method is None:
+                continue
+            results_lst.extend(metric.produce(ctx))
 
-        if include_elo:
-            results_lst.append(self.compute_elo(results_per_task=results_per_task, **elo_kwargs))
-        results_lst.append(results_agg[RANK])
-        if include_winrate:
-            results_lst.append(self.compute_winrate(results_per_task=results_per_task).to_frame())
-        if include_improvability:
-            tasks = list(results_per_task[self.task_col].unique())
-            results_per_task_avg = results_per_task.groupby(self.groupby_columns)[IMPROVABILITY].mean().reset_index()
-            improvability_bootstrap = get_bootstrap_result_lst(
-                data=tasks,
-                func_=self._weighted_groupby_mean,
-                func_kwargs={"data": results_per_task_avg, "agg_column": IMPROVABILITY},
-                num_round=100,
-            )
-            improvability = results_agg[IMPROVABILITY]
-            results_agg = results_agg.drop(columns=[IMPROVABILITY])
-            improvability_quantiles = pd.DataFrame(
-                {
-                    f"{IMPROVABILITY}+": improvability_bootstrap.quantile(0.975) - improvability,
-                    f"{IMPROVABILITY}-": improvability - improvability_bootstrap.quantile(0.025),
-                }
-            )
-
-            results_lst += [improvability, improvability_quantiles]
-        if include_baseline_advantage and baseline_method is not None:
-            results_lst.append(
-                self.compute_baseline_advantage(
-                    results_per_task,
-                    baseline_method=baseline_method,
-                )
-            )
-        if include_frontier_advantage:
-            results_lst.append(self.compute_frontier_advantage(results_per_task=results_per_task))
-        if include_mrr:
-            results_lst.append(self.compute_mrr(results_per_task=results_per_task).to_frame())
-        if baseline_method is not None:
-            if include_relative_error:
-                results_lst.append(
-                    self.compute_relative_error(
-                        results_per_task=results_per_task,
-                        baseline_method=baseline_method,
-                        **relative_error_kwargs,
-                    ).to_frame(),
-                )
-            if include_skill_score:
-                results_lst.append(
-                    self.compute_skill_score(results_per_task=results_per_task, baseline_method=baseline_method),
-                )
-
-        if include_rank_counts:
-            results_lst.append(self.compute_rank_counts(results_per_task=results_per_task))
-
-        cols_to_use = [c for c in results_agg.columns if c != RANK]
-        results_lst.append(results_agg[cols_to_use])
+        # Trailing block: every aggregated column except rank (emitted above). A producer may
+        # have popped its own column out of ctx.results_agg (e.g. improvability), so read it
+        # here, after the loop.
+        cols_to_use = [c for c in ctx.results_agg.columns if c != RANK]
+        results_lst.append(ctx.results_agg[cols_to_use])
 
         results = pd.concat(results_lst, axis=1)
 
@@ -207,247 +316,35 @@ class BenchmarkEvaluator:
             results = results.drop(columns=[self.error_col])
         if not include_rescaled_loss:
             results = results.drop(columns=[LOSS_RESCALED])
-        if not include_improvability:
+        if "improvability" not in enabled:
             results = results.drop(columns=[IMPROVABILITY])
         results.index.name = self.method_col
 
         return results
 
-    def verify_data(self, data: pd.DataFrame):
-        assert isinstance(data, pd.DataFrame)
-        data_columns = list(data.columns)
-        data_columns_set = set(data_columns)
-        assert len(data_columns) == len(data_columns_set)
+    @staticmethod
+    def _resolve_leaderboard_metrics(metrics: Sequence[str] | None, include_flags: dict[str, bool]) -> set[str]:
+        """Resolve the set of enabled metric keys from ``metrics`` or the ``include_*`` flags.
 
-        missing_columns = []
-        present_columns = []
-        for c in self.columns_to_agg:
-            if c not in data_columns_set:
-                missing_columns.append(c)
-            else:
-                present_columns.append(c)
-        for c in self.groupby_columns:
-            if c not in data_columns_set:
-                missing_columns.append(c)
-            else:
-                present_columns.append(c)
-        if self.seed_column is not None:
-            if self.seed_column not in data_columns_set:
-                missing_columns.append(self.seed_column)
-            else:
-                present_columns.append(self.seed_column)
-
-        required_columns = self.groupby_columns + self.columns_to_agg
-        if self.seed_column is not None:
-            required_columns.append(self.seed_column)
-        unused_columns = [d for d in data_columns if d not in required_columns]
-
-        if missing_columns:
-            index_names = data.index.names
-            missing_in_index = []
-            for index_name in index_names:
-                if index_name in missing_columns:
-                    missing_in_index.append(index_name)
-            if missing_in_index:
-                msg_extra = (
-                    "Columns exist in the index that are required to be columns! "
-                    "\n\tEnsure you reset your index to make these columns available: `data = data.reset_index()`\n"
+        ``metrics`` (when not ``None``) takes precedence and is validated against the registry;
+        otherwise the legacy boolean flags select the keys. ``rank`` is always emitted and is
+        not part of this set.
+        """
+        all_keys = {m.key for m in _LEADERBOARD_METRICS}
+        if metrics is not None:
+            requested = set(metrics)
+            unknown = requested - all_keys
+            if unknown:
+                raise ValueError(
+                    f"Unknown leaderboard metric(s): {sorted(unknown)}. Available: {sorted(all_keys)}.",
                 )
-            else:
-                msg_extra = ""
-            raise ValueError(
-                f"{msg_extra}"
-                f"Missing required columns:"
-                f"\n\tMissing columns ({len(missing_columns)}): {missing_columns}"
-                f"\n\tExisting columns ({len(present_columns)}): {present_columns}"
-                f"\n\tUnused columns ({len(unused_columns)}): {unused_columns}"
-                f"\n\tIndex names ({len(index_names)}): {index_names}",
-            )
-
-        for c in self.groupby_columns:
-            assert data[c].isnull().sum() == 0, f"groupby column {c!r} contains NaN!"
-        for c in self.columns_to_agg:
-            assert is_numeric_dtype(data[c]), "aggregation columns must be numeric!"
-        for c in self.columns_to_agg:
-            if data[c].isnull().sum() != 0:
-                invalid_samples = data[data[c].isnull()]
-
-                raise AssertionError(
-                    f"Column {c} should not contain null values. "
-                    f"Found {data[c].isnull().sum()}/{len(data)} null values! "
-                    f"Invalid samples:\n{invalid_samples.head(100).to_markdown()}",
-                )
-
-        # TODO: Check no duplicates
-        len_data = len(data)
-        unique_val_columns = [self.task_col, self.method_col]
-        if self.seed_column is not None:
-            unique_val_columns.append(self.seed_column)
-        len_data_dedupe = len(data.drop_duplicates(unique_val_columns))
-        assert len_data == len_data_dedupe
-
-        self.verify_data_is_dense(data=data)
-        self.verify_error(data=data)
-
-    def verify_data_is_dense(self, data: pd.DataFrame):
-        methods = list(data[self.method_col].unique())
-        num_methods = len(methods)
-        # FIXME: seed_column
-        datasets = list(data[self.task_col].unique())
-        num_datasets = len(datasets)
-
-        task_cols = self.get_task_groupby_cols(include_seed_col=True)
-        unique_tasks = data[task_cols].drop_duplicates().reset_index(drop=True)
-
-        unique_seeds_per_dataset = unique_tasks[self.task_col].value_counts()
-        num_tasks = unique_seeds_per_dataset.sum()
-        valid_tasks_per_method = data[self.method_col].value_counts()
-        valid_methods_per_dataset = data[self.task_col].value_counts()
-        valid_methods_per_task = data[task_cols].value_counts()
-        invalid_tasks_per_method = (-valid_tasks_per_method + num_tasks).sort_values(ascending=False)
-        invalid_methods_per_dataset = (
-            -valid_methods_per_dataset + valid_methods_per_dataset.index.map(unique_seeds_per_dataset) * num_methods
-        ).sort_values(ascending=False)
-        invalid_methods_per_task = (-valid_methods_per_task + num_methods).sort_values(ascending=False)
-
-        if (invalid_tasks_per_method != 0).any():
-            invalid_tasks_per_method_filtered = invalid_tasks_per_method[invalid_tasks_per_method != 0]
-            invalid_methods_per_dataset_filtered = invalid_methods_per_dataset[invalid_methods_per_dataset != 0]
-            invalid_methods_per_task_filtered = invalid_methods_per_task[invalid_methods_per_task != 0]
-            num_invalid_results = invalid_tasks_per_method.sum()
-            # num_invalid_tasks = invalid_methods_per_task_filtered.sum()
-
-            df_experiments_dense = unique_tasks.merge(
-                pd.Series(data=methods, name=self.method_col),
-                how="cross",
-            )
-            experiment_cols = [*task_cols, self.method_col]
-            overlap = pd.merge(
-                df_experiments_dense, data[experiment_cols], on=experiment_cols, how="left", indicator="exist"
-            )
-            df_missing_experiments = (
-                overlap[overlap["exist"] == "left_only"][experiment_cols]
-                .sort_values(by=experiment_cols)
-                .reset_index(drop=True)
-            )
-
-            with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
-                if len(df_missing_experiments) <= 500:
-                    print(f"\nFailed Experiments ({len(df_missing_experiments)}):")
-                    print(df_missing_experiments)
-                print("\nMethods sorted by failure count:")
-                print(invalid_tasks_per_method_filtered)
-                print("\nDatasets sorted by failure count:")
-                print(invalid_methods_per_dataset_filtered)
-            # missing results
-            raise AssertionError(
-                f"Missing results for some methods. Ensure that all methods have results for all tasks.\n"
-                f"If failures exist, fill missing values before passing into this method.\n"
-                f"{len(invalid_tasks_per_method_filtered)}/{num_methods} methods with missing tasks. {num_invalid_results} missing results.\n"
-                f"{len(invalid_methods_per_dataset_filtered)}/{num_datasets} datasets with missing methods.\n"
-                f"{len(invalid_methods_per_task_filtered)}/{num_tasks} tasks with missing methods.\n"
-                f"Methods sorted by failure count:\n"
-                f"{invalid_tasks_per_method_filtered}",
-            )
-
-    def verify_error(self, data: pd.DataFrame):
-        min_error = data[self.error_col].min()
-        if min_error < 0:
-            data_invalid = data[data[self.error_col] < 0]
-            num_invalid = len(data_invalid)
-            raise ValueError(
-                f"Found {num_invalid} rows where {self.error_col} is less than 0! Error can never be less than 0. "
-                f"Ensure your error is computed correctly."
-                f"\nMinimum value found: {min_error}"
-                f"\nSometimes floating point precision can result in a tiny negative value. "
-                f"You can fix this by doing: data['{self.error_col}'] = data['{self.error_col}'].clip(lower=0)",
-            )
+            return requested
+        return {_LEADERBOARD_FLAG_TO_KEY[flag] for flag, on in include_flags.items() if on}
 
     # TODO: Consider moving this to a different class or finding a better separation.
     #  The eval code becomes a lot more complicated if we need to account for improperly formatted / invalid data.
-    def clean_data(
-        self,
-        data: pd.DataFrame,
-    ) -> pd.DataFrame:
-        data = copy.deepcopy(data)
-        min_error = data[self.error_col].min()
-        if min_error < 0:
-            if min_error >= self.negative_error_threshold:
-                data[self.error_col] = data[self.error_col].clip(0)
-            else:
-                self.verify_error(data=data)
-        return data
 
     # FIXME: Cleanup
-    def fillna_data(
-        self,
-        data: pd.DataFrame,
-        df_fillna: pd.DataFrame | None = None,
-        fillna_method: str = "worst",
-    ) -> pd.DataFrame:
-        """Fills missing (task, seed, method) rows in data with the (task, seed) row in df_fillna.
-
-        Parameters
-        ----------
-        data : pd.DataFrame
-            The data to fill.
-        df_fillna : pd.DataFrame | None, default None
-            If specified, will fill methods with missing results in `data` with the results in `df_fillna`.
-            If specified, `fillna_method` is ignored.
-        fillna_method : str, default "worst"
-            Either "worst" or the name of a method in self.method_col.
-            If "worst", will fill with the result of the method with the worst error on a given task.
-            Ignored if `df_fillna` is specified.
-
-        Returns:
-        -------
-        pd.DataFrame
-            The filled data.
-
-        """
-        task_columns = [self.task_col, self.seed_column] if self.seed_column else [self.task_col]
-
-        unique_methods = list(data[self.method_col].unique())
-
-        if df_fillna is None:
-            if fillna_method == "worst":
-                assert df_fillna is None, "df_fillna must be None if fillna_method='worst'"
-                idx_worst = data.groupby(task_columns)[self.error_col].idxmax()
-                df_fillna = data.loc[idx_worst]
-            elif isinstance(fillna_method, str) and fillna_method in data[self.method_col].unique():
-                df_fillna = data.loc[data[self.method_col] == fillna_method]
-            else:
-                raise AssertionError(
-                    f"df_fillna is None and fillna_method {fillna_method!r} is not present in data."
-                    f"\n\tValid methods: {list(data[self.method_col].unique())}",
-                )
-        if self.method_col in df_fillna.columns:
-            df_fillna = df_fillna.drop(columns=[self.method_col])
-
-        data = data.set_index([*task_columns, self.method_col], drop=True)
-
-        df_filled = df_fillna[task_columns].merge(
-            pd.Series(data=unique_methods, name=self.method_col),
-            how="cross",
-        )
-        df_filled = df_filled.set_index(keys=list(df_filled.columns))
-
-        # missing results
-        nan_vals = df_filled.index.difference(data.index)
-
-        # fill valid values
-        fill_cols = list(data.columns)
-        df_filled[fill_cols] = np.nan
-        df_filled[fill_cols] = df_filled[fill_cols].astype(data.dtypes)
-        df_filled.loc[data.index] = data
-
-        df_fillna = df_fillna.set_index(task_columns, drop=True)
-        a = df_fillna.loc[nan_vals.droplevel(level=self.method_col)]
-        a.index = nan_vals
-        df_filled.loc[nan_vals] = a
-        data = df_filled
-
-        return data.reset_index(drop=False)
 
     def get_task_groupby_cols(self, include_seed_col: bool = False):
         task_groupby_cols = self.task_groupby_columns
@@ -847,116 +744,6 @@ class BenchmarkEvaluator:
             seed_col=seed_col,
         )
 
-    @staticmethod
-    def plot_winrate_matrix(
-        winrate_matrix: pd.DataFrame,
-        save_path: str | None,
-        title: str | None = None,
-    ):
-        import matplotlib.pyplot as plt
-
-        z = winrate_matrix.copy()
-        z = (z * 100).round().astype("Int64")
-
-        n_rows, n_cols = z.shape
-
-        # Scale figure size with matrix size, while keeping a sensible minimum
-        fig_w = max(11.1, 0.55 * n_cols + 3)
-        fig_h = max(9.0, 0.45 * n_rows + 2)
-
-        fig, ax = plt.subplots(figsize=(fig_w, fig_h), constrained_layout=True)
-
-        # PRGn-like colormap
-        im = ax.imshow(z.astype(float).to_numpy(), cmap="PRGn", vmin=0, vmax=100)
-
-        # Ticks / labels
-        ax.set_xticks(range(n_cols))
-        ax.set_yticks(range(n_rows))
-        ax.set_xticklabels(
-            z.columns,
-            fontsize=16,
-            rotation=330,
-            ha="right",
-            va="bottom",
-            rotation_mode="anchor",
-        )
-        ax.set_yticklabels(z.index, fontsize=16)
-        ax.tick_params(axis="x", pad=-2)
-        ax.tick_params(axis="x", which="both", length=0)
-        ax.tick_params(axis="y", which="both", length=0)
-
-        ax.xaxis.tick_top()
-        ax.xaxis.set_label_position("top")
-        ax.set_xlabel("Model B: Loser", fontsize=18)
-        ax.set_ylabel("Model A: Winner", fontsize=18)
-
-        cmap = plt.get_cmap("PRGn")
-        norm = plt.Normalize(vmin=0, vmax=100)
-
-        values = z.to_numpy()
-        for i in range(n_rows):
-            for j in range(n_cols):
-                val = values[i, j]
-                if pd.isna(val):
-                    text = ""
-                    text_color = "black"
-                else:
-                    text = f"{int(val)}"
-                    r, g, b, _ = cmap(norm(float(val)))
-                    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
-                    text_color = "black" if luminance > 0.5 else "white"
-
-                ax.text(
-                    j,
-                    i,
-                    text,
-                    ha="center",
-                    va="center",
-                    fontsize=16,
-                    color=text_color,
-                )
-
-        # Colorbar
-        from matplotlib.ticker import FuncFormatter
-
-        cbar = fig.colorbar(im, ax=ax)
-        cbar.ax.set_title("Win Rate", fontsize=18, pad=12, loc="left")
-        cbar.ax.tick_params(labelsize=16)
-        cbar.ax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: f"{int(x)}%"))
-
-        # Clean look
-        for spine in ax.spines.values():
-            spine.set_visible(False)
-
-        ax.set_facecolor("white")
-        fig.patch.set_facecolor("white")
-
-        # Match imshow orientation expectations
-        ax.set_ylim(n_rows - 0.5, -0.5)
-
-        if title is not None:
-            # Center horizontally on the *grid* (i.e. the imshow axes), the
-            # same way ``ax.set_xlabel("Model B: Loser", ...)`` is centered.
-            # ``ax.get_position()`` returns the axes bounding box in figure
-            # coordinates, so the midpoint of its x-range is the matrix
-            # grid's horizontal center — independent of the colorbar that
-            # sits to the right.
-            fig.canvas.draw()
-            ax_bbox = ax.get_position()
-            x_axes_center = (ax_bbox.x0 + ax_bbox.x1) / 2
-            fig.suptitle(
-                title,
-                fontsize=20,
-                fontweight="bold",
-                x=x_axes_center,
-            )
-
-        if save_path is not None:
-            if os.path.dirname(save_path):
-                os.makedirs(os.path.dirname(save_path), exist_ok=True)
-            fig.savefig(save_path, bbox_inches="tight")
-        plt.close(fig)
-
     def compare_rank_per(
         self,
         df: pd.DataFrame,
@@ -1124,38 +911,6 @@ class BenchmarkEvaluator:
         )
         results_rank.name = RANK
         return results_rank
-
-    # TODO: Should plotting live in a separate class?
-    def plot_critical_diagrams(
-        self, results_per_task, save_path: str | None = None, show: bool = False, reverse: bool = False
-    ):
-        import matplotlib.pyplot as plt
-
-        with plt.rc_context({"text.usetex": False}):
-            from autorank import autorank
-            from autorank._util import cd_diagram
-
-            plt.rcParams.update({"font.size": 12})
-
-            fig = plt.figure(figsize=(10, 4))
-            ax = fig.add_subplot(1, 1, 1)
-
-            data = results_per_task.pivot_table(index=self.task_col, columns=self.method_col, values="rank")
-            result = autorank(data, alpha=0.05, verbose=False, order="ascending", force_mode="nonparametric")
-
-            try:
-                _ = cd_diagram(result, reverse=reverse, ax=ax, width=6)
-            except KeyError:
-                print("Not enough methods to generate cd_diagram, skipping...")
-                return
-
-            # plt.tight_layout()  # cuts off text
-            if save_path is not None:
-                parent_dir = str(Path(save_path).parent)
-                os.makedirs(parent_dir, exist_ok=True)
-                plt.savefig(save_path, bbox_inches="tight", pad_inches=0.1)
-            if show:
-                plt.show()
 
     # TODO: Make faster, can be 100x faster if vectorized properly.
     def _weighted_groupby_mean(self, tasks: list[str], data: pd.DataFrame, agg_column: str) -> pd.Series:
@@ -1457,1227 +1212,6 @@ class BenchmarkEvaluator:
             return False
         # "skip"
         return False
-
-    def plot_dataset_metric_distribution(
-        self,
-        results_per_task: pd.DataFrame,
-        dataset: str,
-        metric_col: str | None = None,
-        *,
-        sort_by: str = "median",  # {"median", "mean"}
-        ascending: bool = True,  # lower is better for error-like metrics
-        kind: str = "violin",  # {"violin", "box", "bar"}
-        show_points: str | bool = "outliers",  # plotly: True, False, "all", "outliers"
-        log_y: bool = False,
-        max_methods: int | None = 50,  # cap for readability
-        save_path: str | None = None,
-        title: str | None = None,
-    ):
-        """Plot a single dataset's metric distribution across methods.
-
-        Parameters
-        ----------
-        results_per_task : pd.DataFrame
-            Output of `self.compute_results_per_task(data=data)` (possibly with seeds).
-            Must contain at least: [self.task_col, self.method_col, metric_col].
-        dataset : str
-            Dataset/task name to filter on (value from `self.task_col`).
-        metric_col : str | None, default None
-            Column to plot. If None, defaults to `self.error_col`.
-            Common choices: self.error_col, "rank", "improvability", "loss_rescaled".
-        sort_by : {"median","mean"}, default "median"
-            How to sort methods on the x-axis.
-        ascending : bool, default True
-            Whether to sort ascending (typical for error-like metrics).
-        kind : {"violin","box","bar"}, default "violin"
-            Plot type. If the dataset has only one value per method, it will fall back to "bar".
-        show_points : str | bool, default "outliers"
-            Whether to show individual points for violin/box.
-        log_y : bool, default False
-            Whether to log-scale the y-axis.
-        max_methods : int | None, default 50
-            If set, keep only the top-N methods by the chosen sorter (post-sort).
-        save_path : str | None, default None
-            If provided, writes the figure to this path (format inferred by extension).
-        title : str | None, default None
-            Optional plot title.
-
-        Returns:
-        -------
-        fig : plotly.graph_objects.Figure
-        df_plot : pd.DataFrame
-            Filtered dataframe used for plotting (one row per observation).
-        """
-        import plotly.express as px
-
-        if metric_col is None:
-            metric_col = self.error_col
-
-        required = {self.task_col, self.method_col, metric_col}
-        missing = [c for c in required if c not in results_per_task.columns]
-        if missing:
-            raise ValueError(
-                f"results_per_task is missing required columns: {missing}\n"
-                f"Available columns: {list(results_per_task.columns)}",
-            )
-
-        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
-        if df.empty:
-            raise ValueError(
-                f"No rows found for {self.task_col} == {dataset!r}.\n"
-                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}",
-            )
-
-        # Drop NaNs in the plotted metric (shouldn’t normally exist, but be safe)
-        df = df.dropna(subset=[metric_col])
-
-        # Determine whether we actually have a distribution per method (e.g. seeds)
-        # If each method has a single value, violin/box isn't very informative.
-        per_method_counts = df.groupby(self.method_col)[metric_col].size()
-        has_distribution = bool((per_method_counts > 1).any())
-
-        # Sort methods by mean/median for consistent x-axis ordering
-        if sort_by not in {"median", "mean"}:
-            raise ValueError(f"Invalid sort_by={sort_by!r}. Expected 'median' or 'mean'.")
-
-        if sort_by == "median":
-            sorter = df.groupby(self.method_col)[metric_col].median()
-        else:
-            sorter = df.groupby(self.method_col)[metric_col].mean()
-
-        sorter = sorter.sort_values(ascending=ascending)
-
-        if max_methods is not None and len(sorter) > max_methods:
-            sorter = sorter.iloc[:max_methods]
-            df = df[df[self.method_col].isin(sorter.index)].copy()
-
-        method_order = list(sorter.index)
-
-        # Pick plot type (force bar if no distribution)
-        plot_kind = kind
-        if plot_kind in {"violin", "box"} and not has_distribution:
-            plot_kind = "bar"
-
-        if title is None:
-            title = f"{dataset}: {metric_col} across methods"
-
-        if plot_kind == "violin":
-            fig = px.violin(
-                df,
-                x=self.method_col,
-                y=metric_col,
-                category_orders={self.method_col: method_order},
-                box=True,
-                points=show_points,
-                title=title,
-            )
-        elif plot_kind == "box":
-            fig = px.box(
-                df,
-                x=self.method_col,
-                y=metric_col,
-                category_orders={self.method_col: method_order},
-                points=show_points,
-                title=title,
-            )
-        elif plot_kind == "bar":
-            # One value per method (or user forced bar): use median/mean as height
-            agg = sorter.rename(metric_col).reset_index()
-            fig = px.bar(
-                agg,
-                x=self.method_col,
-                y=metric_col,
-                category_orders={self.method_col: method_order},
-                title=title,
-            )
-        else:
-            raise ValueError(f"Invalid kind={kind!r}. Expected 'violin', 'box', or 'bar'.")
-
-        fig.update_layout(
-            xaxis_title="Method",
-            yaxis_title=metric_col,
-            xaxis_tickangle=45,
-            margin=dict(l=10, r=10, t=40, b=10),
-            plot_bgcolor="white",
-        )
-        fig.update_xaxes(showgrid=False)
-        fig.update_yaxes(showgrid=True)
-
-        if log_y:
-            fig.update_yaxes(type="log")
-
-        if save_path is not None:
-            if os.path.dirname(save_path):
-                os.makedirs(os.path.dirname(save_path), exist_ok=True)
-            fig.write_image(save_path)
-
-        return fig, df
-
-    def dataset_representativeness(
-        self,
-        results_per_task: pd.DataFrame,
-        value_col: str = RANK,
-        *,
-        similarity: str = "spearman",  # {"spearman", "pearson"}
-        population_mode: str = "loo_mean",  # {"loo_mean", "global_mean"}
-        score_mode: str = "to_population",  # {"to_population", "mean_pairwise"}
-        min_methods: int | None = None,
-    ) -> dict:
-        """Quantify how similar each dataset is to the others based on model performance,
-        then identify the most- and least-representative datasets.
-
-        Intuition
-        ---------
-        Each dataset defines a vector over methods (e.g., ranks or errors).
-        Two datasets are "similar" if these vectors are correlated across methods.
-        Representativeness is measured by how well a dataset aligns with the population.
-
-        Parameters
-        ----------
-        results_per_task : pd.DataFrame
-            Output of `self.compute_results_per_task(data=data)` (may include seed col).
-        value_col : str, default "rank"
-            Column used to compare method performance. Common:
-            - RANK (lower is better)
-            - self.error_col (lower is better)
-            - IMPROVABILITY (higher is better) [still fine; correlation handles direction]
-            - LOSS_RESCALED (lower is better)
-        similarity : {"spearman","pearson"}, default "spearman"
-            Similarity metric for comparing datasets via correlation across methods.
-            Spearman is recommended (rank-based; robust to scale).
-        population_mode : {"loo_mean","global_mean"}, default "loo_mean"
-            How to define the population reference vector:
-            - "loo_mean": reference for dataset d is mean vector over all datasets except d
-            - "global_mean": reference is mean vector over all datasets (includes d)
-        score_mode : {"to_population","mean_pairwise"}, default "to_population"
-            How to assign a single representativeness score per dataset:
-            - "to_population": correlation(dataset_vector, population_reference_vector)
-            - "mean_pairwise": average correlation to all other datasets
-        min_methods : int | None
-            If set, require at least this many methods to compute correlations.
-
-        Returns:
-        -------
-        out : dict with keys
-            - "representativeness": pd.DataFrame indexed by dataset with columns:
-                ["score", "num_methods", "num_obs"]
-            - "most_representative": str
-            - "least_representative": str
-            - "dataset_similarity_matrix": pd.DataFrame (dataset x dataset)
-            - "method_matrix": pd.DataFrame (dataset x method), values = value_col (after seed-avg)
-        """
-        if similarity not in {"spearman", "pearson"}:
-            raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
-        if population_mode not in {"loo_mean", "global_mean"}:
-            raise ValueError(f"population_mode must be 'loo_mean' or 'global_mean', got {population_mode!r}")
-        if score_mode not in {"to_population", "mean_pairwise"}:
-            raise ValueError(f"score_mode must be 'to_population' or 'mean_pairwise', got {score_mode!r}")
-
-        required = {self.task_col, self.method_col, value_col}
-        missing = [c for c in required if c not in results_per_task.columns]
-        if missing:
-            raise ValueError(
-                f"results_per_task is missing required columns: {missing}\n"
-                f"Available columns: {list(results_per_task.columns)}",
-            )
-
-        df = results_per_task.copy()
-
-        # If seed column exists, average within (task, method) so each dataset has one value per method.
-        group_cols = [self.task_col, self.method_col]
-        if self.seed_column is not None and self.seed_column in df.columns:
-            df = df.groupby(group_cols, as_index=False)[value_col].mean()
-
-        # Pivot to dataset x method matrix
-        M = df.pivot(index=self.task_col, columns=self.method_col, values=value_col)
-
-        # Optional sanity: require sufficient overlap
-        num_methods_per_dataset = M.notna().sum(axis=1)
-        if min_methods is not None:
-            keep = num_methods_per_dataset >= min_methods
-            M = M.loc[keep]
-            num_methods_per_dataset = num_methods_per_dataset.loc[keep]
-            if M.shape[0] == 0:
-                raise ValueError(f"No datasets have >= {min_methods} methods after filtering.")
-
-        # If you're using BenchmarkEvaluator's verify_data_is_dense, M should be fully dense.
-        # But we handle missingness by using pairwise corr + aligning vectors where needed.
-
-        # 1) Dataset↔dataset similarity matrix (correlation across methods)
-        # corr over rows => easiest via transpose (methods as rows, datasets as cols)
-        dataset_sim = M.T.corr(method=similarity)
-
-        # 2) Representativeness score per dataset
-        if score_mode == "mean_pairwise":
-            # Mean similarity to all other datasets (exclude self)
-            score = (
-                (dataset_sim.sum(axis=1) - 1.0) / (dataset_sim.shape[0] - 1)
-                if dataset_sim.shape[0] > 1
-                else dataset_sim.iloc[:, 0]
-            )
-        # Similarity to a "population reference vector"
-        # Reference vector is mean performance across datasets (optionally leave-one-out).
-        elif population_mode == "global_mean":
-            ref = M.mean(axis=0)
-            score = M.apply(lambda row: row.corr(ref, method=similarity), axis=1)
-        else:
-            # Leave-one-out mean reference: ref_d = mean of all datasets except d
-            # Compute efficiently: total_sum - row, then divide by (n-1)
-            n = M.shape[0]
-            if n <= 1:
-                score = pd.Series(index=M.index, data=np.nan, dtype=float)
-            else:
-                total = M.sum(axis=0)
-
-                def loo_corr(row: pd.Series) -> float:
-                    ref_d = (total - row) / (n - 1)
-                    return row.corr(ref_d, method=similarity)
-
-                score = M.apply(loo_corr, axis=1)
-
-        rep = pd.DataFrame(
-            {
-                "score": score,
-                "num_methods": num_methods_per_dataset,
-                "num_obs": df.groupby(self.task_col).size().reindex(M.index).astype(int),
-            }
-        ).sort_values("score", ascending=False)
-
-        most_rep = rep.index[0]
-        least_rep = rep.index[-1]
-
-        return {
-            "representativeness": rep,
-            "most_representative": most_rep,
-            "least_representative": least_rep,
-            "dataset_similarity_matrix": dataset_sim.loc[M.index, M.index],
-            "method_matrix": M,
-        }
-
-    def dataset_fold_similarity(
-        self,
-        results_per_task: pd.DataFrame,
-        dataset: str,
-        value_col: str = RANK,
-        *,
-        similarity: str = "spearman",  # {"spearman", "pearson"}
-        agg_across_methods: str = "mean",  # {"mean", "median"}
-        min_methods: int | None = None,
-        return_pairwise: bool = True,
-    ) -> dict:
-        """Quantify how similar a dataset's folds/seeds are, based on how methods perform.
-
-        Assumes `results_per_task` was produced with `include_seed_col=True`, so that
-        each row corresponds to (task, seed, method) with a metric like rank/error.
-
-        Approach
-        --------
-        For the chosen dataset, build a matrix:
-            rows = fold/seed
-            cols = method
-            values = value_col (e.g., rank or metric_error)
-
-        Then compute fold↔fold similarity as correlation across methods.
-
-        Parameters
-        ----------
-        results_per_task : pd.DataFrame
-            Output of `self.compute_results_per_task(..., include_seed_col=True)`.
-            Must include `self.seed_column` and `value_col`.
-        dataset : str
-            Task/dataset name (value from `self.task_col`) to analyze.
-        value_col : str, default RANK
-            Performance column to compare across folds. Good defaults:
-            - RANK (ranking alignment)
-            - self.error_col (raw metric error)
-            - IMPROVABILITY, LOSS_RESCALED, etc.
-        similarity : {"spearman","pearson"}, default "spearman"
-            Correlation type for fold similarity.
-        agg_across_methods : {"mean","median"}, default "mean"
-            How to aggregate a per-fold similarity score from its similarities to other folds.
-        min_methods : int | None
-            If set, require each fold have at least this many methods present
-            (after pivot) to be included.
-        return_pairwise : bool, default True
-            If True, also return a tidy dataframe of fold-pair similarities.
-
-        Returns:
-        -------
-        out : dict
-            - "fold_similarity_matrix": pd.DataFrame (fold x fold)
-            - "fold_scores": pd.DataFrame indexed by fold with columns:
-                ["score", "num_methods"]
-            - "most_similar_pair": tuple | None  (fold_i, fold_j, sim)
-            - "least_similar_pair": tuple | None (fold_i, fold_j, sim)
-            - "fold_method_matrix": pd.DataFrame (fold x method)
-            - "pairwise": pd.DataFrame (optional) columns [seed_i, seed_j, similarity]
-        """
-        if self.seed_column is None:
-            raise ValueError("BenchmarkEvaluator.seed_column is None, but fold similarity requires a seed/fold column.")
-        if self.seed_column not in results_per_task.columns:
-            raise ValueError(
-                f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
-            )
-        if similarity not in {"spearman", "pearson"}:
-            raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
-        if agg_across_methods not in {"mean", "median"}:
-            raise ValueError(f"agg_across_methods must be 'mean' or 'median', got {agg_across_methods!r}")
-
-        required = {self.task_col, self.method_col, self.seed_column, value_col}
-        missing = [c for c in required if c not in results_per_task.columns]
-        if missing:
-            raise ValueError(
-                f"results_per_task is missing required columns: {missing}\n"
-                f"Available columns: {list(results_per_task.columns)}",
-            )
-
-        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
-        if df.empty:
-            raise ValueError(
-                f"No rows found for {self.task_col} == {dataset!r}.\n"
-                f"Available datasets: {sorted(results_per_task[self.task_col].unique())[:50]}",
-            )
-
-        # If duplicates exist for (task, seed, method), average them.
-        df = df.groupby([self.task_col, self.seed_column, self.method_col], as_index=False)[value_col].mean()
-
-        # Pivot -> folds x methods
-        M = df.pivot(index=self.seed_column, columns=self.method_col, values=value_col)
-
-        # Optionally filter folds with insufficient method coverage
-        num_methods_per_fold = M.notna().sum(axis=1)
-        if min_methods is not None:
-            keep = num_methods_per_fold >= min_methods
-            M = M.loc[keep]
-            num_methods_per_fold = num_methods_per_fold.loc[keep]
-            if M.shape[0] == 0:
-                raise ValueError(f"No folds have >= {min_methods} methods after filtering.")
-
-        # Correlation across methods between folds
-        # corr over rows => transpose to make folds columns
-        fold_sim = M.T.corr(method=similarity)
-
-        # Per-fold "representativeness among folds": average similarity to other folds
-        if fold_sim.shape[0] <= 1:
-            scores = pd.Series(index=fold_sim.index, data=np.nan, dtype=float)
-        else:
-            off_diag = fold_sim.copy()
-            np.fill_diagonal(off_diag.values, np.nan)
-            if agg_across_methods == "mean":
-                scores = off_diag.mean(axis=1, skipna=True)
-            else:
-                scores = off_diag.median(axis=1, skipna=True)
-
-        fold_scores = pd.DataFrame(
-            {
-                "score": scores,
-                "num_methods": num_methods_per_fold.reindex(fold_sim.index).astype(int),
-            }
-        ).sort_values("score", ascending=False)
-
-        # Identify most/least similar fold pairs
-        most_pair = None
-        least_pair = None
-        if fold_sim.shape[0] >= 2:
-            # consider only upper triangle (excluding diagonal)
-            sim_vals = fold_sim.where(np.triu(np.ones(fold_sim.shape), k=1).astype(bool))
-            stacked = sim_vals.stack(future_stack=True)  # MultiIndex (seed_i, seed_j) -> similarity
-            if len(stacked) > 0:
-                (i_max, j_max), v_max = stacked.idxmax(), float(stacked.max())
-                (i_min, j_min), v_min = stacked.idxmin(), float(stacked.min())
-                most_pair = (i_max, j_max, v_max)
-                least_pair = (i_min, j_min, v_min)
-
-        out = {
-            "fold_similarity_matrix": fold_sim,
-            "fold_scores": fold_scores,
-            "most_similar_pair": most_pair,
-            "least_similar_pair": least_pair,
-            "fold_method_matrix": M,
-        }
-
-        if return_pairwise and fold_sim.shape[0] >= 2:
-            sim_vals = fold_sim.where(np.triu(np.ones(fold_sim.shape), k=1).astype(bool))
-
-            # Ensure the row/col index level names are unique before stacking,
-            # otherwise reset_index can try to insert a column that already exists.
-            idx_name = fold_sim.index.name or self.seed_column or "fold"
-            col_name = fold_sim.columns.name or self.seed_column or "fold"
-
-            # Use internal unique names for stack/reset_index
-            sim_vals_safe = sim_vals.copy()
-            sim_vals_safe.index = sim_vals_safe.index.rename(f"__{idx_name}_i")
-            sim_vals_safe.columns = sim_vals_safe.columns.rename(f"__{col_name}_j")
-
-            # pandas >= 2.1: support future_stack=True (silences FutureWarning)
-            try:
-                s = sim_vals_safe.stack(future_stack=True)
-            except TypeError:
-                s = sim_vals_safe.stack(dropna=True)
-            s = s.dropna()
-
-            pairwise = s.rename("similarity").reset_index()
-
-            # Rename back to desired output names (avoid collisions on rename too)
-            col_i = f"{self.seed_column}_i"
-            col_j = f"{self.seed_column}_j"
-            pairwise = pairwise.rename(
-                columns={
-                    f"__{idx_name}_i": col_i,
-                    f"__{col_name}_j": col_j,
-                }
-            )
-
-            pairwise = pairwise.sort_values("similarity", ascending=False).reset_index(drop=True)
-            out["pairwise"] = pairwise
-        return out
-
-    def rank_datasets_by_fold_similarity(
-        self,
-        results_per_task: pd.DataFrame,
-        value_col: str = RANK,
-        *,
-        similarity: str = "spearman",  # {"spearman", "pearson"}
-        agg_fold_score: str = "mean_pairwise",  # {"mean_pairwise", "median_pairwise"}
-        min_folds: int = 2,
-        min_methods: int | None = None,
-        include_pairwise_extremes: bool = True,
-        # --- new: stability estimation controls ---
-        target_reliability: float = 0.90,
-        stability_cap_folds: int = 100,
-        stability_conservative: bool = True,
-        stability_rho_floor: float = 0.01,
-    ) -> dict:
-        """Rank datasets by how consistently their folds/seeds agree with each other,
-        and estimate how many folds are needed to get a stable global ordering.
-
-        Assumes `results_per_task` was computed with `include_seed_col=True` so that
-        each row corresponds to (task, seed, method) with a metric like rank/error.
-
-        For each dataset:
-          1) build fold x method matrix
-          2) compute fold-fold similarity matrix (correlation across methods)
-          3) summarize it into a single "fold agreement" score
-          4) estimate stability/reliability of the k-fold aggregate and folds needed
-             to hit `target_reliability`, using Spearman–Brown style extrapolation:
-                Rel(k) = (k*rho) / (1 + (k-1)*rho)
-             where rho ~= fold_agreement.
-
-        Parameters
-        ----------
-        results_per_task : pd.DataFrame
-            Output of `self.compute_results_per_task(..., include_seed_col=True)`.
-            Must include `self.seed_column`.
-        value_col : str, default RANK
-            Column used to compare method performance across folds.
-        similarity : {"spearman","pearson"}, default "spearman"
-            Similarity metric for fold-fold correlation across methods.
-        agg_fold_score : {"mean_pairwise","median_pairwise"}, default "mean_pairwise"
-            How to aggregate fold-fold similarities into a dataset score.
-        min_folds : int, default 2
-            Require at least this many folds/seeds for a dataset to be scored.
-        min_methods : int | None
-            If set, require each fold have at least this many methods present.
-            Passed through to `dataset_fold_similarity`.
-        include_pairwise_extremes : bool, default True
-            If True, include the most/least similar fold pair per dataset.
-        target_reliability : float, default 0.90
-            Stability threshold τ in (0,1). Higher = stricter stability requirement.
-        stability_cap_folds : int, default 100
-            Maximum folds to return for `folds_needed_for_stability@τ`.
-        stability_conservative : bool, default True
-            If True, treat rho<=0 as "not stably orderable" and return cap (with rho floored).
-        stability_rho_floor : float, default 0.01
-            Minimum rho used when conservative and rho is extremely small/negative.
-
-        Returns:
-        -------
-        out : dict
-            - "dataset_ranking": pd.DataFrame indexed by dataset with columns:
-                ["fold_agreement", "num_folds", "num_methods_min", "num_methods_mean",
-                 "rho_used", "stability_at_num_folds@{τ}", "folds_needed_for_stability@{τ}",
-                 "most_similar_pair", "least_similar_pair" (optional), "error" (optional)]
-              sorted descending by fold_agreement.
-            - "per_dataset": dict[str, dict]
-              Lightweight per-dataset summary.
-            - "stability_params": dict
-              Echo of stability configuration.
-        """
-        if self.seed_column is None:
-            raise ValueError(
-                "BenchmarkEvaluator.seed_column is None, but fold similarity ranking requires a seed/fold column."
-            )
-        if self.seed_column not in results_per_task.columns:
-            raise ValueError(
-                f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
-            )
-        if agg_fold_score not in {"mean_pairwise", "median_pairwise"}:
-            raise ValueError(
-                f"agg_fold_score must be 'mean_pairwise' or 'median_pairwise', got {agg_fold_score!r}",
-            )
-        if similarity not in {"spearman", "pearson"}:
-            raise ValueError(f"similarity must be 'spearman' or 'pearson', got {similarity!r}")
-        if not (0 < float(target_reliability) < 1):
-            raise ValueError(f"target_reliability must be in (0,1), got {target_reliability!r}")
-
-        tau = float(target_reliability)
-        tau_tag = f"{tau:.2f}".rstrip("0").rstrip(".")  # e.g. "0.9" or "0.95"
-        col_stability_at_k = "stability_at_num_folds"
-        col_folds_needed = f"folds_needed_for_stability@{tau_tag}"
-
-        def _rel(k: int, rho: float) -> float:
-            if k <= 0 or not np.isfinite(rho) or rho <= 0:
-                return 0.0
-            return (k * rho) / (1.0 + (k - 1) * rho)
-
-        def _folds_needed(rho: float) -> int:
-            # k >= tau(1-rho)/(rho(1-tau))
-            if not np.isfinite(rho) or rho <= 0:
-                return int(stability_cap_folds)
-            k_float = (tau * (1.0 - rho)) / (rho * (1.0 - tau))
-            k_req = int(np.ceil(k_float))
-            return max(1, min(int(stability_cap_folds), k_req))
-
-        datasets = list(pd.Index(results_per_task[self.task_col].unique()).sort_values())
-
-        rows: list[dict] = []
-        per_dataset: dict[str, dict] = {}
-
-        for ds in datasets:
-            try:
-                out_ds = self.dataset_fold_similarity(
-                    results_per_task=results_per_task,
-                    dataset=ds,
-                    value_col=value_col,
-                    similarity=similarity,
-                    agg_across_methods="mean",  # not used for dataset score
-                    min_methods=min_methods,
-                    return_pairwise=False,
-                )
-            except Exception as e:
-                rows.append(
-                    {
-                        self.task_col: ds,
-                        "fold_agreement": np.nan,
-                        "num_folds": 0,
-                        "num_methods_min": np.nan,
-                        "num_methods_mean": np.nan,
-                        "rho_used": np.nan,
-                        col_stability_at_k: np.nan,
-                        col_folds_needed: np.nan,
-                        "error": repr(e),
-                    }
-                )
-                continue
-
-            fold_sim = out_ds["fold_similarity_matrix"]
-            fold_method = out_ds["fold_method_matrix"]
-
-            num_folds = int(fold_sim.shape[0])
-            methods_per_fold = fold_method.notna().sum(axis=1)
-            num_methods_min = int(methods_per_fold.min()) if len(methods_per_fold) else np.nan
-            num_methods_mean = float(methods_per_fold.mean()) if len(methods_per_fold) else np.nan
-
-            if num_folds < min_folds:
-                rows.append(
-                    {
-                        self.task_col: ds,
-                        "fold_agreement": np.nan,
-                        "num_folds": num_folds,
-                        "num_methods_min": num_methods_min,
-                        "num_methods_mean": num_methods_mean,
-                        "rho_used": np.nan,
-                        col_stability_at_k: np.nan,
-                        col_folds_needed: np.nan,
-                        "error": f"Too few folds (min_folds={min_folds})",
-                    }
-                )
-                continue
-
-            # Aggregate off-diagonal similarities into dataset agreement score (rho estimate)
-            sim_vals = fold_sim.to_numpy(copy=True)
-            np.fill_diagonal(sim_vals, np.nan)
-
-            rho = float(np.nanmean(sim_vals)) if agg_fold_score == "mean_pairwise" else float(np.nanmedian(sim_vals))
-
-            rho_used = rho
-            notes = None
-            if stability_conservative:
-                # clamp to [-1,1]
-                if rho_used > 1:
-                    rho_used = 1.0
-                if rho_used < -1:
-                    rho_used = -1.0
-                if rho_used <= 0:
-                    # treat as not reliably aggregatable; use floor for rel(k) curve but folds_needed -> cap
-                    notes = "rho<=0; stability may not be achievable by averaging folds alone"
-                    rho_used = max(float(stability_rho_floor), 0.0)
-
-            stability_at_k = float(_rel(num_folds, rho_used))
-            folds_needed = int(_folds_needed(rho_used))
-
-            row = {
-                self.task_col: ds,
-                "fold_agreement": rho,  # raw estimate from observed fold similarities
-                "num_folds": num_folds,
-                "num_methods_min": num_methods_min,
-                "num_methods_mean": num_methods_mean,
-                "rho_used": rho_used,  # what we used for stability extrapolation
-                col_stability_at_k: stability_at_k,
-                col_folds_needed: folds_needed,
-            }
-            if notes is not None:
-                row["stability_note"] = notes
-
-            if include_pairwise_extremes and num_folds >= 2:
-                tri = np.triu(np.ones_like(sim_vals, dtype=bool), k=1)
-                vals = sim_vals[tri]
-                if np.isfinite(vals).any():
-                    fold_labels = list(fold_sim.index)
-                    ij = np.argwhere(tri)
-                    k_max = int(np.nanargmax(vals))
-                    i_max, j_max = map(int, ij[k_max])
-                    row["most_similar_pair"] = (fold_labels[i_max], fold_labels[j_max], float(vals[k_max]))
-
-                    k_min = int(np.nanargmin(vals))
-                    i_min, j_min = map(int, ij[k_min])
-                    row["least_similar_pair"] = (fold_labels[i_min], fold_labels[j_min], float(vals[k_min]))
-                else:
-                    row["most_similar_pair"] = None
-                    row["least_similar_pair"] = None
-
-            rows.append(row)
-
-            per_dataset[ds] = {
-                "fold_agreement": rho,
-                "num_folds": num_folds,
-                "num_methods_min": num_methods_min,
-                "num_methods_mean": num_methods_mean,
-                "rho_used": rho_used,
-                col_stability_at_k: stability_at_k,
-                col_folds_needed: folds_needed,
-            }
-            if notes is not None:
-                per_dataset[ds]["stability_note"] = notes
-            if include_pairwise_extremes:
-                per_dataset[ds]["most_similar_pair"] = row.get("most_similar_pair")
-                per_dataset[ds]["least_similar_pair"] = row.get("least_similar_pair")
-
-        ranking = pd.DataFrame(rows).set_index(self.task_col)
-        ranking = ranking.sort_values(by="fold_agreement", ascending=False)
-
-        return {
-            "dataset_ranking": ranking,
-            "per_dataset": per_dataset,
-            "stability_params": {
-                "target_reliability": tau,
-                "cap_folds": stability_cap_folds,
-                "conservative": stability_conservative,
-                "rho_floor": stability_rho_floor,
-                "similarity": similarity,
-                "agg_fold_score": agg_fold_score,
-            },
-        }
-
-    def jitter_all_datasets(
-        self,
-        results_per_task: pd.DataFrame,
-        *,
-        rank_col: str = RANK,
-        metric: str = "winrate",
-        datasets: list[str] | None = None,
-        return_per_method: bool = False,
-        sort_by: str = "jitter_mean",
-        ascending: bool = True,
-    ) -> tuple[pd.DataFrame, dict[str, dict] | None]:
-        """Compute fold jitter metrics for each dataset.
-
-        This is a wrapper around `self.dataset_jitter(...)`.
-
-        Parameters
-        ----------
-        results_per_task : pd.DataFrame
-            Output of `self.compute_results_per_task(..., include_seed_col=True)`.
-        rank_col : str, default RANK
-            Column read for per-fold ranks (rescaled to winrate when metric="winrate").
-        metric : {"winrate", "rank"}, default "winrate"
-            Per-method per-fold score used to compute jitter. ``"winrate"`` rescales the
-            rank to ``1 - (rank - 1)/(M - 1)`` so jitter values are in [0, 1] and
-            comparable across benchmarks with different method counts.
-        datasets : list[str] | None
-            If specified, only compute for these datasets. Otherwise uses all unique datasets.
-        return_per_method : bool, default False
-            If True, also return a dict keyed by dataset with per-method jitter outputs.
-        sort_by : str, default "jitter_mean"
-            Column name to sort the returned DataFrame by.
-        ascending : bool, default True
-            Sort direction.
-
-        Returns:
-        -------
-        df : pd.DataFrame
-            One row per dataset with:
-            ["dataset", "metric", "num_folds", "num_methods", "jitter_mean", "pairwise_jitter_mean"]
-            plus "error" if a dataset fails.
-        per_method : dict[str, dict] | None
-            If return_per_method=True, a dict of per-dataset detailed outputs; else None.
-        """
-        if self.seed_column is None:
-            raise ValueError("seed_column must be set to compute fold jitter.")
-        if self.seed_column not in results_per_task.columns:
-            raise ValueError(
-                f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
-            )
-
-        if datasets is None:
-            datasets = list(pd.Index(results_per_task[self.task_col].unique()).sort_values())
-
-        rows: list[dict] = []
-        per_method: dict[str, dict] | None = {} if return_per_method else None
-
-        for ds in datasets:
-            try:
-                out = self.dataset_jitter(
-                    results_per_task=results_per_task,
-                    dataset=ds,
-                    rank_col=rank_col,
-                    metric=metric,
-                    return_per_method=return_per_method,
-                )
-                # ensure consistent row schema
-                rows.append(
-                    {
-                        "dataset": out["dataset"],
-                        "metric": out["metric"],
-                        "num_folds": out["num_folds"],
-                        "num_methods": out["num_methods"],
-                        "jitter_mean": out["jitter_mean"],
-                        "pairwise_jitter_mean": out["pairwise_jitter_mean"],
-                    }
-                )
-
-                if return_per_method:
-                    assert per_method is not None
-                    # Keep only the per-method parts to avoid duplication
-                    per_method[ds] = {
-                        "per_method_jitter_mean": out.get("per_method_jitter_mean", None),
-                        "per_method_pairwise_jitter_mean": out.get("per_method_pairwise_jitter_mean", None),
-                    }
-
-            except Exception as e:
-                rows.append(
-                    {
-                        "dataset": ds,
-                        "metric": metric,
-                        "num_folds": np.nan,
-                        "num_methods": np.nan,
-                        "jitter_mean": np.nan,
-                        "pairwise_jitter_mean": np.nan,
-                        "error": repr(e),
-                    }
-                )
-                if return_per_method:
-                    assert per_method is not None
-                    per_method[ds] = {"error": repr(e)}
-
-        df = pd.DataFrame(rows)
-
-        if sort_by is not None and sort_by in df.columns:
-            df = df.sort_values(by=sort_by, ascending=ascending, na_position="last").reset_index(drop=True)
-
-        return df, per_method
-
-    def dataset_jitter(
-        self,
-        results_per_task: pd.DataFrame,
-        dataset: str,
-        *,
-        rank_col: str = RANK,
-        metric: str = "winrate",
-        return_per_method: bool = False,
-    ) -> dict:
-        """Compute fold-instability metrics for a dataset.
-
-        ``metric`` selects the per-fold per-method score:
-          - ``"winrate"`` (default): per-fold winrate ``1 - (rank - 1) / (M - 1)``,
-            in [0, 1] regardless of M. Comparable across benchmarks with different
-            method counts.
-          - ``"rank"``: raw per-fold rank from ``rank_col``, scale depends on M.
-
-        Metrics returned:
-          - jitter_mean:
-                E_{fold, method}[ |score_fold - score_global| ]
-          - pairwise_jitter_mean:
-                E_{fold1<fold2, method}[ |score_f1 - score_f2| ]
-
-        Assumes results_per_task was computed with include_seed_col=True.
-
-        Parameters
-        ----------
-        results_per_task : pd.DataFrame
-        dataset : str
-        rank_col : str
-            Source rank column (default: RANK).
-        metric : {"winrate", "rank"}, default "winrate"
-        return_per_method : bool
-            If True, also return per-method jitter statistics.
-
-        Returns:
-        -------
-        dict
-        """
-        if metric not in ("winrate", "rank"):
-            raise ValueError(f"metric must be 'winrate' or 'rank', got {metric!r}")
-        if self.seed_column is None:
-            raise ValueError("seed_column must be set to compute fold jitter.")
-        if self.seed_column not in results_per_task.columns:
-            raise ValueError(
-                "results_per_task must include seed column. Call compute_results_per_task(..., include_seed_col=True)",
-            )
-
-        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
-
-        if df.empty:
-            raise ValueError(f"No rows found for dataset {dataset!r}")
-
-        # Pivot: folds x methods (values are ranks; rescaled to winrate below if requested)
-        M = df.pivot(
-            index=self.seed_column,
-            columns=self.method_col,
-            values=rank_col,
-        )
-
-        # Drop methods with any missing folds
-        M = M.dropna(axis=1)
-
-        folds = M.index.tolist()
-        methods = M.columns.tolist()
-
-        num_folds = len(folds)
-        num_methods = len(methods)
-
-        if num_folds < 2:
-            raise ValueError("Need at least 2 folds to compute jitter.")
-        if num_methods < 2:
-            raise ValueError("Need at least 2 methods to compute jitter.")
-
-        if metric == "winrate":
-            # winrate = 1 - (rank - 1) / (M - 1); in [0, 1] regardless of M.
-            M = 1.0 - (M - 1.0) / (num_methods - 1)
-
-        # ---------------------------------------------------------
-        # 1) Expected jitter: deviation of per-fold score from the global mean
-        # ---------------------------------------------------------
-
-        global_score = M.mean(axis=0)
-
-        abs_dev = (M - global_score).abs()
-
-        jitter_mean = abs_dev.values.mean()
-
-        # ---------------------------------------------------------
-        # 2) Pairwise jitter: average absolute change between folds
-        # ---------------------------------------------------------
-
-        pairwise_changes = []
-
-        for i in range(num_folds):
-            for j in range(i + 1, num_folds):
-                diff = (M.iloc[i] - M.iloc[j]).abs()
-                pairwise_changes.append(diff.values.mean())
-
-        pairwise_jitter_mean = float(np.mean(pairwise_changes))
-
-        result = {
-            "dataset": dataset,
-            "metric": metric,
-            "num_folds": num_folds,
-            "num_methods": num_methods,
-            "jitter_mean": float(jitter_mean),
-            "pairwise_jitter_mean": pairwise_jitter_mean,
-        }
-
-        if return_per_method:
-            result["per_method_jitter_mean"] = abs_dev.mean(axis=0)
-            result["per_method_pairwise_jitter_mean"] = pd.concat(
-                [(M.iloc[i] - M.iloc[j]).abs() for i in range(num_folds) for j in range(i + 1, num_folds)],
-                axis=1,
-            ).mean(axis=1)
-
-        return result
-
-    def dataset_jitter_bootstrap_curve(
-        self,
-        results_per_task: pd.DataFrame,
-        dataset: str,
-        *,
-        rank_col: str = RANK,
-        metric: str = "winrate",
-        k_values: list[int] | None = None,
-        n_bootstrap: int = 500,
-        seed: int = 0,
-        drop_methods_with_any_missing: bool = True,
-    ) -> pd.DataFrame:
-        """Bootstrap how the k-fold *mean per-method score* converges to the global mean.
-
-        For each bootstrap replicate:
-          - sample k folds WITH replacement
-          - compute per-method mean score across those k folds  (mu_hat_k)
-          - compare to per-method global mean score across ALL folds (mu_global)
-          - jitter_k = mean_m |mu_hat_k[m] - mu_global[m]|
-
-        ``metric`` selects the per-fold per-method score:
-          - ``"winrate"`` (default): per-fold winrate ``1 - (rank - 1) / (M - 1)``,
-            in [0, 1] regardless of M. Comparable across datasets/benchmarks with
-            different method counts.
-          - ``"rank"``: raw per-fold rank from ``rank_col``, scale depends on M.
-
-        Returns a DataFrame with mean/median/95% CI of jitter_k vs k, plus a
-        ``metric`` column identifying which score was used.
-        """
-        if metric not in ("winrate", "rank"):
-            raise ValueError(f"metric must be 'winrate' or 'rank', got {metric!r}")
-        if self.seed_column is None:
-            raise ValueError("seed_column must be set to compute fold jitter.")
-        if self.seed_column not in results_per_task.columns:
-            raise ValueError(
-                f"results_per_task must include seed column {self.seed_column!r}. "
-                "Ensure you called compute_results_per_task(..., include_seed_col=True).",
-            )
-
-        df = results_per_task.loc[results_per_task[self.task_col] == dataset].copy()
-        if df.empty:
-            raise ValueError(f"No rows found for dataset {dataset!r}")
-
-        # folds x methods matrix of ranks (the canonical per-fold score; winrate is a
-        # per-fold linear rescale of rank, see below)
-        M_df = df.pivot(index=self.seed_column, columns=self.method_col, values=rank_col)
-
-        if drop_methods_with_any_missing:
-            M_df = M_df.dropna(axis=1)
-        elif M_df.isna().any().any():
-            raise ValueError(
-                "Found NaNs in fold×method matrix. Set drop_methods_with_any_missing=True "
-                "or impute missing values before bootstrapping.",
-            )
-
-        M_full = M_df.to_numpy(dtype=float)  # shape (F, M), values are ranks
-        F, M = M_full.shape
-        if F < 1:
-            raise ValueError("No folds available after filtering.")
-        if M < 2:
-            raise ValueError("Need at least 2 methods after filtering.")
-
-        if metric == "winrate":
-            # winrate = 1 - (rank - 1) / (M - 1); in [0, 1] regardless of M.
-            # Equivalent to the pairwise winrate convention with average-rank tie handling.
-            M_full = 1.0 - (M_full - 1.0) / (M - 1.0)
-
-        # Global per-method mean score across ALL folds (fixed reference)
-        mu_global = M_full.mean(axis=0)  # shape (M,)
-
-        if k_values is None:
-            k_values = list(range(1, F + 1))
-        else:
-            k_values = [int(k) for k in k_values]
-            if any(k < 1 for k in k_values):
-                raise ValueError("All k_values must be >= 1.")
-            if any(k > F for k in k_values):
-                raise ValueError(f"All k_values must be <= number of available folds ({F}).")
-
-        rng = np.random.default_rng(seed)
-
-        def _summ(x: np.ndarray) -> dict:
-            return dict(
-                mean=float(np.mean(x)),
-                p50=float(np.quantile(x, 0.50)),
-                p025=float(np.quantile(x, 0.025)),
-                p975=float(np.quantile(x, 0.975)),
-            )
-
-        rows: list[dict] = []
-
-        for k in k_values:
-            jit = np.empty(n_bootstrap, dtype=float)
-
-            for b in range(n_bootstrap):
-                # Sample folds WITH replacement: classical bootstrap of the k-fold
-                # mean against the all-folds reference. At k=F this still produces
-                # non-zero jitter (Monte-Carlo resampling noise of the all-folds
-                # mean estimate) — without that, Φ=1 collapses to 0 in the strip.
-                idx = rng.choice(F, size=k, replace=True)
-                M_sel = M_full[idx, :]  # (k, M)
-
-                mu_hat = M_sel.mean(axis=0)  # per-method mean score across sampled folds
-                jit[b] = float(np.abs(mu_hat - mu_global).mean())
-
-            s = _summ(jit)
-            rows.append(
-                {
-                    "dataset": dataset,
-                    "metric": metric,
-                    "k": k,
-                    "n_bootstrap": n_bootstrap,
-                    "n_folds_available": F,
-                    "n_methods": M,
-                    "jitter_mean": s["mean"],
-                    "jitter_p50": s["p50"],
-                    "jitter_p025": s["p025"],
-                    "jitter_p975": s["p975"],
-                }
-            )
-
-        return pd.DataFrame(rows).sort_values("k").reset_index(drop=True)
-
-    def jitter_bootstrap_curve_all_datasets(
-        self,
-        results_per_task: pd.DataFrame,
-        *,
-        rank_col: str = RANK,
-        metric: str = "winrate",
-        k_values: list[int] | None = None,
-        n_bootstrap: int = 300,
-        seed: int = 0,
-        drop_methods_with_any_missing: bool = True,
-    ) -> pd.DataFrame:
-        datasets = list(pd.Index(results_per_task[self.task_col].unique()).sort_values())
-        dfs: list[pd.DataFrame] = []
-
-        for ds in datasets:
-            try:
-                d = self.dataset_jitter_bootstrap_curve(
-                    results_per_task=results_per_task,
-                    dataset=ds,
-                    rank_col=rank_col,
-                    metric=metric,
-                    k_values=k_values,
-                    n_bootstrap=n_bootstrap,
-                    seed=seed,
-                    drop_methods_with_any_missing=drop_methods_with_any_missing,
-                )
-                dfs.append(d)
-            except Exception as e:
-                dfs.append(
-                    pd.DataFrame(
-                        [
-                            {
-                                "dataset": ds,
-                                "metric": metric,
-                                "k": np.nan,
-                                "n_bootstrap": n_bootstrap,
-                                "error": repr(e),
-                            }
-                        ]
-                    )
-                )
-
-        return pd.concat(dfs, axis=0, ignore_index=True)
-
-    @staticmethod
-    def estimate_folds_for_stable_ordering(
-        fold_agreement: float,
-        num_folds: int,
-        *,
-        target_reliability: float = 0.90,  # "stable ordering" threshold
-        cap: int = 100,  # safety cap
-        conservative: bool = True,
-        rho_floor: float = 0.01,
-    ) -> dict:
-        """Estimate how many folds are needed to get a stable global ordering on a dataset,
-        based on observed inter-fold agreement.
-
-        Uses Spearman–Brown style extrapolation:
-            Rel(k) = (k*rho) / (1 + (k-1)*rho)
-        where rho ~ mean pairwise fold correlation ("fold_agreement").
-
-        Parameters
-        ----------
-        fold_agreement : float
-            Mean pairwise fold similarity (e.g., Spearman correlation across methods).
-        num_folds : int
-            Number of folds used to estimate fold_agreement.
-            Used mainly for reporting; the extrapolation itself uses fold_agreement.
-        target_reliability : float, default 0.90
-            Target reliability for considering the ordering "stable".
-        cap : int, default 100
-            Maximum folds to return (avoid absurd numbers).
-        conservative : bool, default True
-            If True, clamp rho into a plausible range and warn on edge cases.
-        rho_floor : float, default 0.01
-            Minimum rho to use when conservative and rho is extremely small/negative.
-
-        Returns:
-        -------
-        dict with:
-            - "rho": used rho
-            - "target_reliability": tau
-            - "k_required": estimated folds needed (int, capped)
-            - "rel_at_num_folds": estimated reliability at the observed num_folds
-            - "rel_curve": optional small table (k, Rel(k)) for k in [1..min(cap, 20)]
-            - "notes": list[str]
-        """
-        notes = []
-        rho = float(fold_agreement)
-
-        if not np.isfinite(rho):
-            raise ValueError("fold_agreement must be finite.")
-
-        # Correlation should be in [-1, 1]; we only have meaningful fold-averaging reliability for rho > 0
-        if conservative:
-            if rho > 1:
-                notes.append("rho > 1 encountered; clamping to 1.")
-                rho = 1.0
-            if rho < -1:
-                notes.append("rho < -1 encountered; clamping to -1.")
-                rho = -1.0
-
-            if rho <= 0:
-                notes.append(
-                    "fold_agreement <= 0 suggests folds disagree or are unrelated; "
-                    "a stable global ordering may not be achievable by averaging folds alone. "
-                    "Returning cap.",
-                )
-                rho = max(rho_floor, 0.0)
-
-        tau = float(target_reliability)
-        if not (0 < tau < 1):
-            raise ValueError("target_reliability must be in (0, 1).")
-
-        def rel(k: int) -> float:
-            if k <= 0:
-                return np.nan
-            if rho <= 0:
-                return 0.0
-            return (k * rho) / (1.0 + (k - 1) * rho)
-
-        rel_at_num = rel(int(num_folds))
-
-        # Solve k >= tau(1-rho)/(rho(1-tau))
-        if rho <= 0:
-            k_req = cap
-        else:
-            k_float = (tau * (1.0 - rho)) / (rho * (1.0 - tau))
-            k_req = int(np.ceil(k_float))
-            k_req = max(1, k_req)
-
-        if k_req > cap:
-            notes.append(f"Estimated folds ({k_req}) exceed cap ({cap}); returning cap.")
-            k_req = cap
-
-        rel_curve = [(k, rel(k)) for k in range(1, min(cap, 20) + 1)]
-        rel_curve_df = pd.DataFrame(rel_curve, columns=["k", "reliability"])
-
-        return {
-            "rho": rho,
-            "target_reliability": tau,
-            "k_required": k_req,
-            "rel_at_num_folds": rel_at_num,
-            "rel_curve": rel_curve_df,
-            "notes": notes,
-        }
 
 
 def get_bootstrap_result_lst(

--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -2017,7 +2017,9 @@ class BenchmarkEvaluator:
         import pandas as pd
 
         if self.seed_column is None:
-            raise ValueError("BenchmarkEvaluator.seed_column is None, but fold similarity ranking requires a seed/fold column.")
+            raise ValueError(
+                "BenchmarkEvaluator.seed_column is None, but fold similarity ranking requires a seed/fold column."
+            )
         if self.seed_column not in results_per_task.columns:
             raise ValueError(
                 f"results_per_task must include seed column {self.seed_column!r}. "

--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -94,17 +94,14 @@ class BenchmarkEvaluator:
             required_input_columns.append(self.seed_column)
         return required_input_columns
 
-    def _get_task_groupby_cols(self, results: pd.DataFrame) -> list[str]:
-        task_groupby_cols = self.task_groupby_columns
-        if self.seed_column is not None and self.seed_column in results.columns:
-            task_groupby_cols = [*task_groupby_cols, self.seed_column]
-        return task_groupby_cols
+    def _resolve_groupby_columns(self, df: pd.DataFrame, *, task_only: bool = False) -> list[str]:
+        """Return the groupby columns, appending the seed column iff it is present in ``df``.
 
-    def _get_groupby_cols(self, results: pd.DataFrame) -> list[str]:
-        groupby_cols = self.groupby_columns
-        if self.seed_column is not None and self.seed_column in results.columns:
-            groupby_cols = [*groupby_cols, self.seed_column]
-        return groupby_cols
+        ``task_only=True`` returns the task-level columns (excluding ``method_col``).
+        """
+        base = self.task_groupby_columns if task_only else self.groupby_columns
+        seed_col = self._seed_col_if_present(df)
+        return [*base, seed_col] if seed_col is not None else base
 
     def leaderboard(
         self,
@@ -197,7 +194,7 @@ class BenchmarkEvaluator:
                 )
 
         if include_rank_counts:
-            results_lst.append(self.compute_ranks(results_per_task=results_per_task))
+            results_lst.append(self.compute_rank_counts(results_per_task=results_per_task))
 
         cols_to_use = [c for c in results_agg.columns if c != RANK]
         results_lst.append(results_agg[cols_to_use])
@@ -495,7 +492,7 @@ class BenchmarkEvaluator:
         # Combine mean and median
         return pd.concat([mean_df, median_df], axis=1)
 
-    def compute_ranks(self, results_per_task: pd.DataFrame) -> pd.DataFrame:
+    def compute_rank_counts(self, results_per_task: pd.DataFrame) -> pd.DataFrame:
         df = results_per_task.copy()
 
         group_cols = self.groupby_columns  # e.g., ["task"] or ["task", "seed"]
@@ -787,7 +784,7 @@ class BenchmarkEvaluator:
         baseline_method: str | None,
         use_optimal: bool = False,
     ):
-        task_groupby_cols = self._get_task_groupby_cols(results=results_per_task)
+        task_groupby_cols = self._resolve_groupby_columns(results_per_task, task_only=True)
         if use_optimal:
             baseline_result = results_per_task.groupby(task_groupby_cols)[self.error_col].min()
         else:
@@ -1004,7 +1001,7 @@ class BenchmarkEvaluator:
         results_per_task: pd.DataFrame,
         baseline_method: str,
     ) -> pd.Series:
-        task_groupby_cols = self._get_task_groupby_cols(results=results_per_task)
+        task_groupby_cols = self._resolve_groupby_columns(results_per_task, task_only=True)
         seed_col = self.seed_column if self.seed_column in task_groupby_cols else None
         results_per_task = results_per_task.copy()
         results_per_task["baseline_advantage"] = self.compute_baseline_advantage_per(
@@ -1089,7 +1086,7 @@ class BenchmarkEvaluator:
 
     def compute_frontier_advantage(self, results_per_task: pd.DataFrame) -> pd.Series:
         """Equal-task-weighted mean frontier advantage per method (higher is better)."""
-        task_groupby_cols = self._get_task_groupby_cols(results=results_per_task)
+        task_groupby_cols = self._resolve_groupby_columns(results_per_task, task_only=True)
         seed_col = self.seed_column if self.seed_column in task_groupby_cols else None
         results_per_task = results_per_task.copy()
         results_per_task[FRONTIER_ADVANTAGE] = self.compute_frontier_advantage_per(results_per_task, task_groupby_cols)
@@ -1127,10 +1124,6 @@ class BenchmarkEvaluator:
         )
         results_rank.name = RANK
         return results_rank
-
-    def dataset_outlier(self, results_per_task: pd.DataFrame):
-        # Compute how much of an outlier the results of a given dataset are (squared rank differential?)
-        raise NotImplementedError
 
     # TODO: Should plotting live in a separate class?
     def plot_critical_diagrams(
@@ -1361,7 +1354,7 @@ class BenchmarkEvaluator:
             return df[self.error_col]
 
         def score(self: BenchmarkEvaluator, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
-            groupby_columns = self._get_groupby_cols(df)
+            groupby_columns = self._resolve_groupby_columns(df)
             tmp = df[groupby_columns].copy()
             tmp[self.error_col] = values.to_numpy()
             per_method = self._score_weighted_mean_by_task(tmp, value_col=self.error_col, sort_asc=True)
@@ -1379,11 +1372,11 @@ class BenchmarkEvaluator:
         """Lower is better. Score = weighted mean rank."""
 
         def compute(self: BenchmarkEvaluator, df: pd.DataFrame) -> pd.Series:
-            task_groupby_cols = self._get_task_groupby_cols(results=df)
+            task_groupby_cols = self._resolve_groupby_columns(df, task_only=True)
             return self.compare_rank_per(df=df, task_groupby_cols=task_groupby_cols)
 
         def score(self: BenchmarkEvaluator, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
-            groupby_columns = self._get_groupby_cols(df)
+            groupby_columns = self._resolve_groupby_columns(df)
             tmp = df[groupby_columns].copy()
             tmp[RANK] = values.to_numpy()
             per_method = self._score_weighted_mean_by_task(tmp, value_col=RANK, sort_asc=True)
@@ -1401,11 +1394,11 @@ class BenchmarkEvaluator:
         """Lower is better (0 is ideal). Score = weighted mean improvability."""
 
         def compute(self: BenchmarkEvaluator, df: pd.DataFrame) -> pd.Series:
-            task_groupby_cols = self._get_task_groupby_cols(results=df)
+            task_groupby_cols = self._resolve_groupby_columns(df, task_only=True)
             return self.compute_improvability_per(results_per_task=df, task_groupby_cols=task_groupby_cols)
 
         def score(self: BenchmarkEvaluator, df: pd.DataFrame, values: pd.Series, method_1: str) -> float:
-            groupby_columns = self._get_groupby_cols(df)
+            groupby_columns = self._resolve_groupby_columns(df)
             tmp = df[groupby_columns].copy()
             tmp[IMPROVABILITY] = values.to_numpy()
             per_method = self._score_weighted_mean_by_task(tmp, value_col=IMPROVABILITY, sort_asc=True)
@@ -1515,8 +1508,6 @@ class BenchmarkEvaluator:
         df_plot : pd.DataFrame
             Filtered dataframe used for plotting (one row per observation).
         """
-        import os
-
         import plotly.express as px
 
         if metric_col is None:
@@ -2013,9 +2004,6 @@ class BenchmarkEvaluator:
             - "stability_params": dict
               Echo of stability configuration.
         """
-        import numpy as np
-        import pandas as pd
-
         if self.seed_column is None:
             raise ValueError(
                 "BenchmarkEvaluator.seed_column is None, but fold similarity ranking requires a seed/fold column."
@@ -2236,9 +2224,6 @@ class BenchmarkEvaluator:
         per_method : dict[str, dict] | None
             If return_per_method=True, a dict of per-dataset detailed outputs; else None.
         """
-        import numpy as np
-        import pandas as pd
-
         if self.seed_column is None:
             raise ValueError("seed_column must be set to compute fold jitter.")
         if self.seed_column not in results_per_task.columns:
@@ -2344,9 +2329,6 @@ class BenchmarkEvaluator:
         -------
         dict
         """
-        import numpy as np
-        import pandas as pd
-
         if metric not in ("winrate", "rank"):
             raise ValueError(f"metric must be 'winrate' or 'rank', got {metric!r}")
         if self.seed_column is None:
@@ -2456,9 +2438,6 @@ class BenchmarkEvaluator:
         Returns a DataFrame with mean/median/95% CI of jitter_k vs k, plus a
         ``metric`` column identifying which score was used.
         """
-        import numpy as np
-        import pandas as pd
-
         if metric not in ("winrate", "rank"):
             raise ValueError(f"metric must be 'winrate' or 'rank', got {metric!r}")
         if self.seed_column is None:
@@ -2564,9 +2543,6 @@ class BenchmarkEvaluator:
         seed: int = 0,
         drop_methods_with_any_missing: bool = True,
     ) -> pd.DataFrame:
-        import numpy as np
-        import pandas as pd
-
         datasets = list(pd.Index(results_per_task[self.task_col].unique()).sort_values())
         dfs: list[pd.DataFrame] = []
 
@@ -2721,35 +2697,3 @@ def get_bootstrap_result_lst(
             rows.append(func_(data_new, **func_kwargs))
     df = pd.DataFrame(rows)
     return df[df.median().sort_values(ascending=False).index]
-
-
-def _jitter_from_fold_method_matrix(
-    M: np.ndarray,  # shape (k_folds, n_methods)
-) -> tuple[float, float]:
-    """Compute:
-      - expected_rank_jitter relative to global (mean across folds)
-      - observed_avg_abs_rank_change between folds.
-
-    Parameters
-    ----------
-    M : np.ndarray
-        Fold x method matrix of ranks (or any scalar performance; ranks recommended).
-
-    Returns:
-    -------
-    expected_rank_jitter : float
-    observed_avg_abs_rank_change : float
-    """
-    k, _m = M.shape
-    global_rank = M.mean(axis=0, keepdims=True)  # (1, m)
-    expected_rank_jitter = float(np.abs(M - global_rank).mean())
-
-    if k < 2:
-        observed = float("nan")
-    else:
-        # Mean over pairs (i<j) and methods of |rank_i - rank_j|
-        diffs = np.abs(M[:, None, :] - M[None, :, :])  # (k, k, m)
-        iu = np.triu_indices(k, k=1)
-        observed = float(diffs[iu].mean())  # averages over pairs and methods
-
-    return expected_rank_jitter, observed

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -667,7 +667,7 @@ class AbstractArenaContext:
         ``compute_fold_similarity`` ranks datasets by how consistently their folds/seeds agree
         (and estimates folds-needed-for-stability), writing ``fold_similarity.csv`` to
         ``output_dir``. ``fold_similarity_kwargs`` is forwarded to
-        :meth:`bencheval.tabarena.TabArena.rank_datasets_by_fold_similarity` (e.g.
+        :meth:`bencheval.evaluator.BenchmarkEvaluator.rank_datasets_by_fold_similarity` (e.g.
         ``{"similarity": "pearson", "target_reliability": 0.95}``); ignored unless
         ``compute_fold_similarity`` is True.
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal, Self
 
 import pandas as pd
 
-from bencheval.tabarena import TabArena
+from bencheval.evaluator import BenchmarkEvaluator
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.nips2025_utils.compare import compare
 from tabarena.nips2025_utils.end_to_end_single import (
@@ -414,7 +414,7 @@ class EndToEndResults:
             # fillna=False,
         )
 
-        tabarena = TabArena(
+        tabarena = BenchmarkEvaluator(
             method_col="method",
             task_col="dataset",
             seed_column="fold",

--- a/packages/tabarena/src/tabarena/nips2025_utils/scripts/run_amlb2025.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/scripts/run_amlb2025.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pandas as pd
 from autogluon.tabular import TabularDataset
 
-from bencheval.tabarena import TabArena
+from bencheval.evaluator import BenchmarkEvaluator
 
 if __name__ == "__main__":
     amlb2025_prefix = "s3://neerick-autogluon/tabarena/benchmarks/amlb2025/"
@@ -71,7 +71,7 @@ if __name__ == "__main__":
         }
     )
 
-    arena = TabArena(
+    arena = BenchmarkEvaluator(
         method_col="method",
         task_col="task",
         error_col="metric_error",

--- a/packages/tabarena/src/tabarena/paper/paper_runner_tabarena.py
+++ b/packages/tabarena/src/tabarena/paper/paper_runner_tabarena.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from bencheval.tabarena import TabArena
+from bencheval.evaluator import BenchmarkEvaluator
 
 from .paper_runner import PaperRun
 
@@ -48,7 +48,7 @@ class PaperRunTabArena(PaperRun):
             combined_data_cur_round = pd.concat(list(results_dict_cur_round.values()), ignore_index=True)
             combined_data = pd.concat([result_baselines, combined_data_cur_round], ignore_index=True)
 
-            arena = TabArena(
+            arena = BenchmarkEvaluator(
                 task_col="dataset",
                 groupby_columns=["problem_type", "metric"],
                 seed_column="fold",

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 from autogluon.common.savers import save_pd
 
-from bencheval.tabarena import TabArena
+from bencheval.evaluator import BenchmarkEvaluator
 from tabarena.benchmark.task.metadata import TaskMetadataCollection, default_task_metadata_collection
 from tabarena.paper.paper_utils import get_f_map_suffix_plots, get_framework_type_method_names, get_method_rename_map
 from tabarena.plot.dataset_analysis import plot_train_time_deep_dive
@@ -794,7 +794,7 @@ class TabArenaEvaluator:
             BOOTSTRAP_ROUNDS=self.elo_bootstrap_rounds,
         )
 
-        tabarena = TabArena(
+        tabarena = BenchmarkEvaluator(
             method_col=self.method_col,
             task_col="dataset",
             seed_column="fold",

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -11,7 +11,7 @@ import pandas as pd
 import seaborn as sns
 from autogluon.common.loaders import load_pd
 
-from bencheval.tabarena import TabArena
+from bencheval.evaluator import BenchmarkEvaluator
 from tabarena.nips2025_utils.compare import subset_tasks
 from tabarena.nips2025_utils.eval_all import (
     get_all_subset_combinations,
@@ -629,12 +629,12 @@ def compute_tuning_trajectories_leaderboard(
         seed_column="fold",
     )
 
-    arena = TabArena(
+    arena = BenchmarkEvaluator(
         **tabarena_init_kwargs,
         error_col="metric_error",
     )
 
-    arena_val = TabArena(
+    arena_val = BenchmarkEvaluator(
         **tabarena_init_kwargs,
         error_col="metric_error_val",
     )

--- a/tst/test_evaluator.py
+++ b/tst/test_evaluator.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import itertools
+import os
 
 import pandas as pd
 import pytest
 
 from bencheval.evaluator import BenchmarkEvaluator
+
+# Headless matplotlib for the plotting smoke tests (must be set before matplotlib import).
+os.environ.setdefault("MPLBACKEND", "Agg")
 
 # ---------------------------------------------------------------------------
 # Deterministic, hand-computable fixture: 3 methods x 3 tasks, no ties.
@@ -35,6 +39,21 @@ def _make_data(seeds: list[int] | None = None) -> pd.DataFrame:
         if s is not None:
             row["seed"] = s
         rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _make_analysis_data(n_seeds: int = 4, n_tasks: int = 4) -> pd.DataFrame:
+    """Seeded data with deterministic per-seed variation, for analysis/jitter/plot smoke tests."""
+    methods = ["A", "B", "C", "D"]
+    tasks = [f"t{i + 1}" for i in range(n_tasks)]
+    rows = []
+    for mi, m in enumerate(methods):
+        for ti, t in enumerate(tasks):
+            for s in range(n_seeds):
+                err = 0.1 * (mi + 1) + 0.05 * ti + 0.01 * ((mi * 7 + ti * 3 + s * 5) % 5)
+                rows.append(
+                    {"method": m, "task": t, "seed": s, "metric_error": err, "time_train_s": 1.0, "time_infer_s": 0.1}
+                )
     return pd.DataFrame(rows)
 
 
@@ -255,3 +274,133 @@ class TestValidation:
         assert len(a_t1) == 1
         # worst error on t1 among present rows is C = 0.4
         assert a_t1["metric_error"].iloc[0] == pytest.approx(0.4)
+
+
+class TestMetricRegistry:
+    def test_metrics_arg_equivalent_to_flags(self, ev, data):
+        # Selecting metrics via `metrics=` yields an identical leaderboard to the
+        # equivalent `include_*` flags (elo omitted: its bootstrap CI is not seeded).
+        keys = [
+            "winrate",
+            "improvability",
+            "mrr",
+            "rank_counts",
+            "baseline_advantage",
+            "frontier_advantage",
+            "relative_error",
+            "skill_score",
+        ]
+        by_flags = ev.leaderboard(
+            data,
+            include_elo=False,
+            include_winrate=True,
+            include_improvability=True,
+            include_mrr=True,
+            include_rank_counts=True,
+            include_baseline_advantage=True,
+            include_frontier_advantage=True,
+            include_relative_error=True,
+            include_skill_score=True,
+            baseline_method="A",
+        )
+        by_metrics = ev.leaderboard(data, metrics=keys, baseline_method="A")
+        pd.testing.assert_frame_equal(by_flags, by_metrics)
+
+    def test_metrics_overrides_flags(self, ev, data):
+        # `metrics=` takes precedence; the include_* flags are ignored for selection.
+        lb = ev.leaderboard(data, include_winrate=True, include_improvability=True, metrics=["elo"])
+        assert "elo" in lb.columns
+        assert "winrate" not in lb.columns
+        assert "improvability" not in lb.columns
+
+    def test_metrics_empty_keeps_only_rank(self, ev, data):
+        lb = ev.leaderboard(data, metrics=[])
+        assert "rank" in lb.columns  # rank is always emitted
+        for absent in ("elo", "winrate", "improvability", "mrr"):
+            assert absent not in lb.columns
+
+    def test_unknown_metric_raises(self, ev, data):
+        with pytest.raises(ValueError, match="Unknown leaderboard metric"):
+            ev.leaderboard(data, metrics=["bogus"])
+
+    def test_baseline_metric_skipped_without_baseline(self, ev, data):
+        # `relative_error` needs a baseline; without one it is silently skipped (parity
+        # with the legacy flag behaviour), while non-baseline metrics still appear.
+        lb = ev.leaderboard(data, metrics=["relative_error", "winrate"])
+        assert "winrate" in lb.columns
+        assert "relative_error" not in lb.columns
+
+
+class TestDatasetAnalysis:
+    """Smoke tests for the extracted DatasetAnalysisMixin (no prior coverage)."""
+
+    @pytest.fixture
+    def seeded(self):
+        ev = BenchmarkEvaluator(seed_column="seed")
+        rpt = ev.compute_results_per_task(_make_analysis_data(), include_seed_col=True)
+        return ev, rpt
+
+    def test_representativeness(self, seeded):
+        ev, rpt = seeded
+        out = ev.dataset_representativeness(rpt)
+        assert {
+            "representativeness",
+            "most_representative",
+            "least_representative",
+            "dataset_similarity_matrix",
+            "method_matrix",
+        } <= set(out)
+
+    def test_fold_similarity_and_ranking(self, seeded):
+        ev, rpt = seeded
+        fs = ev.dataset_fold_similarity(rpt, dataset="t1")
+        assert "fold_similarity_matrix" in fs and "fold_scores" in fs
+        ranking = ev.rank_datasets_by_fold_similarity(rpt)
+        assert "dataset_ranking" in ranking
+        assert len(ranking["dataset_ranking"]) == 4  # one row per task
+
+    def test_jitter(self, seeded):
+        ev, rpt = seeded
+        dj = ev.dataset_jitter(rpt, dataset="t1")
+        assert {"jitter_mean", "pairwise_jitter_mean", "num_folds", "num_methods"} <= set(dj)
+        df_all, _ = ev.jitter_all_datasets(rpt)
+        assert len(df_all) == 4
+        curve = ev.dataset_jitter_bootstrap_curve(rpt, dataset="t1", n_bootstrap=20)
+        assert "jitter_mean" in curve.columns and len(curve) >= 1
+        curves = ev.jitter_bootstrap_curve_all_datasets(rpt, n_bootstrap=10)
+        assert len(curves) >= 1
+
+    def test_estimate_folds_for_stable_ordering(self):
+        out = BenchmarkEvaluator.estimate_folds_for_stable_ordering(fold_agreement=0.8, num_folds=3)
+        assert out["k_required"] >= 1
+        assert 0 <= out["rel_at_num_folds"] <= 1
+
+
+class TestPlotting:
+    """Smoke tests for the extracted PlottingMixin (no prior coverage)."""
+
+    def test_plot_winrate_matrix(self, ev, data, tmp_path):
+        pytest.importorskip("matplotlib")
+        rpt = ev.compute_results_per_task(data)
+        wm = ev.compute_winrate_matrix(rpt)
+        out = tmp_path / "winrate.png"
+        ev.plot_winrate_matrix(wm, save_path=str(out))
+        assert out.exists()
+
+    def test_plot_dataset_metric_distribution(self, ev, data):
+        pytest.importorskip("plotly")
+        rpt = ev.compute_results_per_task(data)
+        # save_path=None avoids the optional kaleido image-export dependency.
+        fig, df_plot = ev.plot_dataset_metric_distribution(rpt, dataset="t1", save_path=None)
+        assert fig is not None
+        assert not df_plot.empty
+
+    def test_plot_critical_diagrams(self, tmp_path):
+        pytest.importorskip("autorank")
+        pytest.importorskip("matplotlib")
+        ev = BenchmarkEvaluator(seed_column="seed")
+        # autorank requires >= 5 rows (tasks), so use 6.
+        rpt = ev.compute_results_per_task(_make_analysis_data(n_tasks=6), include_seed_col=True)
+        out = tmp_path / "cd.png"
+        ev.plot_critical_diagrams(rpt, save_path=str(out))
+        assert out.exists()

--- a/tst/test_evaluator.py
+++ b/tst/test_evaluator.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import itertools
+
+import pandas as pd
+import pytest
+
+from bencheval.evaluator import BenchmarkEvaluator
+
+# ---------------------------------------------------------------------------
+# Deterministic, hand-computable fixture: 3 methods x 3 tasks, no ties.
+#
+#   task    A     B     C
+#   t1     0.1   0.2   0.4
+#   t2     0.1   0.3   0.5
+#   t3     0.2   0.3   0.6
+#
+# A strictly beats B strictly beats C on every task, so per-task ranks are
+# always (A=1, B=2, C=3) and every aggregate metric is exactly computable.
+# ---------------------------------------------------------------------------
+_ERRORS = {
+    ("A", "t1"): 0.1, ("B", "t1"): 0.2, ("C", "t1"): 0.4,
+    ("A", "t2"): 0.1, ("B", "t2"): 0.3, ("C", "t2"): 0.5,
+    ("A", "t3"): 0.2, ("B", "t3"): 0.3, ("C", "t3"): 0.6,
+}  # fmt: skip
+_METHODS = ["A", "B", "C"]
+_TASKS = ["t1", "t2", "t3"]
+
+
+def _make_data(seeds: list[int] | None = None) -> pd.DataFrame:
+    rows = []
+    seed_list: list[int | None] = [None] if seeds is None else list(seeds)
+    for m, t, s in itertools.product(_METHODS, _TASKS, seed_list):
+        row = {"method": m, "task": t, "metric_error": _ERRORS[(m, t)], "time_train_s": 2.0, "time_infer_s": 0.5}
+        if s is not None:
+            row["seed"] = s
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def ev() -> BenchmarkEvaluator:
+    return BenchmarkEvaluator()
+
+
+@pytest.fixture
+def data() -> pd.DataFrame:
+    return _make_data()
+
+
+class TestPerTaskMetrics:
+    def test_compute_results_per_task(self, ev, data):
+        rpt = ev.compute_results_per_task(data).set_index(["method", "task"])
+        # ranks
+        assert rpt.loc[("A", "t1"), "rank"] == pytest.approx(1.0)
+        assert rpt.loc[("B", "t1"), "rank"] == pytest.approx(2.0)
+        assert rpt.loc[("C", "t1"), "rank"] == pytest.approx(3.0)
+        # improvability = 1 - best/error  (0 for the best method)
+        assert rpt.loc[("A", "t1"), "improvability"] == pytest.approx(0.0)
+        assert rpt.loc[("C", "t1"), "improvability"] == pytest.approx(0.75)
+        assert rpt.loc[("B", "t3"), "improvability"] == pytest.approx(1 - 0.2 / 0.3)
+        # loss_rescaled = (error - best) / (worst - best)
+        assert rpt.loc[("A", "t1"), "loss_rescaled"] == pytest.approx(0.0)
+        assert rpt.loc[("C", "t1"), "loss_rescaled"] == pytest.approx(1.0)
+        assert rpt.loc[("B", "t1"), "loss_rescaled"] == pytest.approx(0.1 / 0.3)
+
+    def test_rank_ties_use_average(self, ev):
+        df = pd.DataFrame(
+            {
+                "method": ["A", "B", "C"],
+                "task": ["t1", "t1", "t1"],
+                "metric_error": [0.1, 0.1, 0.3],
+                "time_train_s": [1.0, 1.0, 1.0],
+                "time_infer_s": [0.1, 0.1, 0.1],
+            }
+        )
+        r = ev.compute_results_per_task(df).set_index("method")["rank"]
+        # A and B tie for best -> average of positions 1 and 2 = 1.5
+        assert r.loc["A"] == pytest.approx(1.5)
+        assert r.loc["B"] == pytest.approx(1.5)
+        assert r.loc["C"] == pytest.approx(3.0)
+
+
+class TestAggregateMetrics:
+    def test_rank_counts(self, ev, data):
+        rpt = ev.compute_results_per_task(data)
+        rc = ev.compute_rank_counts(results_per_task=rpt)
+        # each method's bucket counts sum to the number of tasks (3)
+        assert (rc.sum(axis=1).round(6) == 3.0).all()
+        assert rc.loc["A", "rank=1_count"] == pytest.approx(3.0)
+        assert rc.loc["B", "rank=2_count"] == pytest.approx(3.0)
+        assert rc.loc["C", "rank=3_count"] == pytest.approx(3.0)
+        assert rc.loc["A", "rank>3_count"] == pytest.approx(0.0)
+
+    def test_winrate(self, ev, data):
+        rpt = ev.compute_results_per_task(data)
+        wr = ev.compute_winrate(rpt)
+        assert wr.loc["A"] == pytest.approx(1.0)
+        assert wr.loc["B"] == pytest.approx(0.5)
+        assert wr.loc["C"] == pytest.approx(0.0)
+
+    def test_winrate_matrix(self, ev, data):
+        rpt = ev.compute_results_per_task(data)
+        wm = ev.compute_winrate_matrix(rpt)
+        assert wm.loc["A", "B"] == pytest.approx(1.0)
+        assert wm.loc["A", "C"] == pytest.approx(1.0)
+        assert wm.loc["C", "A"] == pytest.approx(0.0)
+        assert wm.loc["B", "C"] == pytest.approx(1.0)
+
+    def test_mrr(self, ev, data):
+        rpt = ev.compute_results_per_task(data)
+        mrr = ev.compute_mrr(rpt)
+        assert mrr.loc["A"] == pytest.approx(1.0)
+        assert mrr.loc["B"] == pytest.approx(0.5)
+        assert mrr.loc["C"] == pytest.approx(1 / 3)
+
+    def test_relative_error(self, ev, data):
+        rpt = ev.compute_results_per_task(data)
+        rel = ev.compute_relative_error(rpt, baseline_method="A")
+        assert rel.loc["A"] == pytest.approx(1.0)
+        assert rel.loc["B"] == pytest.approx((2 + 3 + 1.5) / 3)
+        assert rel.loc["C"] == pytest.approx((4 + 5 + 3) / 3)
+
+    def test_baseline_advantage(self, ev, data):
+        # exercises the consolidated `_resolve_groupby_columns` helper
+        rpt = ev.compute_results_per_task(data)
+        ba = ev.compute_baseline_advantage(rpt, baseline_method="A")
+        assert ba.loc["A"] == pytest.approx(0.0)
+        assert ba.loc["B"] == pytest.approx(-0.5)
+        assert ba.loc["C"] == pytest.approx((-0.75 - 0.8 - 0.4 / 0.6) / 3)
+
+    def test_frontier_advantage(self, ev, data):
+        # exercises the consolidated `_resolve_groupby_columns` helper
+        rpt = ev.compute_results_per_task(data)
+        fa = ev.compute_frontier_advantage(rpt)
+        assert fa.loc["A"] == pytest.approx(0.5)
+        assert fa.loc["B"] == pytest.approx(-0.5)
+        assert fa.loc["C"] == pytest.approx((-0.75 - 0.8 - 0.4 / 0.6) / 3)
+
+    def test_elo_orders_by_dominance(self, ev, data):
+        rpt = ev.compute_results_per_task(data)
+        elo = ev.compute_elo(rpt, include_quantiles=False)
+        assert elo.loc["A", "elo"] > elo.loc["B", "elo"] > elo.loc["C", "elo"]
+
+
+class TestLeaderboard:
+    def test_leaderboard_full(self, ev, data):
+        lb = ev.leaderboard(
+            data,
+            include_error=True,
+            include_elo=True,
+            include_winrate=True,
+            include_improvability=True,
+            include_mrr=True,
+            include_rescaled_loss=True,
+            include_rank_counts=True,
+            include_relative_error=True,
+            include_skill_score=True,
+            include_baseline_advantage=True,
+            include_frontier_advantage=True,
+            baseline_method="A",
+        )
+        # sorted by rank ascending
+        assert list(lb.index) == ["A", "B", "C"]
+        # rank / winrate / mrr
+        assert [lb.loc[m, "rank"] for m in _METHODS] == pytest.approx([1.0, 2.0, 3.0])
+        assert [lb.loc[m, "winrate"] for m in _METHODS] == pytest.approx([1.0, 0.5, 0.0])
+        assert [lb.loc[m, "mrr"] for m in _METHODS] == pytest.approx([1.0, 0.5, 1 / 3])
+        # mean error (equal task weighting)
+        assert [lb.loc[m, "metric_error"] for m in _METHODS] == pytest.approx([0.4 / 3, 0.8 / 3, 0.5])
+        # improvability / loss_rescaled point estimates
+        assert lb.loc["A", "improvability"] == pytest.approx(0.0)
+        assert lb.loc["B", "improvability"] == pytest.approx(0.5)
+        assert lb.loc["C", "loss_rescaled"] == pytest.approx(1.0)
+        assert lb.loc["A", "loss_rescaled"] == pytest.approx(0.0)
+        # relative error / skill score
+        assert lb.loc["A", "relative_error"] == pytest.approx(1.0)
+        assert lb.loc["A", "skill_score"] == pytest.approx(0.0, abs=1e-9)
+        # advantages
+        assert lb.loc["A", "frontier_advantage"] == pytest.approx(0.5)
+        assert lb.loc["B", "baseline_advantage"] == pytest.approx(-0.5)
+        # elo ordering
+        assert lb.loc["A", "elo"] > lb.loc["B", "elo"] > lb.loc["C", "elo"]
+        # rank-count buckets
+        assert lb.loc["A", "rank=1_count"] == pytest.approx(3.0)
+        assert lb.loc["B", "rank=2_count"] == pytest.approx(3.0)
+        assert lb.loc["C", "rank=3_count"] == pytest.approx(3.0)
+
+    def test_seeded_leaderboard_matches_unseeded(self):
+        # identical results across two seeds -> same aggregates as the unseeded case.
+        # Also exercises the seed-present branch of `_resolve_groupby_columns`.
+        ev_s = BenchmarkEvaluator(seed_column="seed")
+        df = _make_data(seeds=[0, 1])
+        for average_seeds in (True, False):
+            lb = ev_s.leaderboard(
+                df,
+                average_seeds=average_seeds,
+                include_baseline_advantage=True,
+                baseline_method="A",
+            )
+            assert list(lb.index) == ["A", "B", "C"]
+            assert lb.loc["A", "rank"] == pytest.approx(1.0)
+            assert lb.loc["C", "rank"] == pytest.approx(3.0)
+            assert lb.loc["B", "baseline_advantage"] == pytest.approx(-0.5)
+
+
+class TestMetricSpecRemoval:
+    def test_score_if_remove_method(self, ev, data):
+        # metric_spec_rank.compute/score route through `_resolve_groupby_columns`
+        rpt = ev.compute_results_per_task(data)
+        spec = ev.metric_spec_rank()
+        # C's weighted-mean rank on the full set is 3.0
+        assert ev.score_if_remove_method(spec, rpt, method_1="C", method_2="C") == pytest.approx(3.0)
+        # removing B promotes C from rank 3 to rank 2 on every task
+        assert ev.score_if_remove_method(spec, rpt, method_1="C", method_2="B") == pytest.approx(2.0)
+
+    def test_greedy_score_matrix(self, ev, data):
+        rpt = ev.compute_results_per_task(data)
+        spec = ev.metric_spec_rank()
+        gm = ev.greedy_score_matrix(spec, rpt, methods_1=["C"])
+        # greedy removes the other two methods one at a time; C's rank improves
+        # 3 -> 2 -> 1. Which removed method maps to which score depends on tie-break
+        # order, so assert on the set of resulting scores instead.
+        assert set(gm.index) == {"A", "B"}
+        assert sorted(gm["C"].dropna().tolist()) == pytest.approx([1.0, 2.0])
+
+
+class TestValidation:
+    def test_missing_column_raises(self, ev, data):
+        with pytest.raises(ValueError):
+            ev.verify_data(data.drop(columns=["time_infer_s"]))
+
+    def test_negative_error_raises(self, ev, data):
+        bad = data.copy()
+        bad.loc[0, "metric_error"] = -0.5
+        with pytest.raises(ValueError):
+            ev.verify_data(bad)
+
+    def test_non_dense_raises(self, ev, data):
+        # drop the (A, t1) row -> not every method has every task
+        with pytest.raises(AssertionError):
+            ev.verify_data(data.iloc[1:])
+
+    def test_clean_data_clips_tiny_negative(self, ev, data):
+        d = data.copy()
+        d.loc[0, "metric_error"] = -1e-16  # within negative_error_threshold (-1e-15)
+        cleaned = ev.clean_data(d)
+        assert cleaned["metric_error"].min() >= 0
+
+    def test_fillna_worst(self, ev, data):
+        missing = data[~((data["method"] == "A") & (data["task"] == "t1"))].copy()
+        filled = ev.fillna_data(missing, fillna_method="worst")
+        assert len(filled) == 9  # all (method, task) combos restored
+        a_t1 = filled[(filled["method"] == "A") & (filled["task"] == "t1")]
+        assert len(a_t1) == 1
+        # worst error on t1 among present rows is C = 0.4
+        assert a_t1["metric_error"].iloc[0] == pytest.approx(0.4)


### PR DESCRIPTION
## Summary

Renames the `bencheval` leaderboard/evaluation engine from `TabArena` to **`BenchmarkEvaluator`** and restructures it. It was a domain-agnostic comparative evaluator over `(method, task, error)` result frames, but the old name collided with the `tabarena` package's many `TabArena*` classes and misleadingly implied it was TabArena-specific.

> **Scope note:** this PR was merged at the bottom of a 3-PR stack and, because the stack was collapsed before landing, it carries the changes from **#362** (Tier 2) and **#363** (Tier 3) as well. All three tiers below landed via this PR.

## 1. Rename + module move (Tier 0)

- `class TabArena` → `class BenchmarkEvaluator`.
- `bencheval/tabarena.py` → `bencheval/evaluator.py` (git-tracked rename).
- Updated all import sites, instantiations, type hints, and `:meth:` docs across the `tabarena` package, examples, and `AGENTS.md`.
- Benchmark/product strings that name the TabArena benchmark itself (plot titles, "TabArena paper results", "global TabArena cache", "TabArena ensemble") were intentionally left unchanged.
- `RANK` / `IMPROVABILITY` / `LOSS_RESCALED` / `FRONTIER_ADVANTAGE` remain importable from `bencheval.evaluator` (re-exported) for backward compatibility.

⚠️ This is a breaking rename of a documented public API (`bencheval.tabarena.TabArena`), with no deprecation shim.

## 2. Tier 1 — behaviour-preserving cleanup

- Consolidated the duplicated seed-column groupby helpers into one `_resolve_groupby_columns(df, *, task_only=False)`.
- Removed dead code: `dataset_outlier` (a `NotImplementedError` stub) and the unused module-level `_jitter_from_fold_method_matrix`.
- Dropped redundant in-method `import numpy/pandas/os` (all already imported at module top).
- Renamed `compute_ranks` → `compute_rank_counts` to disambiguate from the weighted-mean `compute_rank` (no external callers of the `BenchmarkEvaluator` method).

## 3. Tier 2 (#362) — drive `leaderboard()` from an ordered metric registry

- Replaced the ~75-line procedural `if`-chain in `leaderboard()` with a declarative, ordered registry (`_LEADERBOARD_METRICS` of `_LeaderboardMetric` producers).
- Added a composable `metrics=` argument (e.g. `leaderboard(df, metrics=["elo", "winrate", "mrr"])`) that overrides the legacy `include_*` flags; the flags now map onto registry keys, so the public signature stays fully backward compatible. Adding a column is now one registry entry, no new parameter or branch.
- The greedy-removal `MetricSpec` system was intentionally left untouched (different output shape — per-method scalar over arbitrary subsets).

## 4. Tier 3 (#363) — split the god class into concern modules

Extracted the three cohesive clusters out of the 2.8k-line `evaluator.py` into focused modules, mixed back into `BenchmarkEvaluator` via inheritance so the public API is byte-for-byte identical (verbatim bodies, no delegators):

| Module | Mixin | Methods |
|---|---|---|
| `bencheval/_validation.py` | `ResultsValidationMixin` | `verify_data`, `verify_data_is_dense`, `verify_error`, `clean_data`, `fillna_data` |
| `bencheval/_analysis.py` | `DatasetAnalysisMixin` | `dataset_representativeness`, `dataset_fold_similarity`, `rank_datasets_by_fold_similarity`, the `*jitter*` family, `estimate_folds_for_stable_ordering` |
| `bencheval/_plotting.py` | `PlottingMixin` | `plot_winrate_matrix`, `plot_critical_diagrams`, `plot_dataset_metric_distribution` |
| `bencheval/_common.py` | — | shared column-name constants (breaks the evaluator↔mixin import cycle; re-exported from `evaluator.py`) |

`evaluator.py` drops from **2,832 → 1,233 lines**, now focused on construction, the leaderboard/metric registry, the `compute_*` metrics, and the greedy `MetricSpec`. Mixins were chosen over standalone classes + delegation because ~17 of these methods are public and several are called externally; mixins preserve that surface exactly at lowest risk.

## Tests & verification

- New suite `tst/test_evaluator.py` — this class had **no prior tests**. Deterministic, hand-computable fixture covering per-task metrics, rank counts, winrate (+matrix), MRR, relative error, baseline/frontier advantage, Elo ordering, the full `leaderboard()` (seeded and unseeded), the `metrics=` registry path (incl. an `assert_frame_equal` equivalence with the flags path), `MetricSpec` greedy removal, validation/cleaning/fillna, and smoke tests that execute every analysis and plotting method.
- The Tier 1/2/3 refactors are verified behaviour-preserving: the same test suite passes unchanged across the rename, the registry rewrite, and the module split (the registry change additionally proven equivalent via `assert_frame_equal`).
- `ruff check` / `ruff format` clean; all modules byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
