### PR TITLE
Guard temporal-bagging validation test on data_foundry availability

### DIFF
--- a/tst/benchmark/experiment/test_validation_utils.py
+++ b/tst/benchmark/experiment/test_validation_utils.py
@@ -1214,6 +1214,7 @@ def test_build_predictor_args_grouped_bagging_uses_custom_splits_not_tuning_data
         assert set(groups[train_idx]).isdisjoint(set(groups[val_idx])), "a group spans a bagged fold"
 
 
+@pytest.mark.skipif(not _DATA_FOUNDRY_AVAILABLE, reason="data_foundry not installed")
 def test_build_predictor_args_temporal_bagging_uses_custom_splits_not_tuning_data():
     """Bagged temporal fit -> non-empty time-based custom_splits folds, and no tuning_data."""
     n = 600


### PR DESCRIPTION
## Summary

Fixes the 1 failing CI test:

```
FAILED tst/benchmark/experiment/test_validation_utils.py::test_build_predictor_args_temporal_bagging_uses_custom_splits_not_tuning_data - ModuleNotFoundError: No module named 'data_foundry'
```

## Root cause

The temporal **bagged** path (`time_on` + `num_bag_folds >= 2`) routes through `resolve_validation_splits` → `_resolve_group_splits`, which imports `data_foundry` (`from data_foundry.curation_recommendations import get_recommended_grouped_splits`). The test neither monkeypatches `_resolve_group_splits` nor is guarded on `data_foundry` availability, so it passes locally (where `data_foundry` is installed) but fails in CI (where it isn't).

Its direct analogue, `test_build_predictor_args_grouped_bagging_uses_custom_splits_not_tuning_data`, already carries `@pytest.mark.skipif(not _DATA_FOUNDRY_AVAILABLE, ...)` — the temporal sibling was just missing it.

## Fix

Add the same `@pytest.mark.skipif(not _DATA_FOUNDRY_AVAILABLE, reason="data_foundry not installed")` guard to the temporal-bagging test (one line). In CI it now skips (like the grouped sibling); locally it still runs and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
