### PR TITLE
Add benchmark-name plot titles + portfolio tuning-trajectory tooling

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/context/beyond_arena.py
+++ b/packages/tabarena/src/tabarena/evaluation/context/beyond_arena.py
@@ -52,6 +52,8 @@ def _core_subset_predicate() -> SubsetPredicate:
 class BeyondArenaContext(AbstractArenaContext):
     """Evaluation context for the data-foundry BeyondArena benchmark."""
 
+    benchmark_name: str = "BeyondArena"
+
     SUBSET_PREDICATES: dict[str, SubsetPredicate] = {
         "all": SubsetPredicate(lambda df: pd.Series(True, index=df.index)),
         # problem_type

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -54,6 +54,11 @@ class AbstractArenaContext:
     runner, and leaderboard plumbing. Directly instantiable; subclasses add named presets.
     """
 
+    #: Human-readable benchmark name, vended to plot titles (e.g. ``"Arena-large Pareto
+    #: Frontier"``). Subclasses override (``TabArenaContext`` -> ``"TabArena"``,
+    #: ``BeyondArenaContext`` -> ``"BeyondArena"``).
+    benchmark_name: str = "Arena"
+
     #: Subset-filter predicates available to `compare` / `build_jobs`, keyed by
     #: name. Each :class:`SubsetPredicate` declares the grid columns it needs (validated before
     #: it runs). Subclasses override to add arena-specific filters (size buckets, split regimes,
@@ -366,6 +371,64 @@ class AbstractArenaContext:
             df_results_lst.append(df_results)
 
         return pd.concat(df_results_lst, ignore_index=True)
+
+    def load_model_results(
+        self,
+        methods: list[str] | None = None,
+        *,
+        configs: list[str] | None = None,
+        download_results: str | bool = "auto",
+    ) -> pd.DataFrame:
+        """Load the raw per-config ``model_results`` of this arena's methods (downloading on miss).
+
+        Unlike :meth:`load_results` — which returns each method's leaderboard-style rows (for a
+        ``config`` method, the aggregated default / tuned / tuned+ensemble entries) — this returns
+        the per-config rows from each method's ``model_results.parquet``: one row per
+        ``(dataset, fold, config)`` carrying that individual config's own ``time_train_s`` /
+        ``time_infer_s``. Useful for inspecting the configs a portfolio selected (whose ids live in
+        the returned frame's ``method`` column, e.g. ``"CatBoost_r8_BAG_L1"``).
+
+        Args:
+            methods: methods to load (defaults to all of this context's methods).
+            configs: if given, keep only rows whose config id (the ``method`` column) is in this
+                set.
+            download_results: ``"auto"`` (download on cache miss), ``True`` (download first), or
+                ``False`` (never download — raise on a cache miss).
+        """
+        if methods is None:
+            methods = self.methods
+        if not methods:
+            return pd.DataFrame()
+
+        df_results_lst = []
+        for method in methods:
+            method_metadata = self.method_metadata(method=method)
+            if isinstance(download_results, bool) and download_results:
+                method_metadata.method_downloader().download_results()
+
+            try:
+                df_results = method_metadata.load_model_results()
+            except FileNotFoundError as err:
+                if isinstance(download_results, str) and download_results == "auto":
+                    print(
+                        f"Missing local model_results for method! Attempting to download from s3 "
+                        f'and retry... (method="{method_metadata.method}")',
+                    )
+                    method_metadata.method_downloader().download_results()
+                    df_results = method_metadata.load_model_results()
+                else:
+                    print(
+                        f"Missing local model_results for method {method_metadata.method}! "
+                        f"Try setting `download_results=True` to get the required files.",
+                    )
+                    raise err
+            df_results_lst.append(df_results)
+
+        df_model_results = pd.concat(df_results_lst, ignore_index=True)
+        if configs is not None:
+            df_model_results = df_model_results[df_model_results["method"].isin(set(configs))]
+            df_model_results = df_model_results.reset_index(drop=True)
+        return df_model_results
 
     # ------------------------------------------------------------------ metadata views
     def _resolve_task_metadata_collection(
@@ -778,6 +841,7 @@ class AbstractArenaContext:
                 figure_file_type=figure_file_type,
                 compute_fold_similarity=compute_fold_similarity,
                 fold_similarity_kwargs=fold_similarity_kwargs,
+                benchmark_name=self.benchmark_name,
                 **kwargs,
             )
         finally:
@@ -880,7 +944,17 @@ class AbstractArenaContext:
         save_website_leaderboard: bool = False,
         website_leaderboard_kwargs: dict | None = None,
         website_leaderboard_filename: str = "leaderboard_website.csv",
+        trajectory_extra_results: pd.DataFrame | None = None,
     ) -> None:
+        """Generate the compare / tuning-trajectory / runtime figures for each subset.
+
+        ``new_results`` are the new methods compared in the leaderboard (``plot_compare``) and, by
+        default, also the ``extra_results`` overlaid on the tuning-trajectory plots
+        (``plot_tuning_trajectories``). Pass ``trajectory_extra_results`` to give the trajectory
+        pass a *different* frame than the compare pass — e.g. show full per-config trajectories
+        (multiple ``n_configs`` rows per method) on the trajectory plot while the leaderboard keeps
+        the single-point method results — in one call instead of two.
+        """
         if compare_kwargs is None:
             compare_kwargs = {}
         if tuning_trajectory_kwargs is None:
@@ -889,6 +963,7 @@ class AbstractArenaContext:
             website_leaderboard_kwargs = {}
         if subsets == "auto":
             subsets = self._default_subsets
+        output_dir = Path(output_dir)
         for subset in subsets:
             output_suffix = None
             if subset is None:
@@ -928,7 +1003,7 @@ class AbstractArenaContext:
                 self.plot_tuning_trajectories(
                     save_path=output_dir_subset / "tuning_trajectories",
                     subset=subset,
-                    extra_results=new_results,
+                    extra_results=trajectory_extra_results if trajectory_extra_results is not None else new_results,
                     **tuning_trajectory_kwargs,
                 )
             if plot_runtime_per_method:
@@ -1102,6 +1177,95 @@ class AbstractArenaContext:
         hpo_trajectory["display_name"] = display_name
 
         return hpo_trajectory
+
+    def generate_portfolio_trajectories_per(
+        self,
+        portfolios: dict[str, list[str]],
+        *,
+        name: str,
+        config_fallback: str | None = None,
+        n_configs: list[int | None] | str = "auto",
+        seeds: int | list[int] = 1,
+        n_iterations: int = 40,
+        fit_order: Literal["original", "random"] = "original",
+        time_limit: float | None = None,
+        repo: EvaluationRepository | None = None,
+        folds: list[int] | None = None,
+        ta_name: str | None = None,
+        ta_suite: str | None = None,
+        display_name: str | None = None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        """Per-dataset analogue of :meth:`generate_portfolio_trajectories`.
+
+        Where :meth:`generate_portfolio_trajectories` takes a single global ordered ``configs``
+        list, this takes a per-dataset mapping ``portfolios`` (dataset -> ordered config list, e.g.
+        the leave-one-out portfolio each dataset selected). For each ``N`` in ``n_configs`` it
+        evaluates every dataset's *first ``N``* configs as an ensemble (via
+        :meth:`simulate_portfolio_from_configs_per`) and tags the result with ``n_configs=N``.
+
+        All ``N`` share the same ``method`` (== ``name``), so the rows form a single tuning
+        trajectory under the ``extra_results`` convention consumed by ``plot_tuning_trajectories``
+        (each point ensembles a prefix of the order — first config, first two, ...). Because the
+        ensemble's ``time_train_s`` is the cumulative cost of the considered configs, the trajectory
+        directly reflects the config *ordering* — which is what makes two orderings of the same set
+        (identical final point, different anytime curve) comparable.
+        """
+        if n_configs == "auto":
+            n_configs = [1, 2, 5, 10, 25, 50, 100, 150, None]
+        if isinstance(seeds, int):
+            seeds = list(range(seeds))
+
+        datasets = list(portfolios)
+        all_configs = sorted({config for configs in portfolios.values() for config in configs})
+
+        if repo is None:
+            repo = self.load_repo(config_fallback=config_fallback)
+
+        configs_w_fallback = list(all_configs)
+        if config_fallback is not None:
+            if config_fallback not in configs_w_fallback:
+                configs_w_fallback.append(config_fallback)
+            repo.set_config_fallback(config_fallback=config_fallback)
+        repo = repo.subset(configs=configs_w_fallback, datasets=datasets, folds=folds)
+
+        max_n_configs = max(len(configs) for configs in portfolios.values())
+        n_configs = [n_config if n_config is not None else max_n_configs for n_config in n_configs]
+        n_configs = sorted({min(n_config, max_n_configs) for n_config in n_configs})
+
+        # The (dataset, fold) tasks to evaluate, taken from the (subset) repo.
+        dataset_folds = [(dataset, fold) for dataset in datasets for fold in repo.dataset_to_folds(dataset)]
+
+        df_trajectory_lst = []
+        for n_config in n_configs:
+            print(f"Running n_config={n_config}")
+            for seed in seeds:
+                df_info = pd.DataFrame(
+                    [
+                        {"dataset": dataset, "fold": fold, "configs": portfolios[dataset][:n_config]}
+                        for dataset, fold in dataset_folds
+                    ]
+                )
+                df_results = self.simulate_portfolio_from_configs_per(
+                    df_info=df_info,
+                    repo=repo,
+                    n_iterations=n_iterations,
+                    fit_order=fit_order,
+                    seed=seed,
+                    time_limit=time_limit,
+                    **kwargs,
+                )
+                df_results["n_configs"] = n_config
+                df_results["n_iterations"] = n_iterations
+                df_results["seed"] = seed
+                df_trajectory_lst.append(df_results)
+
+        trajectory = pd.concat(df_trajectory_lst, ignore_index=True)
+        trajectory["method"] = name
+        trajectory["ta_name"] = ta_name
+        trajectory["ta_suite"] = ta_suite
+        trajectory["display_name"] = display_name
+        return trajectory
 
     def combine_hpo(
         self,

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -30,6 +30,7 @@ def compare(
     figure_file_type: str = "pdf",
     add_dataset_count: bool = False,
     elo_ymin: float | None = None,
+    benchmark_name: str = "Arena",
     **kwargs,
 ):
     """Evaluate ``df_results`` (already subset to the tasks of interest) into a leaderboard.
@@ -62,6 +63,7 @@ def compare(
         error_col=error_col,
         method_rename_map=method_rename_map,
         figure_file_type=figure_file_type,
+        benchmark_name=benchmark_name,
         **evaluator_kwargs,
     )
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/tabarena_context.py
@@ -66,6 +66,8 @@ class TabArenaContext(AbstractArenaContext):
     results), and adds the paper's ``evaluate_all`` reproduction workflow.
     """
 
+    benchmark_name: str = "TabArena"
+
     SUBSET_PREDICATES: dict[str, SubsetPredicate] = {
         "all": SubsetPredicate(lambda df: pd.Series(True, index=df.index)),
         # problem_type

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -102,6 +102,7 @@ class TabArenaEvaluator:
         keep_best: bool = False,
         figure_file_type: str = "pdf",
         use_latex: bool = False,
+        benchmark_name: str = "Arena",
         tabarena_context=None,  # FIXME: Remove this and refactor after leaderboard v0.2 upload, this is purely to get things working fast
     ):
         """Parameters
@@ -132,6 +133,7 @@ class TabArenaEvaluator:
         self.error_col = error_col
         self.config_types = config_types
         self.figure_file_type = figure_file_type
+        self.benchmark_name = benchmark_name
         self.banned_pareto_methods = banned_pareto_methods
         self._method_rename_map = method_rename_map
 
@@ -643,9 +645,9 @@ class TabArenaEvaluator:
         # prefix (aggregate / no-meaningful-subset case).
         if show_tuning_impact_title and "title" not in plot_tuning_kwargs:
             if subset_label and subset_label != "all":
-                plot_tuning_kwargs["title"] = f"TabArena-{subset_label} Leaderboard"
+                plot_tuning_kwargs["title"] = f"{self.benchmark_name}-{subset_label} Leaderboard"
             else:
-                plot_tuning_kwargs["title"] = "TabArena Leaderboard"
+                plot_tuning_kwargs["title"] = f"{self.benchmark_name} Leaderboard"
 
         if calibration_framework is not None and calibration_framework == "auto":
             calibration_framework = "RF (default)"
@@ -1008,9 +1010,9 @@ class TabArenaEvaluator:
                 winrate_title: str | None = None
                 if show_winrate_title:
                     if subset_label and subset_label != "all":
-                        winrate_title = f"TabArena-{subset_label} Win-rate Matrix"
+                        winrate_title = f"{self.benchmark_name}-{subset_label} Win-rate Matrix"
                     else:
-                        winrate_title = "TabArena Win-rate Matrix"
+                        winrate_title = f"{self.benchmark_name} Win-rate Matrix"
                 try:
                     tabarena.plot_winrate_matrix(
                         winrate_matrix=winrate_matrix,

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -1277,6 +1277,22 @@ def _plot_tuning_trajectories_from_prepared(
             base_meta: dict[str, str] = dict(dataset_metadata or {})
             base_meta.setdefault("Datasets", f"{n_datasets:,}")
             base_meta.setdefault("Tasks", f"{n_tasks:,}")
+
+            # Max/Median/Min per-dataset training-set size (mean over folds) across the datasets
+            # actually present in this subset, taken from the collection's split metadata (keyed by
+            # tabarena_task_name == combined_data["dataset"]).
+            present_datasets = set(filtered["dataset"].unique())
+            train_sizes_per_dataset: dict[str, list[float]] = {}
+            for ttm in tabarena_context.task_metadata_collection:
+                if ttm.tabarena_task_name not in present_datasets:
+                    continue
+                for split in ttm.splits_metadata.values():
+                    train_sizes_per_dataset.setdefault(ttm.tabarena_task_name, []).append(split.num_instances_train)
+            n_train_per_dataset = [sum(sizes) / len(sizes) for sizes in train_sizes_per_dataset.values()]
+            if n_train_per_dataset:
+                base_meta.setdefault("Max train samples", f"{round(max(n_train_per_dataset)):,}")
+                base_meta.setdefault("Median train samples", f"{round(float(np.median(n_train_per_dataset))):,}")
+                base_meta.setdefault("Min train samples", f"{round(min(n_train_per_dataset)):,}")
             subset_dataset_metadata = base_meta
 
         if show_titles:
@@ -1301,6 +1317,7 @@ def _plot_tuning_trajectories_from_prepared(
             show_titles=show_titles,
             title_prefix=subset_title_prefix,
             use_elo_method_order=use_elo_method_order,
+            benchmark_name=getattr(tabarena_context, "benchmark_name", "Arena"),
         )
 
 
@@ -1411,6 +1428,7 @@ def plot_tuning_trajectories_from_leaderboard(
     show_titles: bool = False,
     title_prefix: str | None = None,
     use_elo_method_order: bool = True,
+    benchmark_name: str = "Arena",
 ):
     if plot_kwargs is None:
         plot_kwargs = {}
@@ -1421,15 +1439,15 @@ def plot_tuning_trajectories_from_leaderboard(
     plot_kwargs["dataset_metadata"] = dataset_metadata
 
     # Single shared title across every ``plot_hpo`` call in this set.
-    # ``TabArena-<subset>`` prefix matches the format used by the winrate
+    # ``<benchmark_name>-<subset>`` prefix matches the format used by the winrate
     # matrix and tuning-impact bar plots so the three surfaces read as
     # one report. ``None`` and ``"all"`` collapse to the unsuffixed
-    # ``TabArena`` prefix (aggregate / no-meaningful-subset case).
+    # ``<benchmark_name>`` prefix (aggregate / no-meaningful-subset case).
     if show_titles:
         if title_prefix and title_prefix != "all":
-            plot_kwargs["title"] = f"TabArena-{title_prefix} Pareto Frontier"
+            plot_kwargs["title"] = f"{benchmark_name}-{title_prefix} Pareto Frontier"
         else:
-            plot_kwargs["title"] = "TabArena Pareto Frontier"
+            plot_kwargs["title"] = f"{benchmark_name} Pareto Frontier"
 
     # Pin a single canonical method ordering for every plot in this set so
     # colors and legend positions stay identical across the err / improvability


### PR DESCRIPTION
## Summary

Adds a configurable benchmark name to the arena contexts (so plot titles read the right benchmark) plus the tooling used to generate and plot per-ordering portfolio tuning trajectories.

## Changes

- **`benchmark_name` on the contexts** — `AbstractArenaContext.benchmark_name` defaults to `"Arena"`, with `TabArenaContext` → `"TabArena"` and `BeyondArenaContext` → `"BeyondArena"`. Threaded into the plot titles that previously hardcoded `"TabArena"`: the tuning-trajectory Pareto-frontier (`plot_tuning_trajectories_from_leaderboard`), the tuning-impact leaderboard, and the win-rate matrix (`TabArenaEvaluator`, via `compare`). Defaults keep existing callers unchanged.
- **`AbstractArenaContext.load_model_results(...)`** — concatenates the raw per-config `model_results` across methods, exposing per-`(dataset, fold, config)` `time_train_s` / `time_infer_s` (unlike `load_results`, which returns the aggregated default/tuned/tuned+ensemble rows). Optional `configs` filter; mirrors `load_results`' download-on-cache-miss handling.
- **`AbstractArenaContext.generate_portfolio_trajectories_per(...)`** — per-dataset analogue of `generate_portfolio_trajectories`. Takes a `{dataset: ordered config list}` mapping and, for each `N`, evaluates every dataset's first-`N` configs via `simulate_portfolio_from_configs_per`, tagging `n_configs=N`. All `N` share one `method`, so the rows form a single `extra_results`-style trajectory whose cumulative `time_train_s` reflects the config ordering.
- **`generate_all_figs(...)`** — adds `trajectory_extra_results` so the tuning-trajectory pass can use a different `extra_results` than the compare pass's `new_results` in a single call (e.g. full per-config trajectories on the plot, single-point method rows in the leaderboard), and coerces `output_dir` to `Path` so a `str` works.
- **Tuning-trajectory "Metadata" legend** — adds Max/Median/Min training-set size (per-dataset mean over folds) across the datasets present in the subset, alongside the existing Datasets/Tasks counts.

## Notes

- All new parameters default to prior behavior, so existing call sites are unaffected.
- `ruff check` + `ruff format --check` pass on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
