### PR TITLE
Default verified to True; drop redundant verified=True and name_suffix=None

### DIFF
--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -144,8 +144,10 @@ class MethodMetadata:
     date: str | None = None
     reference_url: str | None = None
     display_name: str | None = None
-    #: A manual trust flag; not (yet) read anywhere in code.
-    verified: bool = False
+    #: Whether this method's results are verified / signed-off. Default ``True``; set ``False`` for
+    #: methods that are not yet verified (e.g. newly-added or not-yet-released models). A manual
+    #: trust flag, not (yet) read anywhere in code.
+    verified: bool = True
 
     def __post_init__(self):
         if self.artifact_name is None:

--- a/packages/tabarena/src/tabarena/models/catboost/info.py
+++ b/packages/tabarena/src/tabarena/models/catboost/info.py
@@ -22,9 +22,7 @@ catboost_method_metadata = catboost_descriptor.method_metadata(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     # FIXME: technically GBDTs are not verified
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/ebm/info.py
+++ b/packages/tabarena/src/tabarena/models/ebm/info.py
@@ -15,12 +15,10 @@ ebm_method_metadata = MethodMetadata.config(
     config_default="ExplainableBM_c1_BAG_L1",
     can_hpo=True,
     is_bag=True,
-    verified=True,
     reference_url="https://www.cs.cornell.edu/~yinlou/papers/lou-kdd13.pdf",
     artifact_name="tabarena-2025-09-03",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/extra_trees/info.py
+++ b/packages/tabarena/src/tabarena/models/extra_trees/info.py
@@ -22,9 +22,7 @@ extra_trees_method_metadata = extra_trees_descriptor.method_metadata(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     # FIXME: technically baselines are not verified
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/fastai/info.py
+++ b/packages/tabarena/src/tabarena/models/fastai/info.py
@@ -18,8 +18,6 @@ fastai_method_metadata = MethodMetadata.config(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
-    verified=True,
     reference_url="https://arxiv.org/abs/2003.06505",
 )
 

--- a/packages/tabarena/src/tabarena/models/iltm/info.py
+++ b/packages/tabarena/src/tabarena/models/iltm/info.py
@@ -15,7 +15,6 @@ iltm_method_metadata = MethodMetadata.config(
     config_default="iLTM_c1_BAG_L1",
     can_hpo=True,
     is_bag=True,
-    verified=True,
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
     cache_type="r2",
     reference_url="https://arxiv.org/abs/2511.15941",

--- a/packages/tabarena/src/tabarena/models/knn/info.py
+++ b/packages/tabarena/src/tabarena/models/knn/info.py
@@ -18,9 +18,7 @@ knn_method_metadata = MethodMetadata.config(
     artifact_name="tabarena-2025-10-20",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     # FIXME: technically kNN is not verified
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/lightgbm/info.py
+++ b/packages/tabarena/src/tabarena/models/lightgbm/info.py
@@ -22,9 +22,7 @@ lightgbm_method_metadata = lightgbm_descriptor.method_metadata(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     # FIXME: technically GBDTs are not verified
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/lr/info.py
+++ b/packages/tabarena/src/tabarena/models/lr/info.py
@@ -22,9 +22,7 @@ lr_method_metadata = lr_descriptor.method_metadata(
     artifact_name="tabarena-2025-10-20",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     # FIXME: technically LR is not verified
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/mitra/info.py
+++ b/packages/tabarena/src/tabarena/models/mitra/info.py
@@ -29,12 +29,10 @@ mitra_method_metadata = MethodMetadata.config(
     config_default="Mitra_GPU_c1_BAG_L1",
     can_hpo=False,
     is_bag=True,
-    verified=True,
     reference_url="https://arxiv.org/abs/2510.21204",
     artifact_name="tabarena-2025-09-03",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/modernnca/info.py
+++ b/packages/tabarena/src/tabarena/models/modernnca/info.py
@@ -17,8 +17,6 @@ modernnca_method_metadata = MethodMetadata.config(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
-    verified=True,
     reference_url="https://arxiv.org/abs/2407.03257",
 )
 
@@ -36,7 +34,6 @@ modernnca_gpu_method_metadata = MethodMetadata.config(
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
     name_suffix="_GPU",
-    verified=True,
     reference_url="https://arxiv.org/abs/2407.03257",
 )
 

--- a/packages/tabarena/src/tabarena/models/nn_torch/info.py
+++ b/packages/tabarena/src/tabarena/models/nn_torch/info.py
@@ -18,8 +18,6 @@ nn_torch_method_metadata = MethodMetadata.config(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
-    verified=True,
     reference_url="https://arxiv.org/abs/2003.06505",
 )
 

--- a/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
+++ b/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
@@ -18,8 +18,6 @@ perpetual_booster_method_metadata = MethodMetadata.config(
     is_bag=True,
     artifact_name="tabarena-2026-03-18",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
-    name_suffix=None,
-    verified=True,
     reference_url="https://perpetual-ml.com/",
     cache_type="r2",
 )

--- a/packages/tabarena/src/tabarena/models/random_forest/info.py
+++ b/packages/tabarena/src/tabarena/models/random_forest/info.py
@@ -22,9 +22,7 @@ random_forest_method_metadata = random_forest_descriptor.method_metadata(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     # FIXME: technically baselines are not verified
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/realmlp/info.py
+++ b/packages/tabarena/src/tabarena/models/realmlp/info.py
@@ -19,11 +19,9 @@ realmlp_method_metadata = realmlp_descriptor.method_metadata(
     model_key="REALMLP_GPU",
     config_default="RealMLP_GPU_c1_BAG_L1",
     can_hpo=True,
-    verified=True,
     artifact_name="tabarena-2025-09-03",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
 )
 
 
@@ -36,11 +34,9 @@ realmlp_cpu_method_metadata = realmlp_descriptor.method_metadata(
     ag_key="REALMLP",
     config_default="RealMLP_c1_BAG_L1",
     can_hpo=True,
-    verified=True,
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
+++ b/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
@@ -17,7 +17,6 @@ sap_rpt_oss_method_metadata = MethodMetadata.config(
     artifact_name="tabarena-2025-11-25",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     verified=False,
     reference_url="https://arxiv.org/abs/2506.10707",
 )

--- a/packages/tabarena/src/tabarena/models/tabdpt/info.py
+++ b/packages/tabarena/src/tabarena/models/tabdpt/info.py
@@ -22,8 +22,6 @@ tabdpt_method_metadata = tabdpt_descriptor.method_metadata(
     artifact_name="tabarena-2025-10-20",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/tabicl/info.py
+++ b/packages/tabarena/src/tabarena/models/tabicl/info.py
@@ -32,7 +32,6 @@ tabicl_method_metadata = tabicl_descriptor.method_metadata(
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
     name_suffix="_GPU",
-    verified=True,
 )
 
 
@@ -45,8 +44,6 @@ tabiclv2_method_metadata = tabiclv2_descriptor.method_metadata(
     artifact_name="tabarena-2026-02-16",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/tabm/info.py
+++ b/packages/tabarena/src/tabarena/models/tabm/info.py
@@ -24,8 +24,6 @@ tabm_method_metadata = tabm_descriptor.method_metadata(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
-    verified=True,
 )
 
 
@@ -39,7 +37,6 @@ tabm_gpu_method_metadata = tabm_descriptor.method_metadata(
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
     name_suffix="_GPU",
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
@@ -21,7 +21,6 @@ tabpfn_3_method_metadata = tabpfn_3_descriptor.method_metadata(
     cache_type="r2",
     artifact_name="tabarena-2026-05-13",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
@@ -32,8 +32,6 @@ realtabpfnv25_method_metadata = realtabpfnv25_descriptor.method_metadata(
     artifact_name="tabarena-2025-11-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
-    verified=True,
 )
 
 
@@ -45,8 +43,6 @@ tabpfnv26_method_metadata = tabpfnv26_descriptor.method_metadata(
     can_hpo=False,
     artifact_name="tabarena-2026-03-18",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
-    name_suffix=None,
-    verified=True,
     cache_type="r2",
 )
 

--- a/packages/tabarena/src/tabarena/models/tabstar/info.py
+++ b/packages/tabarena/src/tabarena/models/tabstar/info.py
@@ -16,8 +16,6 @@ tabstar_method_metadata = MethodMetadata.config(
     is_bag=True,
     artifact_name="tabarena-2026-03-18",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
-    name_suffix=None,
-    verified=True,
     reference_url="https://arxiv.org/abs/2505.18125",
     cache_type="r2",
 )

--- a/packages/tabarena/src/tabarena/models/xgboost/info.py
+++ b/packages/tabarena/src/tabarena/models/xgboost/info.py
@@ -22,9 +22,7 @@ xgboost_method_metadata = xgboost_descriptor.method_metadata(
     artifact_name="tabarena-2025-06-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
     # FIXME: technically GBDTs are not verified
-    verified=True,
 )
 
 

--- a/packages/tabarena/src/tabarena/models/xrfm/info.py
+++ b/packages/tabarena/src/tabarena/models/xrfm/info.py
@@ -15,12 +15,10 @@ xrfm_method_metadata = MethodMetadata.config(
     config_default="xRFM_GPU_c1_BAG_L1",
     can_hpo=True,
     is_bag=True,
-    verified=True,
     reference_url="https://arxiv.org/abs/2508.10053",
     artifact_name="tabarena-2025-09-03",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
-    name_suffix=None,
 )
 
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_beyond_method_metadata.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_beyond_method_metadata.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
 _common_kwargs = dict(
     method_type="config",
     artifact_name="beyond_iid_benchmark_2026",
-    name_suffix=None,
     cache_type="r2",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
 )
@@ -46,7 +45,6 @@ _common_kwargs = dict(
 # they are intrinsic to the model and come from each entry's ModelDescriptor.
 _common_bag_kwargs = dict(
     can_hpo=True,
-    verified=True,
     **_common_kwargs,
 )
 
@@ -112,28 +110,24 @@ beyond_tabdpt_metadata = tabdpt_descriptor.method_metadata(
     method="TA-TabDPT",
     ag_key="TA-TABDPT",
     config_default="TA-TabDPT_c1_BAG_L1",
-    verified=True,
     **_common_fm_kwargs,
 )
 beyond_tabpfnv26_metadata = tabpfnv26_descriptor.method_metadata(
     method="TA-TabPFN-2.6",
     ag_key="TA-TABPFN-2.6",
     config_default="TA-TabPFN-2.6_c1_BAG_L1",
-    verified=True,
     **_common_fm_kwargs,
 )
 beyond_tabiclv2_metadata = tabiclv2_descriptor.method_metadata(
     method="TA-TabICLv2",
     ag_key="TA-TABICLv2",
     config_default="TA-TabICLv2_c1_BAG_L1",
-    verified=True,
     **_common_fm_kwargs,
 )
 beyond_tabpfn3_metadata = tabpfn_3_descriptor.method_metadata(
     method="TA-TabPFN-3",
     ag_key="TA-TABPFN-3",
     config_default="TA-TabPFN-3_c1_BAG_L1",
-    verified=True,
     **_common_fm_kwargs,
 )
 beyond_method_metadata_lst: list[MethodMetadata] = [

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_06_12.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_06_12.py
@@ -43,13 +43,10 @@ common_kwargs = dict(
     artifact_name="tabarena-2025-06-12",
     date="2025-06-12",
     method_type="config",
-    # FIXME: technically GBDTs and baselines are not verified
-    verified=True,
 )
 
 cpu_kwargs = dict(
     compute="cpu",
-    name_suffix=None,
     **common_kwargs,
 )
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_09_03.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_09_03.py
@@ -14,7 +14,6 @@ from tabarena.models._method_metadata import MethodMetadata
 
 _common_kwargs = dict(
     artifact_name="tabarena-2025-09-03",
-    name_suffix=None,
 )
 
 # New methods (tabarena-2025-09-03)
@@ -24,7 +23,6 @@ ag_140_metadata = MethodMetadata.tabarena_legacy_s3(
     display_name="AutoGluon 1.4 (4h)",
     compute="gpu",
     date="2025-09-03",
-    verified=True,
     reference_url="https://arxiv.org/abs/2003.06505",
     **_common_kwargs,
 )

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_10_20.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_10_20.py
@@ -4,9 +4,6 @@ from tabarena.models._method_metadata import MethodMetadata
 
 _common_kwargs = dict(
     artifact_name="tabarena-2025-10-20",
-    name_suffix=None,
-    # FIXME: technically LR and kNN are not verified
-    verified=True,
 )
 
 portfolio_metadata_paper_cr = MethodMetadata.tabarena_legacy_s3(

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_11_01.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_11_01.py
@@ -5,9 +5,7 @@ from tabarena.models._method_metadata import MethodMetadata
 _common_kwargs = dict(
     artifact_name="tabarena-2025-11-01",
     method_type="baseline",
-    name_suffix=None,
     date="2025-11-01",
-    verified=True,
     reference_url="https://arxiv.org/abs/2003.06505",
 )
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_12_18.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_12_18.py
@@ -5,9 +5,7 @@ from tabarena.models._method_metadata import MethodMetadata
 _common_kwargs = dict(
     artifact_name="tabarena-2025-12-18",
     method_type="baseline",
-    name_suffix=None,
     date="2025-12-18",
-    verified=True,
     reference_url="https://arxiv.org/abs/2003.06505",
 )
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2026_01_23_tabprep.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2026_01_23_tabprep.py
@@ -23,10 +23,8 @@ tabprep_gbm_metadata = MethodMetadata.tabarena_legacy_s3(
     ag_key="PREP_GBM",
     # config_default="PrepLightGBM_c1_BAG_L1",  # FIXME
     config_default="prep_LightGBM_icml_v3_c1_BAG_L1",
-    name_suffix=None,
     can_hpo=True,
     is_bag=True,
-    verified=True,
 )
 
 tabprep_lr_metadata = MethodMetadata.tabarena_legacy_s3(
@@ -39,10 +37,8 @@ tabprep_lr_metadata = MethodMetadata.tabarena_legacy_s3(
     ag_key="PREP_LR",
     # config_default="PrepLinearModel_c1_BAG_L1",  # FIXME
     config_default="prep_LinearModel_icml_v3_c1_BAG_L1",
-    name_suffix=None,
     can_hpo=True,
     is_bag=True,
-    verified=True,
 )
 
 
@@ -55,10 +51,8 @@ tabprep_tabm_metadata = MethodMetadata.tabarena_legacy_s3(
     date="2026-01-23",
     ag_key="PREP_TABM",
     config_default="prep_TabM_c1_BAG_L1",  # FIXME
-    name_suffix=None,
     can_hpo=True,
     is_bag=True,
-    verified=True,
 )
 
 
@@ -71,8 +65,6 @@ tabprep_realtabpfnv250_metadata = MethodMetadata.tabarena_legacy_s3(
     date="2026-01-23",
     ag_key="PREP_REALTABPFN-V2.5",
     config_default="prep_RealTabPFN-v2.5_c1_BAG_L1",  # FIXME
-    name_suffix=None,
     can_hpo=True,
     is_bag=False,
-    verified=True,
 )

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_misc.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_misc.py
@@ -13,7 +13,6 @@ gbm_aio_0808_metadata = MethodMetadata.tabarena_legacy_s3(
     ag_key="GBM",
     model_key="GBM_aio_0808",
     config_default="LightGBM_aio_0808_c1_BAG_L1",
-    name_suffix=None,
     can_hpo=True,
     is_bag=True,
     prefix="cache_aio",
@@ -31,9 +30,7 @@ prep_gbm_v6_metadata = MethodMetadata.tabarena_legacy_s3(
     ag_key="prep_GBM",
     model_key="prep_GBM_v6",
     config_default="prep_LightGBM_v6_c1_BAG_L1",
-    name_suffix=None,
     can_hpo=True,
     is_bag=True,
     prefix="cache_aio",
-    verified=True,
 )


### PR DESCRIPTION
## Summary

`verified` is a descriptive trust flag and the common case is verified, so flip its default to `True` and keep only the unverified methods explicit. Also drop the redundant `name_suffix=None` settings (it already defaults to `None`).

- **`verified` default → `True`** (doc comment updated).
- Removed **42** redundant `verified=True` and **35** redundant `name_suffix=None` settings across model `info.py` and the artifact files; removed two now-orphaned `# FIXME … not verified` comments left above the removed `verified=True` lines.
- **`AutoGluon_v130` and `Portfolio-N200-4h`** omitted `verified` (were `False` by default); they now pick up the `True` default, as you requested.

## Highlighted: methods that were `False`
- **Explicitly `False`** (kept): `BetaTabPFN_GPU`, `ChimeraBoost`, `LightGBM_aio_0808`, `LimiX`, `Nori`, `OrionMSP`, `SAP-RPT-OSS`, `TabFlex_GPU`, `TabPFN-Wide`.
- **`False` only via the default** (omitted the field): `AutoGluon_v130`, `Portfolio-N200-4h` → now `True`.

## Testing
- Snapshotted every method's `verified` before/after: only `AutoGluon_v130` + `Portfolio-N200-4h` changed (`False` → `True`); all others identical.
- All `name_suffix` values preserved (the `_GPU` variants intact; only redundant `None`s removed).
- ruff check + format clean; `test_registry` + `test_in_memory_method_metadata` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)