### PR TITLE
Apply tabarena_default preprocessing to full AutoGluon experiments (single + multi-model)

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
@@ -430,6 +430,7 @@ class TabArenaExperimentBundle:
                 model_name=model_name,
                 agexp_kwargs=n_configs_or_kwargs,
                 pipeline_method_kwargs=pipeline_method_kwargs,
+                preprocessing_pipeline=preprocessing_pipeline,
                 time_limit=time_limit,
             )
         return self._generate_model_configs(
@@ -449,18 +450,19 @@ class TabArenaExperimentBundle:
         model_name: str,
         agexp_kwargs: dict,
         pipeline_method_kwargs: dict,
+        preprocessing_pipeline: str | None,
         time_limit: int,
     ) -> list:
         """Build a full-AutoGluon ``AGExperiment`` (a complete ``TabularPredictor`` run).
 
         Unlike the per-config path, the entry's ``agexp_kwargs`` are passed to ``AGExperiment``
         more or less verbatim (with the bundle's ``init_kwargs`` / ``fit_kwargs`` and ``time_limit``
-        merged in). The bundle's ``dynamic_tabarena_validation_protocol`` is forwarded too, so a
-        full-AutoGluon run gets the SAME grouped/temporal validation-split handling as the config
-        experiments (resolved at fit time by the ``AGWrapper`` from the task metadata); the caller
-        can override it per-entry. The per-config ``preprocessing_pipelines`` (e.g.
-        ``tabarena_default``) are NOT applied here: they augment a single model's hyperparameters,
-        which has no analogue for a multi-model predictor.
+        merged in). The bundle's ``dynamic_tabarena_validation_protocol`` and the active
+        ``preprocessing_pipeline`` are forwarded too (each overridable per-entry), so a
+        full-AutoGluon run gets the SAME grouped/temporal validation-split handling AND the same
+        preprocessing as the config experiments — ``AGExperiment._apply_preprocessing`` applies the
+        ``tabarena_default`` model-agnostic generator and wraps every model in its (single- or
+        multi-model) ``hyperparameters`` dict with the model-specific preprocessing.
         """
         from tabarena.benchmark.experiment.experiment_constructor import (
             AGExperiment,
@@ -475,9 +477,11 @@ class TabArenaExperimentBundle:
             if key in pipeline_method_kwargs:
                 agexp_kwargs[key].update(pipeline_method_kwargs[key])
         agexp_kwargs["fit_kwargs"]["time_limit"] = time_limit
-        # Apply the bundle's non-IID validation protocol (same grouped/temporal split handling as
-        # the config experiments) unless the entry set it explicitly.
+        # Apply the bundle's non-IID validation protocol + preprocessing pipeline (same handling as
+        # the config experiments) unless the entry set them explicitly.
         agexp_kwargs.setdefault("dynamic_tabarena_validation_protocol", self.dynamic_tabarena_validation_protocol)
+        if preprocessing_pipeline is not None:
+            agexp_kwargs.setdefault("preprocessing_pipeline", preprocessing_pipeline)
 
         return [AGExperiment(name=model_name, **agexp_kwargs)]
 

--- a/packages/tabarena/src/tabarena/benchmark/experiment/experiment_constructor.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/experiment_constructor.py
@@ -390,11 +390,15 @@ class Experiment:
                 TabArenaModelSpecificPreprocessing,
             )
 
+            # Model-agnostic step: a feature generator AutoGluon applies to all data. Set the same
+            # way for every flavour; ``AGWrapper`` builds it from these keys (forwarding the task's
+            # group/time split columns) for both the single-model wrappers and the full predictor.
             method_kwargs["fit_kwargs"]["feature_generator_cls"] = TabArenaModelAgnosticPreprocessing
             method_kwargs["fit_kwargs"]["feature_generator_kwargs"] = {}
-            method_kwargs["model_hyperparameters"] = TabArenaModelSpecificPreprocessing.add_to_hyperparameters(
-                method_kwargs["model_hyperparameters"]
-            )
+            # Model-specific step: augments each model's hyperparameters. The shape differs by
+            # experiment type (single ``model_hyperparameters`` vs a full predictor's per-model
+            # ``hyperparameters`` dict), so it is delegated to an overridable hook.
+            self._apply_model_specific_preprocessing(method_kwargs, TabArenaModelSpecificPreprocessing)
             return method_kwargs
 
         if pipeline.startswith("FSBench__"):
@@ -407,6 +411,17 @@ class Experiment:
             return apply_fs_bench_preprocessing(preprocessing_name=pipeline, experiment=self).method_kwargs
 
         raise ValueError(f"Preprocessing pipeline name '{pipeline}' not recognized.")
+
+    def _apply_model_specific_preprocessing(self, method_kwargs: dict, model_specific_cls) -> None:
+        """Augment the model hyperparameters in place with the model-specific preprocessing.
+
+        Default (single-model config experiments — ``AGModelExperiment`` / ``AGModelBagExperiment``):
+        wrap the single ``method_kwargs["model_hyperparameters"]``. ``AGExperiment`` (a full
+        ``TabularPredictor`` run) overrides this to walk its per-model ``hyperparameters`` dict.
+        """
+        method_kwargs["model_hyperparameters"] = model_specific_cls.add_to_hyperparameters(
+            method_kwargs["model_hyperparameters"],
+        )
 
     @staticmethod
     def _apply_resources(method_kwargs: dict) -> dict:
@@ -670,6 +685,28 @@ class AGExperiment(Experiment):
                         val = kwargs["fit_kwargs"]["hyperparameters"].pop(model)
                         kwargs["fit_kwargs"]["hyperparameters"][tabarena_model_registry.key_to_cls(model)] = val
         return cls(**kwargs)
+
+    def _apply_model_specific_preprocessing(self, method_kwargs: dict, model_specific_cls) -> None:
+        """Augment a full predictor's per-model hyperparameters with model-specific preprocessing.
+
+        A full ``TabularPredictor`` run has no single ``model_hyperparameters``; its
+        ``fit_kwargs["hyperparameters"]`` maps each model key to a config dict *or a list of config
+        dicts*. Every config is wrapped, so single- and multi-model AutoGluon experiments both get
+        the same model-specific preprocessing as the single-model config experiments. A no-op when
+        there is no ``hyperparameters`` dict (e.g. a preset-driven run) — the model-agnostic feature
+        generator still applies.
+        """
+        hyperparameters = method_kwargs.get("fit_kwargs", {}).get("hyperparameters")
+        if not isinstance(hyperparameters, dict):
+            return
+        for model_key, configs in hyperparameters.items():
+            if isinstance(configs, list):
+                hyperparameters[model_key] = [
+                    model_specific_cls.add_to_hyperparameters(config) if isinstance(config, dict) else config
+                    for config in configs
+                ]
+            elif isinstance(configs, dict):
+                hyperparameters[model_key] = model_specific_cls.add_to_hyperparameters(configs)
 
 
 class AGModelExperiment(Experiment):

--- a/tst/benchmark/experiment/test_build_config_pipeline.py
+++ b/tst/benchmark/experiment/test_build_config_pipeline.py
@@ -172,3 +172,50 @@ def test_bundle_model_constraints_merges_defaults_and_custom():
     effective = bundle.model_constraints
     assert effective["MYMODEL"] is custom  # custom override present
     assert "TABICL" in effective  # default policy preserved
+
+
+# ---------------------------------------------------------------------------
+# tabarena_default applied to a full AutoGluon experiment (AGExperiment)
+# ---------------------------------------------------------------------------
+_MODEL_SPECIFIC_KEY = "ag.model_specific_feature_generator_kwargs"
+
+
+def _apply_tabarena_default(fit_kwargs: dict) -> dict:
+    """Build an AGExperiment with tabarena_default and return its `_apply_preprocessing` output."""
+    from tabarena.benchmark.experiment import AGExperiment
+
+    exp = AGExperiment(name="AutoGluon_x", fit_kwargs=fit_kwargs, preprocessing_pipeline="tabarena_default")
+    return exp._apply_preprocessing(copy.deepcopy(exp.method_kwargs))
+
+
+def _has_model_specific(config) -> bool:
+    return isinstance(config, dict) and _MODEL_SPECIFIC_KEY in config
+
+
+def test_autogluon_experiment_tabarena_default_single_model():
+    """A single-model AutoGluon experiment gets the model-agnostic generator + the single model's
+    hyperparameters wrapped with the model-specific preprocessing (matching the config path).
+    """
+    rmk = _apply_tabarena_default({"hyperparameters": {"GBM": {"num_boost_round": 10}}})
+    assert rmk["fit_kwargs"]["feature_generator_cls"] is TabArenaModelAgnosticPreprocessing
+    assert rmk["fit_kwargs"]["feature_generator_kwargs"] == {}
+    assert _has_model_specific(rmk["fit_kwargs"]["hyperparameters"]["GBM"])
+
+
+def test_autogluon_experiment_tabarena_default_multi_model():
+    """Every model (and every config in a per-model list) is wrapped for a multi-model predictor."""
+    rmk = _apply_tabarena_default(
+        {"hyperparameters": {"GBM": [{"num_boost_round": 10}, {"learning_rate": 0.05}], "CAT": {}, "XGB": {}}},
+    )
+    assert rmk["fit_kwargs"]["feature_generator_cls"] is TabArenaModelAgnosticPreprocessing
+    hp = rmk["fit_kwargs"]["hyperparameters"]
+    assert all(_has_model_specific(c) for c in hp["GBM"])  # list of configs, each wrapped
+    assert _has_model_specific(hp["CAT"])
+    assert _has_model_specific(hp["XGB"])
+
+
+def test_autogluon_experiment_tabarena_default_preset_only_applies_model_agnostic():
+    """With no `hyperparameters` dict (e.g. preset-driven), only the model-agnostic step applies."""
+    rmk = _apply_tabarena_default({"presets": "medium_quality"})
+    assert rmk["fit_kwargs"]["feature_generator_cls"] is TabArenaModelAgnosticPreprocessing
+    assert "hyperparameters" not in rmk["fit_kwargs"]  # nothing to wrap; no crash

--- a/tst/benchmark/experiment/test_bundle.py
+++ b/tst/benchmark/experiment/test_bundle.py
@@ -280,3 +280,19 @@ def test_autogluon_experiment_protocol_off_when_bundle_disables_it():
         dynamic_tabarena_validation_protocol=False,
     )
     assert exp.dynamic_tabarena_validation_protocol is False
+
+
+def test_autogluon_experiment_inherits_preprocessing_pipeline():
+    """A full AutoGluon experiment inherits the bundle's preprocessing pipeline (BeyondArena uses
+    tabarena_default), so it gets the same preprocessing as the config experiments.
+    """
+    exp = _build_single_autogluon(agexp_kwargs={"fit_kwargs": {"hyperparameters": {"GBM": {}}}})
+    assert exp.preprocessing_pipeline == "tabarena_default"
+
+
+def test_autogluon_experiment_preprocessing_override_is_respected():
+    """An explicit per-entry preprocessing_pipeline wins over the bundle default."""
+    exp = _build_single_autogluon(
+        agexp_kwargs={"fit_kwargs": {"hyperparameters": {"GBM": {}}}, "preprocessing_pipeline": "default"},
+    )
+    assert exp.preprocessing_pipeline == "default"


### PR DESCRIPTION
## Description

A full AutoGluon experiment (`AGExperiment` — a complete `TabularPredictor` run) now gets the **same `tabarena_default` preprocessing** as the per-model config experiments. Since both paths terminate at the same `TabularPredictor.fit`, this makes a model run through an AutoGluon experiment match the corresponding standalone config (e.g. a single GBM via `("AutoGluon_gbm", {...})` now matches `("LightGBM", 0)`).

Previously the AutoGluon path applied no `tabarena_default`, which made the two diverge on non-IID datasets (the model-agnostic step does group/time-aware feature engineering). This is the follow-up to #368 (which forwarded the non-IID validation protocol to AutoGluon experiments).

## Changes

- **`Experiment._apply_preprocessing`** delegates the model-specific step to a new overridable hook `_apply_model_specific_preprocessing`. The base wraps the single `model_hyperparameters` (config experiments — unchanged behavior). The model-agnostic step (`fit_kwargs["feature_generator_cls"]`) is shared and already consumed identically by `AGWrapper`.
- **`AGExperiment._apply_model_specific_preprocessing`** override walks the per-model `fit_kwargs["hyperparameters"]` dict and wraps **every model's config — and every config in a per-model list** — so **single- and multi-model** AutoGluon experiments both get the model-specific preprocessing. No-op when there is no `hyperparameters` dict (e.g. preset-driven runs); the model-agnostic generator still applies.
- **`TabArenaExperimentBundle._generate_autogluon_config`** forwards the active `preprocessing_pipeline` to the `AGExperiment` (overridable per entry), alongside the already-forwarded `dynamic_tabarena_validation_protocol`.

## Tests

- `test_build_config_pipeline.py`: `AGExperiment._apply_preprocessing` for single-model, multi-model (dict + per-model list), and preset-only (model-agnostic only, no crash) cases.
- `test_bundle.py`: the bundle forwards `preprocessing_pipeline` to AutoGluon entries, and a per-entry override wins.
- `tst/benchmark/experiment/` → 211 passed; `ruff check`/`format` clean.
- End-to-end on a grouped dataset: a bundle AutoGluon GBM now matches the config GBM exactly (previously diverged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)