### PR TITLE
Document intended `inf` in relative_error; map 0/0 (both perfect) to 1.0

### DIFF
--- a/packages/bencheval/src/bencheval/evaluator.py
+++ b/packages/bencheval/src/bencheval/evaluator.py
@@ -701,7 +701,16 @@ class BenchmarkEvaluator(ResultsValidationMixin, DatasetAnalysisMixin, PlottingM
         # Map (join) the baseline error back onto every row of its task group
         results_per_task = results_per_task.merge(baseline_result, on=task_groupby_cols, how="left")
 
-        relative_error = results_per_task[self.error_col] / results_per_task["baseline_error"]
+        # `relative_error = error / baseline_error` is a deliberate, unbounded ratio. When the
+        # baseline is perfect (baseline_error == 0) but a method is not, the ratio is +inf, and
+        # that +inf is intended: a positive error is infinitely large *relative* to a zero-error
+        # baseline. It is NOT clamped (unlike the bounded baseline/frontier advantage metrics).
+        # The only genuinely undefined case is 0 / 0 — method and baseline both perfect on the
+        # task — which we treat as a tie, i.e. relative error 1.0.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            relative_error = results_per_task[self.error_col] / results_per_task["baseline_error"]
+        both_zero = (results_per_task[self.error_col] == 0) & (results_per_task["baseline_error"] == 0)
+        relative_error = relative_error.mask(both_zero, 1.0)
         relative_error.name = "relative_error"
         return relative_error
 

--- a/tst/test_evaluator.py
+++ b/tst/test_evaluator.py
@@ -406,6 +406,30 @@ class TestPlotting:
         assert out.exists()
 
 
+class TestRelativeErrorZeroBaseline:
+    """relative_error against a perfect (zero-error) baseline."""
+
+    def test_inf_when_baseline_perfect_and_method_not(self, ev):
+        # t1: baseline A is perfect (0.0), B is not -> B's relative error is +inf (intended).
+        # t2: a normal task.
+        df = pd.DataFrame(
+            {
+                "method": ["A", "B", "A", "B"],
+                "task": ["t1", "t1", "t2", "t2"],
+                "metric_error": [0.0, 0.2, 0.1, 0.3],
+                "time_train_s": [1.0, 1.0, 1.0, 1.0],
+                "time_infer_s": [0.1, 0.1, 0.1, 0.1],
+            }
+        )
+        rpt = ev.compute_results_per_task(df)
+        rel = ev.compute_relative_error_per(rpt, baseline_method="A").to_numpy()
+        s = rpt.assign(rel=rel).set_index(["method", "task"])["rel"]
+        assert s.loc[("A", "t1")] == 1.0  # 0/0 (both perfect) -> tie
+        assert s.loc[("B", "t1")] == float("inf")  # positive error vs perfect baseline -> inf
+        assert s.loc[("A", "t2")] == pytest.approx(1.0)
+        assert s.loc[("B", "t2")] == pytest.approx(3.0)
+
+
 class TestBugFixes:
     """Regression tests for specific fixed defects."""
 


### PR DESCRIPTION
## Summary

Clarifies and slightly hardens `BenchmarkEvaluator.compute_relative_error_per`. Follows up the discussion on PR #364: the `inf` from a zero-error baseline is **not** a bug, so this PR documents that it's intended and only fixes the one genuinely-undefined edge. Branched from `main` (which already has #361 and #364).

## What changed

`relative_error = error / baseline_error` is a deliberate, unbounded ratio (lower is better; 1.0 = matches baseline).

- **`inf` is intended, now documented.** When the baseline is perfect (`baseline_error == 0`) and a method is not, the ratio is `+inf` — a positive error is infinitely large *relative* to a zero-error baseline. It is deliberately **not** clamped, unlike the bounded `baseline_advantage` / `frontier_advantage` metrics (whose `max(...)`-denominator guard maps a zero denominator — i.e. *both* perfect — to 0). A comment now spells this out so the asymmetry isn't mistaken for an oversight.
- **`0 / 0` → `1.0`.** The only truly undefined case is method and baseline *both* perfect on a task. That previously produced `NaN`; it's now mapped to `1.0` (a tie — identical error ⇒ relative error 1).
- Intended divide-by-zero / invalid warnings are silenced with `np.errstate`.

## Tests

`tst/test_evaluator.py::TestRelativeErrorZeroBaseline` asserts, on a task with a perfect baseline `A`:
- `A` (0/0, both perfect) → `1.0`;
- `B` (positive error vs perfect baseline) → `inf`;
- a normal task is unaffected (`1.0`, `3.0`).

Full suite: **35 passed**; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
