### PR TITLE
Refactor method artifact I/O: shared base classes + direct key derivation

### DIFF
--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
@@ -36,9 +36,11 @@ class MethodDownloader(ABC):
         self.method_metadata = method_metadata
         self.method = method_metadata.method
         self.bucket = bucket
+        # ``prefix`` is the cache-root prefix only (e.g. "cache"); ``key_prefix`` is this method's
+        # *full* key prefix within the bucket, e.g. "cache/artifacts/<artifact_name>/methods/<method>".
+        # NOTE: this differs from the pre-refactor subclasses, where ``self.prefix`` held the full
+        # per-method key path now stored in ``key_prefix`` — use ``key_prefix`` for object keys.
         self.prefix = prefix
-        # This method's key prefix within the bucket, e.g.
-        # "cache/artifacts/<artifact_name>/methods/<method>".
         self.key_prefix = Path(prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
         self.verbose = verbose
         self.clear_dirs = clear_dirs

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
@@ -47,11 +47,15 @@ class MethodDownloader(ABC):
 
     # -- remote location ----------------------------------------------------------------------
     @property
-    def s3_cache_root(self) -> str:
+    def remote_cache_root(self) -> str:
+        """The cache root as an ``s3://bucket/prefix`` URI. The ``s3://`` scheme is a parsing
+        convention for :func:`s3_path_to_bucket_prefix` (used to derive object keys), not an AWS
+        endpoint — it is correct for any S3-compatible backend (e.g. Cloudflare R2).
+        """
         return f"s3://{self.bucket}/{self.prefix}"
 
     def local_to_s3_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.s3_cache_root)
+        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.remote_cache_root)
         _, key = s3_path_to_bucket_prefix(s3_path_loc)
         return key
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
@@ -6,8 +6,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
 
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
-
 if TYPE_CHECKING:
     from tabarena.models._method_metadata import MethodMetadata
 
@@ -48,16 +46,22 @@ class MethodDownloader(ABC):
     # -- remote location ----------------------------------------------------------------------
     @property
     def remote_cache_root(self) -> str:
-        """The cache root as an ``s3://bucket/prefix`` URI. The ``s3://`` scheme is a parsing
-        convention for :func:`s3_path_to_bucket_prefix` (used to derive object keys), not an AWS
-        endpoint — it is correct for any S3-compatible backend (e.g. Cloudflare R2).
+        """The cache root as a human-readable ``s3://bucket/prefix`` URI (for logging/display).
+
+        The ``s3://`` scheme is just a label — correct for any S3-compatible backend (e.g.
+        Cloudflare R2) — and is not used to derive object keys (see :meth:`local_to_key`).
         """
         return f"s3://{self.bucket}/{self.prefix}"
 
-    def local_to_s3_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.remote_cache_root)
-        _, key = s3_path_to_bucket_prefix(s3_path_loc)
-        return key
+    def local_to_key(self, path_local: str | Path) -> str:
+        """Remote object key for a local cache path: ``prefix`` joined with the path's location
+        relative to the cache root.
+
+        Computed directly (no ``s3://`` URI is built or parsed), the same way :attr:`key_prefix`
+        is — keeping it consistent with the raw/processed zip keys.
+        """
+        rel = self.method_metadata.relative_to_cache_root(Path(path_local))
+        return (Path(self.prefix) / rel).as_posix()
 
     # -- artifact downloads -------------------------------------------------------------------
     def download_all(self):
@@ -68,7 +72,7 @@ class MethodDownloader(ABC):
 
     def download_metadata(self):
         path_local = Path(self.method_metadata.path_metadata)
-        self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+        self._download_to_local_if_exists(key=self.local_to_key(path_local), path_local=path_local)
 
     def download_raw(self):
         dest_dir = Path(self.method_metadata.path_raw)
@@ -82,16 +86,16 @@ class MethodDownloader(ABC):
 
     def download_configs_hyperparameters(self):
         path_local = Path(self.method_metadata.path_configs_hyperparameters())
-        self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+        self._download_to_local_if_exists(key=self.local_to_key(path_local), path_local=path_local)
 
     def download_results(self):
         for path_local in self.method_metadata.path_results_files():
             path_local = Path(path_local)
-            self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+            self._download_to_local_if_exists(key=self.local_to_key(path_local), path_local=path_local)
 
     def download_results_hpo_trajectories(self):
         path_local = Path(self.method_metadata.path_results_hpo_trajectories())
-        self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+        self._download_to_local_if_exists(key=self.local_to_key(path_local), path_local=path_local)
 
     # -- shared helpers -----------------------------------------------------------------------
     def _log(self, msg: str):

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import shutil
+import zipfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import IO, TYPE_CHECKING
+
+from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
+
+if TYPE_CHECKING:
+    from tabarena.models._method_metadata import MethodMetadata
+
+
+class MethodDownloader(ABC):
+    """Downloads a method's cached artifacts from an S3-compatible store and restores the local
+    layout produced by :class:`~tabarena.models._artifacts.uploader.MethodUploader`.
+
+    Holds all the backend-independent logic: which artifacts to fetch (metadata, raw, processed,
+    configs_hyperparameters, results, HPO trajectories) and how local paths map to remote keys.
+    Concrete subclasses supply only the backend specifics — how to fetch a single object
+    (:meth:`_download_to_local_if_exists`) and a zip archive (:meth:`_download_and_unzip_if_exists`),
+    each a no-op (skip with a warning) when the object is missing. Subclasses can reuse
+    :meth:`_extract_zip` for the shared clear/extract step and :meth:`_log` for verbose output.
+    """
+
+    def __init__(
+        self,
+        method_metadata: MethodMetadata,
+        *,
+        bucket: str,
+        prefix: str = "cache",
+        verbose: bool = True,
+        clear_dirs: bool = True,
+    ):
+        self.method_metadata = method_metadata
+        self.method = method_metadata.method
+        self.bucket = bucket
+        self.prefix = prefix
+        # This method's key prefix within the bucket, e.g.
+        # "cache/artifacts/<artifact_name>/methods/<method>".
+        self.key_prefix = Path(prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
+        self.verbose = verbose
+        self.clear_dirs = clear_dirs
+
+    # -- remote location ----------------------------------------------------------------------
+    @property
+    def s3_cache_root(self) -> str:
+        return f"s3://{self.bucket}/{self.prefix}"
+
+    def local_to_s3_path(self, path_local: str | Path) -> str:
+        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.s3_cache_root)
+        _, key = s3_path_to_bucket_prefix(s3_path_loc)
+        return key
+
+    # -- artifact downloads -------------------------------------------------------------------
+    def download_all(self):
+        self.download_metadata()
+        self.download_raw()
+        self.download_processed()
+        self.download_results()
+
+    def download_metadata(self):
+        path_local = Path(self.method_metadata.path_metadata)
+        self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+
+    def download_raw(self):
+        dest_dir = Path(self.method_metadata.path_raw)
+        key = (self.key_prefix / "raw.zip").as_posix()
+        self._download_and_unzip_if_exists(key=key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
+
+    def download_processed(self):
+        dest_dir = Path(self.method_metadata.path_processed)
+        key = (self.key_prefix / "processed.zip").as_posix()
+        self._download_and_unzip_if_exists(key=key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
+
+    def download_configs_hyperparameters(self):
+        path_local = Path(self.method_metadata.path_configs_hyperparameters())
+        self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+
+    def download_results(self):
+        for path_local in self.method_metadata.path_results_files():
+            path_local = Path(path_local)
+            self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+
+    def download_results_hpo_trajectories(self):
+        path_local = Path(self.method_metadata.path_results_hpo_trajectories())
+        self._download_to_local_if_exists(key=self.local_to_s3_path(path_local), path_local=path_local)
+
+    # -- shared helpers -----------------------------------------------------------------------
+    def _log(self, msg: str):
+        if self.verbose:
+            print(msg)
+
+    def _extract_zip(self, zip_source: str | Path | IO[bytes], dest_dir: Path, clear_dir: bool):
+        """Extract a zip (a path or an in-memory/file-like object) into ``dest_dir``."""
+        if clear_dir and dest_dir.exists():
+            shutil.rmtree(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_source, "r") as zf:
+            zf.extractall(path=dest_dir)
+
+    # -- backend-specific fetch ---------------------------------------------------------------
+    @abstractmethod
+    def _download_to_local_if_exists(self, key: str, path_local: Path):
+        """Download the object at ``key`` to ``path_local``; skip quietly if it is missing."""
+
+    @abstractmethod
+    def _download_and_unzip_if_exists(self, key: str, dest_dir: Path, clear_dir: bool = True):
+        """Download the zip at ``key`` and extract into ``dest_dir``; skip quietly if missing."""

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_public_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_public_r2.py
@@ -1,41 +1,26 @@
 from __future__ import annotations
 
-import shutil
 import tempfile
-import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote, urljoin
 
 import requests
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
+
+from tabarena.models._artifacts.downloader import MethodDownloader
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from tabarena.models._method_metadata import MethodMetadata
 
 
-class MethodDownloaderPublicR2:
-    """Download a method's cached artifacts from a public Cloudflare R2 bucket exposed
-    via a custom domain, and restore the original local layout expected by
-    MethodUploaderR2 / MethodMetadata.
+class MethodDownloaderPublicR2(MethodDownloader):
+    """Download a method's cached artifacts from a public Cloudflare R2 bucket exposed via a
+    custom domain (e.g. ``https://data.tabarena.ai/cache/.../raw.zip``).
 
-    Artifacts handled:
-      - metadata YAML
-      - raw.zip  -> extracted into `method_metadata.path_raw`
-      - processed.zip -> extracted into `method_metadata.path_processed`
-      - configs_hyperparameters (standalone YAML/JSON/etc. per your metadata)
-      - results files (the set returned by `method_metadata.path_results_files()`)
-
-    Notes:
-    -----
-    - Object keys are reconstructed from the local target paths via
-      MethodMetadata.to_s3_cache_loc so the local <-> public R2 mapping stays
-      symmetric with the uploader.
-    - This class assumes the custom domain serves objects directly by key, e.g.
-      https://data.tabarena.ai/cache/.../raw.zip
-    - If an optional artifact is missing remotely, it is skipped with a warning.
+    Backend specifics over :class:`MethodDownloader`: anonymous HTTP(S) GETs against the custom
+    domain (no credentials, no boto3), streaming large archives to a temp file before extracting.
+    The bucket name is irrelevant — objects are addressed by key relative to ``base_url`` — so a
+    ``"public"`` placeholder bucket is used purely to make the key mapping resolve.
     """
 
     def __init__(
@@ -49,116 +34,28 @@ class MethodDownloaderPublicR2:
         chunk_size: int = 1024 * 1024,
         session: requests.Session | None = None,
     ):
-        self.method_metadata = method_metadata
-        self.method = method_metadata.method
-
+        super().__init__(
+            method_metadata,
+            bucket="public",
+            prefix=r2_prefix.strip("/"),
+            verbose=verbose,
+            clear_dirs=clear_dirs,
+        )
         self.base_url = base_url.rstrip("/") + "/"
-        self.r2_prefix = r2_prefix.strip("/")
-        self.verbose = verbose
-        self.clear_dirs = clear_dirs
         self.timeout = timeout
         self.chunk_size = chunk_size
-
-        self.prefix = Path(self.r2_prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
-
         self.session = session if session is not None else requests.Session()
 
-    @property
-    def r2_cache_root(self) -> str:
-        # Keep s3:// style since existing helper utilities expect bucket/key semantics.
-        # The bucket name itself is irrelevant here; only the key extracted from the
-        # resulting s3 path is used.
-        return f"s3://public/{self.r2_prefix}"
-
-    @property
-    def s3_cache_root(self) -> str:
-        # Alias for compatibility with existing helper naming.
-        return self.r2_cache_root
-
-    # --------------------
-    # Properties / mapping
-    # --------------------
-    def local_to_r2_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(
-            path=Path(path_local),
-            s3_cache_root=self.r2_cache_root,
-        )
-        _, r2_key = s3_path_to_bucket_prefix(s3_path_loc)
-        return r2_key
-
-    def local_to_s3_path(self, path_local: str | Path) -> str:
-        return self.local_to_r2_path(path_local=path_local)
-
-    def r2_key_to_url(self, r2_key: str | Path) -> str:
-        if isinstance(r2_key, Path):
-            r2_key = r2_key.as_posix()
+    def key_to_url(self, key: str | Path) -> str:
+        if isinstance(key, Path):
+            key = key.as_posix()
         # Quote each path segment but preserve '/'
-        quoted_key = quote(r2_key, safe="/")
+        quoted_key = quote(key, safe="/")
         return urljoin(self.base_url, quoted_key)
 
-    # ---------------
-    # Public entrypoint
-    # ---------------
-    def download_all(self):
-        self.download_metadata()
-        self.download_raw()
-        self.download_processed()
-        self.download_results()
-
-    # --------
-    # Downloads
-    # --------
-    def download_metadata(self):
-        path_local = Path(self.method_metadata.path_metadata)
-        r2_key = self.local_to_r2_path(path_local=path_local)
-        self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
-
-    def download_raw(self):
-        dest_dir = Path(self.method_metadata.path_raw)
-        r2_key = (self.prefix / "raw.zip").as_posix()
-        self._download_and_unzip_if_exists(
-            r2_key=r2_key,
-            dest_dir=dest_dir,
-            clear_dir=self.clear_dirs,
-        )
-
-    def download_processed(self):
-        dest_dir = Path(self.method_metadata.path_processed)
-        r2_key = (self.prefix / "processed.zip").as_posix()
-
-        self._download_and_unzip_if_exists(
-            r2_key=r2_key,
-            dest_dir=dest_dir,
-            clear_dir=self.clear_dirs,
-        )
-
-    def download_configs_hyperparameters(self):
-        path_local = Path(self.method_metadata.path_configs_hyperparameters())
-        r2_key = self.local_to_r2_path(path_local=path_local)
-        self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
-
-    def download_results(self):
-        file_names: Iterable[Path | str] = self.method_metadata.path_results_files()
-        for path_local in file_names:
-            path_local = Path(path_local)
-            r2_key = self.local_to_r2_path(path_local=path_local)
-            self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
-
-    def download_results_hpo_trajectories(self):
-        path_local = Path(self.method_metadata.path_results_hpo_trajectories())
-        r2_key = self.local_to_r2_path(path_local=path_local)
-        self._download_to_local_if_exists(r2_key=r2_key, path_local=Path(path_local))
-
-    # --------------
-    # Helper methods
-    # --------------
     def _head_exists(self, url: str) -> bool:
         try:
-            response = self.session.head(
-                url,
-                allow_redirects=True,
-                timeout=self.timeout,
-            )
+            response = self.session.head(url, allow_redirects=True, timeout=self.timeout)
             if response.status_code == 404:
                 return False
             response.raise_for_status()
@@ -169,11 +66,7 @@ class MethodDownloaderPublicR2:
             # Some public object endpoints may not support HEAD correctly.
             # Fall back to a streamed GET and close immediately.
             try:
-                response = self.session.get(
-                    url,
-                    stream=True,
-                    timeout=self.timeout,
-                )
+                response = self.session.get(url, stream=True, timeout=self.timeout)
                 if response.status_code == 404:
                     response.close()
                     return False
@@ -183,18 +76,16 @@ class MethodDownloaderPublicR2:
             except requests.RequestException:
                 return False
 
-    def _download_to_local_if_exists(self, r2_key: str | Path, path_local: Path):
+    def _download_to_local_if_exists(self, key: str, path_local: Path):
         """Attempts to download a single file to `path_local`. Skips quietly if not found."""
-        url = self.r2_key_to_url(r2_key)
+        url = self.key_to_url(key)
 
         if not self._head_exists(url):
-            if self.verbose:
-                print(f"[WARN] Missing on public R2, skipping: {url}")
+            self._log(f"[WARN] Missing on public R2, skipping: {url}")
             return
 
         path_local.parent.mkdir(parents=True, exist_ok=True)
-        if self.verbose:
-            print(f"[INFO] Downloading {url} -> {path_local}")
+        self._log(f"[INFO] Downloading {url} -> {path_local}")
 
         with self.session.get(url, stream=True, timeout=self.timeout) as response:
             response.raise_for_status()
@@ -203,31 +94,19 @@ class MethodDownloaderPublicR2:
                     if chunk:
                         f.write(chunk)
 
-    def _download_and_unzip_if_exists(
-        self,
-        r2_key: str | Path,
-        dest_dir: Path,
-        clear_dir: bool = True,
-    ):
-        """Downloads a zip from public R2 to a temporary file and extracts it into
-        `dest_dir`. Skips if the object does not exist.
+    def _download_and_unzip_if_exists(self, key: str, dest_dir: Path, clear_dir: bool = True):
+        """Downloads a zip from public R2 to a temporary file and extracts it into `dest_dir`.
+        Skips if the object does not exist.
 
-        This avoids loading the full zip into memory, which is important for large
-        archives.
+        This avoids loading the full zip into memory, which is important for large archives.
         """
-        url = self.r2_key_to_url(r2_key)
+        url = self.key_to_url(key)
 
         if not self._head_exists(url):
-            if self.verbose:
-                print(f"[WARN] Missing on public R2, skipping unzip: {url}")
+            self._log(f"[WARN] Missing on public R2, skipping unzip: {url}")
             return
 
-        if self.verbose:
-            print(f"[INFO] Downloading {url} -> extracting to {dest_dir}")
-
-        if clear_dir and dest_dir.exists():
-            shutil.rmtree(dest_dir)
-        dest_dir.mkdir(parents=True, exist_ok=True)
+        self._log(f"[INFO] Downloading {url} -> extracting to {dest_dir}")
 
         with tempfile.NamedTemporaryFile(suffix=".zip") as tmp:
             with self.session.get(url, stream=True, timeout=self.timeout) as response:
@@ -235,8 +114,5 @@ class MethodDownloaderPublicR2:
                 for chunk in response.iter_content(chunk_size=self.chunk_size):
                     if chunk:
                         tmp.write(chunk)
-
             tmp.flush()
-
-            with zipfile.ZipFile(tmp.name, "r") as zf:
-                zf.extractall(path=dest_dir)
+            self._extract_zip(tmp.name, dest_dir=dest_dir, clear_dir=clear_dir)

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_r2.py
@@ -1,36 +1,22 @@
 from __future__ import annotations
 
 import io
-import shutil
-import zipfile
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
+from tabarena.models._artifacts.downloader import MethodDownloader
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from pathlib import Path
 
     from tabarena.models._method_metadata import MethodMetadata
 
 
-class MethodDownloaderR2:
-    """Download a method's cached artifacts from Cloudflare R2 and restore the original
-    local layout expected by MethodUploaderR2 / MethodMetadata.
+class MethodDownloaderR2(MethodDownloader):
+    """Download a method's cached artifacts from Cloudflare R2 using explicit credentials.
 
-    Artifacts handled:
-      - metadata YAML
-      - raw.zip  -> extracted into `method_metadata.path_raw`
-      - processed.zip -> extracted into `method_metadata.path_processed`
-      - configs_hyperparameters (standalone YAML/JSON/etc. per your metadata)
-      - results files (the set returned by `method_metadata.path_results_files()`)
-
-    Notes:
-    -----
-    - Object keys are reconstructed from the local target paths via
-      MethodMetadata.to_s3_cache_loc so the local <-> R2 mapping stays perfectly
-      symmetric with MethodUploaderR2.
-    - If an optional artifact is missing on R2, it is skipped with a warning.
+    Backend specifics over :class:`MethodDownloader`: a ``boto3`` client pointed at the account's
+    R2 endpoint with explicit access keys. R2 uses ``s3://`` bucket/key semantics, so all of the
+    generic key-mapping logic is inherited unchanged.
     """
 
     def __init__(
@@ -44,111 +30,26 @@ class MethodDownloaderR2:
         verbose: bool = True,
         clear_dirs: bool = True,
     ):
-        self.method_metadata = method_metadata
-        self.method = method_metadata.method
-
+        super().__init__(method_metadata, bucket=r2_bucket, prefix=r2_prefix, verbose=verbose, clear_dirs=clear_dirs)
         self.r2_account_id = r2_account_id
-        self.r2_bucket = r2_bucket
         self.r2_access_key_id = r2_access_key_id
         self.r2_secret_access_key = r2_secret_access_key
-        self.r2_prefix = r2_prefix
-
-        self.prefix = Path(self.r2_prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
-        self.verbose = verbose
-        self.clear_dirs = clear_dirs
-
-        self._r2_client = None
+        self._client = None
 
     @property
-    def endpoint_url(self) -> str:
-        return f"https://{self.r2_account_id}.r2.cloudflarestorage.com"
-
-    @property
-    def r2_cache_root(self) -> str:
-        # Keep s3:// style since existing helper utilities expect bucket/key semantics.
-        return f"s3://{self.r2_bucket}/{self.r2_prefix}"
-
-    @property
-    def s3_cache_root(self) -> str:
-        # Alias for compatibility with existing helper naming.
-        return self.r2_cache_root
-
-    @property
-    def r2_client(self):
-        if self._r2_client is None:
+    def client(self):
+        if self._client is None:
             import boto3
 
-            self._r2_client = boto3.client(
+            self._client = boto3.client(
                 "s3",
-                endpoint_url=self.endpoint_url,
+                endpoint_url=f"https://{self.r2_account_id}.r2.cloudflarestorage.com",
                 aws_access_key_id=self.r2_access_key_id,
                 aws_secret_access_key=self.r2_secret_access_key,
                 region_name="auto",
             )
-        return self._r2_client
+        return self._client
 
-    # --------------------
-    # Properties / mapping
-    # --------------------
-    def local_to_r2_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(
-            path=Path(path_local),
-            s3_cache_root=self.r2_cache_root,
-        )
-        _, r2_key = s3_path_to_bucket_prefix(s3_path_loc)
-        return r2_key
-
-    def local_to_s3_path(self, path_local: str | Path) -> str:
-        return self.local_to_r2_path(path_local=path_local)
-
-    # ---------------
-    # Public entrypoint
-    # ---------------
-    def download_all(self):
-        self.download_metadata()
-        self.download_raw()
-        self.download_processed()
-        self.download_results()
-
-    # --------
-    # Downloads
-    # --------
-    def download_metadata(self):
-        path_local = Path(self.method_metadata.path_metadata)
-        r2_key = self.local_to_r2_path(path_local=path_local)
-        self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
-
-    def download_raw(self):
-        dest_dir = Path(self.method_metadata.path_raw)
-        r2_key = (self.prefix / "raw.zip").as_posix()
-        self._download_and_unzip_if_exists(r2_key=r2_key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
-
-    def download_processed(self):
-        dest_dir = Path(self.method_metadata.path_processed)
-        r2_key = (self.prefix / "processed.zip").as_posix()
-
-        self._download_and_unzip_if_exists(r2_key=r2_key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
-
-    def download_configs_hyperparameters(self):
-        path_local = Path(self.method_metadata.path_configs_hyperparameters())
-        r2_key = self.local_to_r2_path(path_local=path_local)
-        self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
-
-    def download_results(self):
-        file_names: Iterable[Path | str] = self.method_metadata.path_results_files()
-        for path_local in file_names:
-            path_local = Path(path_local)
-            r2_key = self.local_to_r2_path(path_local=path_local)
-            self._download_to_local_if_exists(r2_key=r2_key, path_local=path_local)
-
-    def download_results_hpo_trajectories(self):
-        path_local = self.method_metadata.path_results_hpo_trajectories()
-        r2_key = self.local_to_r2_path(path_local=path_local)
-        self._download_to_local_if_exists(r2_key=r2_key, path_local=Path(path_local))
-
-    # --------------
-    # Helper methods
-    # --------------
     def _is_missing_error(self, e: Exception) -> bool:
         from botocore.exceptions import ClientError
 
@@ -157,61 +58,38 @@ class MethodDownloaderR2:
         code = e.response.get("Error", {}).get("Code")
         return code in ("404", "NoSuchKey", "NotFound")
 
-    def _download_to_local_if_exists(self, r2_key: str | Path, path_local: Path):
+    def _download_to_local_if_exists(self, key: str, path_local: Path):
         """Attempts to download a single file to `path_local`. Skips quietly if not found."""
         from botocore.exceptions import ClientError
 
-        if isinstance(r2_key, Path):
-            r2_key = r2_key.as_posix()
-
         try:
-            self.r2_client.head_object(Bucket=self.r2_bucket, Key=r2_key)
+            self.client.head_object(Bucket=self.bucket, Key=key)
         except ClientError as e:
             if self._is_missing_error(e):
-                if self.verbose:
-                    print(f"[WARN] Missing on R2, skipping: r2://{self.r2_bucket}/{r2_key}")
+                self._log(f"[WARN] Missing on R2, skipping: r2://{self.bucket}/{key}")
                 return
             raise
 
         path_local.parent.mkdir(parents=True, exist_ok=True)
-        if self.verbose:
-            print(f"[INFO] Downloading r2://{self.r2_bucket}/{r2_key} -> {path_local}")
+        self._log(f"[INFO] Downloading r2://{self.bucket}/{key} -> {path_local}")
 
-        self.r2_client.download_file(
-            Bucket=self.r2_bucket,
-            Key=r2_key,
-            Filename=str(path_local),
-        )
+        self.client.download_file(Bucket=self.bucket, Key=key, Filename=str(path_local))
 
-    def _download_and_unzip_if_exists(self, r2_key: str | Path, dest_dir: Path, clear_dir: bool = True):
+    def _download_and_unzip_if_exists(self, key: str, dest_dir: Path, clear_dir: bool = True):
         """Downloads a zip from R2 into memory and extracts into `dest_dir`.
         Skips if the object does not exist.
         """
         from botocore.exceptions import ClientError
 
-        if isinstance(r2_key, Path):
-            r2_key = r2_key.as_posix()
-
         try:
-            self.r2_client.head_object(Bucket=self.r2_bucket, Key=r2_key)
+            self.client.head_object(Bucket=self.bucket, Key=key)
         except ClientError as e:
             if self._is_missing_error(e):
-                if self.verbose:
-                    print(f"[WARN] Missing on R2, skipping unzip: r2://{self.r2_bucket}/{r2_key}")
+                self._log(f"[WARN] Missing on R2, skipping unzip: r2://{self.bucket}/{key}")
                 return
             raise
 
-        if self.verbose:
-            print(f"[INFO] Downloading r2://{self.r2_bucket}/{r2_key} -> extracting to {dest_dir}")
+        self._log(f"[INFO] Downloading r2://{self.bucket}/{key} -> extracting to {dest_dir}")
 
-        obj = self.r2_client.get_object(Bucket=self.r2_bucket, Key=r2_key)
-
-        body = obj["Body"].read()
-        buf = io.BytesIO(body)
-
-        if clear_dir and dest_dir.exists():
-            shutil.rmtree(dest_dir)
-        dest_dir.mkdir(parents=True, exist_ok=True)
-
-        with zipfile.ZipFile(buf, "r") as zf:
-            zf.extractall(path=dest_dir)
+        obj = self.client.get_object(Bucket=self.bucket, Key=key)
+        self._extract_zip(io.BytesIO(obj["Body"].read()), dest_dir=dest_dir, clear_dir=clear_dir)

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
@@ -27,17 +27,35 @@ class MethodDownloaderS3(MethodDownloader):
         clear_dirs: bool = True,
     ):
         super().__init__(method_metadata, bucket=s3_bucket, prefix=s3_prefix, verbose=verbose, clear_dirs=clear_dirs)
+        self._signed_client = None
+        self._unsigned_client = None
+
+    @property
+    def signed_client(self):
+        """Lazily-created, cached credentialed S3 client (one per downloader, not per object)."""
+        if self._signed_client is None:
+            import boto3
+
+            self._signed_client = boto3.session.Session().client("s3")
+        return self._signed_client
+
+    @property
+    def unsigned_client(self):
+        """Lazily-created, cached anonymous (unsigned) S3 client for publicly-readable objects."""
+        if self._unsigned_client is None:
+            import boto3
+            from botocore import UNSIGNED
+            from botocore.config import Config
+
+            self._unsigned_client = boto3.session.Session().client("s3", config=Config(signature_version=UNSIGNED))
+        return self._unsigned_client
 
     def _download_to_local_if_exists(self, key: str, path_local: Path):
         """Attempts to download a single file to `path_local`. Skips quietly if not found."""
-        import boto3
-        from botocore import UNSIGNED
-        from botocore.config import Config
         from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
 
-        sess = boto3.session.Session()
-        s3_signed = sess.client("s3")
-        s3_unsigned = sess.client("s3", config=Config(signature_version=UNSIGNED))
+        s3_signed = self.signed_client
+        s3_unsigned = self.unsigned_client
 
         def _head(client):
             return client.head_object(Bucket=self.bucket, Key=key)
@@ -88,14 +106,10 @@ class MethodDownloaderS3(MethodDownloader):
         Skips if the object does not exist. Supports public objects by retrying
         with an unsigned client when a signed request is denied or creds are missing.
         """
-        import boto3
-        from botocore import UNSIGNED
-        from botocore.config import Config
         from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
 
-        sess = boto3.session.Session()
-        s3_signed = sess.client("s3")
-        s3_unsigned = sess.client("s3", config=Config(signature_version=UNSIGNED))
+        s3_signed = self.signed_client
+        s3_unsigned = self.unsigned_client
 
         def _head(c):
             return c.head_object(Bucket=self.bucket, Key=key)

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader_s3.py
@@ -1,35 +1,21 @@
 from __future__ import annotations
 
 import io
-import shutil
-import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
+from tabarena.models._artifacts.downloader import MethodDownloader
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from tabarena.models._method_metadata import MethodMetadata
 
 
-class MethodDownloaderS3:
-    """Download a method's cached artifacts from S3 and restore the original local layout
-    expected by MethodUploaderS3 / MethodMetadata.
+class MethodDownloaderS3(MethodDownloader):
+    """Download a method's cached artifacts from AWS S3.
 
-    Artifacts handled:
-      - metadata YAML
-      - raw.zip  -> extracted into `method_metadata.path_raw`
-      - processed.zip -> extracted into `method_metadata.path_processed`
-      - configs_hyperparameters (standalone YAML/JSON/etc. per your metadata)
-      - results files (the set returned by `method_metadata.path_results_files()`)
-
-    Notes:
-    -----
-    - S3 keys are reconstructed from the local target paths via MethodMetadata.to_s3_cache_loc
-      so the local <-> S3 mapping stays perfectly symmetric with MethodUploaderS3.
-    - If an optional artifact is missing on S3, it is skipped with a warning (no exception).
+    Backend specifics over :class:`MethodDownloader`: signed (credentialed) access with a fallback
+    to an unsigned (anonymous) client for publicly-readable objects, so the same downloader works
+    for both private and public buckets.
     """
 
     def __init__(
@@ -40,89 +26,21 @@ class MethodDownloaderS3:
         verbose: bool = True,
         clear_dirs: bool = True,
     ):
-        self.method_metadata = method_metadata
-        self.method = method_metadata.method
-        self.s3_bucket = s3_bucket
-        self.s3_prefix = s3_prefix
-        self.prefix = Path(self.s3_prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
-        self.verbose = verbose
-        self.clear_dirs = clear_dirs
+        super().__init__(method_metadata, bucket=s3_bucket, prefix=s3_prefix, verbose=verbose, clear_dirs=clear_dirs)
 
-    # --------------------
-    # Properties / mapping
-    # --------------------
-    @property
-    def s3_cache_root(self) -> str:
-        return f"s3://{self.s3_bucket}/{self.s3_prefix}"
-
-    def local_to_s3_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.s3_cache_root)
-        _, s3_key = s3_path_to_bucket_prefix(s3_path_loc)
-        return s3_key
-
-    # ---------------
-    # Public entrypoint
-    # ---------------
-    def download_all(self):
-        self.download_metadata()
-        self.download_raw()
-        self.download_processed()
-        self.download_results()
-
-    # --------
-    # Downloads
-    # --------
-    def download_metadata(self):
-        path_local = Path(self.method_metadata.path_metadata)
-        s3_key = self.local_to_s3_path(path_local=path_local)
-        self._download_to_local_if_exists(s3_key=s3_key, path_local=path_local)
-
-    def download_raw(self):
-        dest_dir = Path(self.method_metadata.path_raw)
-        s3_key = (self.prefix / "raw.zip").as_posix()
-        self._download_and_unzip_if_exists(s3_key=s3_key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
-
-    def download_processed(self):
-        dest_dir = Path(self.method_metadata.path_processed)
-        s3_key = (self.prefix / "processed.zip").as_posix()
-        self._download_and_unzip_if_exists(s3_key=s3_key, dest_dir=dest_dir, clear_dir=self.clear_dirs)
-
-    def download_configs_hyperparameters(self):
-        path_local = Path(self.method_metadata.path_configs_hyperparameters())
-        s3_key = self.local_to_s3_path(path_local=path_local)
-        self._download_to_local_if_exists(s3_key=s3_key, path_local=path_local)
-
-    def download_results(self):
-        file_names: Iterable[Path | str] = self.method_metadata.path_results_files()
-        for path_local in file_names:
-            path_local = Path(path_local)
-            s3_key = self.local_to_s3_path(path_local=path_local)
-            self._download_to_local_if_exists(s3_key=s3_key, path_local=path_local)
-
-    def download_results_hpo_trajectories(self):
-        path_local = self.method_metadata.path_results_hpo_trajectories()
-        s3_key = self.local_to_s3_path(path_local=path_local)
-        self._download_to_local_if_exists(s3_key=s3_key, path_local=path_local)
-
-    # --------------
-    # Helper methods
-    # --------------
-    def _download_to_local_if_exists(self, s3_key: str | Path, path_local: Path):
+    def _download_to_local_if_exists(self, key: str, path_local: Path):
         """Attempts to download a single file to `path_local`. Skips quietly if not found."""
         import boto3
         from botocore import UNSIGNED
         from botocore.config import Config
         from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
 
-        if isinstance(s3_key, Path):
-            s3_key = s3_key.as_posix()
-
         sess = boto3.session.Session()
         s3_signed = sess.client("s3")
         s3_unsigned = sess.client("s3", config=Config(signature_version=UNSIGNED))
 
         def _head(client):
-            return client.head_object(Bucket=self.s3_bucket, Key=s3_key)
+            return client.head_object(Bucket=self.bucket, Key=key)
 
         # ---------- Existence check (HEAD) ----------
         client_for_get = None
@@ -134,8 +52,7 @@ class MethodDownloaderS3:
             if isinstance(e, ClientError):
                 code = e.response.get("Error", {}).get("Code")
                 if code in ("404", "NoSuchKey", "NotFound"):
-                    if self.verbose:
-                        print(f"[WARN] Missing on S3, skipping: s3://{self.s3_bucket}/{s3_key}")
+                    self._log(f"[WARN] Missing on S3, skipping: s3://{self.bucket}/{key}")
                     return
             # Retry anonymously for publicly readable objects
             try:
@@ -144,31 +61,29 @@ class MethodDownloaderS3:
             except ClientError as e2:
                 code2 = e2.response.get("Error", {}).get("Code")
                 if code2 in ("404", "NoSuchKey", "NotFound"):
-                    if self.verbose:
-                        print(f"[WARN] Missing on S3, skipping: s3://{self.s3_bucket}/{s3_key}")
+                    self._log(f"[WARN] Missing on S3, skipping: s3://{self.bucket}/{key}")
                     return
                 # Still denied or other error -> propagate
                 raise
 
         # ---------- Download ----------
         path_local.parent.mkdir(parents=True, exist_ok=True)
-        if self.verbose:
-            print(f"[INFO] Downloading s3://{self.s3_bucket}/{s3_key} -> {path_local}")
+        self._log(f"[INFO] Downloading s3://{self.bucket}/{key} -> {path_local}")
 
         try:
-            client_for_get.download_file(Bucket=self.s3_bucket, Key=s3_key, Filename=str(path_local))
+            client_for_get.download_file(Bucket=self.bucket, Key=key, Filename=str(path_local))
         except (NoCredentialsError, PartialCredentialsError, ClientError):
             # If we tried signed and it failed but the object might be public, try unsigned once.
             if client_for_get is s3_signed:
                 try:
-                    s3_unsigned.download_file(Bucket=self.s3_bucket, Key=s3_key, Filename=str(path_local))
+                    s3_unsigned.download_file(Bucket=self.bucket, Key=key, Filename=str(path_local))
                     return
                 except ClientError:
                     pass
             # propagate original error if unsigned also failed or we were already unsigned
             raise
 
-    def _download_and_unzip_if_exists(self, s3_key: str | Path, dest_dir: Path, clear_dir: bool = True):
+    def _download_and_unzip_if_exists(self, key: str, dest_dir: Path, clear_dir: bool = True):
         """Downloads a zip from S3 into memory and extracts into `dest_dir`.
         Skips if the object does not exist. Supports public objects by retrying
         with an unsigned client when a signed request is denied or creds are missing.
@@ -178,15 +93,12 @@ class MethodDownloaderS3:
         from botocore.config import Config
         from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
 
-        if isinstance(s3_key, Path):
-            s3_key = s3_key.as_posix()
-
         sess = boto3.session.Session()
         s3_signed = sess.client("s3")
         s3_unsigned = sess.client("s3", config=Config(signature_version=UNSIGNED))
 
         def _head(c):
-            return c.head_object(Bucket=self.s3_bucket, Key=s3_key)
+            return c.head_object(Bucket=self.bucket, Key=key)
 
         # ---- Existence check (HEAD) with unsigned fallback ----
         client_for_get = None
@@ -197,8 +109,7 @@ class MethodDownloaderS3:
             if isinstance(e, ClientError):
                 code = e.response.get("Error", {}).get("Code")
                 if code in ("404", "NoSuchKey", "NotFound"):
-                    if self.verbose:
-                        print(f"[WARN] Missing on S3, skipping unzip: s3://{self.s3_bucket}/{s3_key}")
+                    self._log(f"[WARN] Missing on S3, skipping unzip: s3://{self.bucket}/{key}")
                     return
             try:
                 _head(s3_unsigned)
@@ -206,17 +117,15 @@ class MethodDownloaderS3:
             except ClientError as e2:
                 code2 = e2.response.get("Error", {}).get("Code")
                 if code2 in ("404", "NoSuchKey", "NotFound"):
-                    if self.verbose:
-                        print(f"[WARN] Missing on S3, skipping unzip: s3://{self.s3_bucket}/{s3_key}")
+                    self._log(f"[WARN] Missing on S3, skipping unzip: s3://{self.bucket}/{key}")
                     return
                 raise
 
-        if self.verbose:
-            print(f"[INFO] Downloading s3://{self.s3_bucket}/{s3_key} -> extracting to {dest_dir}")
+        self._log(f"[INFO] Downloading s3://{self.bucket}/{key} -> extracting to {dest_dir}")
 
         # ---- GET with fallback to unsigned only for credential-related failures ----
         try:
-            obj = client_for_get.get_object(Bucket=self.s3_bucket, Key=s3_key)
+            obj = client_for_get.get_object(Bucket=self.bucket, Key=key)
         except (NoCredentialsError, PartialCredentialsError, ClientError) as e:
             # Only retry unsigned for specific credential/signing errors
             if isinstance(e, ClientError):
@@ -224,17 +133,9 @@ class MethodDownloaderS3:
                 if code not in {"AccessDenied", "InvalidAccessKeyId", "SignatureDoesNotMatch"}:
                     raise
             if client_for_get is s3_signed:
-                obj = s3_unsigned.get_object(Bucket=self.s3_bucket, Key=s3_key)
+                obj = s3_unsigned.get_object(Bucket=self.bucket, Key=key)
             else:
                 raise
 
         # ---- In-memory unzip ----
-        body = obj["Body"].read()
-        buf = io.BytesIO(body)
-
-        if clear_dir and dest_dir.exists():
-            shutil.rmtree(dest_dir)
-        dest_dir.mkdir(parents=True, exist_ok=True)
-
-        with zipfile.ZipFile(buf, "r") as zf:
-            zf.extractall(path=dest_dir)
+        self._extract_zip(io.BytesIO(obj["Body"].read()), dest_dir=dest_dir, clear_dir=clear_dir)

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
+
+from tabarena.models._artifacts.uploader_utils import zip_in_memory
+
+if TYPE_CHECKING:
+    import io
+
+    from tabarena.models._method_metadata import MethodMetadata
+
+
+class MethodUploader(ABC):
+    """Uploads a method's cached artifacts to an S3-compatible object store.
+
+    Holds all the backend-independent logic: which artifacts to upload (metadata, raw, processed,
+    results, HPO trajectories), how local paths map to remote keys, and the low-level put calls.
+    Concrete subclasses (:class:`~tabarena.models._artifacts.uploader_s3.MethodUploaderS3`,
+    :class:`~tabarena.models._artifacts.uploader_r2.MethodUploaderR2`) supply only the backend
+    specifics — the boto3 client via :meth:`_make_client`, and any per-upload extra args via
+    :meth:`_extra_args` (e.g. a public-read ACL).
+    """
+
+    def __init__(self, method_metadata: MethodMetadata, *, bucket: str, prefix: str = "cache"):
+        self.method_metadata = method_metadata
+        self.method = method_metadata.method
+        self.bucket = bucket
+        self.prefix = prefix
+        # This method's key prefix within the bucket, e.g.
+        # "cache/artifacts/<artifact_name>/methods/<method>".
+        self.key_prefix = Path(prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
+        self._client = None
+
+    # -- backend-specific hooks ---------------------------------------------------------------
+    @abstractmethod
+    def _make_client(self):
+        """Create and return the boto3 (S3-compatible) client used for uploads."""
+
+    def _extra_args(self) -> dict:
+        """Extra args passed to ``upload_file`` / ``upload_fileobj`` (e.g. an ACL). Default: none."""
+        return {}
+
+    @property
+    def client(self):
+        """The lazily-created, cached boto3 client (see :meth:`_make_client`)."""
+        if self._client is None:
+            self._client = self._make_client()
+        return self._client
+
+    # -- remote location ----------------------------------------------------------------------
+    @property
+    def s3_cache_root(self) -> str:
+        return f"s3://{self.bucket}/{self.prefix}"
+
+    def local_to_s3_path(self, path_local: str | Path) -> str:
+        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.s3_cache_root)
+        _, key = s3_path_to_bucket_prefix(s3_path_loc)
+        return key
+
+    # -- artifact uploads ---------------------------------------------------------------------
+    def upload_all(self):
+        self.upload_metadata()
+        self.upload_raw()
+        self.upload_processed()
+        self.upload_results()
+        if self.method_metadata.method_type == "config":
+            self.upload_results_hpo_trajectories()
+
+    def upload_metadata(self):
+        fileobj = self.method_metadata.to_yaml_fileobj()
+        key = self.local_to_s3_path(path_local=self.method_metadata.path_metadata)
+        self._upload_fileobj(fileobj=fileobj, key=key)
+
+    def upload_raw(self):
+        path_raw = Path(self.method_metadata.path_raw)
+
+        print(f"Zipping raw files into memory under: {path_raw}")
+        fileobj = zip_in_memory(path=path_raw)
+        key = self.key_prefix / "raw.zip"
+
+        print(f"Uploading raw zipped files to: {key}")
+        self._upload_fileobj(fileobj=fileobj, key=key)
+
+    def upload_processed(self):
+        path_processed = self.method_metadata.path_processed
+
+        print(f"Zipping processed files into memory under: {path_processed}")
+        fileobj = zip_in_memory(path=path_processed)
+        key = self.key_prefix / "processed.zip"
+
+        print(f"Uploading processed zipped files to: {key}")
+        self._upload_fileobj(fileobj=fileobj, key=key)
+
+        # Upload configs_hyperparameters as a standalone file for fast access
+        self.upload_configs_hyperparameters()
+
+    def upload_configs_hyperparameters(self):
+        self._upload_file(path_local=self.method_metadata.path_configs_hyperparameters())
+
+    def upload_results(self):
+        for path_local in self.method_metadata.path_results_files():
+            self._upload_file(path_local=path_local)
+
+    def upload_results_hpo_trajectories(self):
+        self._upload_file(path_local=self.method_metadata.path_results_hpo_trajectories())
+
+    # -- low-level put ------------------------------------------------------------------------
+    def _upload_fileobj(self, fileobj: io.BytesIO, key: str | Path):
+        if isinstance(key, Path):
+            key = key.as_posix()
+        extra_args = self._extra_args()
+        kwargs = {"ExtraArgs": extra_args} if extra_args else {}
+        self.client.upload_fileobj(Fileobj=fileobj, Bucket=self.bucket, Key=key, **kwargs)
+
+    def _upload_file(self, path_local: str | Path, key: str | Path | None = None):
+        if key is None:
+            key = self.local_to_s3_path(path_local=path_local)
+        if isinstance(key, Path):
+            key = key.as_posix()
+        extra_args = self._extra_args()
+        kwargs = {"ExtraArgs": extra_args} if extra_args else {}
+        self.client.upload_file(Filename=str(path_local), Bucket=self.bucket, Key=key, **kwargs)

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
-
 from tabarena.models._artifacts.uploader_utils import zip_in_memory
 
 if TYPE_CHECKING:
@@ -56,16 +54,22 @@ class MethodUploader(ABC):
     # -- remote location ----------------------------------------------------------------------
     @property
     def remote_cache_root(self) -> str:
-        """The cache root as an ``s3://bucket/prefix`` URI. The ``s3://`` scheme is a parsing
-        convention for :func:`s3_path_to_bucket_prefix` (used to derive object keys), not an AWS
-        endpoint — it is correct for any S3-compatible backend (e.g. Cloudflare R2).
+        """The cache root as a human-readable ``s3://bucket/prefix`` URI (for logging/display).
+
+        The ``s3://`` scheme is just a label — correct for any S3-compatible backend (e.g.
+        Cloudflare R2) — and is not used to derive object keys (see :meth:`local_to_key`).
         """
         return f"s3://{self.bucket}/{self.prefix}"
 
-    def local_to_s3_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.remote_cache_root)
-        _, key = s3_path_to_bucket_prefix(s3_path_loc)
-        return key
+    def local_to_key(self, path_local: str | Path) -> str:
+        """Remote object key for a local cache path: ``prefix`` joined with the path's location
+        relative to the cache root.
+
+        Computed directly (no ``s3://`` URI is built or parsed), the same way :attr:`key_prefix`
+        is — keeping it consistent with the raw/processed zip keys.
+        """
+        rel = self.method_metadata.relative_to_cache_root(Path(path_local))
+        return (Path(self.prefix) / rel).as_posix()
 
     # -- artifact uploads ---------------------------------------------------------------------
     def upload_all(self):
@@ -78,7 +82,7 @@ class MethodUploader(ABC):
 
     def upload_metadata(self):
         fileobj = self.method_metadata.to_yaml_fileobj()
-        key = self.local_to_s3_path(path_local=self.method_metadata.path_metadata)
+        key = self.local_to_key(path_local=self.method_metadata.path_metadata)
         self._upload_fileobj(fileobj=fileobj, key=key)
 
     def upload_raw(self):
@@ -124,7 +128,7 @@ class MethodUploader(ABC):
 
     def _upload_file(self, path_local: str | Path, key: str | Path | None = None):
         if key is None:
-            key = self.local_to_s3_path(path_local=path_local)
+            key = self.local_to_key(path_local=path_local)
         if isinstance(key, Path):
             key = key.as_posix()
         extra_args = self._extra_args()

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
@@ -55,11 +55,15 @@ class MethodUploader(ABC):
 
     # -- remote location ----------------------------------------------------------------------
     @property
-    def s3_cache_root(self) -> str:
+    def remote_cache_root(self) -> str:
+        """The cache root as an ``s3://bucket/prefix`` URI. The ``s3://`` scheme is a parsing
+        convention for :func:`s3_path_to_bucket_prefix` (used to derive object keys), not an AWS
+        endpoint — it is correct for any S3-compatible backend (e.g. Cloudflare R2).
+        """
         return f"s3://{self.bucket}/{self.prefix}"
 
     def local_to_s3_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.s3_cache_root)
+        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.remote_cache_root)
         _, key = s3_path_to_bucket_prefix(s3_path_loc)
         return key
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
@@ -29,9 +29,11 @@ class MethodUploader(ABC):
         self.method_metadata = method_metadata
         self.method = method_metadata.method
         self.bucket = bucket
+        # ``prefix`` is the cache-root prefix only (e.g. "cache"); ``key_prefix`` is this method's
+        # *full* key prefix within the bucket, e.g. "cache/artifacts/<artifact_name>/methods/<method>".
+        # NOTE: this differs from the pre-refactor subclasses, where ``self.prefix`` held the full
+        # per-method key path now stored in ``key_prefix`` — use ``key_prefix`` for object keys.
         self.prefix = prefix
-        # This method's key prefix within the bucket, e.g.
-        # "cache/artifacts/<artifact_name>/methods/<method>".
         self.key_prefix = Path(prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
         self._client = None
 

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader_r2.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader_r2.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
-
-from tabarena.models._artifacts.uploader_utils import zip_in_memory
+from tabarena.models._artifacts.uploader import MethodUploader
 
 if TYPE_CHECKING:
-    import io
-
     from tabarena.models._method_metadata import MethodMetadata
 
 
-class MethodUploaderR2:
+class MethodUploaderR2(MethodUploader):
+    """Uploads method artifacts to Cloudflare R2 (S3-compatible) using explicit credentials.
+
+    Backend specifics over :class:`MethodUploader`: a ``boto3`` client pointed at the account's R2
+    endpoint with explicit access keys. R2 uses ``s3://`` bucket/key semantics, so all of the
+    generic key-mapping logic is inherited unchanged.
+    """
+
     def __init__(
         self,
         method_metadata: MethodMetadata,
@@ -23,128 +25,18 @@ class MethodUploaderR2:
         r2_secret_access_key: str,
         r2_prefix: str = "cache",
     ):
-        self.method_metadata = method_metadata
-        self.method = method_metadata.method
-
+        super().__init__(method_metadata, bucket=r2_bucket, prefix=r2_prefix)
         self.r2_account_id = r2_account_id
-        self.r2_bucket = r2_bucket
         self.r2_access_key_id = r2_access_key_id
         self.r2_secret_access_key = r2_secret_access_key
-        self.r2_prefix = r2_prefix
 
-        self.prefix = Path(self.r2_prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
+    def _make_client(self):
+        import boto3
 
-        self._r2_client = None
-
-    @property
-    def endpoint_url(self) -> str:
-        return f"https://{self.r2_account_id}.r2.cloudflarestorage.com"
-
-    @property
-    def r2_cache_root(self) -> str:
-        # Keep s3:// style since existing helper utilities expect bucket/key semantics.
-        return f"s3://{self.r2_bucket}/{self.r2_prefix}"
-
-    @property
-    def s3_cache_root(self) -> str:
-        # Alias for compatibility with existing helper naming.
-        return self.r2_cache_root
-
-    @property
-    def r2_client(self):
-        if self._r2_client is None:
-            import boto3
-
-            self._r2_client = boto3.client(
-                "s3",
-                endpoint_url=self.endpoint_url,
-                aws_access_key_id=self.r2_access_key_id,
-                aws_secret_access_key=self.r2_secret_access_key,
-                region_name="auto",
-            )
-        return self._r2_client
-
-    def upload_all(self):
-        self.upload_metadata()
-        self.upload_raw()
-        self.upload_processed()
-        self.upload_results()
-        if self.method_metadata.method_type == "config":
-            self.upload_results_hpo_trajectories()
-
-    def upload_metadata(self):
-        fileobj = self.method_metadata.to_yaml_fileobj()
-        path_local = self.method_metadata.path_metadata
-        r2_key = self.local_to_r2_path(path_local=path_local)
-        self._upload_fileobj(fileobj=fileobj, r2_key=r2_key)
-
-    def upload_raw(self):
-        path_raw = Path(self.method_metadata.path_raw)
-
-        print(f"Zipping raw files into memory under: {path_raw}")
-        fileobj = zip_in_memory(path=path_raw)
-        r2_key = self.prefix / "raw.zip"
-
-        print(f"Uploading raw zipped files to: {r2_key}")
-        self._upload_fileobj(fileobj=fileobj, r2_key=r2_key)
-
-    def upload_processed(self):
-        path_processed = self.method_metadata.path_processed
-
-        print(f"Zipping processed files into memory under: {path_processed}")
-        fileobj = zip_in_memory(path=path_processed)
-        r2_key = self.prefix / "processed.zip"
-
-        print(f"Uploading processed zipped files to: {r2_key}")
-        self._upload_fileobj(fileobj=fileobj, r2_key=r2_key)
-
-        self.upload_configs_hyperparameters()
-
-    def _upload_fileobj(self, fileobj: io.BytesIO, r2_key: str | Path):
-        if isinstance(r2_key, Path):
-            r2_key = r2_key.as_posix()
-
-        self.r2_client.upload_fileobj(
-            Fileobj=fileobj,
-            Bucket=self.r2_bucket,
-            Key=r2_key,
+        return boto3.client(
+            "s3",
+            endpoint_url=f"https://{self.r2_account_id}.r2.cloudflarestorage.com",
+            aws_access_key_id=self.r2_access_key_id,
+            aws_secret_access_key=self.r2_secret_access_key,
+            region_name="auto",
         )
-
-    def _upload_file(self, path_local: str | Path, r2_key: str | Path | None = None):
-        if r2_key is None:
-            r2_key = self.local_to_r2_path(path_local=path_local)
-
-        if isinstance(path_local, Path):
-            path_local = str(path_local)
-        if isinstance(r2_key, Path):
-            r2_key = r2_key.as_posix()
-
-        self.r2_client.upload_file(
-            Filename=path_local,
-            Bucket=self.r2_bucket,
-            Key=r2_key,
-        )
-
-    def upload_configs_hyperparameters(self):
-        path_local = self.method_metadata.path_configs_hyperparameters()
-        self._upload_file(path_local=path_local)
-
-    def local_to_r2_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(
-            path=Path(path_local),
-            s3_cache_root=self.r2_cache_root,
-        )
-        _, r2_key = s3_path_to_bucket_prefix(s3_path_loc)
-        return r2_key
-
-    def local_to_s3_path(self, path_local: str | Path) -> str:
-        return self.local_to_r2_path(path_local=path_local)
-
-    def upload_results(self):
-        file_names = self.method_metadata.path_results_files()
-        for path_local in file_names:
-            self._upload_file(path_local=path_local)
-
-    def upload_results_hpo_trajectories(self):
-        path_local = self.method_metadata.path_results_hpo_trajectories()
-        self._upload_file(path_local=path_local)

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader_s3.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader_s3.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
-
-from tabarena.models._artifacts.uploader_utils import zip_in_memory
+from tabarena.models._artifacts.uploader import MethodUploader
 
 if TYPE_CHECKING:
-    import io
-
     from tabarena.models._method_metadata import MethodMetadata
 
 
-class MethodUploaderS3:
+class MethodUploaderS3(MethodUploader):
+    """Uploads method artifacts to AWS S3 using ambient AWS credentials.
+
+    Backend specifics over :class:`MethodUploader`: a default ``boto3`` S3 client, and an optional
+    ``public-read`` ACL on every uploaded object when ``upload_as_public`` is set.
+    """
+
     def __init__(
         self,
         method_metadata: MethodMetadata,
@@ -21,102 +22,13 @@ class MethodUploaderS3:
         s3_prefix: str = "cache",
         upload_as_public: bool = False,
     ):
-        self.method_metadata = method_metadata
-        self.method = method_metadata.method
-        self.s3_bucket = s3_bucket
-        self.s3_prefix = s3_prefix
-        self.prefix = Path(self.s3_prefix) / method_metadata.relative_to_cache_root(method_metadata.path)
+        super().__init__(method_metadata, bucket=s3_bucket, prefix=s3_prefix)
         self.upload_as_public = upload_as_public
 
-    @property
-    def s3_cache_root(self) -> str:
-        return f"s3://{self.s3_bucket}/{self.s3_prefix}"
-
-    def upload_all(self):
-        self.upload_metadata()
-        self.upload_raw()
-        self.upload_processed()
-        self.upload_results()
-        if self.method_metadata.method_type == "config":
-            self.upload_results_hpo_trajectories()
-
-    def upload_metadata(self):
-        fileobj = self.method_metadata.to_yaml_fileobj()
-        path_local = self.method_metadata.path_metadata
-        s3_key = self.local_to_s3_path(path_local=path_local)
-        self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
-
-    def upload_raw(self):
-        path_raw = Path(self.method_metadata.path_raw)
-
-        print(f"Zipping raw files into memory under: {path_raw}")
-        fileobj = zip_in_memory(path=path_raw)
-        s3_key = self.prefix / "raw.zip"
-
-        # Upload to S3 directly from memory
-        print(f"Uploading raw zipped files to: {s3_key}")
-        self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
-
-    def upload_processed(self):
-        path_processed = self.method_metadata.path_processed
-
-        print(f"Zipping processed files into memory under: {path_processed}")
-        fileobj = zip_in_memory(path=path_processed)
-        s3_key = self.prefix / "processed.zip"
-
-        # Upload to S3 directly from memory
-        print(f"Uploading processed zipped files to: {s3_key}")
-        self._upload_fileobj(fileobj=fileobj, s3_key=s3_key)
-
-        # Upload configs_hyperparameters as a standalone file for fast access
-        self.upload_configs_hyperparameters()
-
-    def _upload_fileobj(self, fileobj: io.BytesIO, s3_key: str | Path):
+    def _make_client(self):
         import boto3
 
-        if isinstance(s3_key, Path):
-            s3_key = s3_key.as_posix()
+        return boto3.client("s3")
 
-        kwargs = {}
-        if self.upload_as_public:
-            kwargs = {"ExtraArgs": {"ACL": "public-read"}}
-
-        s3_client = boto3.client("s3")
-        s3_client.upload_fileobj(Fileobj=fileobj, Bucket=self.s3_bucket, Key=s3_key, **kwargs)
-
-    def _upload_file(self, path_local: str | Path, s3_key: str | Path | None = None):
-        import boto3
-
-        if s3_key is None:
-            s3_key = self.local_to_s3_path(path_local=path_local)
-
-        if isinstance(path_local, Path):
-            path_local = str(path_local)
-        if isinstance(s3_key, Path):
-            s3_key = s3_key.as_posix()
-
-        kwargs = {}
-        if self.upload_as_public:
-            kwargs = {"ExtraArgs": {"ACL": "public-read"}}
-
-        # Upload the file
-        s3_client = boto3.client("s3")
-        s3_client.upload_file(Filename=path_local, Bucket=self.s3_bucket, Key=s3_key, **kwargs)
-
-    def upload_configs_hyperparameters(self):
-        path_local = self.method_metadata.path_configs_hyperparameters()
-        self._upload_file(path_local=path_local)
-
-    def local_to_s3_path(self, path_local: str | Path) -> str:
-        s3_path_loc = self.method_metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=self.s3_cache_root)
-        _, s3_key = s3_path_to_bucket_prefix(s3_path_loc)
-        return s3_key
-
-    def upload_results(self):
-        file_names = self.method_metadata.path_results_files()
-        for path_local in file_names:
-            self._upload_file(path_local=path_local)
-
-    def upload_results_hpo_trajectories(self):
-        path_local = self.method_metadata.path_results_hpo_trajectories()
-        self._upload_file(path_local=path_local)
+    def _extra_args(self) -> dict:
+        return {"ACL": "public-read"} if self.upload_as_public else {}

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -452,10 +452,6 @@ class MethodMetadata:
     def relative_to_method(self, path: Path) -> Path:
         return path.relative_to(self.path)
 
-    def to_s3_cache_loc(self, path: Path, s3_cache_root: str) -> str:
-        path_suffix: str = self.relative_to_cache_root(path=path).as_posix()
-        return f"{s3_cache_root}/{path_suffix}"
-
     def method_downloader(
         self,
         cache_type: str = "auto",

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -24,8 +24,8 @@ from tabarena.utils.s3_utils import s3_get_object
 if TYPE_CHECKING:
     from tabarena.benchmark.result import BaselineResult
     from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection
-    from tabarena.models._artifacts.downloader_s3 import MethodDownloaderS3
-    from tabarena.models._artifacts.uploader_s3 import MethodUploaderS3
+    from tabarena.models._artifacts.downloader import MethodDownloader
+    from tabarena.models._artifacts.uploader import MethodUploader
 
 
 class MethodType(StrEnum):
@@ -461,12 +461,12 @@ class MethodMetadata:
         self,
         cache_type: str = "auto",
         verbose: bool = False,
-    ) -> MethodDownloaderS3:
+    ) -> MethodDownloader:
         if cache_type == "auto":
             cache_type = self.cache_type
         if not self.has_s3_cache:
             raise AssertionError(
-                f"Tried to get MethodDownloaderS3 from MethodMetadata, "
+                f"Tried to get MethodDownloader from MethodMetadata, "
                 f"but s3_bucket and/or s3_prefix were not specified!"
                 f"\n\t(method={self.method}, artifact_name={self.artifact_name}, "
                 f"s3_bucket={self.s3_bucket}, s3_prefix={self.s3_prefix})"
@@ -495,12 +495,12 @@ class MethodMetadata:
             )
         raise ValueError(f"Invalid cache_type for downloads: {cache_type}")
 
-    def method_uploader(self, cache_type: str = "auto") -> MethodUploaderS3:
+    def method_uploader(self, cache_type: str = "auto") -> MethodUploader:
         if cache_type == "auto":
             cache_type = self.cache_type
         if not self.has_s3_cache:
             raise AssertionError(
-                f"Tried to get MethodUploaderS3 from MethodMetadata, "
+                f"Tried to get MethodUploader from MethodMetadata, "
                 f"but s3_bucket and/or s3_prefix were not specified!"
                 f"\n\t(method={self.method}, artifact_name={self.artifact_name}, "
                 f"s3_bucket={self.s3_bucket}, s3_prefix={self.s3_prefix})"

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, ClassVar, Literal, Self
 
 import pandas as pd
 import yaml
-from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
 
 from tabarena.loaders import get_tabarena_cache_root
 from tabarena.nips2025_utils.generate_repo import generate_repo_from_results_lst
@@ -804,9 +803,9 @@ class MethodMetadata:
             artifact_name=artifact_name,
         )
         path_local = Path(metadata.path_metadata)
-        s3_cache_root = f"s3://{s3_bucket}/{s3_prefix}"
-        s3_path_loc = metadata.to_s3_cache_loc(path=Path(path_local), s3_cache_root=s3_cache_root)
-        _, s3_key = s3_path_to_bucket_prefix(s3_path_loc)
+        # The remote key is just the prefix joined with the path's location relative to the cache
+        # root — computed directly rather than by building and re-parsing an "s3://..." URI.
+        s3_key = (Path(s3_prefix) / metadata.relative_to_cache_root(path_local)).as_posix()
         # Stream into memory
         try:
             obj = s3_get_object(Bucket=s3_bucket, Key=s3_key)

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -230,8 +230,6 @@ class MethodMetadata:
             has_raw=True,
             has_processed=True,
             has_results=True,
-            # Preserve the historical default now that the field default is "r2".
-            cache_type="s3",
         )
 
     @classmethod

--- a/scripts/run_process_local_raw_data.py
+++ b/scripts/run_process_local_raw_data.py
@@ -1,0 +1,428 @@
+"""Process *already-present* raw TabArena results into method metadata + cached artifacts.
+
+A download/upload-free counterpart to
+``examples/!old/run_download_url_and_cache_to_s3_2025_09_03.py``. That script's job was
+URL-download -> local cache -> S3/R2 upload, orchestrated through ``MethodArtifactManager``.
+Here we assume the raw ``results.pkl`` files are already on local disk (e.g. you unzipped a
+submission yourself), and there is **no download and no upload**. The remaining two concerns are:
+
+  1. ``inspect``  — read the raw artifacts and report the fields that drive ``MethodMetadata``
+                    construction (method_type, ag_key, compute -> cpu/gpu, is_bag, can_hpo,
+                    config_default, ...), plus task/problem-type/metric coverage. Prints a
+                    copy-paste ``MethodMetadata(...)`` snippet built from the inferred values,
+                    and — if you pass an existing ``MethodMetadata`` — an inferred-vs-provided
+                    diff so you can confirm the hand-authored metadata matches the raw data.
+
+  2. ``process``  — build the processed ``EvaluationRepository`` + per-task results and cache
+                    them locally (``metadata.yaml`` + ``processed/`` + ``results/`` under the
+                    TabArena cache root) via ``EndToEndSingle.from_path_raw(cache=True)``. This
+                    is the same processing the old script ran inside ``MethodArtifactManager.cache``,
+                    minus the raw download and the S3/R2 upload.
+
+Two ways to specify each method (see ``RawMethod``):
+  * Pass a fully-specified ``method_metadata`` (e.g. imported from a model's ``info.py``), or
+  * leave it ``None`` and give ``name`` / ``artifact_name`` / ``model_key`` hints so the
+    metadata is inferred from the raw data during processing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from tabarena.nips2025_utils.end_to_end_single import EndToEndSingle
+from tabarena.nips2025_utils.method_processor import get_info_from_result, load_raw
+
+if TYPE_CHECKING:
+    from tabarena.models._method_metadata import MethodMetadata
+
+
+@dataclass
+class RawMethod:
+    """A local directory of raw ``results.pkl`` files to inspect and/or process.
+
+    Parameters
+    ----------
+    path_raw
+        Directory containing the method's raw ``results.pkl`` files (recursively). This is the
+        already-present raw data; nothing is downloaded.
+    method_metadata
+        A fully-specified ``MethodMetadata`` (e.g. ``from tabarena.models.tabpfn_3.info import
+        tabpfn_3_method_metadata``). If given, it is used as-is and ``name`` / ``artifact_name`` /
+        ``model_key`` below are ignored (their values are taken from the metadata).
+    name, artifact_name, model_key
+        Used only when ``method_metadata is None``: naming hints forwarded to
+        ``EndToEndSingle.from_path_raw`` so the metadata is inferred from the raw data. Leaving
+        all of them ``None`` lets the method name / artifact / model_key be inferred too.
+    """
+
+    path_raw: Path
+    method_metadata: MethodMetadata | None = None
+    name: str | None = None
+    artifact_name: str | None = None
+    model_key: str | None = None
+
+    def __post_init__(self) -> None:
+        self.path_raw = Path(self.path_raw)
+
+    # Resolve naming from the metadata when provided, else from the explicit hints — mirroring
+    # what ``MethodArtifactManager.from_method_metadata`` did before forwarding to from_path_raw.
+    @property
+    def resolved_name(self) -> str | None:
+        if self.name is not None:
+            return self.name
+        return self.method_metadata.method if self.method_metadata is not None else None
+
+    @property
+    def resolved_artifact_name(self) -> str | None:
+        if self.artifact_name is not None:
+            return self.artifact_name
+        return self.method_metadata.artifact_name if self.method_metadata is not None else None
+
+    @property
+    def resolved_model_key(self) -> str | None:
+        if self.model_key is not None:
+            return self.model_key
+        return self.method_metadata.model_key if self.method_metadata is not None else None
+
+
+def _format_py_value(val: object) -> str:
+    """Render a Python literal that lints clean under ruff (double-quoted strings)."""
+    if isinstance(val, str):
+        return json.dumps(val)  # ensures double-quoted, properly escaped
+    return repr(val)  # bool/int/float/None render the same under repr and ruff
+
+
+def _compare_with_provided_metadata(
+    method: RawMethod,
+    *,
+    inferred_method: str | None,
+    method_types: list,
+    ag_keys: list,
+    inferred_compute: str,
+    inferred_can_hpo: bool,
+    inferred_config_default: str | None,
+    is_bag_any: bool,
+) -> None:
+    """Print a side-by-side comparison of raw-inferred values against the provided
+    ``MethodMetadata`` (only when one was supplied). Useful for confirming that hand-authored
+    metadata in an ``info.py`` matches what the raw data implies.
+    """
+    if method.method_metadata is None:
+        return
+    m = method.method_metadata
+
+    inferred_method_type = method_types[0] if len(method_types) == 1 else None
+    inferred_ag_key = ag_keys[0] if len(ag_keys) == 1 else None
+    # model_key has no independent raw signal; from_raw defaults it to ag_key.
+    inferred_model_key = inferred_ag_key
+
+    rows: list[tuple[str, object, object]] = [
+        ("method", inferred_method, m.method),
+        ("method_type", inferred_method_type, m.method_type),
+        ("compute", inferred_compute, m.compute),
+        ("ag_key", inferred_ag_key, m.ag_key),
+        ("model_key", inferred_model_key, m.model_key),
+        ("config_default", inferred_config_default, m.config_default),
+        ("can_hpo", inferred_can_hpo, m.can_hpo),
+        ("is_bag", is_bag_any, m.is_bag),
+    ]
+
+    field_w = max(len("field"), *(len(f) for f, _, _ in rows))
+    inf_w = max(len("inferred"), *(len(str(i)) for _, i, _ in rows))
+    prov_w = max(len("provided"), *(len(str(p)) for _, _, p in rows))
+
+    print("[raw-info]   Comparison: inferred (raw) vs provided MethodMetadata:")
+    header = f"{'field'.ljust(field_w)} | {'inferred'.ljust(inf_w)} | {'provided'.ljust(prov_w)} | match"
+    print(f"[raw-info]     {header}")
+    print(f"[raw-info]     {'-' * len(header)}")
+
+    n_mismatch = 0
+    for field, inferred, provided in rows:
+        if inferred is None:
+            match = "?"  # not enough info to infer; skip mismatch counting
+        elif inferred == provided:
+            match = "yes"
+        else:
+            match = "NO"
+            n_mismatch += 1
+        print(
+            f"[raw-info]     {field.ljust(field_w)} | {str(inferred).ljust(inf_w)} | {str(provided).ljust(prov_w)} | {match}"
+        )
+
+    if n_mismatch == 0:
+        print("[raw-info]   All inferable fields match the provided MethodMetadata.")
+    else:
+        print(
+            f"[raw-info]   WARNING: {n_mismatch} field(s) differ between inferred and provided "
+            f"MethodMetadata (see 'NO' rows above). Note some differences are intentional "
+            f"(e.g. a deliberately-overridden can_hpo / config_default / model_key)."
+        )
+
+
+def _print_method_metadata_snippet(
+    method: RawMethod,
+    *,
+    inferred_method: str | None,
+    method_types: list,
+    ag_keys: list,
+    inferred_compute: str,
+    inferred_can_hpo: bool,
+    inferred_config_default: str | None,
+    is_bag_any: bool,
+) -> None:
+    """Print a copy-pasteable ``MethodMetadata(...)`` snippet from raw-inferred values.
+
+    Only the fields that can be inferred from the raw data are emitted; the manual fields a
+    human still owns (display_name, reference_url, date, verified, cache_type, and — if you
+    later upload — s3_bucket / s3_prefix / upload_as_public) are listed in a trailing comment.
+    """
+    snippet_method = method.resolved_name or inferred_method or "method"
+    inferred_ag_key = ag_keys[0] if len(ag_keys) == 1 else None
+
+    snippet_fields: list[tuple[str, object]] = [
+        ("method", snippet_method),
+        ("method_type", method_types[0] if len(method_types) == 1 else None),
+        ("compute", inferred_compute),
+        ("ag_key", inferred_ag_key),
+    ]
+    # Only emit model_key when it was explicitly provided and differs from ag_key (it defaults
+    # to ag_key otherwise, so emitting it would be noise).
+    if method.resolved_model_key is not None and method.resolved_model_key != inferred_ag_key:
+        snippet_fields.append(("model_key", method.resolved_model_key))
+    snippet_fields += [
+        ("config_default", inferred_config_default),
+        ("can_hpo", inferred_can_hpo),
+        ("is_bag", is_bag_any),
+        ("has_raw", True),
+        ("has_processed", True),
+        ("has_results", True),
+    ]
+    if method.resolved_artifact_name is not None:
+        snippet_fields.append(("artifact_name", method.resolved_artifact_name))
+
+    slug = re.sub(r"[^a-z0-9]", "", str(snippet_method).lower()) or "method"
+    print("[raw-info]   Suggested MethodMetadata (copy-paste; fill in the manual fields):")
+    print(f"{slug}_metadata = MethodMetadata(")
+    for key, val in snippet_fields:
+        if val is None:
+            continue
+        print(f"    {key}={_format_py_value(val)},")
+    # Manual fields, one per line as commented kwargs: uncomment (drop the leading "# ") and fill
+    # in the value. Indentation matches the inferred fields above, so an uncommented line drops
+    # straight into the MethodMetadata(...) call.
+    manual_fields: list[tuple[str, str, str]] = [
+        ("display_name", '"..."', ""),
+        ("reference_url", '"https://..."', ""),
+        ("date", '"YYYY-MM-DD"', ""),
+        ("verified", "False", ""),
+        ("cache_type", '"r2"', '  # one of: "s3", "r2", "local"'),
+        ("s3_bucket", '"tabarena"', "  # only if uploading"),
+        ("s3_prefix", '"cache"', "  # only if uploading"),
+        ("upload_as_public", "True", "  # only if uploading"),
+    ]
+    print("    # --- Manual fields (not inferable from raw); uncomment and fill in: ---")
+    for key, placeholder, note in manual_fields:
+        print(f"    # {key}={placeholder},{note}")
+    print(")")
+
+
+def log_raw_data_info(method: RawMethod, *, engine: str = "ray") -> None:
+    """Inspect the raw artifacts at ``method.path_raw`` and print a summary of the fields that
+    drive ``MethodMetadata`` construction (method_type, model_type, ag_key, name_prefix,
+    num_gpus -> compute, is_bag, config_default / can_hpo) plus task/problem-type/metric coverage.
+
+    Intended to be run before ``process_raw`` so you can sanity-check or build a ``MethodMetadata``
+    for this artifact.
+    """
+    print(f"[raw-info] Loading raw results from '{method.path_raw}' for inspection...")
+    results_lst = load_raw(path_raw=method.path_raw, engine=engine)
+    info_df = pd.DataFrame([get_info_from_result(r) for r in results_lst])
+
+    label = method.resolved_name or str(method.path_raw.name)
+    print(f"[raw-info] {label}: {len(results_lst)} result files")
+
+    def _unique(col: str):
+        return sorted(info_df[col].dropna().unique().tolist())
+
+    method_types = _unique("method_type")
+    model_types = _unique("model_type")
+    ag_keys = _unique("ag_key")
+    name_prefixes = _unique("name_prefix")
+    problem_types = _unique("problem_type")
+    metrics = _unique("metric")
+    frameworks = _unique("framework")
+    num_gpus_vals = _unique("num_gpus")
+    is_bag_any = bool(info_df["is_bag"].any())
+
+    inferred_compute = "gpu" if (num_gpus_vals and max(num_gpus_vals) > 0) else "cpu"
+    inferred_can_hpo = len(frameworks) > 1
+    inferred_config_default = frameworks[0] if len(frameworks) == 1 else None
+    # method is inferred from name_prefix for configs, and from framework for baselines.
+    if len(method_types) == 1 and method_types[0] == "baseline":
+        inferred_method = frameworks[0] if len(frameworks) == 1 else None
+    else:
+        inferred_method = name_prefixes[0] if len(name_prefixes) == 1 else None
+
+    n_tasks = (
+        info_df[["tid", "split_idx"]].drop_duplicates().shape[0]
+        if {"tid", "split_idx"}.issubset(info_df.columns)
+        else None
+    )
+    n_datasets = info_df["name"].nunique() if "name" in info_df.columns else None
+    n_folds = info_df["split_idx"].nunique() if "split_idx" in info_df.columns else None
+
+    # Per-config (framework) coverage: total occurrences (dataset x fold) each config has results
+    # for. These frameworks are the valid configs present in the raw data.
+    config_task_counts = info_df.groupby("framework").size().sort_index() if "framework" in info_df.columns else None
+
+    print(f"[raw-info]   method_type   = {method_types}")
+    print(f"[raw-info]   model_type    = {model_types}")
+    print(f"[raw-info]   ag_key        = {ag_keys}")
+    print(f"[raw-info]   name_prefix   = {name_prefixes} -> method={inferred_method!r}")
+    print(f"[raw-info]   problem_type  = {problem_types}")
+    print(f"[raw-info]   metric        = {metrics}")
+    print(f"[raw-info]   num_gpus      = {num_gpus_vals} -> compute='{inferred_compute}'")
+    print(f"[raw-info]   is_bag (any)  = {is_bag_any}")
+    print(
+        f"[raw-info]   n_frameworks  = {len(frameworks)} -> can_hpo={inferred_can_hpo}, "
+        f"config_default={inferred_config_default!r}"
+    )
+    print(f"[raw-info]   n_datasets    = {n_datasets}")
+    print(f"[raw-info]   n_tasks (dxf) = {n_tasks}")
+    print(f"[raw-info]   n_folds       = {n_folds}")
+
+    if config_task_counts is not None:
+        print(f"[raw-info]   valid configs ({len(config_task_counts)}) and their n_tasks (dataset x fold):")
+        name_w = max((len(str(f)) for f in config_task_counts.index), default=0)
+        for framework, n in config_task_counts.items():
+            print(f"[raw-info]     {str(framework).ljust(name_w)} -> {n}")
+    else:
+        print(f"[raw-info]   valid configs = {frameworks}")
+
+    _compare_with_provided_metadata(
+        method,
+        inferred_method=inferred_method,
+        method_types=method_types,
+        ag_keys=ag_keys,
+        inferred_compute=inferred_compute,
+        inferred_can_hpo=inferred_can_hpo,
+        inferred_config_default=inferred_config_default,
+        is_bag_any=is_bag_any,
+    )
+    _print_method_metadata_snippet(
+        method,
+        inferred_method=inferred_method,
+        method_types=method_types,
+        ag_keys=ag_keys,
+        inferred_compute=inferred_compute,
+        inferred_can_hpo=inferred_can_hpo,
+        inferred_config_default=inferred_config_default,
+        is_bag_any=is_bag_any,
+    )
+
+
+def process_raw(
+    method: RawMethod,
+    *,
+    cache_raw: bool = False,
+    cache_hpo_trajectories: bool = False,
+    backend: str = "ray",
+) -> EndToEndSingle:
+    """Process the already-present raw data into cached method artifacts (no upload).
+
+    Builds the processed ``EvaluationRepository`` and per-task results and caches them under the
+    TabArena cache root (``~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/``):
+    ``metadata.yaml`` + ``processed/`` + ``results/``.
+
+    Parameters
+    ----------
+    cache_raw
+        Whether to also copy the raw ``results.pkl`` files into the TabArena cache. Defaults to
+        ``False`` here because the raw data is already present locally at ``method.path_raw`` —
+        set ``True`` only if you also want a copy under the cache layout.
+    cache_hpo_trajectories
+        Whether to also generate and cache HPO trajectories (only applies to ``config`` methods).
+    backend
+        ``"ray"`` (parallel) or ``"native"`` (sequential) for the HPO/model-result simulation.
+    """
+    return EndToEndSingle.from_path_raw(
+        path_raw=method.path_raw,
+        method_metadata=method.method_metadata,
+        name=method.resolved_name,
+        model_key=method.resolved_model_key,
+        artifact_name=method.resolved_artifact_name,
+        cache=True,
+        cache_raw=cache_raw,
+        cache_hpo_trajectories=cache_hpo_trajectories,
+        backend=backend,
+    )
+
+
+if __name__ == "__main__":
+    # --- What to do ---------------------------------------------------------------------------
+    inspect = True  # print inferred MethodMetadata fields + a copy-paste snippet for each method
+    process = False  # build + cache processed repo and results locally (no upload)
+
+    # --- Processing options (only used when process=True) -------------------------------------
+    cache_raw = False  # raw is already present locally; don't duplicate it into the cache
+    cache_hpo_trajectories = False  # also generate+cache HPO trajectories (config methods only)
+    backend = "ray"  # "ray" (parallel) or "native" (sequential)
+
+    # --- Methods to process -------------------------------------------------------------------
+    # Each entry points at a local directory of already-extracted raw `results.pkl` files.
+    #
+    # Mode A — infer the metadata from the raw data (optionally give naming hints):
+    #     RawMethod(
+    #         path_raw=Path("local_data/leaderboard_submissions/data_SomeNewModel"),
+    #         name="SomeNewModel_GPU",
+    #         artifact_name="tabarena-2026-06-22",
+    #         model_key="SOMENEWMODEL_GPU",
+    #     )
+    #
+    # Mode B — reuse a fully-specified MethodMetadata from a model's info.py:
+    #     from tabarena.models.tabpfn_3.info import tabpfn_3_method_metadata
+    #     RawMethod(
+    #         path_raw=Path("local_data/leaderboard_submissions/data_TabPFN_3_12052026"),
+    #         method_metadata=tabpfn_3_method_metadata,
+    #     )
+    # TabPFN-3: point at the raw cache its committed MethodMetadata already resolves to
+    # (`.path_raw`), but do NOT pass the metadata — let it be inferred from the raw data so
+    # `inspect` exercises the inference path (the printed snippet can be eyeballed against the
+    # committed metadata in tabarena/models/tabpfn_3/info.py).
+    from tabarena.models.tabpfn_3.info import tabpfn_3_method_metadata
+
+    methods: list[RawMethod] = [
+        RawMethod(path_raw=tabpfn_3_method_metadata.path_raw),
+        # RawMethod(path_raw=Path("local_data/.../data_SomeNewModel"), name="SomeNewModel_GPU"),
+    ]
+
+    if len(methods) == 0:
+        raise AssertionError("Populate `methods` with one or more RawMethod entries to run. Currently empty.")
+
+    engine = "ray" if backend == "ray" else "sequential"
+    print(f"Processing {len(methods)} method(s) (inspect={inspect}, process={process})")
+    for i, method in enumerate(methods):
+        label = method.resolved_name or str(method.path_raw.name)
+        print(f"\n({i + 1}/{len(methods)}) {label}  <- {method.path_raw}")
+        if not method.path_raw.is_dir():
+            raise FileNotFoundError(f"path_raw does not exist or is not a directory: {method.path_raw}")
+        ts = time.time()
+        if inspect:
+            log_raw_data_info(method, engine=engine)
+        if process:
+            print(f"[process] Building + caching processed repo and results for '{label}'...")
+            process_raw(
+                method,
+                cache_raw=cache_raw,
+                cache_hpo_trajectories=cache_hpo_trajectories,
+                backend=backend,
+            )
+        te = time.time()
+        print(f"Finished {label} (duration={te - ts:.1f}s)")

--- a/scripts/run_process_local_raw_data.py
+++ b/scripts/run_process_local_raw_data.py
@@ -392,14 +392,13 @@ if __name__ == "__main__":
     #         path_raw=Path("local_data/leaderboard_submissions/data_TabPFN_3_12052026"),
     #         method_metadata=tabpfn_3_method_metadata,
     #     )
-    # TabPFN-3: point at the raw cache its committed MethodMetadata already resolves to
+    # Example (Mode B): point at the raw cache a committed MethodMetadata already resolves to
     # (`.path_raw`), but do NOT pass the metadata — let it be inferred from the raw data so
     # `inspect` exercises the inference path (the printed snippet can be eyeballed against the
-    # committed metadata in tabarena/models/tabpfn_3/info.py).
-    from tabarena.models.tabpfn_3.info import tabpfn_3_method_metadata
-
+    # committed metadata in tabarena/models/tabpfn_3/info.py):
+    #     from tabarena.models.tabpfn_3.info import tabpfn_3_method_metadata
+    #     RawMethod(path_raw=tabpfn_3_method_metadata.path_raw),
     methods: list[RawMethod] = [
-        RawMethod(path_raw=tabpfn_3_method_metadata.path_raw),
         # RawMethod(path_raw=Path("local_data/.../data_SomeNewModel"), name="SomeNewModel_GPU"),
     ]
 

--- a/scripts/run_upload_results.py
+++ b/scripts/run_upload_results.py
@@ -1,0 +1,188 @@
+"""Upload already-generated method artifacts to the method's configured object store.
+
+Companion to ``scripts/run_process_local_raw_data.py``: that script processes raw results into a
+local cache (``metadata.yaml`` + ``processed/`` + ``results/`` under the TabArena cache root); this
+one uploads those already-cached artifacts. It assumes the artifacts and the method's
+``MethodMetadata`` already exist locally — it does not generate anything.
+
+The destination backend is whatever the method's ``MethodMetadata.cache_type`` says (``"s3"`` or
+``"r2"``); this script is not specific to any one backend — it just calls
+``method_metadata.method_uploader()`` (``cache_type="auto"``).
+
+Before uploading, every part that will be uploaded is verified to exist locally and be non-empty
+(see ``plan_and_verify_upload``); the upload is aborted with a clear, aggregated error if anything
+is missing, so a method is never partially uploaded.
+
+Set ``dry_run=True`` (the default in ``__main__``) to run the verification and print what would be
+uploaded and where, without uploading anything and without needing credentials.
+
+Credentials are required only for the real upload, and depend on the backend: ``"r2"`` reads
+``R2_ACCOUNT_ID`` / ``R2_ACCESS_KEY_ID`` / ``R2_SECRET_ACCESS_KEY`` from the environment, while
+``"s3"`` uses ambient AWS credentials. ``method_uploader`` raises a descriptive error if the
+required credentials are missing.
+
+Specify the methods to upload either by importing a ``MethodMetadata`` from a model's ``info.py``,
+or by loading one from the local cache with
+``MethodMetadata.from_yaml(method=..., artifact_name=...)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Imported at runtime (not under TYPE_CHECKING) so this script can be edited to build the
+# `methods` list below via `MethodMetadata.from_yaml(...)`.
+from tabarena.models._method_metadata import MethodMetadata  # noqa: TC001
+
+
+def _check_file(path: Path, problems: list[str], label: str) -> None:
+    """Record a problem if ``path`` is not an existing, non-empty file."""
+    if not path.is_file():
+        problems.append(f"{label}: missing file '{path}'")
+    elif path.stat().st_size == 0:
+        problems.append(f"{label}: file is empty '{path}'")
+
+
+def _dir_has_files(path: Path) -> bool:
+    """True if ``path`` is a directory containing at least one (recursive) file."""
+    return path.is_dir() and any(p.is_file() for p in path.rglob("*"))
+
+
+def plan_and_verify_upload(method_metadata: MethodMetadata, *, upload_raw: bool = False) -> list[str]:
+    """Decide which parts of the method to upload and verify each is present and non-empty.
+
+    Returns the ordered list of part names to upload (a subset of ``metadata``, ``results``,
+    ``processed``, ``hpo_trajectories``, ``raw``). ``metadata`` is always included and is
+    generated in memory from the ``MethodMetadata`` (so there is nothing to check on disk);
+    ``results`` is always required. ``processed`` and ``hpo_trajectories`` are uploaded when
+    present locally, and ``raw`` only when ``upload_raw=True``. Raises ``FileNotFoundError`` —
+    listing every problem at once — if any planned part is missing or empty, so we never start a
+    partial upload.
+    """
+    problems: list[str] = []
+    parts = ["metadata"]
+
+    # results — always uploaded and required (the per-task result parquet files for this
+    # method_type: model/hpo for configs, model for baselines, portfolio for portfolios).
+    for path_local in method_metadata.path_results_files():
+        _check_file(path_local, problems, "results")
+    parts.append("results")
+
+    # processed — uploaded when cached; upload_processed also (re)uploads the processed dir's
+    # configs_hyperparameters.json, so verify both.
+    if method_metadata.path_processed_exists:
+        if not _dir_has_files(method_metadata.path_processed):
+            problems.append(f"processed: directory is empty '{method_metadata.path_processed}'")
+        _check_file(
+            method_metadata.path_configs_hyperparameters(),
+            problems,
+            "processed/configs_hyperparameters.json",
+        )
+        parts.append("processed")
+
+    # hpo trajectories — config methods only, when the trajectory file was generated/cached.
+    if method_metadata.method_type == "config" and method_metadata.path_results_hpo_trajectories().exists():
+        _check_file(method_metadata.path_results_hpo_trajectories(), problems, "hpo_trajectories")
+        parts.append("hpo_trajectories")
+
+    # raw — only when explicitly requested; the dir must exist, be non-empty, and contain the
+    # per-run results.pkl files that upload_raw zips.
+    if upload_raw:
+        path_raw = method_metadata.path_raw
+        if not _dir_has_files(path_raw):
+            problems.append(f"raw: directory missing or empty '{path_raw}'")
+        elif not any(path_raw.rglob("results.pkl")):
+            problems.append(f"raw: no 'results.pkl' files found under '{path_raw}'")
+        else:
+            parts.append("raw")
+
+    if problems:
+        raise FileNotFoundError(
+            f"Refusing to upload '{method_metadata.method}' (artifact_name="
+            f"{method_metadata.artifact_name!r}); {len(problems)} artifact check(s) failed:\n  - "
+            + "\n  - ".join(problems)
+        )
+    return parts
+
+
+def _destination(method_metadata: MethodMetadata) -> str:
+    """The remote location this method would upload to, computed from the metadata alone (no client).
+
+    Uses ``s3://bucket/prefix`` semantics, which is what both the S3 and R2 backends use.
+    """
+    root = f"s3://{method_metadata.s3_bucket}/{method_metadata.s3_prefix}"
+    try:
+        rel = method_metadata.relative_to_cache_root(method_metadata.path).as_posix()
+        return f"{root}/{rel}"
+    except ValueError:
+        # path not under the global cache root (e.g. a flat cache_root override)
+        return f"{root}/ (method={method_metadata.method})"
+
+
+def upload_method(
+    method_metadata: MethodMetadata,
+    *,
+    upload_raw: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """Verify then upload one method's cached artifacts to its configured backend.
+
+    The backend follows ``method_metadata.cache_type`` (``method_uploader(cache_type="auto")``).
+    All local checks run first (before the client is created), so missing/empty artifacts are
+    reported without needing credentials and without starting a partial upload.
+
+    ``dry_run=True`` runs the same verification and prints what *would* be uploaded and where, but
+    performs no upload and does not construct the client — so it needs no credentials.
+    """
+    parts = plan_and_verify_upload(method_metadata, upload_raw=upload_raw)
+
+    if dry_run:
+        print(
+            f"[dry-run] '{method_metadata.method}' (artifact={method_metadata.artifact_name}) "
+            f"verified OK; would upload parts={parts} -> {_destination(method_metadata)} "
+            f"(cache_type={method_metadata.cache_type})"
+        )
+        if not method_metadata.has_s3_cache:
+            print("[dry-run]   WARNING: s3_bucket/s3_prefix not set on this metadata; a real upload would fail.")
+        return
+
+    uploader = method_metadata.method_uploader()
+    print(
+        f"Uploading '{method_metadata.method}' (artifact={method_metadata.artifact_name}) "
+        f"to {uploader.s3_cache_root} | cache_type={method_metadata.cache_type} | parts={parts}"
+    )
+    uploader.upload_metadata()
+    uploader.upload_results()
+    if "processed" in parts:
+        uploader.upload_processed()
+    if "hpo_trajectories" in parts:
+        uploader.upload_results_hpo_trajectories()
+    if "raw" in parts:
+        uploader.upload_raw()
+    print(f"\tDone: {method_metadata.method}")
+
+
+if __name__ == "__main__":
+    # When True, verify + print what would be uploaded (and where) without uploading anything.
+    # No credentials are needed for a dry run. Flip to False to perform the real upload.
+    dry_run = True
+
+    # raw/ is large and usually not cached locally; flip on only if you intend to upload it too.
+    upload_raw = False
+
+    # Methods to upload. Either import a fully-specified MethodMetadata from a model's info.py:
+    #     from tabarena.models.tabpfn_3.info import tabpfn_3_method_metadata
+    #     methods = [tabpfn_3_method_metadata]
+    # or load one from the local cache by (method, artifact_name):
+    #     MethodMetadata.from_yaml(method="TabPFN-3", artifact_name="tabarena-2026-05-13")
+    methods: list[MethodMetadata] = [
+        # MethodMetadata.from_yaml(method="...", artifact_name="..."),
+    ]
+
+    if len(methods) == 0:
+        raise AssertionError("Populate `methods` with one or more MethodMetadata to upload. Currently empty.")
+
+    print(f"{'[dry-run] ' if dry_run else ''}Uploading {len(methods)} method(s) (upload_raw={upload_raw})")
+    for i, method_metadata in enumerate(methods):
+        print(f"\n({i + 1}/{len(methods)}) {method_metadata.method}")
+        upload_method(method_metadata, upload_raw=upload_raw, dry_run=dry_run)

--- a/scripts/run_upload_results.py
+++ b/scripts/run_upload_results.py
@@ -149,7 +149,7 @@ def upload_method(
     uploader = method_metadata.method_uploader()
     print(
         f"Uploading '{method_metadata.method}' (artifact={method_metadata.artifact_name}) "
-        f"to {uploader.s3_cache_root} | cache_type={method_metadata.cache_type} | parts={parts}"
+        f"to {uploader.remote_cache_root} | cache_type={method_metadata.cache_type} | parts={parts}"
     )
     uploader.upload_metadata()
     uploader.upload_results()


### PR DESCRIPTION
## Summary

Refactors the method artifact upload/download code under `models/_artifacts/` so the backend-specific classes share a common base, and simplifies how remote object keys are derived. Also adds two operational scripts.

### Abstract base classes
- New `MethodDownloader` (`downloader.py`) and `MethodUploader` (`uploader.py`) ABCs hold all backend-independent logic: which artifacts to fetch/upload, local↔remote key mapping, zip extraction, and the low-level put/get calls.
- `MethodDownloaderS3` / `MethodDownloaderR2` / `MethodDownloaderPublicR2` and `MethodUploaderS3` / `MethodUploaderR2` now subclass the bases and supply only backend specifics — for uploaders, the boto3 client (`_make_client`) and per-upload extra args (`_extra_args`, e.g. a public-read ACL); for downloaders, how to fetch a single object / a zip. Net ~660 lines of duplication removed.

### Direct key derivation (no more `s3://` round-trip)
- Previously, `local_to_s3_path` (and `MethodMetadata.from_s3_cache`) built an `s3://bucket/prefix/<rel>` URI only to re-parse it with autogluon's `s3_path_to_bucket_prefix` and discard the bucket — a round-trip whose only output was the object key.
- Replaced with `local_to_key`, which computes the key directly as `prefix / relative_to_cache_root(path)` — the same rule `key_prefix` (the `raw.zip` / `processed.zip` keys) already uses. Key derivation now follows one path-arithmetic rule everywhere.
- Dropped the `autogluon ... s3_path_to_bucket_prefix` dependency from the artifact flow, and removed the now-unused `MethodMetadata.to_s3_cache_loc`.
- Each step verified byte-for-byte equivalent to the old computation across buckets, prefixes, and every artifact path.

### Naming + clients
- Renamed the `s3_cache_root` property to `remote_cache_root` (it's backend-agnostic — the `s3://` scheme is just a label, correct for any S3-compatible store including R2) and demoted it to a logging-only convenience.
- `MethodDownloaderS3` now builds its signed/unsigned boto3 clients once per instance (cached `signed_client` / `unsigned_client`) instead of constructing a `Session` + two clients on every object fetch.

### Scripts
- `scripts/run_process_local_raw_data.py` — inspect already-local raw `results.pkl` and (optionally) process them into cached method artifacts; no download/upload. Prints inferred `MethodMetadata` fields + a copy-paste snippet, and an inferred-vs-provided diff.
- `scripts/run_upload_results.py` — verify-then-upload already-cached artifacts to the method's configured backend; dry-run by default, refuses partial uploads.

## Testing
- `ruff check` clean on all touched files.
- All `_artifacts` modules + `MethodMetadata` import.
- Key-derivation equivalence confirmed programmatically (old build-then-parse vs new direct) across method/artifact/bucket/prefix combinations, on both the uploader and downloader and in `from_s3_cache`.

## Notes
- No dedicated unit tests exist for the up/downloaders; parity here is by inspection + the equivalence checks above. A follow-up test for the S3 signed→unsigned fallback path would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)