### PR TITLE
Make r2 base_url a cache_kwargs option (default unchanged)

### DIFF
--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -116,8 +116,10 @@ class MethodMetadata:
     #: their own keys without new fields. For ``"s3"``/``"r2"`` it carries the remote location
     #: ``{"bucket": ..., "prefix": ...}`` (the s3-compatible coordinates used by both, formerly the
     #: top-level ``s3_bucket`` / ``s3_prefix`` fields); ``"s3"`` may additionally set
-    #: ``{"upload_as_public": True}`` for a public-read ACL. The uploader/downloader factories read
-    #: what they need from here. Empty for ``"local"``.
+    #: ``{"upload_as_public": True}`` for a public-read ACL, and ``"r2"`` may set
+    #: ``{"base_url": ...}`` to override the public download domain (default
+    #: ``"https://data.tabarena.ai/"``). The uploader/downloader factories read what they need from
+    #: here. Empty for ``"local"``.
     cache_kwargs: dict = field(default_factory=dict)
     #: Optional override pointing at a self-contained, *flat* method directory
     #: (``<cache_root>/<method>/`` holding ``metadata.yaml`` + ``results/``), used to load a
@@ -603,7 +605,7 @@ class MethodMetadata:
 
             return MethodDownloaderPublicR2(
                 method_metadata=self,
-                base_url="https://data.tabarena.ai/",
+                base_url=self.cache_kwargs.get("base_url", "https://data.tabarena.ai/"),
                 r2_prefix=prefix,
                 verbose=verbose,
                 clear_dirs=False,


### PR DESCRIPTION
## Summary

`method_downloader` hard-coded the public Cloudflare R2 download domain (`"https://data.tabarena.ai/"`) for the r2 backend. Read it from `cache_kwargs["base_url"]` instead, defaulting to the same value so existing behavior is unchanged. This lets advanced users point r2 downloads at a different custom domain via `cache_kwargs`, consistent with how the other backend-specific knobs (`bucket`/`prefix`, s3's `upload_as_public`) already live there.

- `MethodMetadata.method_downloader` (r2 branch): `base_url=self.cache_kwargs.get("base_url", "https://data.tabarena.ai/")`.
- Documented the optional r2 `base_url` key on the `cache_kwargs` field.

## Testing
- ruff clean.
- Default preserved (r2 method with no `base_url` → `"https://data.tabarena.ai/"`); override via `cache_kwargs={"base_url": ...}` works and the method still infers `cache_type="r2"`.
- Beyond-IID (r2) methods construct; `test_registry` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)