### PR TITLE
Update add-model skill from DenseLight integration

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -128,12 +128,12 @@ _LAZY_CLASSES = {
 ```
 Also add `"{ClassName}Model"` to `__all__` and (under `TYPE_CHECKING`) to the static `from tabarena.models.{ModelKey}.model import {ClassName}Model` block, both kept alphabetised.
 
-### 4b. `packages/tabarena/src/tabarena/models/utils.py`
+### 4b. `packages/tabarena/src/tabarena/models/utils.py` — no edit needed
 
-Add to the `name_to_import_map` dict in `get_configs_generator_from_name()`. The key is the friendly model name (often the same as `ModelName`):
-```python
-"{ModelName}": lambda: importlib.import_module("tabarena.models.{ModelKey}.hpo").gen_{ModelKey},
-```
+**No longer required** (auto-registry). `get_configs_generator_from_name()` now resolves the
+search space from the auto-discovered `MODEL_REGISTRY` (via `get_model_info_from_name`); there is
+no `name_to_import_map` dict to update. Creating `info.py` (Step 3d) is what makes the model
+resolvable by name. Leave `utils.py` untouched.
 
 ### 4c. `packages/tabarena/pyproject.toml`
 
@@ -157,8 +157,23 @@ Always declare the pip spec exactly once in the per-model extra, then reference 
 | **Default**: new extended model | Add `"tabarena[{ModelKey}]"` to the `extended` extra. |
 | Core benchmark model (only if user explicitly says so) | Add `"tabarena[{ModelKey}]"` to the `benchmark` extra. |
 | Model has known dependency conflicts (rare, like `probmetrics`) | Skip both `benchmark` and `extended`; add `"tabarena[{ModelKey}]"` to `all` only. |
+| We reuse only a slice of a heavy library's code (`--no-deps` pattern, like `denselight` reusing LightAutoML's NN stack) | Declare the per-model extra, but leave it OUT of `benchmark`/`extended`/`all` and document the `--no-deps` install (see below). |
 
 After this, users can install the model alone (`uv sync --extra benchmark --extra {ModelKey}`), as part of the extended set (`uv sync --extra benchmark --extra extended`), or via `--extra all`.
+
+**`--no-deps` minimal-reuse pattern.** Sometimes the goal is to reuse only a small part of a large
+library (e.g. one model class + its training loop) without pulling that library's heavy,
+conflict-prone transitive tree. If the *specific* modules you import resolve using only packages
+TabArena already ships (`torch`, `numpy`, `pandas`, `scikit-learn`, `catboost`, `lightgbm`,
+`xgboost`, `tqdm`), then the library can be installed with `pip install <lib> --no-deps`. To check:
+clone the upstream repo and trace the import chain of *exactly* the modules your wrapper imports
+(package `__init__.py`s that only declare `__all__` without eager submodule imports are the enabler —
+they let you reach a deep submodule without triggering the whole package). The pip extra (`{ModelKey}
+= ["<lib>"]`) still names the library so the drift checker passes, but a plain `pip install
+tabarena[{ModelKey}]` would pull the full tree — so keep it out of the union extras and document
+the `--no-deps` install in the wrapper docstring + the pyproject comment. `denselight` is the
+reference example. Keep all `<lib>` imports lazy (inside `_fit` / a private `_internal/` runner)
+so model discovery never needs the optional dep.
 
 **Step 3 — verify the per-model extra matches `info.py`** with the drift checker:
 

--- a/.claude/skills/add-model/references/model_patterns.md
+++ b/.claude/skills/add-model/references/model_patterns.md
@@ -260,6 +260,29 @@ Set the class attribute `seed_name = "random_state"` (or whatever the library's 
 AutoGluon then injects the *framework* seed there so every model uses the same seeding strategy.
 **Do not** hardcode `random_state=0` in `_set_default_params()`.
 
+### 5. Leave *global* torch state unchanged — snapshot & restore in a `finally`
+
+The model fit-test (`autogluon.core.testing.global_context_snapshot.GlobalContextSnapshot`) asserts
+that `_fit` does **not** leak changes into global torch state — it guards
+`torch.get_num_threads()`, `torch.backends.cudnn.{benchmark,deterministic,enabled}`, the TF32 flags,
+and the default dtype. Many libraries mutate these as a side effect: `torch.set_num_threads(...)`,
+or seeding helpers that set `torch.backends.cudnn.deterministic = True` (LightAutoML's
+`seed_everything` does exactly this). If your wrapper (or the lib it calls) touches any guarded
+field, snapshot it before fitting and restore it in a `finally`:
+
+```python
+original_num_threads = torch.get_num_threads()
+original_cudnn_deterministic = torch.backends.cudnn.deterministic
+try:
+    ...  # build + fit the inner model (may call set_num_threads / seed_everything)
+finally:
+    torch.set_num_threads(original_num_threads)
+    torch.backends.cudnn.deterministic = original_cudnn_deterministic
+```
+
+`models/denselight/model.py` is the reference. Symptom if you forget: the smoke test fails with
+`AssertionError: Global context changed across operation: - torch_cudnn_deterministic changed`.
+
 ---
 
 ## Categorical & missing-value handling — prefer the library's native path
@@ -375,8 +398,8 @@ from tabarena.models.{ModelKey}.model import {ClassName}Model
     display_name="{ModelName}",
     compute="gpu",                          # or "cpu"
     date="YYYY-MM-DD",                     # date of the benchmarking run (or planning date if unbenchmarked)
-    ag_key="{ag_key_without_TA}",          # e.g. "TABSTAR" (matches {ClassName}Model.ag_key without the TA- prefix)
-    model_key="{ag_key_without_TA}",
+    ag_key="{ag_key}",                     # MUST equal {ClassName}Model.ag_key EXACTLY, incl. any "TA-" prefix (e.g. "TA-DENSELIGHT")
+    model_key="{MODEL_KEY_UPPER}",         # short upper-case key (e.g. "DENSELIGHT"), commonly ag_key without the "TA-" prefix
     config_default="{ModelName}_c1_BAG_L1",
     can_hpo=True,
     is_bag=True,
@@ -457,12 +480,7 @@ _LAZY_CLASSES = {
     ...
 }
 
-# Add to __all__ (keep sorted):
-__all__ = [
-    ...
-    "{ClassName}Model",
-    ...
-]
+# `__all__` is auto-derived from `_LAZY_CLASSES` + `_EAGER_EXPORTS` — do NOT edit it by hand.
 
 # Add to the TYPE_CHECKING block (keep sorted):
 if TYPE_CHECKING:
@@ -470,13 +488,8 @@ if TYPE_CHECKING:
     from tabarena.models.{ModelKey}.model import {ClassName}Model
 ```
 
-### `packages/tabarena/src/tabarena/models/utils.py` — `name_to_import_map` entry
-
-Used by `get_configs_generator_from_name()`. The key is the friendly model name (typically same as `ModelName`):
-
-```python
-"{ModelName}": lambda: importlib.import_module("tabarena.models.{ModelKey}.hpo").gen_{ModelKey},
-```
+`utils.py` needs no edit: `get_configs_generator_from_name()` resolves the search space from the
+auto-discovered `MODEL_REGISTRY`, so there is no `name_to_import_map` to update.
 
 ### `packages/tabarena/pyproject.toml`
 


### PR DESCRIPTION
Fold the lessons from adding DenseLight back into the add-model skill docs:

- utils.py needs no edit: get_configs_generator_from_name() resolves the search space from the auto-discovered MODEL_REGISTRY (via info.py), so there is no name_to_import_map dict to update.
- Document the `--no-deps` minimal-reuse pattern: reuse a slice of a heavy library without pulling its transitive tree (DenseLight reuses LightAutoML's NN stack); keep the extra out of the union extras.
- Snapshot/restore global torch state in a finally: the model fit-test's GlobalContextSnapshot guards num_threads, cudnn flags, TF32, and default dtype; seeding helpers (e.g. LightAutoML's seed_everything) mutate them.
- __all__ in models/__init__.py is auto-derived; do not hand-edit it.
- ag_key must equal {ClassName}Model.ag_key exactly (incl. any TA- prefix).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
