### PR TITLE
Fix loss_rescaled NaN on tied tasks and Elo quantile crash

### DIFF
--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -629,7 +629,12 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
 
         if include_quantiles:
             assert bars_quantiles is not None
-            relative_to = bootstrap_median if use_bootstrap_median_for_quantiles else elo
+            # Center the bars on the bootstrap median only when it was actually computed;
+            # otherwise (e.g. BOOTSTRAP_ROUNDS <= 1) fall back to the point estimate so the
+            # bar widths collapse to 0 instead of raising on `bootstrap_median is None`.
+            relative_to = (
+                bootstrap_median if (use_bootstrap_median_for_quantiles and bootstrap_median is not None) else elo
+            )
             bars["elo+"] = bars_quantiles["upper"] - relative_to
             bars["elo-"] = relative_to - bars_quantiles["lower"]
 
@@ -889,9 +894,11 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
     def compute_loss_rescaled_per(self, results_per_task: pd.DataFrame, task_groupby_cols: list[str]) -> pd.Series:
         best_error_per = results_per_task.groupby(task_groupby_cols)[self.error_col].transform("min")
         worst_error_per = results_per_task.groupby(task_groupby_cols)[self.error_col].transform("max")
-        loss_rescaled = (results_per_task[self.error_col] - best_error_per) / (worst_error_per - best_error_per).fillna(
-            0
-        )
+        # fillna(0) must wrap the whole ratio: when worst == best (all methods tied on a
+        # task) the denominator is 0 and the ratio is 0/0 = NaN, which should rescale to 0.
+        loss_rescaled = (
+            (results_per_task[self.error_col] - best_error_per) / (worst_error_per - best_error_per)
+        ).fillna(0)
         loss_rescaled.name = LOSS_RESCALED
         return loss_rescaled
 

--- a/tst/test_evaluator.py
+++ b/tst/test_evaluator.py
@@ -404,3 +404,57 @@ class TestPlotting:
         out = tmp_path / "cd.png"
         ev.plot_critical_diagrams(rpt, save_path=str(out))
         assert out.exists()
+
+
+class TestBugFixes:
+    """Regression tests for specific fixed defects."""
+
+    def _tied_task_data(self) -> pd.DataFrame:
+        # t1: A and B tie (worst == best -> zero denominator); t2: a normal task.
+        return pd.DataFrame(
+            {
+                "method": ["A", "B", "A", "B"],
+                "task": ["t1", "t1", "t2", "t2"],
+                "metric_error": [0.5, 0.5, 0.1, 0.2],
+                "time_train_s": [1.0, 1.0, 1.0, 1.0],
+                "time_infer_s": [0.1, 0.1, 0.1, 0.1],
+            }
+        )
+
+    def test_loss_rescaled_zero_on_tied_task(self, ev):
+        # Bug: misplaced .fillna(0) on the denominator left a 0/0 = NaN; it must be 0.
+        rpt = ev.compute_results_per_task(self._tied_task_data()).set_index(["method", "task"])
+        loss = rpt.loc[[("A", "t1"), ("B", "t1")], "loss_rescaled"]
+        assert loss.notna().all()
+        assert (loss == 0.0).all()
+        # the normal task is unaffected: best -> 0, worst -> 1
+        assert rpt.loc[("A", "t2"), "loss_rescaled"] == pytest.approx(0.0)
+        assert rpt.loc[("B", "t2"), "loss_rescaled"] == pytest.approx(1.0)
+
+    def test_loss_rescaled_no_nan_in_leaderboard(self, ev):
+        lb = ev.leaderboard(self._tied_task_data(), include_rescaled_loss=True, include_elo=False)
+        assert lb["loss_rescaled"].notna().all()
+
+    def test_elo_quantiles_without_bootstrap_does_not_crash(self, ev):
+        # Bug: use_bootstrap_median_for_quantiles=True with no bootstrap median (BOOTSTRAP_ROUNDS<=1)
+        # raised `float - None`. It must fall back to the point estimate and give zero-width bars.
+        df = pd.DataFrame(
+            {
+                "method": ["A", "B", "A", "B"],
+                "task": ["t1", "t1", "t2", "t2"],
+                "metric_error": [0.1, 0.2, 0.1, 0.3],
+                "time_train_s": [1.0, 1.0, 1.0, 1.0],
+                "time_infer_s": [0.1, 0.1, 0.1, 0.1],
+            }
+        )
+        rpt = ev.compute_results_per_task(df)
+        bars = ev.compute_elo(
+            rpt,
+            BOOTSTRAP_ROUNDS=1,
+            include_quantiles=True,
+            use_bootstrap_median=False,
+            use_bootstrap_median_for_quantiles=True,
+        )
+        assert {"elo", "elo+", "elo-"} <= set(bars.columns)
+        assert (bars["elo+"] == 0).all()
+        assert (bars["elo-"] == 0).all()


### PR DESCRIPTION
## Summary

Fixes two pre-existing defects in `BenchmarkEvaluator` (surfaced during the structural review of the rename/refactor work; not introduced by it). Branched from `main`.

## Bug 1 — `compute_loss_rescaled_per`: NaN on tied tasks

The `.fillna(0)` bound only to the **denominator** `(worst - best)` — which is never NaN, so it was a no-op:

```python
# before
loss_rescaled = (error - best) / (worst - best).fillna(0)
# after
loss_rescaled = ((error - best) / (worst - best)).fillna(0)
```

When a task has all methods tied (`worst == best`), the old code computed `0 / 0 = NaN` instead of `0`. The NaN propagated into the leaderboard `loss_rescaled` column, where `aggregate`'s `mean(numeric_only=True)` **silently dropped** the degenerate task (so it was excluded rather than contributing 0), and an all-tied / single-method benchmark produced a NaN column. The sibling `compute_improvability_per` already wraps the whole expression in `.fillna(0)`; this aligns the two.

## Bug 2 — `compute_elo`: `TypeError` when centering quantiles on a missing bootstrap median

With `use_bootstrap_median_for_quantiles=True` but no bootstrap actually run (e.g. `BOOTSTRAP_ROUNDS <= 1` and `use_bootstrap_median=False`), `bootstrap_median` stayed `None`, so `bars_quantiles[...] - relative_to` raised `unsupported operand type(s) for -: 'float' and 'NoneType'`.

```python
relative_to = bootstrap_median if (use_bootstrap_median_for_quantiles and bootstrap_median is not None) else elo
```

Now it falls back to the point estimate, so the bar widths collapse to 0 — exactly what the existing `BOOTSTRAP_ROUNDS<=1` warning ("widths will be set to 0") already promises.

## Tests

3 regression tests in `tst/test_evaluator.py::TestBugFixes`:
- tied-task `loss_rescaled` is `0` (not NaN), normal task unaffected;
- the leaderboard `loss_rescaled` column has no NaNs on tied data;
- the previously-crashing Elo parameter combination runs and yields zero-width bars.

Both fixes are behaviour-preserving outside the degenerate cases. Full suite: **34 passed** (31 existing + 3 new); `ruff check` / `ruff format` clean.

> Not included here: the third finding from the review — `relative_error` / `skill_score` producing `inf` when a baseline task error is exactly 0 — was intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
