### PR TITLE
Fix config_default merge error when loading partially completed runs

### DIFF
--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -689,10 +689,19 @@ class EndToEndResultsSingle:
                 method_metadata_other.is_bag = True
 
             if method_metadata.config_default != method_metadata_other.config_default:
-                if method_metadata.config_default is None:
-                    method_metadata.config_default = method_metadata_other.config_default
-                elif method_metadata_other.config_default is None:
-                    method_metadata_other.config_default = method_metadata.config_default
+                # The two sides disagree on the default config. Either one already spans multiple
+                # configs (config_default None), or — when merging per-task results from partially
+                # completed runs — different tasks each finished a single, *different* config, which
+                # MethodMetadata.from_raw infers as that task's config_default. Across the merged
+                # set the method therefore has multiple configs and no single default: defer it to
+                # None (resolved later via get_config_default(use_first_if_missing=True)) and mark
+                # the method HPO-capable. This matches what a single-pass from_path_raw over all of
+                # the method's files produces, and keeps the merge order-independent (a later
+                # single-config task can never overwrite the deferred None).
+                method_metadata.config_default = None
+                method_metadata_other.config_default = None
+                method_metadata.can_hpo = True
+                method_metadata_other.can_hpo = True
             if method_metadata.can_hpo != method_metadata_other.can_hpo:
                 method_metadata.can_hpo = True
                 method_metadata_other.can_hpo = True

--- a/tests/tabarena/nips2025_utils/test_end_to_end_single.py
+++ b/tests/tabarena/nips2025_utils/test_end_to_end_single.py
@@ -6,7 +6,9 @@ import pandas as pd
 import pytest
 
 from tabarena.benchmark.task.metadata import TaskMetadataCollection
+from tabarena.models._method_metadata import MethodMetadata
 from tabarena.nips2025_utils.end_to_end_single import (
+    EndToEndResultsSingle,
     EndToEndSingle,
     _filter_file_paths_by_task_metadata,
     _reject_legacy_task_metadata,
@@ -67,3 +69,59 @@ class TestFetchTaskMetadata:
         coll = EndToEndSingle.fetch_task_metadata(tids=[], verbose=False)
         assert isinstance(coll, TaskMetadataCollection)
         assert len(coll) > 0
+
+
+def _e2e_single_for_config(config_default: str, *, method: str = "TA-TabPFN-3") -> EndToEndResultsSingle:
+    """A per-task result whose method completed exactly one config (`config_default`).
+
+    Mirrors what ``MethodMetadata.from_raw`` infers for a task whose result set has a single
+    config: that lone config becomes ``config_default`` and ``can_hpo`` is False. Real
+    model/hpo frames are passed so the constructor never falls back to a disk load.
+    """
+    method_metadata = MethodMetadata(
+        method=method,
+        artifact_name=method,
+        method_type="config",
+        config_default=config_default,
+        can_hpo=False,
+    )
+    df = pd.DataFrame({"method": [config_default], "dataset": ["d"], "fold": [0], "metric_error": [0.1]})
+    return EndToEndResultsSingle(method_metadata, model_results=df, hpo_results=df)
+
+
+class TestConcatPartialResults:
+    """Regression for merging per-task results of a partially completed run.
+
+    When different tasks finished different single configs of the same method,
+    ``MethodMetadata.from_raw`` infers a different lone ``config_default`` per task. ``concat``
+    must treat that disagreement as "multiple configs across tasks" — defer ``config_default``
+    to None and mark ``can_hpo`` — instead of raising "Method metadata mismatch".
+    """
+
+    def test_differing_single_config_defaults_defer_to_none(self):
+        merged = EndToEndResultsSingle.concat(
+            [
+                _e2e_single_for_config("TA-TabPFN-3_c5_BAG_L1"),
+                _e2e_single_for_config("TA-TabPFN-3_c2_BAG_L1"),
+            ],
+        )
+        assert merged.method_metadata.config_default is None
+        assert merged.method_metadata.can_hpo is True
+
+    def test_order_independent_with_three_tasks(self):
+        # A later single-config task must not overwrite the deferred None.
+        merged = EndToEndResultsSingle.concat(
+            [_e2e_single_for_config(f"TA-TabPFN-3_c{i}_BAG_L1") for i in (5, 2, 3)],
+        )
+        assert merged.method_metadata.config_default is None
+        assert merged.method_metadata.can_hpo is True
+
+    def test_agreeing_single_config_is_preserved(self):
+        # When every task agrees on the same single config, it stays the default.
+        merged = EndToEndResultsSingle.concat(
+            [
+                _e2e_single_for_config("TA-TabPFN-3_c1_BAG_L1"),
+                _e2e_single_for_config("TA-TabPFN-3_c1_BAG_L1"),
+            ],
+        )
+        assert merged.method_metadata.config_default == "TA-TabPFN-3_c1_BAG_L1"


### PR DESCRIPTION
## Problem

Loading a **partially completed** benchmark run via `EndToEnd.from_path_raw_to_results(...)` can fail with:

```
ValueError: Method metadata mismatch! The following fields differ:
  config_default: 'TA-TabPFN-3_c5_BAG_L1' != 'TA-TabPFN-3_c2_BAG_L1'
```

`from_path_raw_to_results` builds `MethodMetadata` **per task** and merges per method via `EndToEndResultsSingle.concat`. `MethodMetadata.from_raw` infers `config_default` from the configs present, so a task that completed a **single** config treats that lone config as its default. When different tasks finish different single configs of the same method (common in a partial run), their per-task `config_default` diverge. `concat` only reconciled the `None`-vs-value case, so two differing non-`None` defaults fell through to the dict-equality guard and raised.

`EndToEnd.from_path_raw` is immune because it processes all of a method's files together, so `config_default` is computed once over the union of configs (→ `None`).

## Fix

In `EndToEndResultsSingle.concat`, treat **any** `config_default` disagreement as "the method spans multiple configs across tasks": defer `config_default` to `None` and set `can_hpo=True`. This matches what a single-pass `from_path_raw` produces and is order-independent (a later single-config task cannot overwrite the deferred `None`). The concrete default is resolved downstream via `get_config_default(use_first_if_missing=True)`.

## Tests

Adds `TestConcatPartialResults` to `tests/tabarena/nips2025_utils/test_end_to_end_single.py`: differing single configs → deferred `None` + `can_hpo`, order-independence across 3 tasks, and preserved behavior when all tasks agree on one config. Full file passes (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
