### PR TITLE
MethodMetadata: type-specific constructors + method_type guards

### DIFF
--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -46,6 +46,12 @@ class MethodType(StrEnum):
         return [m.value for m in cls]
 
 
+#: String form of :class:`MethodType`, for annotating ``method_type`` fields and parameters.
+#: Mirrors the enum members above (kept honest at runtime by the ``MethodType.values()`` check in
+#: :meth:`MethodMetadata.__post_init__`).
+MethodTypeLiteral = Literal["config", "baseline", "portfolio"]
+
+
 # FIXME: Implement `best` and `best-N`
 @dataclass(eq=False)
 class MethodMetadata:
@@ -78,12 +84,16 @@ class MethodMetadata:
     #: inspector) from the raw result frame, so they can be left to inference when authoring from
     #: raw artifacts. ``model_key`` and ``can_hpo`` have no independent raw signal and are derived
     #: in :meth:`__post_init__` (from ``ag_key`` and ``method_type`` respectively).
-    method_type: str = "config"
+    method_type: MethodTypeLiteral = "config"
     ag_key: str | None = None
     model_key: str | None = None
     config_default: str | None = None
     can_hpo: bool | None = None
     compute: Literal["cpu", "gpu"] = "cpu"
+    #: Whether the model was trained with bagging (cross-validation across folds). When ``True``,
+    #: the raw data contains per-fold test *and* validation predictions, and the reported test
+    #: predictions are the average of the per-fold test predictions. Config-only by convention
+    #: (enforced in :meth:`__post_init__`) — baselines/portfolios are recorded as ``False``.
     is_bag: bool = False
     has_raw: bool = False
     has_processed: bool = False
@@ -140,10 +150,32 @@ class MethodMetadata:
             f"Unknown method_type: {self.method_type!r}. Valid values: {MethodType.values()}"
         )
         assert self.compute in ["cpu", "gpu"]
+        # Guard against arguments that belong to a different method_type, so a mismatched field is
+        # surfaced at construction rather than silently ignored. `name` is the baseline/portfolio
+        # display-name override; `ag_key` / `model_key` / `config_default` / `name_suffix` are
+        # config-only, as are `can_hpo=True` and `is_bag=True` (only configs are bagged by
+        # convention). (Checks run after the derived defaults above.)
         if self.name is not None and self.method_type == "config":
             raise AssertionError("Cannot specify `name` for method_type: 'config'.")
         if self.name is not None and self.name_suffix is not None:
             raise AssertionError("Must only specify one of `name` and `name_suffix`.")
+        if self.method_type != "config":
+            config_only_set = [
+                field
+                for field in ("ag_key", "model_key", "config_default", "name_suffix")
+                if getattr(self, field) is not None
+            ]
+            if config_only_set:
+                raise AssertionError(
+                    f"Fields {config_only_set} are only valid for method_type='config', but "
+                    f"method_type={self.method_type!r} (method={self.method!r})."
+                )
+            for flag in ("can_hpo", "is_bag"):
+                if getattr(self, flag):
+                    raise AssertionError(
+                        f"{flag}=True is only valid for method_type='config', but "
+                        f"method_type={self.method_type!r} (method={self.method!r})."
+                    )
 
         if self.display_name is None:
             self.display_name = self._compute_display_name()
@@ -168,6 +200,61 @@ class MethodMetadata:
         if self.name_suffix is not None:
             return f"{self.model_key}{self.name_suffix}"
         return self.model_key
+
+    # -- type-specific constructors -----------------------------------------------------------
+    # Thin wrappers over the dataclass constructor that expose only the arguments relevant to each
+    # method_type, so a caller is never presented with fields that belong to a different type.
+    # Each sets ``method_type`` and forwards the shared fields (identity, ``compute``, ``has_*``,
+    # storage/transport, informative) via ``**kwargs``; ``__post_init__`` still validates the
+    # result. Orthogonal to :meth:`tabarena_public`, which is the public-store *storage* preset.
+
+    @classmethod
+    def config(
+        cls,
+        *,
+        method: str,
+        ag_key: str | None = None,
+        model_key: str | None = None,
+        config_default: str | None = None,
+        name_suffix: str | None = None,
+        can_hpo: bool | None = None,
+        is_bag: bool = False,
+        **kwargs,
+    ) -> Self:
+        """A ``config`` method (a tunable model with one or more configs; the default type).
+
+        Exposes the config-only fields (``ag_key`` / ``model_key`` / ``config_default`` /
+        ``name_suffix`` / ``can_hpo`` / ``is_bag``); ``name`` is rejected (it is
+        baseline/portfolio-only).
+        """
+        return cls(
+            method=method,
+            method_type="config",
+            ag_key=ag_key,
+            model_key=model_key,
+            config_default=config_default,
+            name_suffix=name_suffix,
+            can_hpo=can_hpo,
+            is_bag=is_bag,
+            **kwargs,
+        )
+
+    @classmethod
+    def baseline(cls, *, method: str, name: str | None = None, **kwargs) -> Self:
+        """A ``baseline`` method (e.g. an AutoGluon preset).
+
+        Exposes ``name`` (the display-name override); the config-only fields are rejected.
+        """
+        return cls(method=method, method_type="baseline", name=name, **kwargs)
+
+    @classmethod
+    def portfolio(cls, *, method: str, name: str | None = None, has_raw: bool = False, **kwargs) -> Self:
+        """A ``portfolio`` method (a fixed selection/ensemble over configs).
+
+        Exposes ``name`` and defaults ``has_raw=False`` (portfolios usually have no raw
+        artifacts); the config-only fields are rejected.
+        """
+        return cls(method=method, method_type="portfolio", name=name, has_raw=has_raw, **kwargs)
 
     # TODO: Also support baseline methods
     @classmethod

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -326,14 +326,10 @@ class MethodMetadata:
         if artifact_name is None:
             artifact_name = method
 
-        return cls(
+        return cls.baseline(
             method=method,
             artifact_name=artifact_name,
-            method_type=method_type,
             compute=compute,
-            config_default=None,
-            can_hpo=False,
-            is_bag=False,
             has_raw=True,
             has_processed=True,
             has_results=True,
@@ -437,10 +433,9 @@ class MethodMetadata:
         if artifact_name is None:
             artifact_name = method
 
-        return cls(
+        return cls.config(
             method=method,
             artifact_name=artifact_name,
-            method_type=method_type,
             compute=compute,
             config_default=config_default,
             ag_key=ag_key,
@@ -997,7 +992,16 @@ class ModelDescriptor:
         override for a variant (e.g. a CPU build of a GPU model, which keeps the same paper
         but a different ``display_name`` and ``compute``). All other (run-specific)
         :class:`MethodMetadata` fields come from ``**kwargs``.
+
+        A descriptor always describes a ``config`` method, so this routes through
+        :meth:`MethodMetadata.config`; an explicit ``method_type="config"`` is accepted (and
+        dropped) for back-compat, but any other ``method_type`` is rejected.
         """
+        method_type = kwargs.pop("method_type", "config")
+        if method_type != "config":
+            raise ValueError(
+                f"ModelDescriptor describes config methods; got method_type={method_type!r} (method={method!r})."
+            )
         fields_from_descriptor = dict(
             display_name=self.display_name,
             compute=self.compute,
@@ -1005,4 +1009,4 @@ class ModelDescriptor:
             reference_url=self.reference_url,
         )
         # Caller-provided values win, so a variant can override an intrinsic default.
-        return MethodMetadata(method=method, **{**fields_from_descriptor, **kwargs})
+        return MethodMetadata.config(method=method, **{**fields_from_descriptor, **kwargs})

--- a/packages/tabarena/src/tabarena/models/catboost/info.py
+++ b/packages/tabarena/src/tabarena/models/catboost/info.py
@@ -15,7 +15,6 @@ catboost_descriptor = ModelDescriptor(
 
 catboost_method_metadata = catboost_descriptor.method_metadata(
     method="CatBoost",
-    method_type="config",
     date="2025-06-12",
     ag_key="CAT",
     config_default="CatBoost_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/chimeraboost/info.py
+++ b/packages/tabarena/src/tabarena/models/chimeraboost/info.py
@@ -5,10 +5,9 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.chimeraboost.hpo import gen_chimeraboost
 from tabarena.models.chimeraboost.model import ChimeraBoostModel
 
-chimeraboost_method_metadata = MethodMetadata(
+chimeraboost_method_metadata = MethodMetadata.config(
     method="ChimeraBoost",
     display_name="ChimeraBoost",
-    method_type="config",
     compute="cpu",
     date="2026-06-15",
     ag_key="CHIMERA",

--- a/packages/tabarena/src/tabarena/models/ebm/info.py
+++ b/packages/tabarena/src/tabarena/models/ebm/info.py
@@ -6,9 +6,8 @@ from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.ebm.hpo import gen_ebm
 
-ebm_method_metadata = MethodMetadata(
+ebm_method_metadata = MethodMetadata.config(
     method="ExplainableBM",
-    method_type="config",
     display_name="EBM",
     compute="cpu",
     date="2025-09-03",

--- a/packages/tabarena/src/tabarena/models/extra_trees/info.py
+++ b/packages/tabarena/src/tabarena/models/extra_trees/info.py
@@ -15,7 +15,6 @@ extra_trees_descriptor = ModelDescriptor(
 
 extra_trees_method_metadata = extra_trees_descriptor.method_metadata(
     method="ExtraTrees",
-    method_type="config",
     date="2025-06-12",
     ag_key="XT",
     config_default="ExtraTrees_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/fastai/info.py
+++ b/packages/tabarena/src/tabarena/models/fastai/info.py
@@ -6,9 +6,8 @@ from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.fastai.hpo import gen_fastai
 
-fastai_method_metadata = MethodMetadata(
+fastai_method_metadata = MethodMetadata.config(
     method="NeuralNetFastAI",
-    method_type="config",
     display_name="FastaiMLP",
     compute="cpu",
     date="2025-06-12",

--- a/packages/tabarena/src/tabarena/models/iltm/info.py
+++ b/packages/tabarena/src/tabarena/models/iltm/info.py
@@ -5,11 +5,10 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.iltm.hpo import gen_iltm
 from tabarena.models.iltm.model import ILTMModel
 
-iltm_method_metadata = MethodMetadata(
+iltm_method_metadata = MethodMetadata.config(
     method="iLTM",
     date="2026-05-29",
     artifact_name="tabarena-2026-05-13",
-    method_type="config",
     display_name="iLTM",
     compute="gpu",
     ag_key="TA-ILTM",

--- a/packages/tabarena/src/tabarena/models/knn/info.py
+++ b/packages/tabarena/src/tabarena/models/knn/info.py
@@ -5,9 +5,8 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.knn.hpo import gen_knn
 from tabarena.models.knn.model import KNNNewModel
 
-knn_method_metadata = MethodMetadata(
+knn_method_metadata = MethodMetadata.config(
     method="KNeighbors",
-    method_type="config",
     display_name="KNN",
     compute="cpu",
     date="2025-10-20",

--- a/packages/tabarena/src/tabarena/models/lightgbm/info.py
+++ b/packages/tabarena/src/tabarena/models/lightgbm/info.py
@@ -15,7 +15,6 @@ lightgbm_descriptor = ModelDescriptor(
 
 lightgbm_method_metadata = lightgbm_descriptor.method_metadata(
     method="LightGBM",
-    method_type="config",
     date="2025-06-12",
     ag_key="GBM",
     config_default="LightGBM_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/limix/info.py
+++ b/packages/tabarena/src/tabarena/models/limix/info.py
@@ -5,9 +5,8 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.limix.hpo import gen_limix
 from tabarena.models.limix.model import LimiXModel
 
-limix_method_metadata = MethodMetadata(
+limix_method_metadata = MethodMetadata.config(
     method="LimiX",
-    method_type="config",
     display_name="LimiX",
     compute="gpu",
     date="2026-05-13",

--- a/packages/tabarena/src/tabarena/models/lr/info.py
+++ b/packages/tabarena/src/tabarena/models/lr/info.py
@@ -15,7 +15,6 @@ lr_descriptor = ModelDescriptor(
 
 lr_method_metadata = lr_descriptor.method_metadata(
     method="LinearModel",
-    method_type="config",
     date="2025-10-20",
     ag_key="LR",
     config_default="LinearModel_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/mitra/info.py
+++ b/packages/tabarena/src/tabarena/models/mitra/info.py
@@ -19,9 +19,8 @@ def prefetch_weights() -> None:
         hf_hub_download(repo_id=repo_id, filename="model.safetensors")
 
 
-mitra_method_metadata = MethodMetadata(
+mitra_method_metadata = MethodMetadata.config(
     method="Mitra_GPU",
-    method_type="config",
     display_name="Mitra",
     compute="gpu",
     date="2025-09-03",

--- a/packages/tabarena/src/tabarena/models/modernnca/info.py
+++ b/packages/tabarena/src/tabarena/models/modernnca/info.py
@@ -5,9 +5,8 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.modernnca.hpo import gen_modernnca
 from tabarena.models.modernnca.model import ModernNCAModel
 
-modernnca_method_metadata = MethodMetadata(
+modernnca_method_metadata = MethodMetadata.config(
     method="ModernNCA",
-    method_type="config",
     display_name="ModernNCA (CPU)",
     compute="cpu",
     date="2025-06-12",
@@ -29,9 +28,8 @@ modernnca_method_metadata = MethodMetadata(
 )
 
 
-modernnca_gpu_method_metadata = MethodMetadata(
+modernnca_gpu_method_metadata = MethodMetadata.config(
     method="ModernNCA_GPU",
-    method_type="config",
     display_name="ModernNCA",
     compute="gpu",
     date="2025-06-12",

--- a/packages/tabarena/src/tabarena/models/nn_torch/info.py
+++ b/packages/tabarena/src/tabarena/models/nn_torch/info.py
@@ -6,9 +6,8 @@ from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._model_info import ModelInfo
 from tabarena.models.nn_torch.hpo import gen_nn_torch
 
-nn_torch_method_metadata = MethodMetadata(
+nn_torch_method_metadata = MethodMetadata.config(
     method="NeuralNetTorch",
-    method_type="config",
     display_name="TorchMLP",
     compute="cpu",
     date="2025-06-12",

--- a/packages/tabarena/src/tabarena/models/nori/info.py
+++ b/packages/tabarena/src/tabarena/models/nori/info.py
@@ -5,10 +5,9 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.nori.hpo import gen_nori
 from tabarena.models.nori.model import NoriModel
 
-nori_method_metadata = MethodMetadata(
+nori_method_metadata = MethodMetadata.config(
     method="Nori",
     display_name="Nori",
-    method_type="config",
     compute="gpu",
     date="2026-06-18",
     ag_key="TA-NORI",

--- a/packages/tabarena/src/tabarena/models/orionmsp/info.py
+++ b/packages/tabarena/src/tabarena/models/orionmsp/info.py
@@ -5,11 +5,10 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.orionmsp.hpo import gen_orionmsp
 from tabarena.models.orionmsp.model import OrionMSPModel, prefetch_weights
 
-orionmsp_method_metadata = MethodMetadata(
+orionmsp_method_metadata = MethodMetadata.config(
     method="OrionMSP",
     artifact_name="tabarena-2026-05-13",
     display_name="OrionMSP",
-    method_type="config",
     compute="gpu",
     date="2026-05-13",
     ag_key="TA-ORION-MSP",

--- a/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
+++ b/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
@@ -7,9 +7,8 @@ from tabarena.models.perpetual_booster.model import (
     PerpetualBoosterModel,
 )
 
-perpetual_booster_method_metadata = MethodMetadata(
+perpetual_booster_method_metadata = MethodMetadata.config(
     method="PerpetualBooster",
-    method_type="config",
     display_name="PerpetualBooster",
     compute="cpu",
     date="2026-03-06",

--- a/packages/tabarena/src/tabarena/models/random_forest/info.py
+++ b/packages/tabarena/src/tabarena/models/random_forest/info.py
@@ -15,7 +15,6 @@ random_forest_descriptor = ModelDescriptor(
 
 random_forest_method_metadata = random_forest_descriptor.method_metadata(
     method="RandomForest",
-    method_type="config",
     date="2025-06-12",
     ag_key="RF",
     config_default="RandomForest_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/realmlp/info.py
+++ b/packages/tabarena/src/tabarena/models/realmlp/info.py
@@ -14,7 +14,6 @@ realmlp_descriptor = ModelDescriptor(
 
 realmlp_method_metadata = realmlp_descriptor.method_metadata(
     method="RealMLP_GPU",
-    method_type="config",
     date="2025-09-03",
     ag_key="TA-REALMLP",
     model_key="REALMLP_GPU",
@@ -36,7 +35,6 @@ realmlp_method_metadata = realmlp_descriptor.method_metadata(
 # CPU variant — same model class, same search space, different compute target.
 realmlp_cpu_method_metadata = realmlp_descriptor.method_metadata(
     method="RealMLP",
-    method_type="config",
     display_name="RealMLP (CPU)",
     compute="cpu",
     date="2025-06-12",

--- a/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
+++ b/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
@@ -5,9 +5,8 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.sap_rpt_oss.hpo import gen_sap_rpt_oss
 from tabarena.models.sap_rpt_oss.model import SAPRPTOSSModel, prefetch_weights
 
-sap_rpt_oss_method_metadata = MethodMetadata(
+sap_rpt_oss_method_metadata = MethodMetadata.config(
     method="SAP-RPT-OSS",
-    method_type="config",
     display_name="SAP-RPT-OSS",
     compute="gpu",
     date="2025-11-25",

--- a/packages/tabarena/src/tabarena/models/tabdpt/info.py
+++ b/packages/tabarena/src/tabarena/models/tabdpt/info.py
@@ -14,7 +14,6 @@ tabdpt_descriptor = ModelDescriptor(
 
 tabdpt_method_metadata = tabdpt_descriptor.method_metadata(
     method="TabDPT_GPU",
-    method_type="config",
     date="2025-10-20",
     ag_key="TABDPT",
     model_key="TABDPT_GPU",

--- a/packages/tabarena/src/tabarena/models/tabicl/info.py
+++ b/packages/tabarena/src/tabarena/models/tabicl/info.py
@@ -24,7 +24,6 @@ tabiclv2_descriptor = ModelDescriptor(
 
 tabicl_method_metadata = tabicl_descriptor.method_metadata(
     method="TabICL_GPU",
-    method_type="config",
     date="2025-06-12",
     ag_key="TABICL",
     model_key="TABICL",
@@ -45,7 +44,6 @@ tabicl_method_metadata = tabicl_descriptor.method_metadata(
 
 tabiclv2_method_metadata = tabiclv2_descriptor.method_metadata(
     method="TabICLv2",
-    method_type="config",
     date="2026-02-16",
     ag_key="TABICLV2",
     model_key="TABICLV2",

--- a/packages/tabarena/src/tabarena/models/tabm/info.py
+++ b/packages/tabarena/src/tabarena/models/tabm/info.py
@@ -17,7 +17,6 @@ tabm_method_metadata = tabm_descriptor.method_metadata(
     method="TabM",
     display_name="TabM (CPU)",
     compute="cpu",
-    method_type="config",
     date="2025-06-12",
     ag_key="TABM",
     config_default="TabM_c1_BAG_L1",
@@ -37,7 +36,6 @@ tabm_method_metadata = tabm_descriptor.method_metadata(
 
 tabm_gpu_method_metadata = tabm_descriptor.method_metadata(
     method="TabM_GPU",
-    method_type="config",
     date="2025-06-12",
     ag_key="TABM",
     model_key="TABM",

--- a/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
@@ -14,7 +14,6 @@ tabpfn_3_descriptor = ModelDescriptor(
 
 tabpfn_3_method_metadata = tabpfn_3_descriptor.method_metadata(
     method="TabPFN-3",
-    method_type="config",
     ag_key="TA-TABPFN-3",
     config_default="TabPFN-3_c1_BAG_L1",
     can_hpo=False,

--- a/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
@@ -25,7 +25,6 @@ tabpfnv26_descriptor = ModelDescriptor(
 
 realtabpfnv25_method_metadata = realtabpfnv25_descriptor.method_metadata(
     method="RealTabPFN-v2.5",
-    method_type="config",
     date="2025-11-12",
     ag_key="REALTABPFN-V2.5",
     model_key="REALTABPFN-V2.5",
@@ -46,7 +45,6 @@ realtabpfnv25_method_metadata = realtabpfnv25_descriptor.method_metadata(
 
 tabpfnv26_method_metadata = tabpfnv26_descriptor.method_metadata(
     method="TabPFN-v2.6",
-    method_type="config",
     date="2026-03-25",
     ag_key="TABPFN-V2.6",
     model_key="TABPFN-V2.6",

--- a/packages/tabarena/src/tabarena/models/tabpfnwide/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnwide/info.py
@@ -5,9 +5,8 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.tabpfnwide.hpo import gen_tabpfnwide
 from tabarena.models.tabpfnwide.model import TabPFNWideModel
 
-tabpfnwide_method_metadata = MethodMetadata(
+tabpfnwide_method_metadata = MethodMetadata.config(
     method="TabPFN-Wide",
-    method_type="config",
     display_name="TabPFN-Wide",
     compute="gpu",
     date="2026-05-13",

--- a/packages/tabarena/src/tabarena/models/tabstar/info.py
+++ b/packages/tabarena/src/tabarena/models/tabstar/info.py
@@ -5,9 +5,8 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.tabstar.hpo import gen_tabstar
 from tabarena.models.tabstar.model import TabSTARModel, prefetch_weights
 
-tabstar_method_metadata = MethodMetadata(
+tabstar_method_metadata = MethodMetadata.config(
     method="TabSTAR",
-    method_type="config",
     display_name="TabSTAR",
     compute="gpu",
     date="2026-03-02",

--- a/packages/tabarena/src/tabarena/models/xgboost/info.py
+++ b/packages/tabarena/src/tabarena/models/xgboost/info.py
@@ -15,7 +15,6 @@ xgboost_descriptor = ModelDescriptor(
 
 xgboost_method_metadata = xgboost_descriptor.method_metadata(
     method="XGBoost",
-    method_type="config",
     date="2025-06-12",
     ag_key="XGB",
     config_default="XGBoost_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/xrfm/info.py
+++ b/packages/tabarena/src/tabarena/models/xrfm/info.py
@@ -5,9 +5,8 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.xrfm.hpo import gen_xrfm
 from tabarena.models.xrfm.model import XRFMModel
 
-xrfm_method_metadata = MethodMetadata(
+xrfm_method_metadata = MethodMetadata.config(
     method="xRFM_GPU",
-    method_type="config",
     display_name="xRFM",
     compute="gpu",
     date="2025-09-03",


### PR DESCRIPTION
## Summary

Makes `MethodMetadata` construction type-aware so a caller is never presented with arguments that belong to a different `method_type`, and routes the existing construction paths through the new constructors.

### Schema (`_method_metadata.py`)
- **`method_type` is now a `Literal`** — added `MethodTypeLiteral = Literal["config", "baseline", "portfolio"]` (mirrors the `MethodType` enum, kept honest by the existing `MethodType.values()` check) and annotated the field with it (consistent with `compute`/`cache_type`).
- **Type-specific factory classmethods** `config()` / `baseline()` / `portfolio()` — each exposes only the arguments relevant to its `method_type` and sets `method_type` itself; shared fields (identity, `compute`, `has_*`, storage, informative) flow via `**kwargs`. `config()` exposes the config-only fields `ag_key`/`model_key`/`config_default`/`name_suffix`/`can_hpo`/`is_bag`.
- **Validation guards in `__post_init__`** — for non-`config` methods, setting `ag_key`/`model_key`/`config_default`/`name_suffix` (non-None) or `can_hpo=True`/`is_bag=True` now raises with a clear message (previously only `name`-on-config was guarded). Surfaces mismatched arguments at construction instead of silently ignoring them.
- Documented `is_bag` (bagged CV: raw data holds per-fold test+val predictions, reported test preds are the per-fold average; config-only by convention).

### Routing existing construction through the factories
- `_from_raw_config` / `_from_raw_baseline` build via `cls.config()` / `cls.baseline()`.
- `ModelDescriptor.method_metadata` routes through `MethodMetadata.config()` (a descriptor always describes a config method; an explicit `method_type="config"` is accepted-and-dropped, any other type rejected) — so all 12 descriptor-based model `info.py` files construct via `config()` transparently.
- Model `info.py`: the 16 direct constructors now use `MethodMetadata.config(...)`; all 28 drop the now-redundant `method_type="config"` line.

### Left as-is on purpose
- The `tabarena_public(...)` artifact/baseline/portfolio sites — `tabarena_public` is the orthogonal public-store *storage* preset; converting them to the bare factories would drop storage and *add* boilerplate. The new guards still validate these paths.
- `from_s3_cache`'s load-time construction.

## Testing
- ruff clean on all changed files (the 3 pre-existing errors are in unrelated `*/model.py`, not touched here).
- The entire registry constructs under the new guards: 28 model `info.py` modules + the artifact aggregator + Beyond-IID + baselines all import; descriptor-built and direct-`.config()` configs verified equivalent.
- `test_in_memory_method_metadata` + `test_registry` + `test_end_to_end_single` = **67 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)