### PR TITLE
[New Model] Nori (Synthefy)

### DIFF
--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -95,6 +95,7 @@ limix = [
 tabpfnwide = ["tabpfnwide>=0.3.0"]
 iltm = ["iltm>=0.1.1"]
 chimeraboost = ["chimeraboost>=0.13.0"]
+nori = ["synthefy-nori>=0.6.0"]
 
 # Core benchmark set: the always-on models for benchmarking. Self-references avoid duplicating package specs.
 benchmark = [
@@ -122,6 +123,7 @@ extended = [
   "tabarena[tabpfnwide]",
   "tabarena[iltm]",
   "tabarena[chimeraboost]",
+  "tabarena[nori]",
 ]
 
 # Convenience: everything (core + extended + probmetrics).

--- a/packages/tabarena/src/tabarena/models/__init__.py
+++ b/packages/tabarena/src/tabarena/models/__init__.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from tabarena.models.knn.model import KNNNewModel
     from tabarena.models.limix.model import LimiXModel
     from tabarena.models.modernnca.model import ModernNCAModel
+    from tabarena.models.nori.model import NoriModel
     from tabarena.models.orionmsp.model import OrionMSPModel
     from tabarena.models.perpetual_booster.model import PerpetualBoosterModel
     from tabarena.models.realmlp.model import RealMLPModel
@@ -41,6 +42,7 @@ _LAZY_CLASSES: dict[str, str] = {
     "KNNNewModel": "tabarena.models.knn.model",
     "LimiXModel": "tabarena.models.limix.model",
     "ModernNCAModel": "tabarena.models.modernnca.model",
+    "NoriModel": "tabarena.models.nori.model",
     "OrionMSPModel": "tabarena.models.orionmsp.model",
     "PerpetualBoosterModel": "tabarena.models.perpetual_booster.model",
     "RealMLPModel": "tabarena.models.realmlp.model",

--- a/packages/tabarena/src/tabarena/models/nori/__init__.py
+++ b/packages/tabarena/src/tabarena/models/nori/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from tabarena.models.nori.hpo import gen_nori
+from tabarena.models.nori.info import nori_info, nori_method_metadata
+
+__all__ = ["gen_nori", "nori_info", "nori_method_metadata"]

--- a/packages/tabarena/src/tabarena/models/nori/_patch.py
+++ b/packages/tabarena/src/tabarena/models/nori/_patch.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sklearn.preprocessing import FunctionTransformer
+
+# Make a fitted ``synthefy_nori`` model picklable by AutoGluon.
+#
+# Nori builds its feature-rebalancing pipeline (``RebalanceFeatureDistribution._set``)
+# out of ``sklearn.preprocessing.FunctionTransformer`` steps whose ``func``/``inverse_func``
+# are *local lambdas*. The stdlib ``pickle`` AutoGluon uses to persist a fitted model cannot
+# serialize local lambdas, so saving raises::
+#
+#     AttributeError: Can't pickle local object
+#     'RebalanceFeatureDistribution._set.<locals>.<lambda>'
+#
+# For LimiX we fixed the same class of bug by replacing the lambdas with module-level
+# functions in the *vendored* source. ``synthefy_nori`` is a pip dependency (not vendored),
+# so instead we monkeypatch the ``FunctionTransformer`` symbol the pipeline is built from
+# with a subclass that (de)serializes its callables via ``cloudpickle`` (which pickles
+# lambdas by value). Behavior is otherwise identical to the base class.
+
+
+def _load_pft(state: bytes) -> _PicklableFunctionTransformer:
+    """Rebuild a :class:`_PicklableFunctionTransformer` from its cloudpickled state."""
+    import cloudpickle
+
+    obj = _PicklableFunctionTransformer.__new__(_PicklableFunctionTransformer)
+    obj.__dict__.update(cloudpickle.loads(state))
+    return obj
+
+
+class _PicklableFunctionTransformer(FunctionTransformer):
+    """A ``FunctionTransformer`` that pickles via ``cloudpickle``.
+
+    Only the pickling protocol differs from the base class; ``fit``/``transform`` are
+    inherited unchanged. Rebuilding into this subclass (rather than the base class) keeps a
+    loaded model re-picklable, e.g. for ``refit_full`` or cross-process fold fitting.
+    """
+
+    def __reduce__(self) -> tuple:
+        import cloudpickle
+
+        return (_load_pft, (cloudpickle.dumps(self.__dict__),))
+
+
+_PATCHED = False
+
+
+def ensure_picklable_preprocessing() -> None:
+    """Idempotently make ``synthefy_nori``'s fitted pipeline picklable.
+
+    Swaps ``synthefy_nori.inference.preprocess.FunctionTransformer`` for
+    :class:`_PicklableFunctionTransformer` so every transformer the pipeline builds afterwards
+    survives the stdlib pickle AutoGluon uses to save models. Safe to call repeatedly; must be
+    called before the model is fit (the pipeline is built during fit).
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    from synthefy_nori.inference import preprocess
+
+    preprocess.FunctionTransformer = _PicklableFunctionTransformer
+    _PATCHED = True

--- a/packages/tabarena/src/tabarena/models/nori/hpo.py
+++ b/packages/tabarena/src/tabarena/models/nori/hpo.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from tabarena.models.nori.model import NoriModel
+from tabarena.utils.config_utils import ConfigGenerator
+
+gen_nori = ConfigGenerator(
+    model_cls=NoriModel,
+    search_space={},
+    manual_configs=[{}],
+)
+
+
+if __name__ == "__main__":
+    from tabarena.benchmark.experiment import YamlExperimentSerializer
+
+    print(
+        YamlExperimentSerializer.to_yaml_str(
+            experiments=gen_nori.generate_all_bag_experiments(num_random_configs=0),
+        ),
+    )

--- a/packages/tabarena/src/tabarena/models/nori/info.py
+++ b/packages/tabarena/src/tabarena/models/nori/info.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models._model_info import ModelInfo
+from tabarena.models.nori.hpo import gen_nori
+from tabarena.models.nori.model import NoriModel
+
+nori_method_metadata = MethodMetadata(
+    method="Nori",
+    display_name="Nori",
+    method_type="config",
+    compute="gpu",
+    date="2026-06-18",
+    ag_key="TA-NORI",
+    config_default="Nori_c1_BAG_L1",
+    can_hpo=False,
+    is_bag=False,
+    verified=False,
+    reference_url="https://github.com/Synthefy/synthefy-nori",
+    # has_raw/has_processed/has_results + s3_bucket/s3_prefix/cache_type are set by
+    # the maintainers when the result artifacts are hosted in the official pool.
+)
+
+nori_info = ModelInfo(
+    model_cls=NoriModel,
+    search_space=gen_nori,
+    method_metadata=nori_method_metadata,
+    pip_extra=("synthefy-nori>=0.6.0",),
+    prefetch_weights=NoriModel.prefetch_weights,
+)

--- a/packages/tabarena/src/tabarena/models/nori/model.py
+++ b/packages/tabarena/src/tabarena/models/nori/model.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
+from autogluon.common.utils.resource_utils import ResourceManager
+from autogluon.features.generators import LabelEncoderFeatureGenerator
+from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class NoriModel(AbstractTorchModel):
+    """Nori: a tabular foundation model for regression via in-context learning.
+
+    Paper/citation: Synthefy Nori
+    Authors: Synthefy (Li Po-han, Aditya Narayanan, Sai Shankar Narasimhan, et al.)
+    Codebase: https://github.com/Synthefy/synthefy-nori
+    License: Apache-2.0
+
+    Notes:
+        - ``NoriRegressor`` is a scikit-learn estimator (``fit``/``predict``) and
+          normalizes the target internally, so we pass ``y`` through unchanged and
+          rely on the default regression ``_predict_proba`` path.
+        - ``NoriRegressor.fit`` coerces ``X`` to a float32 array, so categoricals are
+          label-encoded here. NaN is forwarded as-is: Nori's inference pipeline
+          handles missing values natively (``allow-nan``).
+        - ``NoriRegressor`` exposes no random seed (inference is deterministic given
+          the context), so ``seed_name`` is left unset.
+    """
+
+    ag_key = "TA-NORI"
+    ag_name = "TA-Nori"
+    ag_priority = 65
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._feature_generator: LabelEncoderFeatureGenerator | None = None
+        self._cat_indices: list[int] | None = None
+
+    def _preprocess(self, X: pd.DataFrame, *, is_train: bool = False, **kwargs) -> np.ndarray:
+        """Label-encode categoricals to numeric and return a float32 array.
+
+        NaN is preserved (Nori handles missing values natively); only categorical
+        columns are encoded, numeric columns pass through untouched.
+        """
+        X = super()._preprocess(X, **kwargs)
+
+        if is_train:
+            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
+            self._feature_generator.fit(X=X)
+
+        if self._feature_generator.features_in:
+            X = X.copy()
+            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+            if is_train:
+                self._cat_indices = [X.columns.get_loc(c) for c in self._feature_generator.features_in]
+
+        return np.asarray(X.to_numpy(), dtype=np.float32)
+
+    def _fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        num_gpus: int = 0,
+        **kwargs,
+    ):
+        import torch
+        from synthefy_nori import NoriRegressor
+
+        from tabarena.models.nori._patch import ensure_picklable_preprocessing
+
+        # Nori's fitted preprocessing pipeline uses local lambdas that the stdlib pickle
+        # AutoGluon saves models with cannot serialize; patch before fit builds the pipeline.
+        ensure_picklable_preprocessing()
+
+        if self.problem_type != "regression":
+            raise AssertionError(f"{self.ag_name} only supports regression, got problem_type={self.problem_type!r}.")
+
+        available_num_gpus = ResourceManager.get_gpu_count_torch(cuda_only=True)
+        if num_gpus > available_num_gpus:
+            raise AssertionError(
+                f"Fit specified to use {num_gpus} GPU, but only {available_num_gpus} "
+                "CUDA GPUs are available. Please activate CUDA or switch to CPU usage.",
+            )
+        device = "cuda" if num_gpus != 0 else "cpu"
+        if device == "cuda" and not torch.cuda.is_available():
+            raise AssertionError(
+                "Fit specified to use GPU, but CUDA is not available on this machine. "
+                "Please switch to CPU usage instead.",
+            )
+
+        X = self.preprocess(X, y=y, is_train=True)
+
+        hps = self._get_model_params()
+        hps.pop("device", None)  # device is set explicitly from the allocated resources
+
+        # NoriRegressor normalizes y internally and denormalizes its predictions, so
+        # we pass y through unchanged (it is coerced to float64 inside fit).
+        self.model = NoriRegressor(device=device, **hps)
+        self.model.fit(X, y)
+
+    def _set_default_params(self):
+        default_params = {}
+        for param, val in default_params.items():
+            self._set_default_param_value(param, val)
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["regression"]
+
+    # --- Resource and GPU management ---
+    def get_device(self) -> str:
+        device = self.model.device
+        if device is None:
+            return "cpu"
+        return device if isinstance(device, str) else device.type
+
+    def _set_device(self, device: str):
+        import torch
+
+        torch_device = torch.device(device)
+        self.model.device = torch_device
+        # The predictor (and its torch module) are built lazily on the first predict
+        # call; move them only if they already exist.
+        predictor = getattr(self.model, "_predictor", None)
+        if predictor is not None:
+            predictor.device = torch_device
+            if getattr(predictor, "model", None) is not None:
+                predictor.model.to(torch_device)
+
+    def _get_default_resources(self) -> tuple[int, int]:
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
+        return num_cpus, num_gpus
+
+    def get_minimum_resources(self, is_gpu_available: bool = False) -> dict[str, int | float]:
+        return {
+            "num_cpus": 1,
+            "num_gpus": 1 if is_gpu_available else 0,
+        }
+
+    def _get_default_auxiliary_params(self) -> dict:
+        """Cap context size at 100k rows; no feature or class limits (regression-only)."""
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        default_auxiliary_params.update(
+            {
+                "max_rows": 100_000,
+            },
+        )
+        return default_auxiliary_params
+
+    @classmethod
+    def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
+        """Fit one fold at a time (avoids contention on the shared checkpoint cache) and
+        refit by default (a single forward-pass model has no per-fold validation cost).
+        """
+        default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
+        default_ag_args_ensemble.update(
+            {
+                "fold_fitting_strategy": "sequential_local",
+                "refit_folds": default_ag_args_ensemble.pop("refit_folds", True),
+            },
+        )
+        return default_ag_args_ensemble
+
+    def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:
+        return self.estimate_memory_usage_static(
+            X=X,
+            problem_type=self.problem_type,
+            num_classes=self.num_classes,
+            hyperparameters=self._get_model_params(),
+            **kwargs,
+        )
+
+    @classmethod
+    def _estimate_memory_usage_static(cls, *, X: pd.DataFrame, **kwargs) -> int:
+        """Assume a small-model baseline (weights + activations) plus the dataset footprint."""
+        baseline_mem_est = 3 * 1e9  # 3 GB for the model + activations
+        dataset_mem_est = 5 * get_approximate_df_mem_usage(X).sum()
+        return int(baseline_mem_est + dataset_mem_est)
+
+    @classmethod
+    def _class_tags(cls) -> dict:
+        return {"can_estimate_memory_usage_static": True}
+
+    def _more_tags(self) -> dict:
+        return {"can_refit_full": True}
+
+    @classmethod
+    def prefetch_weights(cls) -> None:
+        """Pre-download the default Nori checkpoint from the Hugging Face Hub.
+
+        Used by the foundation-model pre-download scripts to warm the cache before
+        parallel fit runs. The Hub repo is gated, so this requires a Hugging Face
+        token (``HF_TOKEN`` / ``hf auth login``).
+        """
+        from synthefy_nori.hf import download_checkpoint
+
+        download_checkpoint()

--- a/packages/tabflow_slurm/BENCHMARK_LOG.md
+++ b/packages/tabflow_slurm/BENCHMARK_LOG.md
@@ -33,6 +33,53 @@ run against `main`. To reproduce an entry, check out its recorded **git SHA**.
 
 ---
 
+## 2026-06-18 — nori_regression_18062026
+
+- **Model(s):** Nori (0 — default config only)
+- **Git SHA:** `f2eca5c3`
+- **Purpose:** Nori (regression-only GPU foundation model) on the TabArena-v0.1 regression subset, single-node GCP GPU run.
+- **Notes:** GPU partition `gpurtxpro6000spotinteractive`, 1 GPU. Scoped to the `regression`
+  task subset via `task_subset=TaskSubset(subset="regression")` — every regression task/split.
+  Empty search space, so it runs its single default config (0 random configs).
+  `num_cpus`/`memory_limit` left `None` so the node's values are picked up.
+
+```python
+from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
+from tabarena.benchmark.task.metadata import TaskSubset
+from tabarena.nips2025_utils.tabarena_context import TabArenaContext
+from tabflow_slurm import (
+    GCPSlurmSetup,
+    ModelJob,
+    PathSetup,
+    TabArenaBenchmarkPlan,
+    TabArenaV0pt1ResourcesSetup,
+)
+
+benchmark_plan = TabArenaBenchmarkPlan(
+    benchmark_name="nori_regression_18062026",
+    model_jobs=[
+        # Nori is a regression-only GPU foundation model with an empty search space,
+        # so it runs its single default config (0 random configs) on a GPU node.
+        ModelJob(models=("Nori", 0), name="gpu", resources={"num_gpus": 1}),
+    ],
+    # The TabArena-v0.1 context owns the task metadata + subset predicates; `task_subset`
+    # scopes `context.build_jobs`. `subset="regression"` keeps every regression task/split.
+    context=TabArenaContext(),
+    task_subset=TaskSubset(subset="regression"),
+    experiment_bundle=TabArenaV0pt1ExperimentBundle(),
+    path_setup=PathSetup(
+        workspace="/home/lennart_priorlabs_ai/workspace/benchmarking/tabarena_workspace",
+        python_path="/home/lennart_priorlabs_ai/.venvs/tabarena_18062026/bin/python",
+    ),
+    resources_setup=TabArenaV0pt1ResourcesSetup(num_cpus=None, memory_limit=None),
+    scheduler_setup=GCPSlurmSetup(gpu_partition="gpurtxpro6000spotinteractive"),
+)
+
+benchmark_plan.setup_jobs()
+```
+
+---
+
 ## 2026-06-16 — benchmark_chimeraboost_16062026
 
 - **Model(s):** ChimeraBoost (all configs)

--- a/tst/models/test_nori.py
+++ b/tst/models/test_nori.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_nori():
+    try:
+        from autogluon.tabular.testing import FitHelper
+
+        from tabarena.models.nori.model import NoriModel
+
+        model_cls = NoriModel
+        # Nori only supports regression.
+        FitHelper.verify_model(
+            model_cls=model_cls,
+            model_hyperparameters={},
+            problem_types=["regression"],
+        )
+    except ImportError as err:
+        pytest.skip(
+            f"Import Error, skipping test... Ensure you have the proper dependencies installed to run this test:\n{err}"
+        )


### PR DESCRIPTION
# Add Nori model

Adds Synthefy's **Nori** tabular foundation model (regression, in-context learning) as a
TabArena model wrapper: `models/nori/` (`model.py`, `hpo.py`, `info.py`) plus the
`pyproject.toml` extra and a test.

## One non-standard fix worth flagging

Saving a fitted Nori model failed under AutoGluon's stdlib pickle:

```
AttributeError: Can't pickle local object 'RebalanceFeatureDistribution._set.<locals>.<lambda>'
```

`synthefy_nori` builds its preprocessing pipeline from `sklearn.FunctionTransformer` steps
whose `func`/`inverse_func` are **local lambdas**, which stdlib pickle can't serialize. We hit
the same bug in LimiX and fixed it there by rewriting the lambdas as module-level functions —
but LimiX is vendored, whereas `synthefy_nori` is a pip dependency we can't edit.

So `models/nori/_patch.py` monkeypatches the `FunctionTransformer` the pipeline is built from
with a subclass that pickles via `cloudpickle` (serializes lambdas by value); `_fit` applies it
before fitting. Model behavior is unchanged.

**Upstream candidate:** the real fix belongs in `synthefy_nori` — replacing those local lambdas
in `RebalanceFeatureDistribution._set` with module-level functions would drop the monkeypatch
entirely.
