### PR TITLE
Route task-metadata verbose output through logging

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, fields, replace
 from typing import TYPE_CHECKING, Any, Literal, Self
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
     from tabarena.benchmark.experiment.job import Job
     from tabarena.benchmark.task.metadata.sources import TaskMetadataSource
     from tabarena.nips2025_utils.subset_predicate import SubsetPredicate
+
+logger = logging.getLogger(__name__)
 
 
 def _preset_subset_predicates_provider(
@@ -337,7 +340,7 @@ class TaskMetadataCollection:
                 "\tTask Filter History:",
                 *(f"\t({i}) {label}: {len(coll)}." for i, (label, coll) in enumerate(steps, start=1)),
             ]
-            print("\n".join(lines))
+            logger.info("\n".join(lines))
         return result
 
     def _with_tasks(self, tasks: list[TabArenaTaskMetadata]) -> TaskMetadataCollection:

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/base.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/base.py
@@ -18,12 +18,15 @@ filtering (``subset_tasks``), the source owns loading + materialization.
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 
 import pandas as pd
 
 from tabarena.benchmark.task.metadata.schema import TabArenaTaskMetadata
+
+logger = logging.getLogger(__name__)
 
 
 def committed_metadata_dir() -> Path:
@@ -88,7 +91,7 @@ class InMemoryTaskMetadataSource(TaskMetadataSource):
         data = self.data
         if isinstance(data, (str, Path)):
             if verbose:
-                print(f"Loading task metadata from {data}...")
+                logger.info("Loading task metadata from %s...", data)
             data = pd.read_csv(data, index_col=False)
         if isinstance(data, pd.DataFrame):
             data = [TabArenaTaskMetadata.from_row(row) for _, row in data.iterrows()]

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/tabarena_v0pt1.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/tabarena_v0pt1.py
@@ -11,6 +11,7 @@ backward compatibility and is what :func:`generate_tabarena_v0_1_reference_metad
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pandas as pd
@@ -18,6 +19,8 @@ import pandas as pd
 from tabarena.benchmark.task.metadata.schema import SplitMetadata, TabArenaTaskMetadata, derive_task_type
 from tabarena.benchmark.task.metadata.sources.base import committed_metadata_path as _committed_metadata_path
 from tabarena.benchmark.task.metadata.sources.openml import OpenMLTaskMetadataSource
+
+logger = logging.getLogger(__name__)
 
 #: Surface suite name used for the committed reference CSV and the source registry.
 TABARENA_V0PT1_NAME = "TabArena-v0.1"
@@ -172,7 +175,7 @@ class TabArenaV0pt1TaskMetadataSource(OpenMLTaskMetadataSource):
         path = committed_metadata_path()
         if path.exists():
             if verbose:
-                print(f"Loading committed TabArena v0.1 reference metadata from {path}.")
+                logger.info("Loading committed TabArena v0.1 reference metadata from %s.", path)
             metadata_df = pd.read_csv(path)
             return [TabArenaTaskMetadata.from_row(row) for _, row in metadata_df.iterrows()]
 


### PR DESCRIPTION
## What

The `verbose`-gated messages in the task-metadata layer used bare `print()`, which has no off-switch. The per-`build_jobs` filter-history block in `subset_tasks` floods training logs — the same problem the in-process `_run` helper currently works around by redirecting stdout to `/dev/null`.

This adds a module logger to `collection.py` and the two metadata sources, and emits those messages via `logger.info(...)` instead of `print(...)`.

## Behavior

- The `verbose` flags still gate **whether** a message is produced — no signature changes, no behavior change for existing callers at default log levels.
- Callers can now additionally silence or reroute the output via standard logging config without touching call sites, e.g.:

  ```python
  logging.getLogger("tabarena.benchmark.task.metadata").setLevel(logging.WARNING)
  ```

## Files

- `benchmark/task/metadata/collection.py` — `subset_tasks` filter-history block
- `benchmark/task/metadata/sources/base.py` — per-load message
- `benchmark/task/metadata/sources/tabarena_v0pt1.py` — per-load message

🤖 Generated with [Claude Code](https://claude.com/claude-code)