### PR TITLE
Fix pre-existing ruff lint/format errors

### DIFF
--- a/packages/tabarena/src/tabarena/models/realmlp/model.py
+++ b/packages/tabarena/src/tabarena/models/realmlp/model.py
@@ -137,7 +137,7 @@ class RealMLPModel(AbstractTorchModel):
             "mean_average_error": "mae",
         }
 
-        val_metric_name = metric_map.get(self.stopping_metric.name, None)
+        val_metric_name = metric_map.get(self.stopping_metric.name)
 
         init_kwargs = {}
 

--- a/packages/tabarena/src/tabarena/models/tabpfnv2_5/model.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnv2_5/model.py
@@ -230,7 +230,7 @@ class TabPFNModel(AbstractTorchModel):
                 "log_loss": "log_loss",
                 "rmse": "mse",
             }
-            eval_metric = metric_map.get(self.stopping_metric.name, None)
+            eval_metric = metric_map.get(self.stopping_metric.name)
             model_base = FinetunedTabPFNClassifier if is_classification else FinetunedTabPFNRegressor
             # Large default number to avoid stopping on it.
             epochs = finetuning_config.pop("epochs", 10_000)

--- a/packages/tabarena/src/tabarena/models/xrfm/model.py
+++ b/packages/tabarena/src/tabarena/models/xrfm/model.py
@@ -228,7 +228,7 @@ class XRFMModel(AbstractModel):
             "mean_average_error": "mae",
         }
 
-        tuning_metric = metric_map.get(self.stopping_metric.name, None)
+        tuning_metric = metric_map.get(self.stopping_metric.name)
 
         init_kwargs = copy.copy(hyp)
 

--- a/packages/tabarena/src/tabarena/simulation/ensemble_scorer_val_subsample.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble_scorer_val_subsample.py
@@ -69,9 +69,7 @@ class EnsembleScorerValSubsample(EnsembleScorerMaxModels):
 
     def _task_seed(self, dataset: str, fold: int) -> int:
         """Deterministic per-task seed (stable across processes, unlike ``hash()``)."""
-        digest = hashlib.md5(
-            f"{dataset}|{fold}|{self.val_subsample_seed}".encode(), usedforsecurity=False
-        ).hexdigest()
+        digest = hashlib.md5(f"{dataset}|{fold}|{self.val_subsample_seed}".encode(), usedforsecurity=False).hexdigest()
         return int(digest[:8], 16)
 
     def _class_counts(self, y_val: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -157,8 +155,6 @@ class EnsembleScorerValSubsample(EnsembleScorerMaxModels):
                 f"pred_val row axis ({pred_val.shape[1]}) does not match y_val length "
                 f"({len(y_val)}) for ({dataset}, fold {fold}).",
             )
-        idx = self._select_indices(
-            y_val=y_val, problem_type=problem_type, seed=self._task_seed(dataset, fold)
-        )
+        idx = self._select_indices(y_val=y_val, problem_type=problem_type, seed=self._task_seed(dataset, fold))
         # pred_val is (n_models, n_rows) or (n_models, n_rows, n_classes); subsample the row axis.
         return y_val[idx], pred_val[:, idx]


### PR DESCRIPTION
## Summary

Clears the ruff errors currently on `main` (unrelated to any feature work):

- **SIM910** — drop the redundant `, None` from `metric_map.get(self.stopping_metric.name, None)` in `realmlp/model.py`, `tabpfnv2_5/model.py`, and `xrfm/model.py`. `dict.get` already defaults to `None`, so this is behavior-identical.
- **format** — `ruff format` on `simulation/ensemble_scorer_val_subsample.py` (collapses two call expressions that now fit under the line-length limit).

No behavior change.

## Testing
- `ruff check` and `ruff format --check` pass on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)