### PR TITLE
Remove unused remote_cache_root from MethodDownloader/MethodUploader

### DIFF
--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
@@ -44,15 +44,6 @@ class MethodDownloader(ABC):
         self.clear_dirs = clear_dirs
 
     # -- remote location ----------------------------------------------------------------------
-    @property
-    def remote_cache_root(self) -> str:
-        """The cache root as a human-readable ``s3://bucket/prefix`` URI (for logging/display).
-
-        The ``s3://`` scheme is just a label — correct for any S3-compatible backend (e.g.
-        Cloudflare R2) — and is not used to derive object keys (see :meth:`local_to_key`).
-        """
-        return f"s3://{self.bucket}/{self.prefix}"
-
     def local_to_key(self, path_local: str | Path) -> str:
         """Remote object key for a local cache path: ``prefix`` joined with the path's location
         relative to the cache root.

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
@@ -52,15 +52,6 @@ class MethodUploader(ABC):
         return self._client
 
     # -- remote location ----------------------------------------------------------------------
-    @property
-    def remote_cache_root(self) -> str:
-        """The cache root as a human-readable ``s3://bucket/prefix`` URI (for logging/display).
-
-        The ``s3://`` scheme is just a label — correct for any S3-compatible backend (e.g.
-        Cloudflare R2) — and is not used to derive object keys (see :meth:`local_to_key`).
-        """
-        return f"s3://{self.bucket}/{self.prefix}"
-
     def local_to_key(self, path_local: str | Path) -> str:
         """Remote object key for a local cache path: ``prefix`` joined with the path's location
         relative to the cache root.

--- a/scripts/run_upload_results.py
+++ b/scripts/run_upload_results.py
@@ -153,7 +153,7 @@ def upload_method(
     uploader = method_metadata.method_uploader()
     print(
         f"Uploading '{method_metadata.method}' (artifact={method_metadata.artifact_name}) "
-        f"to {uploader.remote_cache_root} | cache_type={method_metadata.cache_type} | parts={parts}"
+        f"to s3://{uploader.bucket}/{uploader.prefix} | cache_type={method_metadata.cache_type} | parts={parts}"
     )
     uploader.upload_metadata()
     uploader.upload_results()


### PR DESCRIPTION
## Summary

`remote_cache_root` (a human-readable `s3://bucket/prefix` display URI) on the artifact-IO base classes is dead on `MethodDownloader` and was only consumed by one `run_upload_results.py` log line on `MethodUploader`. Remove it from both `MethodDownloader` and `MethodUploader`, and inline that log line's destination as `f"s3://{uploader.bucket}/{uploader.prefix}"` (the uploader still exposes `bucket`/`prefix`).

## Testing
- No `remote_cache_root` references remain anywhere.
- ruff check + format clean; the up/download factories still build (`bucket`/`prefix` intact, s3 ACL still applied); registry constructs; `test_registry` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)