### PR TITLE
Bundle: per-model hyperparameters + non-IID protocol for AutoGluon experiments

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
@@ -50,7 +50,11 @@ class TabArenaExperimentBundle:
     into each experiment so the resulting YAML is self-contained.
     """
 
-    models: list[tuple[str | AGConfigGenerator, int | str | dict] | Experiment] = field(default_factory=list)
+    models: list[
+        tuple[str | AGConfigGenerator, int | str | dict]
+        | tuple[str | AGConfigGenerator, int | str | dict, dict]
+        | Experiment
+    ] = field(default_factory=list)
     """List of models to run in the benchmark with metadata.
     Metadata keys from left to right:
         - model name: str
@@ -59,6 +63,16 @@ class TabArenaExperimentBundle:
                 - If 0, only the default configuration is run.
                 - If "all", `n_random_configs`-many configurations are run.
                 - If dict, kwargs for AGExperiment
+        - (optional) per-model hyperparameters: dict
+            A 3rd tuple element with model hyperparameters merged into EVERY config of
+            this model — the default config and any sampled HPO configs alike — keeping
+            all other bundle logic (preprocessing, validation protocol, resources, ...).
+            Use it to pin a hyperparameter without writing a custom search space, e.g.
+            `("LightGBM", 0, {"num_boost_round": 100})` runs the default LightGBM config
+            with `num_boost_round=100`. The keys must not collide with a config's own
+            hyperparameters (asserted at build time), so it suits fixed hyperparameters
+            outside the search space. Not supported for full `AutoGluon...` entries (put
+            those in the AGExperiment kwargs dict instead).
 
     Custom (non-registry) models — two ways to include one:
         - RECOMMENDED: pass a `(config_generator, n_configs)` tuple, where
@@ -78,11 +92,12 @@ class TabArenaExperimentBundle:
 
     Example usage:
         # Run all random configs for LightGBM, 10 random configs for Random Forest,
-        and only the default for TabDPT.
+        # only the default for TabDPT, and the default XGBoost with n_estimators pinned to 100.
         default_factory=lambda: [
                 ("LightGBM", "all"),
                 ("RandomForest", 10),
                 ("TabDPT", 0),
+                ("XGBoost", 0, {"n_estimators": 100}),
             ]
         )
 
@@ -401,7 +416,16 @@ class TabArenaExperimentBundle:
         if isinstance(model, Experiment):
             return [model]
         model_name, n_configs_or_kwargs = model[0], model[1]
+        # Optional 3rd tuple element: per-model hyperparameters merged into every config of this
+        # model (e.g. ``("LightGBM", 0, {"num_boost_round": 100})``).
+        model_hyperparameters = model[2] if len(model) > 2 else None
         if isinstance(model_name, str) and model_name.startswith("AutoGluon"):
+            if model_hyperparameters is not None:
+                raise ValueError(
+                    "Per-model hyperparameters (the 3rd tuple element) are not supported for full "
+                    "`AutoGluon...` entries; pass model hyperparameters inside the AGExperiment "
+                    "kwargs dict (the 2nd tuple element) instead.",
+                )
             return self._generate_autogluon_config(
                 model_name=model_name,
                 agexp_kwargs=n_configs_or_kwargs,
@@ -416,17 +440,28 @@ class TabArenaExperimentBundle:
             preprocessing_pipeline=preprocessing_pipeline,
             time_limit=time_limit,
             time_limit_with_preprocessing=time_limit_with_preprocessing,
+            model_hyperparameters=model_hyperparameters,
         )
 
-    @staticmethod
     def _generate_autogluon_config(
+        self,
         *,
         model_name: str,
         agexp_kwargs: dict,
         pipeline_method_kwargs: dict,
         time_limit: int,
     ) -> list:
-        """Parse the AutoGluon config from the models."""
+        """Build a full-AutoGluon ``AGExperiment`` (a complete ``TabularPredictor`` run).
+
+        Unlike the per-config path, the entry's ``agexp_kwargs`` are passed to ``AGExperiment``
+        more or less verbatim (with the bundle's ``init_kwargs`` / ``fit_kwargs`` and ``time_limit``
+        merged in). The bundle's ``dynamic_tabarena_validation_protocol`` is forwarded too, so a
+        full-AutoGluon run gets the SAME grouped/temporal validation-split handling as the config
+        experiments (resolved at fit time by the ``AGWrapper`` from the task metadata); the caller
+        can override it per-entry. The per-config ``preprocessing_pipelines`` (e.g.
+        ``tabarena_default``) are NOT applied here: they augment a single model's hyperparameters,
+        which has no analogue for a multi-model predictor.
+        """
         from tabarena.benchmark.experiment.experiment_constructor import (
             AGExperiment,
         )
@@ -440,8 +475,25 @@ class TabArenaExperimentBundle:
             if key in pipeline_method_kwargs:
                 agexp_kwargs[key].update(pipeline_method_kwargs[key])
         agexp_kwargs["fit_kwargs"]["time_limit"] = time_limit
+        # Apply the bundle's non-IID validation protocol (same grouped/temporal split handling as
+        # the config experiments) unless the entry set it explicitly.
+        agexp_kwargs.setdefault("dynamic_tabarena_validation_protocol", self.dynamic_tabarena_validation_protocol)
 
         return [AGExperiment(name=model_name, **agexp_kwargs)]
+
+    @staticmethod
+    def _merge_extra_model_hyperparameters(
+        bundle_extra: dict | None,
+        model_hyperparameters: dict | None,
+    ) -> dict:
+        """Merge bundle-level extra hyperparameters with per-model overrides (per-model wins).
+
+        ``bundle_extra`` holds the model-agnostic extras the bundle adds to every model (e.g.
+        ``ag.verbosity`` / ``ag.max_batch_size``); ``model_hyperparameters`` are the per-model
+        overrides from a ``(model_name, n_configs, model_hyperparameters)`` entry. Both default to
+        empty; on a key collision the per-model value takes precedence.
+        """
+        return {**(bundle_extra or {}), **(model_hyperparameters or {})}
 
     def _generate_model_configs(
         self,
@@ -453,6 +505,7 @@ class TabArenaExperimentBundle:
         preprocessing_pipeline: str | None,
         time_limit: int,
         time_limit_with_preprocessing: bool,
+        model_hyperparameters: dict | None = None,
         default_seed_config: str = "fold-config-wise",
     ) -> list:
         from tabarena.models.utils import get_configs_generator_from_name
@@ -467,6 +520,14 @@ class TabArenaExperimentBundle:
             config_generator = get_configs_generator_from_name(model_name)
         else:
             config_generator = deepcopy(model_name)
+
+        # Merge the bundle-level extra hyperparameters (e.g. ``ag.verbosity``) with any per-model
+        # overrides; the result is merged into every config of this model (default + sampled). It
+        # must not collide with a config's own hyperparameters (asserted downstream).
+        extra_model_hyperparameters = self._merge_extra_model_hyperparameters(
+            pipeline_method_kwargs.get("extra_model_hyperparameters"),
+            model_hyperparameters,
+        )
 
         if self.outer_experiments:
             # No-validation path: one direct ``AGModelWrapper`` fit on all data, no bagging /
@@ -490,7 +551,7 @@ class TabArenaExperimentBundle:
                     "verbosity": self.verbosity,
                 },
                 preprocessing_pipeline=preprocessing_pipeline,
-                extra_model_hyperparameters=pipeline_method_kwargs.get("extra_model_hyperparameters") or None,
+                extra_model_hyperparameters=extra_model_hyperparameters or None,
             )
 
         if self.holdout_experiments:
@@ -511,14 +572,17 @@ class TabArenaExperimentBundle:
                 time_limit_with_preprocessing=time_limit_with_preprocessing,
                 preprocessing_pipeline=preprocessing_pipeline,
                 dynamic_tabarena_validation_protocol=self.dynamic_tabarena_validation_protocol,
-                extra_model_hyperparameters=pipeline_method_kwargs.get("extra_model_hyperparameters") or None,
+                extra_model_hyperparameters=extra_model_hyperparameters or None,
             )
 
+        # The bagged path consumes ``extra_model_hyperparameters`` via ``method_kwargs``; replace the
+        # bundle-level value with the per-model merge so 3-tuple overrides take effect here too.
+        bag_method_kwargs = {**pipeline_method_kwargs, "extra_model_hyperparameters": extra_model_hyperparameters}
         return config_generator.generate_all_bag_experiments(
             num_random_configs=n_configs,
             add_seed=default_seed_config,
             name_id_suffix=name_id_suffix,
-            method_kwargs=pipeline_method_kwargs,
+            method_kwargs=bag_method_kwargs,
             time_limit=time_limit,
             time_limit_with_preprocessing=time_limit_with_preprocessing,
             preprocessing_pipeline=preprocessing_pipeline,

--- a/tst/benchmark/experiment/test_bundle.py
+++ b/tst/benchmark/experiment/test_bundle.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import dataclasses
 
+import pytest
+
 from tabarena.benchmark.experiment import (
     BeyondArenaExperimentBundle,
     TabArenaExperimentBundle,
@@ -159,3 +161,122 @@ def test_build_experiments_attaches_model_constraints():
     registry_built = [e for name, e in by_name.items() if name != "explicitly_constrained"]
     assert registry_built, "expected at least the default LightGBM config"
     assert all(e.model_constraints == gbm_constraints for e in registry_built)
+
+
+# ===========================================================================
+# Per-model hyperparameter override — the optional 3rd `models` tuple element
+# ===========================================================================
+
+
+def _model_hyperparameters(experiment):
+    """Read the per-model hyperparameters off a built experiment, regardless of flavour.
+
+    Bagged / holdout experiments store them under ``model_hyperparameters``; the no-validation
+    outer flavour stores them under ``hyperparameters``.
+    """
+    method_kwargs = experiment.method_kwargs
+    return method_kwargs.get("model_hyperparameters", method_kwargs.get("hyperparameters"))
+
+
+def _build_single_lightgbm(*, hyperparameters, **bundle_kwargs):
+    """Build the single default-LightGBM experiment with a per-model hyperparameter override."""
+    bundle = BeyondArenaExperimentBundle(
+        models=[("LightGBM", 0, hyperparameters)],
+        **bundle_kwargs,
+    )
+    experiments = bundle.build_experiments(time_limit=60, num_cpus=1, num_gpus=0, memory_limit=4)
+    assert len(experiments) == 1
+    return experiments[0]
+
+
+@pytest.mark.parametrize(
+    "bundle_kwargs",
+    [{}, {"holdout_experiments": True}, {"outer_experiments": True}],
+    ids=["bagged", "holdout", "outer"],
+)
+def test_per_model_hyperparameters_injected_for_each_flavour(bundle_kwargs):
+    """The 3rd tuple element lands in the model hyperparameters for bag / holdout / outer alike."""
+    experiment = _build_single_lightgbm(hyperparameters={"num_boost_round": 100}, **bundle_kwargs)
+    hyperparameters = _model_hyperparameters(experiment)
+    assert hyperparameters["num_boost_round"] == 100
+    # The bundle-level extras (here model_verbosity -> ag.verbosity) are still merged in alongside.
+    assert hyperparameters["ag.verbosity"] == BeyondArenaExperimentBundle.model_verbosity
+
+
+def test_per_model_hyperparameters_supports_multiple_keys():
+    """Arbitrary hyperparameters (not just one) flow through the 3rd tuple element."""
+    experiment = _build_single_lightgbm(hyperparameters={"learning_rate": 0.05, "num_leaves": 31})
+    hyperparameters = _model_hyperparameters(experiment)
+    assert hyperparameters["learning_rate"] == 0.05
+    assert hyperparameters["num_leaves"] == 31
+
+
+def test_per_model_hyperparameters_only_apply_to_that_model():
+    """An override on one model must not leak onto the other models in the bundle."""
+    bundle = BeyondArenaExperimentBundle(
+        models=[("LightGBM", 0, {"num_boost_round": 100}), ("RandomForest", 0)],
+    )
+    experiments = bundle.build_experiments(time_limit=60, num_cpus=1, num_gpus=0, memory_limit=4)
+    by_name = {e.name: e for e in experiments}
+    lightgbm = next(e for name, e in by_name.items() if name.startswith("LightGBM"))
+    random_forest = next(e for name, e in by_name.items() if name.startswith("RandomForest"))
+    assert _model_hyperparameters(lightgbm)["num_boost_round"] == 100
+    assert "num_boost_round" not in _model_hyperparameters(random_forest)
+
+
+def test_two_tuple_still_works_without_override():
+    """Backward compatibility: a plain (name, n_configs) entry builds as before (no override)."""
+    bundle = BeyondArenaExperimentBundle(models=[("LightGBM", 0)])
+    experiments = bundle.build_experiments(time_limit=60, num_cpus=1, num_gpus=0, memory_limit=4)
+    assert len(experiments) == 1
+    assert "num_boost_round" not in _model_hyperparameters(experiments[0])
+
+
+def test_per_model_hyperparameters_rejected_for_full_autogluon_entry():
+    """Per-model hyperparameters are not supported for full ``AutoGluon...`` entries."""
+    bundle = BeyondArenaExperimentBundle(models=[("AutoGluon_bq", {}, {"num_boost_round": 100})])
+    with pytest.raises(ValueError, match="not supported for full"):
+        bundle.build_experiments(time_limit=60, num_cpus=1, num_gpus=0, memory_limit=4)
+
+
+# ===========================================================================
+# Full AutoGluon experiment entries — non-IID validation protocol forwarding
+# ===========================================================================
+
+
+def _build_single_autogluon(*, agexp_kwargs, **bundle_kwargs):
+    from tabarena.benchmark.experiment import AGExperiment
+
+    bundle = BeyondArenaExperimentBundle(models=[("AutoGluon_custom", agexp_kwargs)], **bundle_kwargs)
+    experiments = bundle.build_experiments(time_limit=60, num_cpus=1, num_gpus=0, memory_limit=4)
+    assert len(experiments) == 1
+    exp = experiments[0]
+    assert isinstance(exp, AGExperiment)
+    return exp
+
+
+def test_autogluon_experiment_inherits_dynamic_validation_protocol():
+    """A full AutoGluon experiment gets the bundle's non-IID validation protocol auto-forwarded."""
+    exp = _build_single_autogluon(agexp_kwargs={"fit_kwargs": {"hyperparameters": {"GBM": {}}, "num_bag_folds": 8}})
+    # BeyondArena defaults the protocol on; the AutoGluon path now forwards it (was previously lost).
+    assert exp.dynamic_tabarena_validation_protocol is True
+    # Custom hyperparameters and bagging settings pass through to the predictor fit kwargs.
+    assert exp.method_kwargs["fit_kwargs"]["hyperparameters"] == {"GBM": {}}
+    assert exp.method_kwargs["fit_kwargs"]["num_bag_folds"] == 8
+
+
+def test_autogluon_experiment_protocol_override_is_respected():
+    """An explicit per-entry ``dynamic_tabarena_validation_protocol`` wins over the bundle default."""
+    exp = _build_single_autogluon(
+        agexp_kwargs={"fit_kwargs": {"hyperparameters": {"GBM": {}}}, "dynamic_tabarena_validation_protocol": False},
+    )
+    assert exp.dynamic_tabarena_validation_protocol is False
+
+
+def test_autogluon_experiment_protocol_off_when_bundle_disables_it():
+    """When the bundle disables the protocol, the AutoGluon experiment does not get it."""
+    exp = _build_single_autogluon(
+        agexp_kwargs={"fit_kwargs": {"hyperparameters": {"GBM": {}}}},
+        dynamic_tabarena_validation_protocol=False,
+    )
+    assert exp.dynamic_tabarena_validation_protocol is False

--- a/tst/benchmark/experiment/test_holdout_experiments.py
+++ b/tst/benchmark/experiment/test_holdout_experiments.py
@@ -1,0 +1,109 @@
+"""Tests for the holdout experiment path: a single ``TabularPredictor`` fit with a real
+train/val split but no bagging or weighted ensemble.
+
+Covers the generator (:func:`generate_holdout_experiments` /
+``AGConfigGenerator.generate_all_holdout_experiments``) and the bundle's ``holdout_experiments``
+mode, contrasting it with the bagged default. No models are fit here (construction only).
+"""
+
+from __future__ import annotations
+
+import pytest
+from autogluon.core.models import AbstractModel
+
+from tabarena.benchmark.experiment import (
+    AGModelBagExperiment,
+    AGModelExperiment,
+    AGModelOuterExperiment,
+    BeyondArenaExperimentBundle,
+)
+from tabarena.utils.config_utils import ConfigGenerator, generate_holdout_experiments
+
+
+class _DummyModel(AbstractModel):
+    ag_key = "DUMMYTESTMODEL"
+    ag_name = "DummyTestModel"
+
+
+class TestGenerateHoldoutExperiments:
+    def test_builds_single_model_experiment_without_bag_suffix(self):
+        configs = [{"ag_args": {"name_suffix": "_c1"}}]
+        experiments = generate_holdout_experiments(
+            _DummyModel,
+            configs,
+            name_suffix_from_ag_args=True,
+            preprocessing_pipeline="tabarena_default",
+            dynamic_tabarena_validation_protocol=True,
+        )
+        assert len(experiments) == 1
+        exp = experiments[0]
+        assert isinstance(exp, AGModelExperiment)
+        # A holdout fit is a single (non-bagged) model, tagged `_HOLDOUT` (mirrors bagged `_BAG_L1`).
+        assert not isinstance(exp, (AGModelBagExperiment, AGModelOuterExperiment))
+        assert exp.name == "DummyTestModel_c1_HOLDOUT"
+        assert exp.preprocessing_pipeline == "tabarena_default"
+        assert exp.dynamic_tabarena_validation_protocol is True
+
+    def test_keeps_ag_args_in_model_hyperparameters(self):
+        # Unlike the outer flavour, holdout goes through `TabularPredictor`, which consumes
+        # `ag_args` (e.g. for naming), so it is kept in the model hyperparameters.
+        experiments = generate_holdout_experiments(
+            _DummyModel,
+            [{"ag_args": {"name_suffix": "_c1"}}],
+            name_suffix_from_ag_args=True,
+        )
+        assert "ag_args" in experiments[0].method_kwargs["model_hyperparameters"]
+
+    def test_merges_extra_model_hyperparameters(self):
+        experiments = generate_holdout_experiments(
+            _DummyModel,
+            [{"ag_args": {"name_suffix": "_c1"}}],
+            name_suffix_from_ag_args=True,
+            extra_model_hyperparameters={"ag.verbosity": 4},
+        )
+        assert experiments[0].method_kwargs["model_hyperparameters"]["ag.verbosity"] == 4
+
+    def test_time_limit_injected_as_model_max_time_limit(self):
+        experiments = generate_holdout_experiments(
+            _DummyModel,
+            [{"ag_args": {"name_suffix": "_c1"}}],
+            name_suffix_from_ag_args=True,
+            time_limit=123,
+        )
+        # No bagging -> the limit rides on the model's top-level `ag.max_time_limit`.
+        assert experiments[0].method_kwargs["model_hyperparameters"]["ag.max_time_limit"] == 123
+
+
+class TestBundleHoldoutMode:
+    def test_emits_holdout_experiments_with_pipeline_resources_and_protocol(self):
+        generator = ConfigGenerator(search_space={}, model_cls=_DummyModel, manual_configs=[{}])
+        bundle = BeyondArenaExperimentBundle(models=[(generator, 0)], holdout_experiments=True)
+        experiments = bundle.build_experiments()
+        assert len(experiments) == 1
+        exp = experiments[0]
+        assert isinstance(exp, AGModelExperiment)
+        assert not isinstance(exp, (AGModelBagExperiment, AGModelOuterExperiment))
+        # Single model -> tagged `_HOLDOUT` rather than the bagged `_BAG_L1`.
+        assert exp.name == "DummyTestModel_c1_HOLDOUT"
+        # The bundle's preprocessing + shuffle_features + validation protocol all still apply.
+        assert exp.preprocessing_pipeline == "tabarena_default"
+        assert exp.dynamic_tabarena_validation_protocol is True
+        assert exp.method_kwargs["shuffle_features"] is True
+        # Compute resources are baked into the predictor fit kwargs (None == auto-detect at run time).
+        fit_kwargs = exp.method_kwargs["fit_kwargs"]
+        assert "num_cpus" in fit_kwargs and "num_gpus" in fit_kwargs and "memory_limit" in fit_kwargs
+        # time_limit (no bagging) -> model-level `ag.max_time_limit`; model_verbosity merged in.
+        model_hyperparameters = exp.method_kwargs["model_hyperparameters"]
+        assert model_hyperparameters["ag.max_time_limit"] == bundle.DEFAULT_TIME_LIMIT
+        assert model_hyperparameters["ag.verbosity"] == bundle.model_verbosity
+
+    def test_bagged_mode_is_unaffected(self):
+        generator = ConfigGenerator(search_space={}, model_cls=_DummyModel, manual_configs=[{}])
+        bundle = BeyondArenaExperimentBundle(models=[(generator, 0)])  # default: bagged
+        exp = bundle.build_experiments()[0]
+        assert isinstance(exp, AGModelBagExperiment)
+        assert exp.name.endswith("_BAG_L1")
+
+    def test_outer_and_holdout_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            BeyondArenaExperimentBundle(outer_experiments=True, holdout_experiments=True)

--- a/tst/benchmark/experiment/test_validation_utils.py
+++ b/tst/benchmark/experiment/test_validation_utils.py
@@ -1075,8 +1075,17 @@ def test_resolve_holdout_split_grouped_stratified_keeps_all_train_classes():
 # ===========================================================================
 
 
-def _make_holdout_wrapper(validation_metadata: dict | None, *, use_task_specific_validation: bool = True):
-    """Build a bare ``AGWrapper`` (no fit) for exercising the holdout carve-out logic."""
+def _make_holdout_wrapper(
+    validation_metadata: dict | None,
+    *,
+    use_task_specific_validation: bool = True,
+    fit_kwargs: dict | None = None,
+):
+    """Build a bare ``AGWrapper`` (no fit) for exercising the validation-split logic.
+
+    ``fit_kwargs`` lets a test choose the validation mode the way a full ``TabularPredictor`` run
+    would: include ``num_bag_folds`` (>= 2) for the bagged path, or omit it for the holdout path.
+    """
     from tabarena.benchmark.exec_models.autogluon import AGWrapper
 
     return AGWrapper(
@@ -1084,6 +1093,7 @@ def _make_holdout_wrapper(validation_metadata: dict | None, *, use_task_specific
         eval_metric=None,
         validation_metadata=validation_metadata,
         use_task_specific_validation=use_task_specific_validation,
+        fit_kwargs=fit_kwargs,
     )
 
 
@@ -1164,3 +1174,73 @@ def test_build_predictor_args_sets_tuning_data_for_grouped_holdout():
     tuning_data = fit_kwargs["tuning_data"]
     # Train and validation frames must not share a group.
     assert set(train_data["grp"]).isdisjoint(set(tuning_data["grp"]))
+
+
+# ===========================================================================
+# AGWrapper validation dispatch: bagging (custom_splits) vs holdout (tuning_data)
+#
+# A full AutoGluon `TabularPredictor` run (AGWrapper) validates via bagging or holdout depending on
+# its settings. Both must get the task-aware (grouped/temporal) non-IID split. `num_bag_folds >= 2`
+# -> grouped/temporal `custom_splits` (no `tuning_data`); otherwise a single grouped/temporal
+# `tuning_data` holdout (no `custom_splits`). The two are mutually exclusive.
+# ===========================================================================
+
+
+def _custom_splits(fit_kwargs: dict):
+    return fit_kwargs.get("ag_args_ensemble", {}).get("custom_splits")
+
+
+@pytest.mark.skipif(not _DATA_FOUNDRY_AVAILABLE, reason="data_foundry not installed")
+def test_build_predictor_args_grouped_bagging_uses_custom_splits_not_tuning_data():
+    """Bagged grouped fit -> group-disjoint custom_splits folds, and NOT a tuning_data holdout."""
+    n = 600
+    group_values = [f"g{i % 20}" for i in range(n)]
+    wrapper = _make_holdout_wrapper(
+        {"group_on": "grp", "group_labels": GroupLabelTypes.PER_SAMPLE},
+        fit_kwargs={"num_bag_folds": 8, "num_bag_sets": 1},
+    )
+    X = pd.DataFrame({"feature": np.arange(n, dtype=float), "grp": group_values})
+    y = pd.Series(np.arange(n, dtype=float))
+
+    _train_data, _init_kwargs, fit_kwargs = wrapper._build_predictor_args(X=X, y=y, X_val=None, y_val=None)
+
+    # Bagging path: custom_splits, no holdout tuning_data, fold count preserved.
+    assert "tuning_data" not in fit_kwargs
+    splits = _custom_splits(fit_kwargs)
+    assert splits is not None and len(splits) == 8
+    assert fit_kwargs.get("num_bag_folds") == 8
+    groups = np.asarray(group_values)
+    for train_idx, val_idx in splits:
+        assert set(groups[train_idx]).isdisjoint(set(groups[val_idx])), "a group spans a bagged fold"
+
+
+def test_build_predictor_args_temporal_bagging_uses_custom_splits_not_tuning_data():
+    """Bagged temporal fit -> non-empty time-based custom_splits folds, and no tuning_data."""
+    n = 600
+    wrapper = _make_holdout_wrapper({"time_on": "time"}, fit_kwargs={"num_bag_folds": 8, "num_bag_sets": 1})
+    X = pd.DataFrame({"feature": np.arange(n, dtype=float), "time": np.arange(n)})
+    y = pd.Series(np.arange(n, dtype=float))
+
+    _train_data, _init_kwargs, fit_kwargs = wrapper._build_predictor_args(X=X, y=y, X_val=None, y_val=None)
+
+    assert "tuning_data" not in fit_kwargs
+    splits = _custom_splits(fit_kwargs)
+    assert splits is not None and len(splits) > 0
+    for train_idx, val_idx in splits:
+        assert len(train_idx) > 0 and len(val_idx) > 0
+
+
+def test_build_predictor_args_temporal_holdout_is_forward_and_has_no_custom_splits():
+    """Non-bagged temporal fit -> forward tuning_data holdout (latest block), no custom_splits."""
+    n = 600
+    wrapper = _make_holdout_wrapper({"time_on": "time"})  # no num_bag_folds -> holdout
+    X = pd.DataFrame({"feature": np.arange(n, dtype=float), "time": np.arange(n)})
+    y = pd.Series(np.arange(n, dtype=float))
+
+    train_data, _init_kwargs, fit_kwargs = wrapper._build_predictor_args(X=X, y=y, X_val=None, y_val=None)
+
+    assert _custom_splits(fit_kwargs) is None
+    assert "tuning_data" in fit_kwargs
+    tuning_data = fit_kwargs["tuning_data"]
+    # Forward holdout: every validation timestamp is later than every training one.
+    assert train_data["time"].max() < tuning_data["time"].min()


### PR DESCRIPTION
## Description

Two `TabArenaExperimentBundle` enhancements (building on the merged holdout non-IID split support) plus companion tests.

### 1. Per-model hyperparameters (optional 3rd `models` tuple element)

`(name, n_configs, model_hyperparameters)` merges a hyperparameter dict into **every** config of that model (the default config and any sampled HPO configs), across the bagged / holdout / outer flavours — so you can pin a hyperparameter without writing a custom search space:

```python
models=[("LightGBM", 0, {"num_boost_round": 100})]
```

The keys must not collide with a config's own hyperparameters (asserted at build time), so it suits fixed hyperparameters outside the search space. Not supported for full `AutoGluon...` entries (pass those in the AGExperiment kwargs dict). The `models` type hint is updated to allow the 3-tuple.

### 2. Non-IID validation protocol for full AutoGluon experiments

`_generate_autogluon_config` now forwards the bundle's `dynamic_tabarena_validation_protocol` to the `AGExperiment` (overridable per entry). Previously it was dropped, so a full `TabularPredictor` run validated with AutoGluon's default **IID** CV even on grouped/temporal tasks. Now a full AutoGluon experiment resolves the **same grouped/temporal validation split** as the config experiments (via `AGWrapper` at fit time).

The per-config `tabarena_default` preprocessing is still not applied to the AutoGluon path: its model-specific step augments a single model's hyperparameters, which has no analogue for a multi-model predictor (documented in the method).

## Tests

- `test_bundle.py` — per-model hyperparameter injection across flavours, per-model isolation, backward-compatible 2-tuple, rejection for `AutoGluon...` entries, and AutoGluon dynamic-protocol forwarding/override.
- `test_validation_utils.py` — `AGWrapper` validation dispatch: bagging → group-disjoint / time-based `custom_splits`; holdout → group-disjoint / forward-in-time `tuning_data`; the two are mutually exclusive.
- `test_holdout_experiments.py` — holdout experiment construction (companion test for the already-merged holdout support, previously untracked).

`pytest test_bundle.py test_validation_utils.py test_holdout_experiments.py` → 128 passed; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)