### PR TITLE
Rename MethodMetadata.artifact_name -> suite

### DIFF
--- a/.claude/skills/add-model/references/model_patterns.md
+++ b/.claude/skills/add-model/references/model_patterns.md
@@ -405,7 +405,7 @@ from tabarena.models.{ModelKey}.model import {ClassName}Model
     has_raw=True,
     has_processed=True,
     has_results=True,
-    artifact_name="tabarena-YYYY-MM-DD",
+    suite="tabarena-YYYY-MM-DD",
     # Storage backend is inferred from the cache location in cache_kwargs: once results are hosted
     # in the official pool, set cache_kwargs={"bucket": ..., "prefix": ...} and cache_type infers
     # "r2" (the default public backend). Omit cache_kwargs until hosted -> cache_type infers

--- a/examples/!experimental/run_scratch_add_calibration_logic.py
+++ b/examples/!experimental/run_scratch_add_calibration_logic.py
@@ -184,7 +184,7 @@ def simulate_calibration(method_metadata, run_toy: bool = False, problem_types: 
 
     ta_context = TabArenaContext()
     leaderboard = ta_context.compare(
-        output_dir=Path("output_test_calibration") / method_metadata.artifact_name / method_metadata.method,
+        output_dir=Path("output_test_calibration") / method_metadata.suite / method_metadata.method,
         new_results=new_results,
         only_valid_tasks=True,
         average_seeds=False,
@@ -229,7 +229,7 @@ if __name__ == "__main__":
     new_results_lst = []
     for i, metadata in enumerate(metadata_lst):
         print(f"({i+1}/{num_methods}) Running calibration for {metadata.method}")
-        cache_dir = Path(out_dir) / f"{metadata.artifact_name}" / f"{metadata.method}.csv"
+        cache_dir = Path(out_dir) / f"{metadata.suite}" / f"{metadata.method}.csv"
         if not cache_overwrite and cache_dir.exists():
             cur_new_results = TabularDataset.load(path=cache_dir)
         else:

--- a/examples/!old/run_download_url_and_cache_to_s3_2025_09_03.py
+++ b/examples/!old/run_download_url_and_cache_to_s3_2025_09_03.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 import pandas as pd
+
 from tabarena.models.iltm.info import iltm_method_metadata
 from tabarena.models.limix.info import limix_method_metadata as limix_metadata_new
 from tabarena.models.orionmsp.info import orionmsp_method_metadata as orionmsp_metadata
@@ -52,7 +53,7 @@ def _compare_with_provided_metadata(
 
     rows: list[tuple[str, object, object]] = [
         ("method", method_info.name, m.method),
-        ("artifact_name", method_info.artifact_name, m.artifact_name),
+        ("suite", method_info.suite, m.suite),
         ("method_type", inferred_method_type, m.method_type),
         ("compute", inferred_compute, m.compute),
         ("ag_key", inferred_ag_key, m.ag_key),
@@ -122,7 +123,7 @@ def _print_method_metadata_snippet(
     """Print a copy-pasteable `MethodMetadata(...)` snippet from raw-inferred values."""
     snippet_fields: list[tuple[str, object]] = [
         ("method", method_info.name),
-        ("artifact_name", method_info.artifact_name),
+        ("suite", method_info.suite),
         ("method_type", method_types[0] if len(method_types) == 1 else None),
         ("compute", inferred_compute),
         ("ag_key", ag_keys[0] if len(ag_keys) == 1 else None),
@@ -282,78 +283,78 @@ if __name__ == "__main__":
     )
 
     # 31 GB
-    # Uploaded to s3, artifact_name="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
     xrfm_info = MethodArtifactManager(
         path_suffix=Path("leaderboard_submissions") / "data_xRFM_11092025.zip",
         name="xRFM_GPU",
-        artifact_name="tabarena-2025-09-03",
+        suite="tabarena-2025-09-03",
         model_key="XRFM_GPU",
         **shared_args,
     )
 
     # 33 MB
-    # Uploaded to s3, artifact_name="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
     mitra_info = MethodArtifactManager(
         path_suffix=Path("leaderboard_submissions") / "data_Mitra_14082025.zip",
         name="Mitra_GPU",
-        artifact_name="tabarena-2025-09-03",
+        suite="tabarena-2025-09-03",
         model_key="MITRA_GPU",
         **shared_args,
     )
 
     # 37 GB
-    # Uploaded to s3, artifact_name="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
     ebm_info = MethodArtifactManager(
         path_suffix=Path("leaderboard_submissions") / "data_EBM_12082025.zip",
         name="ExplainableBM",
-        artifact_name="tabarena-2025-09-03",
+        suite="tabarena-2025-09-03",
         model_key="EBM",
         **shared_args,
     )
 
     # 37 GB
-    # Uploaded to s3, artifact_name="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
     realmlp_info = MethodArtifactManager(
         path_suffix=Path("leaderboard_submissions") / "data_RealMLP_20082025.zip",
         name="RealMLP_GPU",
-        artifact_name="tabarena-2025-09-03",
+        suite="tabarena-2025-09-03",
         model_key="REALMLP_GPU",
         **shared_args,
     )
 
     # 74 MB
-    # Uploaded to s3, artifact_name="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
     tabflex_info = MethodArtifactManager(
         path_suffix=Path("data_TabFlex.zip"),
         name="TabFlex_GPU",
-        artifact_name="tabarena-2025-09-03",
+        suite="tabarena-2025-09-03",
         model_key="TABFLEX_GPU",
         **shared_args,
     )
 
     # 71 MB
-    # Uploaded to s3, artifact_name="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
     limix_info = MethodArtifactManager(
         path_suffix=Path("data_LimiX.zip"),
         name="LimiX_GPU",
-        artifact_name="tabarena-2025-09-03",
+        suite="tabarena-2025-09-03",
         model_key="LIMIX_GPU",
         **shared_args,
     )
 
     # 122 MB
-    # Uploaded to s3, artifact_name="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-09-03", s3_prefix="cache", upload_as_public=True
     betatabpfn_info = MethodArtifactManager(
         path_suffix=Path("data_BetaTabPFN.zip"),
         name="BetaTabPFN_GPU",
-        artifact_name="tabarena-2025-09-03",
+        suite="tabarena-2025-09-03",
         model_key="BETA_GPU",
         **shared_args,
     )
 
 
     # 17 GB
-    # Uploaded to s3, artifact_name="tabarena-2025-10-20", s3_prefix="cache", upload_as_public=True
+    # Uploaded to s3, suite="tabarena-2025-10-20", s3_prefix="cache", upload_as_public=True
     tabdpt_info = MethodArtifactManager.from_method_metadata(
         method_metadata=tabdpt_metadata,
         path_suffix=Path("leaderboard_submissions") / "data_TabDPT_28102025.zip",

--- a/packages/tabarena/src/tabarena/baselines/info.py
+++ b/packages/tabarena/src/tabarena/baselines/info.py
@@ -13,7 +13,7 @@ from tabarena.models._method_metadata import MethodMetadata
 ag_130_metadata = MethodMetadata.tabarena_legacy_s3(
     method="AutoGluon_v130",
     name="AutoGluon 1.3 (best, 4h)",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     date="2025-06-12",
     method_type="baseline",
     compute="cpu",
@@ -22,7 +22,7 @@ ag_130_metadata = MethodMetadata.tabarena_legacy_s3(
 
 portfolio_metadata = MethodMetadata.tabarena_legacy_s3(
     method="Portfolio-N200-4h",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     date="2025-06-12",
     method_type="portfolio",
     has_raw=False,

--- a/packages/tabarena/src/tabarena/evaluation/_eval_common.py
+++ b/packages/tabarena/src/tabarena/evaluation/_eval_common.py
@@ -32,14 +32,14 @@ class MethodArtifact:
 
     A flat, runner-agnostic spec: the v0.1 runner builds one per ``EvalMethod`` (all sharing the
     config's ``path_raw``/``benchmark_name``); the BeyondArena runner builds one per (run, model),
-    so a single method name can appear under multiple ``artifact_name``s.
+    so a single method name can appear under multiple ``suite``s.
     """
 
     ag_name: str
     """The model's AutoGluon name — both the raw-folder prefix and the cache method name."""
     path_raw: Path
     """Directory holding the raw ``results.pkl`` artifacts (the run's ``<output_dir>/data``)."""
-    artifact_name: str
+    suite: str
     """Cache artifact name (upper cache dir); distinct values disambiguate the same method
     across different runs."""
     result_suffix: str | None = None
@@ -103,7 +103,7 @@ def post_process_to_results(
 
     1. **Cache:** for each non-``only_load_cache`` method, ``EndToEndSingle.from_path_raw_to_results``
        processes the raw ``results.pkl`` files into per-task results and writes them to the cache
-       (keyed by ``(artifact_name, ag_name)``). ``task_metadata`` is a native
+       (keyed by ``(suite, ag_name)``). ``task_metadata`` is a native
        :class:`~tabarena.benchmark.task.metadata.TaskMetadataCollection`, forwarded so custom (e.g.
        BeyondArena) task sets match correctly; pass ``None`` to infer it from the results.
     2. **Load:** every method is (re-)loaded from the cache via ``EndToEndResults.from_cache`` — in
@@ -117,19 +117,19 @@ def post_process_to_results(
     for ma in method_artifacts:
         if ma.only_load_cache:
             continue
-        print(f"Post-processing raw results for ag_name={ma.ag_name} (artifact={ma.artifact_name})...")
+        print(f"Post-processing raw results for ag_name={ma.ag_name} (artifact={ma.suite})...")
         EndToEndSingle.from_path_raw_to_results(
             path_raw=ma.path_raw,
             name_prefix_raw=ma.ag_name,
             name_suffix=ma.result_suffix,
             method=ma.ag_name,
-            artifact_name=ma.artifact_name,
+            suite=ma.suite,
             task_metadata=task_metadata,
             num_cpus=num_cpus,
         )
 
-    # Phase 2: re-load every method from the cache (one (ag_name, artifact_name) per artifact).
-    return EndToEndResults.from_cache(methods=[(ma.ag_name, ma.artifact_name) for ma in method_artifacts])
+    # Phase 2: re-load every method from the cache (one (ag_name, suite) per artifact).
+    return EndToEndResults.from_cache(methods=[(ma.ag_name, ma.suite) for ma in method_artifacts])
 
 
 def subset_label(subset: list[str]) -> str:

--- a/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
@@ -56,7 +56,7 @@ class TabArenaEvalConfig:
     """Inputs for `run_eval`. Use the SAME `benchmark_name` as the plan."""
 
     benchmark_name: str
-    """Matches the plan's benchmark name; also used as the cache ``artifact_name``."""
+    """Matches the plan's benchmark name; also used as the cache ``suite``."""
     output_dir: str | Path
     """The run's output dir of TabArena runs."""
     methods: list[EvalMethod]
@@ -130,7 +130,7 @@ def run_eval(config: TabArenaEvalConfig) -> dict[str, pd.DataFrame]:
         MethodArtifact(
             ag_name=method.ag_name,
             path_raw=config.path_raw,
-            artifact_name=config.benchmark_name,
+            suite=config.benchmark_name,
             result_suffix=method.result_suffix,
             only_load_cache=method.only_load_cache,
         )

--- a/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
@@ -149,13 +149,13 @@ def run_beyond_arena_eval(config: BeyondArenaEvalConfig) -> dict[str, pd.DataFra
     # One self-contained native collection, shared by post-processing, compare, and subset filtering.
     task_metadata = load_beyond_task_metadata_collection(config.metadata_source)
 
-    # Flatten (run, model) into post-processing specs; distinct artifact_name per run keeps a
+    # Flatten (run, model) into post-processing specs; distinct suite per run keeps a
     # method that appears in multiple runs from colliding in the cache.
     artifacts = [
         MethodArtifact(
             ag_name=resolve_ag_name(model, (run.ag_name_overrides or {}).get(model)),
             path_raw=Path(run.output_dir) / "data",
-            artifact_name=run.benchmark_name,
+            suite=run.benchmark_name,
             result_suffix=run.result_suffix,
             only_load_cache=run.loads_from_cache(model),
         )

--- a/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/downloader.py
@@ -35,7 +35,7 @@ class MethodDownloader(ABC):
         self.method = method_metadata.method
         self.bucket = bucket
         # ``prefix`` is the cache-root prefix only (e.g. "cache"); ``key_prefix`` is this method's
-        # *full* key prefix within the bucket, e.g. "cache/artifacts/<artifact_name>/methods/<method>".
+        # *full* key prefix within the bucket, e.g. "cache/artifacts/<suite>/methods/<method>".
         # NOTE: this differs from the pre-refactor subclasses, where ``self.prefix`` held the full
         # per-method key path now stored in ``key_prefix`` — use ``key_prefix`` for object keys.
         self.prefix = prefix

--- a/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
+++ b/packages/tabarena/src/tabarena/models/_artifacts/uploader.py
@@ -28,7 +28,7 @@ class MethodUploader(ABC):
         self.method = method_metadata.method
         self.bucket = bucket
         # ``prefix`` is the cache-root prefix only (e.g. "cache"); ``key_prefix`` is this method's
-        # *full* key prefix within the bucket, e.g. "cache/artifacts/<artifact_name>/methods/<method>".
+        # *full* key prefix within the bucket, e.g. "cache/artifacts/<suite>/methods/<method>".
         # NOTE: this differs from the pre-refactor subclasses, where ``self.prefix`` held the full
         # per-method key path now stored in ``key_prefix`` — use ``key_prefix`` for object keys.
         self.prefix = prefix

--- a/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
@@ -68,7 +68,7 @@ class InMemoryMethodMetadata(MethodMetadata):
 
         ``use_artifact_name_in_prefix`` / ``use_model_results`` are forwarded to
         :meth:`EndToEndResultsSingle.get_results`. When the artifact-name prefix is applied, the
-        same ``[artifact_name] `` segment get_results prepends to the frame's identity columns is
+        same ``[suite] `` segment get_results prepends to the frame's identity columns is
         baked into the metadata identity here too, so the website merge still matches.
         """
         base = results_single.method_metadata
@@ -82,15 +82,15 @@ class InMemoryMethodMetadata(MethodMetadata):
         # ta_suite columns, mirrored so the metadata identity stays in lock-step.
         identity_prefix = new_result_prefix or ""
         if use_artifact_name_in_prefix:
-            identity_prefix = identity_prefix + f"[{base.artifact_name}] "
+            identity_prefix = identity_prefix + f"[{base.suite}] "
 
         kwargs = base.to_info_dict()
         if identity_prefix:
             # Bake the prefix into identity so it matches the (already-prefixed) frame:
-            #   * method/artifact_name -> ta_name/ta_suite (the website merge key)
+            #   * method/suite -> ta_name/ta_suite (the website merge key)
             #   * model_key            -> config_type (the rename-map / family key)
             #   * display_name         -> rendered method name
-            for field in ("method", "artifact_name", "model_key", "display_name"):
+            for field in ("method", "suite", "model_key", "display_name"):
                 value = kwargs.get(field)
                 if isinstance(value, str):
                     kwargs[field] = identity_prefix + value

--- a/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
@@ -56,7 +56,7 @@ class InMemoryMethodMetadata(MethodMetadata):
         results_single: EndToEndResultsSingle,
         *,
         new_result_prefix: str | None = None,
-        use_artifact_name_in_prefix: bool = False,
+        use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
     ) -> Self:
         """Build from an ``EndToEndResultsSingle`` (its ``method_metadata`` + in-memory results).
@@ -66,7 +66,7 @@ class InMemoryMethodMetadata(MethodMetadata):
         metadata's name fields, so the website leaderboard merge on ``(ta_name, ta_suite)``
         still matches.
 
-        ``use_artifact_name_in_prefix`` / ``use_model_results`` are forwarded to
+        ``use_suite_in_prefix`` / ``use_model_results`` are forwarded to
         :meth:`EndToEndResultsSingle.get_results`. When the artifact-name prefix is applied, the
         same ``[suite] `` segment get_results prepends to the frame's identity columns is
         baked into the metadata identity here too, so the website merge still matches.
@@ -74,14 +74,14 @@ class InMemoryMethodMetadata(MethodMetadata):
         base = results_single.method_metadata
         results = results_single.get_results(
             new_result_prefix=new_result_prefix,
-            use_artifact_name_in_prefix=use_artifact_name_in_prefix,
+            use_suite_in_prefix=use_suite_in_prefix,
             use_model_results=use_model_results,
         )
 
         # The total prefix get_results prepended to the frame's method/config_type/ta_name/
         # ta_suite columns, mirrored so the metadata identity stays in lock-step.
         identity_prefix = new_result_prefix or ""
-        if use_artifact_name_in_prefix:
+        if use_suite_in_prefix:
             identity_prefix = identity_prefix + f"[{base.suite}] "
 
         kwargs = base.to_info_dict()

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -62,7 +62,7 @@ class MethodMetadata:
     pre-dataclass class): the field declarations below are the canonical schema, and
     :meth:`to_info_dict` derives the serialized YAML / info-table surface from those fields (an
     allowlist) rather than from ``self.__dict__``. :meth:`__post_init__` fills the derived
-    defaults (``artifact_name`` <- ``method``, ``model_key`` <- ``ag_key``, ``can_hpo`` <-
+    defaults (``suite`` <- ``method``, ``model_key`` <- ``ag_key``, ``can_hpo`` <-
     ``method_type``, ``display_name``) and validates the inputs.
     """
 
@@ -108,10 +108,10 @@ class MethodMetadata:
 
     # -- (3) Manual (not inferable) -----------------------------------------------------------
     #: Must be specified by hand when relevant: artifact identity/naming and storage/transport
-    #: config (where and how artifacts are cached and uploaded). ``artifact_name`` defaults to
+    #: config (where and how artifacts are cached and uploaded). ``suite`` defaults to
     #: ``method`` but is normally the dated artifact set (e.g. ``"tabarena-2026-05-13"``) and is
     #: part of the cache/S3 path.
-    artifact_name: str | None = None
+    suite: str | None = None
     name: str | None = None
     name_suffix: str | None = None
     #: Storage backend for this method's artifacts. ``None`` (the default) infers it in
@@ -150,8 +150,8 @@ class MethodMetadata:
     verified: bool = True
 
     def __post_init__(self):
-        if self.artifact_name is None:
-            self.artifact_name = self.method
+        if self.suite is None:
+            self.suite = self.method
         if self.model_key is None:
             self.model_key = self.ag_key
         if self.can_hpo is None:
@@ -160,8 +160,8 @@ class MethodMetadata:
 
         assert isinstance(self.method, str)
         assert len(self.method) > 0
-        assert isinstance(self.artifact_name, str)
-        assert len(self.artifact_name) > 0
+        assert isinstance(self.suite, str)
+        assert len(self.suite) > 0
         # Accept a MethodType member or its plain string, normalize to the string for storage,
         # then validate against the canonical set (the constructor's previous hardcoded list).
         if isinstance(self.method_type, MethodType):
@@ -315,7 +315,7 @@ class MethodMetadata:
         cls,
         results_lst: list[BaselineResult],
         method: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         config_default: str | None = None,
         compute: Literal["cpu", "gpu"] | None = None,
     ) -> Self:
@@ -334,7 +334,7 @@ class MethodMetadata:
             method_metadata = cls._from_raw_config(
                 result_df=result_df,
                 method=method,
-                artifact_name=artifact_name,
+                suite=suite,
                 config_default=config_default,
                 compute=compute,
             )
@@ -342,7 +342,7 @@ class MethodMetadata:
             method_metadata = cls._from_raw_baseline(
                 result_df=result_df,
                 method=method,
-                artifact_name=artifact_name,
+                suite=suite,
                 compute=compute,
             )
         else:
@@ -355,7 +355,7 @@ class MethodMetadata:
         cls,
         result_df: pd.DataFrame,
         method: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         compute: Literal["cpu", "gpu"] | None = None,
     ) -> Self:
         unique_method_types = result_df["method_type"].unique()
@@ -376,12 +376,12 @@ class MethodMetadata:
         if compute is None:
             compute: Literal["cpu", "gpu"] = "cpu" if num_gpus == 0 else "gpu"
 
-        if artifact_name is None:
-            artifact_name = method
+        if suite is None:
+            suite = method
 
         return cls.baseline(
             method=method,
-            artifact_name=artifact_name,
+            suite=suite,
             compute=compute,
         )
 
@@ -430,7 +430,7 @@ class MethodMetadata:
         cls,
         result_df: pd.DataFrame,
         method: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         config_default: str | None = None,
         compute: Literal["cpu", "gpu"] | None = None,
     ) -> Self:
@@ -480,12 +480,12 @@ class MethodMetadata:
         if method is None:
             method = name_prefix
 
-        if artifact_name is None:
-            artifact_name = method
+        if suite is None:
+            suite = method
 
         return cls.config(
             method=method,
-            artifact_name=artifact_name,
+            suite=suite,
             compute=compute,
             config_default=config_default,
             ag_key=ag_key,
@@ -498,7 +498,7 @@ class MethodMetadata:
         cls,
         *,
         method: str,
-        artifact_name: str,
+        suite: str,
         has_raw: bool = True,
         has_processed: bool = True,
         has_results: bool = True,
@@ -519,7 +519,7 @@ class MethodMetadata:
         """
         return cls(
             method=method,
-            artifact_name=artifact_name,
+            suite=suite,
             has_raw=has_raw,
             has_processed=has_processed,
             has_results=has_results,
@@ -551,10 +551,10 @@ class MethodMetadata:
     @property
     def path(self) -> Path:
         # When ``cache_root`` is set, artifacts live in a flat ``<cache_root>/<method>/`` dir
-        # (no ``artifacts/<artifact_name>/methods/`` infix) so committed copies stay shallow.
+        # (no ``artifacts/<suite>/methods/`` infix) so committed copies stay shallow.
         if self.cache_root is not None:
             return self.cache_root / self.method
-        return self._path_root / self.artifact_name / "methods" / self.method
+        return self._path_root / self.suite / "methods" / self.method
 
     @property
     def path_raw(self) -> Path:
@@ -612,7 +612,7 @@ class MethodMetadata:
             raise AssertionError(
                 f"Tried to get MethodDownloader from MethodMetadata, but cache_type={self.cache_type!r} "
                 f"has no remote store to download from."
-                f"\n\t(method={self.method}, artifact_name={self.artifact_name}, cache_type={self.cache_type})"
+                f"\n\t(method={self.method}, suite={self.suite}, cache_type={self.cache_type})"
                 f"\nUse a remote backend ('s3'/'r2') with bucket + prefix to enable artifact download.",
             )
 
@@ -647,7 +647,7 @@ class MethodMetadata:
             raise AssertionError(
                 f"Tried to get MethodUploader from MethodMetadata, but cache_type={self.cache_type!r} "
                 f"has no remote store to upload to."
-                f"\n\t(method={self.method}, artifact_name={self.artifact_name}, cache_type={self.cache_type})"
+                f"\n\t(method={self.method}, suite={self.suite}, cache_type={self.cache_type})"
                 f"\nUse a remote backend ('s3'/'r2') with bucket + prefix to enable artifact upload.",
             )
 
@@ -879,6 +879,9 @@ class MethodMetadata:
         an older schema still constructs. Mutates and returns ``kwargs``. All backwards-compat
         handling for the on-disk format lives here:
 
+        - ``artifact_name``: renamed to ``suite``. Fold a legacy ``artifact_name`` key onto
+          ``suite`` so metadata.yaml written before the rename still loads. (We only ever wrote
+          one of the two, so this never clobbers an explicit ``suite``.)
         - ``use_artifact_name_in_prefix``: field removed from the schema; drop it if present.
         - ``upload_as_public``: moved into ``cache_kwargs`` (an s3-specific public-read ACL knob).
           Fold a ``True`` value into ``cache_kwargs`` only when ``cache_type == "s3"``; otherwise
@@ -887,6 +890,8 @@ class MethodMetadata:
           before they moved into ``cache_kwargs``): fold onto ``cache_kwargs["bucket"]`` /
           ``cache_kwargs["prefix"]`` so previously-written metadata.yaml still loads.
         """
+        if "artifact_name" in kwargs:
+            kwargs.setdefault("suite", kwargs.pop("artifact_name"))
         kwargs.pop("use_artifact_name_in_prefix", None)
         if kwargs.pop("upload_as_public", False) and kwargs.get("cache_type") == "s3":
             kwargs.setdefault("cache_kwargs", {}).setdefault("upload_as_public", True)
@@ -905,7 +910,7 @@ class MethodMetadata:
         cls,
         path: Path | str | None = None,
         method: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         *,
         cache_root: str | Path | None = None,
         relative_cache: bool | Literal["auto"] = "auto",
@@ -925,7 +930,7 @@ class MethodMetadata:
 
         The default ``"auto"`` applies that inference exactly when it is safe and unambiguous: an
         explicit ``path`` is given and no ``cache_root`` was passed. It is a no-op for the
-        ``method``/``artifact_name`` lookup forms (so those callers are unaffected), and the
+        ``method``/``suite`` lookup forms (so those callers are unaffected), and the
         inference is correct for both the flat committed layout and the global cache layout, since
         in both the yaml's parent directory is named ``<method>``.
         """
@@ -941,11 +946,11 @@ class MethodMetadata:
 
         if path is None:
             assert method is not None, "method must be specified if path is not specified"
-            assert artifact_name is not None, "artifact_name must be specified if path is not specified"
+            assert suite is not None, "suite must be specified if path is not specified"
             if cache_root is not None:
                 path = Path(cache_root) / method / "metadata.yaml"
             else:
-                path = get_tabarena_cache_root() / "artifacts" / artifact_name / "methods" / method / "metadata.yaml"
+                path = get_tabarena_cache_root() / "artifacts" / suite / "methods" / method / "metadata.yaml"
 
         assert str(path).endswith(".yaml")
         with open(path) as file:
@@ -1009,7 +1014,7 @@ class ModelDescriptor:
     *and* the Beyond-IID re-run in
     :mod:`tabarena.nips2025_utils.artifacts._beyond_method_metadata` — instead of being
     re-typed per artifact. It carries only the fields that are identical across those runs;
-    everything run-specific (``method`` name, ``ag_key``, ``artifact_name``, ``config_default``,
+    everything run-specific (``method`` name, ``ag_key``, ``suite``, ``config_default``,
     ``can_hpo``, ``date``, storage) is supplied per call to :meth:`method_metadata`.
     """
 

--- a/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
@@ -15,11 +15,11 @@ class MethodMetadataCollection:
     def get_method_metadata(
         self,
         method: str,
-        artifact_name: str | None = None,
+        suite: str | None = None,
     ) -> MethodMetadata:
         """Return the unique MethodMetadata that matches the provided identifiers.
 
-        The full unique key is (method, artifact_name). This function accepts a
+        The full unique key is (method, suite). This function accepts a
         *partial* key: it filters using only the provided (non-None) fields. If
         that partial key matches exactly one item, that item is returned. If it
         matches zero or multiple items, an informative exception is raised. In the
@@ -30,7 +30,7 @@ class MethodMetadataCollection:
         ----------
         method
             Method name to match (required).
-        artifact_name
+        suite
             Optional artifact name to further constrain the search.
 
         Returns:
@@ -60,7 +60,7 @@ class MethodMetadataCollection:
             )
 
         # 2) Apply only the provided (non-None) fields.
-        candidates = [m for m in by_method if artifact_name is None or m.artifact_name == artifact_name]
+        candidates = [m for m in by_method if suite is None or m.suite == suite]
 
         # 3) Resolve outcomes without building any DataFrame unless necessary.
         if len(candidates) == 1:
@@ -71,7 +71,7 @@ class MethodMetadataCollection:
             rows = [
                 {
                     "method": getattr(m, "method", None),
-                    "artifact_name": getattr(m, "artifact_name", None),
+                    "suite": getattr(m, "suite", None),
                 }
                 for m in objs
             ]
@@ -83,7 +83,7 @@ class MethodMetadataCollection:
             df = _candidates_df(by_method)
             raise LookupError(
                 "No MethodMetadata matches the provided filters.\n"
-                f"Filters used: method={method!r}, artifact_name={artifact_name!r}\n"
+                f"Filters used: method={method!r}, suite={suite!r}\n"
                 "Available candidates for this method:\n"
                 f"{df.to_string(index=False)}",
             )
@@ -92,7 +92,7 @@ class MethodMetadataCollection:
         df = _candidates_df(candidates)
         raise ValueError(
             "Provided filters are insufficient to uniquely identify a MethodMetadata.\n"
-            f"Filters used: method={method!r}, artifact_name={artifact_name!r}\n"
+            f"Filters used: method={method!r}, suite={suite!r}\n"
             "Indistinguishable candidates:\n"
             f"{df.to_string(index=False)}",
         )

--- a/packages/tabarena/src/tabarena/models/_method_simulator.py
+++ b/packages/tabarena/src/tabarena/models/_method_simulator.py
@@ -6,7 +6,7 @@ simulation logic (which drives :class:`~tabarena.paper.paper_runner_tabarena.Pap
 over the method's processed results) is a separate concern.
 
 A ``MethodSimulator`` wraps a ``MethodMetadata`` and reads its identity (``method``,
-``artifact_name``, ``config_type``, ``method_type``, ``can_hpo``, ``config_default``), its
+``suite``, ``config_type``, ``method_type``, ``can_hpo``, ``config_default``), its
 artifact-path helpers, and its ``load_processed`` repo loader. Construct one as
 ``MethodSimulator(method_metadata)`` and call the ``generate_*`` / ``get_config_default``
 methods that previously hung off the metadata.
@@ -71,7 +71,7 @@ class MethodSimulator:
         if mm.method_type == "config":
             hpo_results = simulator.run_minimal_single(model_type=model_type, tune=mm.can_hpo)
             hpo_results["ta_name"] = mm.method
-            hpo_results["ta_suite"] = mm.artifact_name
+            hpo_results["ta_suite"] = mm.suite
             hpo_results = hpo_results.rename(
                 columns={"framework": "method"}
             )  # FIXME: Don't do this, make it method by default
@@ -89,7 +89,7 @@ class MethodSimulator:
         model_results = pd.concat(results_lst, ignore_index=True)
 
         model_results["ta_name"] = mm.method
-        model_results["ta_suite"] = mm.artifact_name
+        model_results["ta_suite"] = mm.suite
         model_results = model_results.rename(
             columns={"framework": "method"}
         )  # FIXME: Don't do this, make it method by default
@@ -140,7 +140,7 @@ class MethodSimulator:
         df_results_hpo["n_iterations"] = n_iterations
         df_results_hpo["seed"] = seed
         df_results_hpo["ta_name"] = mm.method
-        df_results_hpo["ta_suite"] = mm.artifact_name
+        df_results_hpo["ta_suite"] = mm.suite
         return df_results_hpo
 
     def generate_hpo_trajectories(
@@ -250,5 +250,5 @@ class MethodSimulator:
         df_results_best["n_configs"] = n_configs
         df_results_best["n_iterations"] = n_iterations
         df_results_best["ta_name"] = mm.method
-        df_results_best["ta_suite"] = mm.artifact_name
+        df_results_best["ta_suite"] = mm.suite
         return df_results_best

--- a/packages/tabarena/src/tabarena/models/_registry.py
+++ b/packages/tabarena/src/tabarena/models/_registry.py
@@ -82,9 +82,9 @@ def register_model_info(info: ModelInfo) -> None:
 
     Extensions sometimes redeclare a method that's already in the core
     registry (e.g. a re-benchmarked LinearModel with a different
-    `artifact_name`). When `info.method_metadata.method` is already
+    `suite`). When `info.method_metadata.method` is already
     registered with a different `ModelInfo`, this function keys the new
-    entry as ``f"{method}@{artifact_name}"`` instead, preserving the core
+    entry as ``f"{method}@{suite}"`` instead, preserving the core
     entry under the bare method name.
     """
     registry = discover_models()
@@ -93,8 +93,8 @@ def register_model_info(info: ModelInfo) -> None:
     if existing is None or existing is info:
         registry[key] = info
         return
-    # Disambiguate by appending artifact_name to the key.
-    artifact = info.method_metadata.artifact_name or "ext"
+    # Disambiguate by appending suite to the key.
+    artifact = info.method_metadata.suite or "ext"
     composite_key = f"{key}@{artifact}"
     if composite_key in registry and registry[composite_key] is not info:
         raise RuntimeError(

--- a/packages/tabarena/src/tabarena/models/catboost/info.py
+++ b/packages/tabarena/src/tabarena/models/catboost/info.py
@@ -15,7 +15,7 @@ catboost_descriptor = ModelDescriptor(
 
 catboost_method_metadata = catboost_descriptor.method_metadata(
     method="CatBoost",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="CAT",
     config_default="CatBoost_c1_BAG_L1",
     cache_type="s3",

--- a/packages/tabarena/src/tabarena/models/ebm/info.py
+++ b/packages/tabarena/src/tabarena/models/ebm/info.py
@@ -8,7 +8,7 @@ from tabarena.models.ebm.hpo import gen_ebm
 
 ebm_method_metadata = MethodMetadata.config(
     method="ExplainableBM",
-    artifact_name="tabarena-2025-09-03",
+    suite="tabarena-2025-09-03",
     ag_key="EBM",
     config_default="ExplainableBM_c1_BAG_L1",
     compute="cpu",

--- a/packages/tabarena/src/tabarena/models/extra_trees/info.py
+++ b/packages/tabarena/src/tabarena/models/extra_trees/info.py
@@ -15,7 +15,7 @@ extra_trees_descriptor = ModelDescriptor(
 
 extra_trees_method_metadata = extra_trees_descriptor.method_metadata(
     method="ExtraTrees",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="XT",
     config_default="ExtraTrees_c1_BAG_L1",
     cache_type="s3",

--- a/packages/tabarena/src/tabarena/models/fastai/info.py
+++ b/packages/tabarena/src/tabarena/models/fastai/info.py
@@ -8,7 +8,7 @@ from tabarena.models.fastai.hpo import gen_fastai
 
 fastai_method_metadata = MethodMetadata.config(
     method="NeuralNetFastAI",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="FASTAI",
     config_default="NeuralNetFastAI_c1_BAG_L1",
     compute="cpu",

--- a/packages/tabarena/src/tabarena/models/iltm/info.py
+++ b/packages/tabarena/src/tabarena/models/iltm/info.py
@@ -7,7 +7,7 @@ from tabarena.models.iltm.model import ILTMModel
 
 iltm_method_metadata = MethodMetadata.config(
     method="iLTM",
-    artifact_name="tabarena-2026-05-13",
+    suite="tabarena-2026-05-13",
     ag_key="TA-ILTM",
     config_default="iLTM_c1_BAG_L1",
     compute="gpu",

--- a/packages/tabarena/src/tabarena/models/knn/info.py
+++ b/packages/tabarena/src/tabarena/models/knn/info.py
@@ -7,7 +7,7 @@ from tabarena.models.knn.model import KNNNewModel
 
 knn_method_metadata = MethodMetadata.config(
     method="KNeighbors",
-    artifact_name="tabarena-2025-10-20",
+    suite="tabarena-2025-10-20",
     ag_key="KNN",
     config_default="KNeighbors_c1_BAG_L1",
     compute="cpu",

--- a/packages/tabarena/src/tabarena/models/lightgbm/info.py
+++ b/packages/tabarena/src/tabarena/models/lightgbm/info.py
@@ -15,7 +15,7 @@ lightgbm_descriptor = ModelDescriptor(
 
 lightgbm_method_metadata = lightgbm_descriptor.method_metadata(
     method="LightGBM",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="GBM",
     config_default="LightGBM_c1_BAG_L1",
     cache_type="s3",

--- a/packages/tabarena/src/tabarena/models/limix/info.py
+++ b/packages/tabarena/src/tabarena/models/limix/info.py
@@ -7,7 +7,7 @@ from tabarena.models.limix.model import LimiXModel
 
 limix_method_metadata = MethodMetadata.config(
     method="LimiX",
-    artifact_name="tabarena-2026-05-13",
+    suite="tabarena-2026-05-13",
     ag_key="TA-LIMIX",
     config_default="LimiX_c1_BAG_L1",
     can_hpo=False,

--- a/packages/tabarena/src/tabarena/models/lr/info.py
+++ b/packages/tabarena/src/tabarena/models/lr/info.py
@@ -15,7 +15,7 @@ lr_descriptor = ModelDescriptor(
 
 lr_method_metadata = lr_descriptor.method_metadata(
     method="LinearModel",
-    artifact_name="tabarena-2025-10-20",
+    suite="tabarena-2025-10-20",
     ag_key="LR",
     config_default="LinearModel_c1_BAG_L1",
     cache_type="s3",

--- a/packages/tabarena/src/tabarena/models/mitra/info.py
+++ b/packages/tabarena/src/tabarena/models/mitra/info.py
@@ -21,7 +21,7 @@ def prefetch_weights() -> None:
 
 mitra_method_metadata = MethodMetadata.config(
     method="Mitra_GPU",
-    artifact_name="tabarena-2025-09-03",
+    suite="tabarena-2025-09-03",
     ag_key="MITRA",
     model_key="MITRA_GPU",
     config_default="Mitra_GPU_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/modernnca/info.py
+++ b/packages/tabarena/src/tabarena/models/modernnca/info.py
@@ -7,7 +7,7 @@ from tabarena.models.modernnca.model import ModernNCAModel
 
 modernnca_method_metadata = MethodMetadata.config(
     method="ModernNCA",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="MNCA",
     config_default="ModernNCA_c1_BAG_L1",
     compute="cpu",
@@ -22,7 +22,7 @@ modernnca_method_metadata = MethodMetadata.config(
 
 modernnca_gpu_method_metadata = MethodMetadata.config(
     method="ModernNCA_GPU",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="MNCA",
     config_default="ModernNCA_GPU_c1_BAG_L1",
     compute="gpu",

--- a/packages/tabarena/src/tabarena/models/nn_torch/info.py
+++ b/packages/tabarena/src/tabarena/models/nn_torch/info.py
@@ -8,7 +8,7 @@ from tabarena.models.nn_torch.hpo import gen_nn_torch
 
 nn_torch_method_metadata = MethodMetadata.config(
     method="NeuralNetTorch",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="NN_TORCH",
     config_default="NeuralNetTorch_c1_BAG_L1",
     compute="cpu",

--- a/packages/tabarena/src/tabarena/models/orionmsp/info.py
+++ b/packages/tabarena/src/tabarena/models/orionmsp/info.py
@@ -7,7 +7,7 @@ from tabarena.models.orionmsp.model import OrionMSPModel, prefetch_weights
 
 orionmsp_method_metadata = MethodMetadata.config(
     method="OrionMSP",
-    artifact_name="tabarena-2026-05-13",
+    suite="tabarena-2026-05-13",
     ag_key="TA-ORION-MSP",
     config_default="OrionMSP_c1_BAG_L1",
     can_hpo=False,

--- a/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
+++ b/packages/tabarena/src/tabarena/models/perpetual_booster/info.py
@@ -9,7 +9,7 @@ from tabarena.models.perpetual_booster.model import (
 
 perpetual_booster_method_metadata = MethodMetadata.config(
     method="PerpetualBooster",
-    artifact_name="tabarena-2026-03-18",
+    suite="tabarena-2026-03-18",
     ag_key="PB",
     config_default="PerpetualBooster_c1_BAG_L1",
     compute="cpu",

--- a/packages/tabarena/src/tabarena/models/random_forest/info.py
+++ b/packages/tabarena/src/tabarena/models/random_forest/info.py
@@ -15,7 +15,7 @@ random_forest_descriptor = ModelDescriptor(
 
 random_forest_method_metadata = random_forest_descriptor.method_metadata(
     method="RandomForest",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="RF",
     config_default="RandomForest_c1_BAG_L1",
     cache_type="s3",

--- a/packages/tabarena/src/tabarena/models/realmlp/info.py
+++ b/packages/tabarena/src/tabarena/models/realmlp/info.py
@@ -14,7 +14,7 @@ realmlp_descriptor = ModelDescriptor(
 
 realmlp_method_metadata = realmlp_descriptor.method_metadata(
     method="RealMLP_GPU",
-    artifact_name="tabarena-2025-09-03",
+    suite="tabarena-2025-09-03",
     ag_key="TA-REALMLP",
     model_key="REALMLP_GPU",
     config_default="RealMLP_GPU_c1_BAG_L1",
@@ -27,7 +27,7 @@ realmlp_method_metadata = realmlp_descriptor.method_metadata(
 # CPU variant — same model class, same search space, different compute target.
 realmlp_cpu_method_metadata = realmlp_descriptor.method_metadata(
     method="RealMLP",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="REALMLP",
     config_default="RealMLP_c1_BAG_L1",
     compute="cpu",

--- a/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
+++ b/packages/tabarena/src/tabarena/models/sap_rpt_oss/info.py
@@ -7,7 +7,7 @@ from tabarena.models.sap_rpt_oss.model import SAPRPTOSSModel, prefetch_weights
 
 sap_rpt_oss_method_metadata = MethodMetadata.config(
     method="SAP-RPT-OSS",
-    artifact_name="tabarena-2025-11-25",
+    suite="tabarena-2025-11-25",
     ag_key="SAP-RPT-OSS",
     config_default="SAP-RPT-OSS_c1_BAG_L1",
     can_hpo=False,

--- a/packages/tabarena/src/tabarena/models/tabdpt/info.py
+++ b/packages/tabarena/src/tabarena/models/tabdpt/info.py
@@ -14,7 +14,7 @@ tabdpt_descriptor = ModelDescriptor(
 
 tabdpt_method_metadata = tabdpt_descriptor.method_metadata(
     method="TabDPT_GPU",
-    artifact_name="tabarena-2025-10-20",
+    suite="tabarena-2025-10-20",
     ag_key="TABDPT",
     model_key="TABDPT_GPU",
     config_default="TabDPT_GPU_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/models/tabicl/info.py
+++ b/packages/tabarena/src/tabarena/models/tabicl/info.py
@@ -24,7 +24,7 @@ tabiclv2_descriptor = ModelDescriptor(
 
 tabicl_method_metadata = tabicl_descriptor.method_metadata(
     method="TabICL_GPU",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="TABICL",
     config_default="TabICL_GPU_c1_BAG_L1",
     can_hpo=False,
@@ -41,7 +41,7 @@ tabiclv2_method_metadata = tabiclv2_descriptor.method_metadata(
     ag_key="TABICLV2",
     config_default="TabICLv2_c1_BAG_L1",
     can_hpo=False,
-    artifact_name="tabarena-2026-02-16",
+    suite="tabarena-2026-02-16",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
 )

--- a/packages/tabarena/src/tabarena/models/tabm/info.py
+++ b/packages/tabarena/src/tabarena/models/tabm/info.py
@@ -15,7 +15,7 @@ tabm_descriptor = ModelDescriptor(
 # CPU variant — same model class, same search space, different compute target.
 tabm_method_metadata = tabm_descriptor.method_metadata(
     method="TabM",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="TABM",
     config_default="TabM_c1_BAG_L1",
     compute="cpu",
@@ -28,7 +28,7 @@ tabm_method_metadata = tabm_descriptor.method_metadata(
 
 tabm_gpu_method_metadata = tabm_descriptor.method_metadata(
     method="TabM_GPU",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="TABM",
     config_default="TabM_GPU_c1_BAG_L1",
     name_suffix="_GPU",

--- a/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfn_3/info.py
@@ -19,7 +19,7 @@ tabpfn_3_method_metadata = tabpfn_3_descriptor.method_metadata(
     can_hpo=False,
     date="2026-05-13",
     cache_type="r2",
-    artifact_name="tabarena-2026-05-13",
+    suite="tabarena-2026-05-13",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
 )
 

--- a/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnv2_5/info.py
@@ -28,7 +28,7 @@ realtabpfnv25_method_metadata = realtabpfnv25_descriptor.method_metadata(
     date="2025-11-12",
     ag_key="REALTABPFN-V2.5",
     config_default="RealTabPFN-v2.5_c1_BAG_L1",
-    artifact_name="tabarena-2025-11-12",
+    suite="tabarena-2025-11-12",
     cache_type="s3",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache", "upload_as_public": True},
 )
@@ -40,7 +40,7 @@ tabpfnv26_method_metadata = tabpfnv26_descriptor.method_metadata(
     ag_key="TABPFN-V2.6",
     config_default="TabPFN-v2.6_c1_BAG_L1",
     can_hpo=False,
-    artifact_name="tabarena-2026-03-18",
+    suite="tabarena-2026-03-18",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
     cache_type="r2",
 )

--- a/packages/tabarena/src/tabarena/models/tabpfnwide/info.py
+++ b/packages/tabarena/src/tabarena/models/tabpfnwide/info.py
@@ -7,7 +7,7 @@ from tabarena.models.tabpfnwide.model import TabPFNWideModel
 
 tabpfnwide_method_metadata = MethodMetadata.config(
     method="TabPFN-Wide",
-    artifact_name="tabarena-2026-05-13",
+    suite="tabarena-2026-05-13",
     ag_key="TA-TABPFN-WIDE",
     config_default="TabPFN-Wide_c1_BAG_L1",
     can_hpo=False,

--- a/packages/tabarena/src/tabarena/models/tabstar/info.py
+++ b/packages/tabarena/src/tabarena/models/tabstar/info.py
@@ -7,7 +7,7 @@ from tabarena.models.tabstar.model import TabSTARModel, prefetch_weights
 
 tabstar_method_metadata = MethodMetadata.config(
     method="TabSTAR",
-    artifact_name="tabarena-2026-03-18",
+    suite="tabarena-2026-03-18",
     ag_key="TABSTAR",
     config_default="TabSTAR_c1_BAG_L1",
     compute="gpu",

--- a/packages/tabarena/src/tabarena/models/xgboost/info.py
+++ b/packages/tabarena/src/tabarena/models/xgboost/info.py
@@ -15,7 +15,7 @@ xgboost_descriptor = ModelDescriptor(
 
 xgboost_method_metadata = xgboost_descriptor.method_metadata(
     method="XGBoost",
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     ag_key="XGB",
     config_default="XGBoost_c1_BAG_L1",
     cache_type="s3",

--- a/packages/tabarena/src/tabarena/models/xrfm/info.py
+++ b/packages/tabarena/src/tabarena/models/xrfm/info.py
@@ -7,7 +7,7 @@ from tabarena.models.xrfm.model import XRFMModel
 
 xrfm_method_metadata = MethodMetadata.config(
     method="xRFM_GPU",
-    artifact_name="tabarena-2025-09-03",
+    suite="tabarena-2025-09-03",
     ag_key="XRFM",
     model_key="XRFM_GPU",
     config_default="xRFM_GPU_c1_BAG_L1",

--- a/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/abstract_arena_context.py
@@ -522,11 +522,11 @@ class AbstractArenaContext:
     def method_metadata(
         self,
         method: str,
-        artifact_name: str | None = None,
+        suite: str | None = None,
     ) -> MethodMetadata:
         return self.method_metadata_collection.get_method_metadata(
             method=method,
-            artifact_name=artifact_name,
+            suite=suite,
         )
 
     def get_method_rename_map(self) -> dict[str, str]:
@@ -573,7 +573,7 @@ class AbstractArenaContext:
         method_metadata_info = method_metadata_info.rename(
             columns={
                 "method": "ta_name",
-                "artifact_name": "ta_suite",
+                "suite": "ta_suite",
             },
         )
         return format_leaderboard(
@@ -868,7 +868,7 @@ class AbstractArenaContext:
         )
 
         # TODO: only methods that exist in runs
-        #  Pair with (method, artifact_name)
+        #  Pair with (method, suite)
         method_rename_map = self.get_method_rename_map()
 
         # `output_dir=None` means "I only want the leaderboard": write the figures / CSVs to a

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_beyond_method_metadata.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_beyond_method_metadata.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 _common_kwargs = dict(
     method_type="config",
-    artifact_name="beyond_iid_benchmark_2026",
+    suite="beyond_iid_benchmark_2026",
     cache_type="r2",
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
 )

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_06_12.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_06_12.py
@@ -40,7 +40,7 @@ _migrated_method_names = {m.method for m in _per_model_metadata}
 methods_2025_06_12 = list(_per_model_metadata)
 
 common_kwargs = dict(
-    artifact_name="tabarena-2025-06-12",
+    suite="tabarena-2025-06-12",
     date="2025-06-12",
     method_type="config",
 )

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_09_03.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_09_03.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from tabarena.models._method_metadata import MethodMetadata
 
 _common_kwargs = dict(
-    artifact_name="tabarena-2025-09-03",
+    suite="tabarena-2025-09-03",
 )
 
 # New methods (tabarena-2025-09-03)

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_10_20.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_10_20.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from tabarena.models._method_metadata import MethodMetadata
 
 _common_kwargs = dict(
-    artifact_name="tabarena-2025-10-20",
+    suite="tabarena-2025-10-20",
 )
 
 portfolio_metadata_paper_cr = MethodMetadata.tabarena_legacy_s3(

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_11_01.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_11_01.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from tabarena.models._method_metadata import MethodMetadata
 
 _common_kwargs = dict(
-    artifact_name="tabarena-2025-11-01",
+    suite="tabarena-2025-11-01",
     method_type="baseline",
     date="2025-11-01",
     reference_url="https://arxiv.org/abs/2003.06505",

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_12_18.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2025_12_18.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from tabarena.models._method_metadata import MethodMetadata
 
 _common_kwargs = dict(
-    artifact_name="tabarena-2025-12-18",
+    suite="tabarena-2025-12-18",
     method_type="baseline",
     date="2025-12-18",
     reference_url="https://arxiv.org/abs/2003.06505",

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2026_01_23_tabprep.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_2026_01_23_tabprep.py
@@ -15,7 +15,7 @@ from tabarena.models._method_metadata import MethodMetadata
 
 tabprep_gbm_metadata = MethodMetadata.tabarena_legacy_s3(
     method="PrepLightGBM",
-    artifact_name="tabarena-2026-01-23",
+    suite="tabarena-2026-01-23",
     display_name="PrepLightGBM",
     method_type="config",
     compute="cpu",
@@ -28,7 +28,7 @@ tabprep_gbm_metadata = MethodMetadata.tabarena_legacy_s3(
 
 tabprep_lr_metadata = MethodMetadata.tabarena_legacy_s3(
     method="PrepLinearModel",
-    artifact_name="tabarena-2026-01-23",
+    suite="tabarena-2026-01-23",
     display_name="PrepLinear",
     method_type="config",
     compute="cpu",
@@ -42,7 +42,7 @@ tabprep_lr_metadata = MethodMetadata.tabarena_legacy_s3(
 
 tabprep_tabm_metadata = MethodMetadata.tabarena_legacy_s3(
     method="PrepTabM",
-    artifact_name="tabarena-2026-01-23",
+    suite="tabarena-2026-01-23",
     display_name="PrepTabM",
     method_type="config",
     compute="gpu",
@@ -55,7 +55,7 @@ tabprep_tabm_metadata = MethodMetadata.tabarena_legacy_s3(
 
 tabprep_realtabpfnv250_metadata = MethodMetadata.tabarena_legacy_s3(
     method="PrepRealTabPFN-v2.5",
-    artifact_name="tabarena-2026-01-23",
+    suite="tabarena-2026-01-23",
     display_name="PrepRealTabPFN-2.5",
     method_type="config",
     compute="gpu",

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_misc.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/_tabarena_method_metadata_misc.py
@@ -6,7 +6,7 @@ from tabarena.models._method_metadata import MethodMetadata
 # s3 cache = "cache_aio"
 gbm_aio_0808_metadata = MethodMetadata.tabarena_legacy_s3(
     method="LightGBM_aio_0808",
-    artifact_name="LightGBM_aio_0808",
+    suite="LightGBM_aio_0808",
     method_type="config",
     compute="cpu",
     date="2025-08-08",
@@ -22,7 +22,7 @@ gbm_aio_0808_metadata = MethodMetadata.tabarena_legacy_s3(
 # s3 cache = "cache_aio"
 prep_gbm_v6_metadata = MethodMetadata.tabarena_legacy_s3(
     method="prep_LightGBM_v6",
-    artifact_name="prep_LightGBM_v6",
+    suite="prep_LightGBM_v6",
     method_type="config",
     compute="cpu",
     date="2025-12-16",

--- a/packages/tabarena/src/tabarena/nips2025_utils/artifacts/method_artifact_manager.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/artifacts/method_artifact_manager.py
@@ -13,9 +13,9 @@ from tabarena.nips2025_utils.end_to_end import EndToEndSingle
 class MethodArtifactManager:
     """Orchestrates download → local cache → upload-to-S3 for a single method."""
 
-    name: str  # method name, e.g., "xRFM_GPU" <- Method identifier. (name, artifact_name) must be unique.
+    name: str  # method name, e.g., "xRFM_GPU" <- Method identifier. (name, suite) must be unique.
     model_key: str  # e.g., "XRFM_GPU" <- Model key to use for differentiating model families.
-    artifact_name: str  # e.g., "tabarena-2025-09-03" <- Differentiates methods with the same name by origin.
+    suite: str  # e.g., "tabarena-2025-09-03" <- Differentiates methods with the same name by origin.
     path_suffix: Path  # e.g., Path("leaderboard_submissions/data_xRFM_11092025.zip")
     download_prefix: str  # e.g., "https://data.lennart-purucker.com/tabarena/"
     local_prefix: Path  # e.g., Path("local_data") <- Local dir to download raw files. Can delete after cache.
@@ -47,7 +47,7 @@ class MethodArtifactManager:
     ) -> Self:
         return cls(
             name=method_metadata.method,
-            artifact_name=method_metadata.artifact_name,
+            suite=method_metadata.suite,
             model_key=method_metadata.model_key,
             s3_bucket=method_metadata.cache_kwargs.get("bucket"),
             s3_prefix=method_metadata.cache_kwargs.get("prefix"),
@@ -73,7 +73,7 @@ class MethodArtifactManager:
     def cache(self, cache_hpo_trajectories: bool = False) -> EndToEndSingle:
         """Requires first having the raw files locally by calling `self.download_raw()`.
 
-        Cached files will be saved under ~/.cache/tabarena/artifacts/{self.artifact_name}/methods/{self.name}/
+        Cached files will be saved under ~/.cache/tabarena/artifacts/{self.suite}/methods/{self.name}/
 
         Run logic end-to-end and cache all results:
         1. load raw artifacts
@@ -101,7 +101,7 @@ class MethodArtifactManager:
             method_metadata=self.method_metadata,
             name=self.name,
             model_key=self.model_key,
-            artifact_name=self.artifact_name,
+            suite=self.suite,
             cache=True,
             cache_raw=True,
             cache_hpo_trajectories=cache_hpo_trajectories,
@@ -109,7 +109,7 @@ class MethodArtifactManager:
 
     def upload_to_s3(self) -> None:
         """Upload the local cache for this method to S3 under:
-        s3://{self.s3_bucket}/{self.s3_prefix}/artifacts/{self.artifact_name}/methods/{self.name}/.
+        s3://{self.s3_bucket}/{self.s3_prefix}/artifacts/{self.suite}/methods/{self.name}/.
         """
         method_metadata = self.load_metadata()
         uploader = method_metadata.method_uploader()
@@ -117,4 +117,4 @@ class MethodArtifactManager:
 
     def load_metadata(self) -> MethodMetadata:
         """Load MethodMetadata from the local cache for this method."""
-        return MethodMetadata.from_yaml(method=self.name, artifact_name=self.artifact_name)
+        return MethodMetadata.from_yaml(method=self.name, suite=self.suite)

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -56,7 +56,7 @@ class EndToEnd:
         name_prefix: str | None = None,
         name_suffix: str | None = None,
         model_key: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
@@ -75,7 +75,7 @@ class EndToEnd:
         result_types_dict = {}
         for r in results_lst:
             cur_method_metadata = MethodMetadata.from_raw(results_lst=[r])
-            cur_tuple = (cur_method_metadata.method, cur_method_metadata.artifact_name, cur_method_metadata.method_type)
+            cur_tuple = (cur_method_metadata.method, cur_method_metadata.suite, cur_method_metadata.method_type)
             if cur_tuple not in result_types_dict:
                 result_types_dict[cur_tuple] = []
             result_types_dict[cur_tuple].append(r)
@@ -98,7 +98,7 @@ class EndToEnd:
                 name_prefix=name_prefix,
                 name_suffix=name_suffix,
                 model_key=model_key,
-                artifact_name=artifact_name,
+                suite=suite,
                 backend=backend,
                 verbose=verbose,
             )
@@ -117,7 +117,7 @@ class EndToEnd:
         name_prefix: str | None = None,
         name_suffix: str | None = None,
         model_key: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
@@ -160,7 +160,7 @@ class EndToEnd:
                 name_prefix=name_prefix,
                 name_suffix=name_suffix,
                 model_key=model_key,
-                artifact_name=artifact_name,
+                suite=suite,
                 backend=backend,
                 verbose=verbose,
             )
@@ -172,12 +172,12 @@ class EndToEnd:
         end_to_end_lst = []
         for method in methods:
             if isinstance(method, tuple):
-                method, artifact_name = method
+                method, suite = method
             else:
-                artifact_name = None
+                suite = None
             end_to_end_single = EndToEndSingle.from_cache(
                 method=method,
-                artifact_name=artifact_name,
+                suite=suite,
             )
             end_to_end_lst.append(end_to_end_single)
         return cls(end_to_end_lst=end_to_end_lst)
@@ -191,7 +191,7 @@ class EndToEnd:
         name_prefix: str | None = None,
         name_suffix: str | None = None,
         model_key: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         num_cpus: int | None = None,
         verbose: bool = True,
     ) -> EndToEndResults:
@@ -229,9 +229,9 @@ class EndToEnd:
             If specified, will overwrite the model_key of the method (result.model_type).
             This is the `ag_key` value, used to distinguish between different config families
             during portfolio simulation.
-        artifact_name : str or None = None
+        suite : str or None = None
             The name of the upper directory in the cache:
-                ~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/
+                ~/.cache/tabarena/artifacts/{suite}/methods/{method}/
             If unspecified, will default to ``{method}``
         num_cpus : int or None = None
             Number of CPUs to use for parallel processing.
@@ -270,7 +270,7 @@ class EndToEnd:
                 name_prefix=name_prefix,
                 name_suffix=name_suffix,
                 model_key=model_key,
-                artifact_name=artifact_name,
+                suite=suite,
             ),
             track_progress=True,
             tqdm_kwargs={"desc": "Processing Results"},
@@ -409,7 +409,7 @@ class EndToEndResults:
     ) -> pd.DataFrame:
         results = self.get_results(
             # new_result_prefix=new_result_prefix,
-            # use_artifact_name_in_prefix=use_artifact_name_in_prefix,
+            # use_suite_in_prefix=use_suite_in_prefix,
             # use_model_results=use_model_results,
             # fillna=False,
         )
@@ -452,7 +452,7 @@ class EndToEndResults:
         fillna: str | None = None,
         only_valid_tasks: str | list[str] | None = None,
         new_result_prefix: str | None = None,
-        use_artifact_name_in_prefix: bool = False,
+        use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
         score_on_val: bool = False,
         average_seeds: bool = False,
@@ -469,7 +469,7 @@ class EndToEndResults:
         """
         results = self.get_results(
             new_result_prefix=new_result_prefix,
-            use_artifact_name_in_prefix=use_artifact_name_in_prefix,
+            use_suite_in_prefix=use_suite_in_prefix,
             use_model_results=use_model_results,
             fillna=False,
         )
@@ -500,18 +500,18 @@ class EndToEndResults:
         self,
         *,
         new_result_prefix: str | None = None,
-        use_artifact_name_in_prefix: bool = False,
+        use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
     ) -> list:
         """Vend each method as an :class:`InMemoryMethodMetadata` for context registration.
 
-        ``use_artifact_name_in_prefix`` / ``use_model_results`` are forwarded to each method's
+        ``use_suite_in_prefix`` / ``use_model_results`` are forwarded to each method's
         :meth:`EndToEndResultsSingle.to_method_metadata`.
         """
         return [
             result.to_method_metadata(
                 new_result_prefix=new_result_prefix,
-                use_artifact_name_in_prefix=use_artifact_name_in_prefix,
+                use_suite_in_prefix=use_suite_in_prefix,
                 use_model_results=use_model_results,
             )
             for result in self.end_to_end_results_lst
@@ -520,7 +520,7 @@ class EndToEndResults:
     def get_results(
         self,
         new_result_prefix: str | None = None,
-        use_artifact_name_in_prefix: bool = False,
+        use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
         fillna: bool = False,
     ) -> pd.DataFrame:
@@ -529,7 +529,7 @@ class EndToEndResults:
             df_results_lst.append(
                 result.get_results(
                     new_result_prefix=new_result_prefix,
-                    use_artifact_name_in_prefix=use_artifact_name_in_prefix,
+                    use_suite_in_prefix=use_suite_in_prefix,
                     use_model_results=use_model_results,
                     fillna=fillna,
                 ),
@@ -538,20 +538,20 @@ class EndToEndResults:
 
     @classmethod
     def from_cache(
-        cls, methods: list[str | MethodMetadata | tuple[str, str]], *, default_artifact_name: None | str = None
+        cls, methods: list[str | MethodMetadata | tuple[str, str]], *, default_suite: None | str = None
     ) -> Self:
         end_to_end_results_lst = []
         for method in methods:
             if isinstance(method, tuple):
-                method, artifact_name = method
+                method, suite = method
             else:
-                artifact_name = default_artifact_name
+                suite = default_suite
             if isinstance(method, MethodMetadata):
                 method_metadata = method
             else:
                 method_metadata = MethodMetadata.from_yaml(
                     method=method,
-                    artifact_name=artifact_name if artifact_name is not None else method,
+                    suite=suite if suite is not None else method,
                 )
             end_to_end_results_lst.append(EndToEndResultsSingle(method_metadata=method_metadata))
         return cls(end_to_end_results_lst=end_to_end_results_lst)
@@ -569,7 +569,7 @@ def _process_result_list(
     name_prefix: str | None = None,
     name_suffix: str | None = None,
     model_key: str | None = None,
-    artifact_name: str | None = None,
+    suite: str | None = None,
 ) -> EndToEndResults:
     results_lst = load_all_artifacts(
         file_paths=file_paths_method,
@@ -584,7 +584,7 @@ def _process_result_list(
         name_prefix=name_prefix,
         name_suffix=name_suffix,
         model_key=model_key,
-        artifact_name=artifact_name,
+        suite=suite,
         cache=False,
         cache_raw=False,
         backend="native",

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -165,7 +165,7 @@ class EndToEndSingle:
         name_suffix: str | None = None,
         model_key: str | None = None,
         method: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
@@ -185,7 +185,7 @@ class EndToEndSingle:
         method_metadata : MethodMetadata or None = None
             The method_metadata containing information about the method.
             If unspecified, will be inferred from ``results_lst``.
-            If specified, ``method`` and ``artifact_name`` will be ignored.
+            If specified, ``method`` and ``suite`` will be ignored.
         task_metadata : pd.DataFrame or None = None
             The task_metadata containing information for each task,
             such as the target evaluation metric and problem_type.
@@ -217,11 +217,11 @@ class EndToEndSingle:
             during portfolio simulation.
         method : str or None = None
             The name of the lower directory in the cache:
-                ~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/
+                ~/.cache/tabarena/artifacts/{suite}/methods/{method}/
             If unspecified, will default to ``{name_prefix}`` for configs or ``{name}`` for baselines.
-        artifact_name : str or None = None
+        suite : str or None = None
             The name of the upper directory in the cache:
-                ~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/
+                ~/.cache/tabarena/artifacts/{suite}/methods/{method}/
             If unspecified, will default to ``{method}``
         backend : "ray" or "native" = "ray"
             If "ray", will parallelize the calculation of hpo_results and model_results.
@@ -252,7 +252,7 @@ class EndToEndSingle:
             method_metadata: MethodMetadata = MethodMetadata.from_raw(
                 results_lst=results_lst,
                 method=method,
-                artifact_name=artifact_name,
+                suite=suite,
             )
 
         log(
@@ -327,7 +327,7 @@ class EndToEndSingle:
         name_suffix: str | None = None,
         model_key: str | None = None,
         method: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         name_prefix_raw: str | None = None,
         backend: Literal["ray", "native"] = "ray",
         num_cpus: int | None = None,
@@ -348,7 +348,7 @@ class EndToEndSingle:
         name_suffix
         model_key
         method
-        artifact_name
+        suite
         backend
         verbose
 
@@ -379,7 +379,7 @@ class EndToEndSingle:
             name_suffix=name_suffix,
             model_key=model_key,
             method=method,
-            artifact_name=artifact_name,
+            suite=suite,
             backend=backend,
             verbose=verbose,
         )
@@ -407,15 +407,15 @@ class EndToEndSingle:
         return results_lst
 
     @classmethod
-    def from_cache(cls, method: str | MethodMetadata, artifact_name: str | None = None) -> Self:
+    def from_cache(cls, method: str | MethodMetadata, suite: str | None = None) -> Self:
         if isinstance(method, MethodMetadata):
             method_metadata = method
         else:
-            if artifact_name is None:
-                artifact_name = method
+            if suite is None:
+                suite = method
             method_metadata = MethodMetadata.from_yaml(
                 method=method,
-                artifact_name=artifact_name,
+                suite=suite,
             )
         repo = method_metadata.load_processed()
         end_to_end_results_single = EndToEndResultsSingle(method_metadata=method_metadata)
@@ -453,7 +453,7 @@ class EndToEndSingle:
         name_suffix: str | None = None,
         model_key: str | None = None,
         method: str | None = None,
-        artifact_name: str | None = None,
+        suite: str | None = None,
         num_cpus: int | None = None,
         name_prefix_raw: str | None = None,
         verbose: bool = True,
@@ -471,7 +471,7 @@ class EndToEndSingle:
         method_metadata : MethodMetadata or None = None
             The method_metadata containing information about the method.
             If unspecified, will be inferred from ``results_lst``.
-            If specified, ``method`` and ``artifact_name`` will be ignored.
+            If specified, ``method`` and ``suite`` will be ignored.
         task_metadata : pd.DataFrame or None = None
             The task_metadata containing information for each task,
             such as the target evaluation metric and problem_type.
@@ -488,11 +488,11 @@ class EndToEndSingle:
             such as when re-running LightGBM.
         method : str or None = None
             The name of the lower directory in the cache:
-                ~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/
+                ~/.cache/tabarena/artifacts/{suite}/methods/{method}/
             If unspecified, will default to ``{name_prefix}`` for configs or ``{name}`` for baselines.
-        artifact_name : str or None = None
+        suite : str or None = None
             The name of the upper directory in the cache:
-                ~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/
+                ~/.cache/tabarena/artifacts/{suite}/methods/{method}/
             If unspecified, will default to ``{method}``
         num_cpus : int or None = None
             Number of CPUs to use for parallel processing.
@@ -550,7 +550,7 @@ class EndToEndSingle:
                 name_suffix=name_suffix,
                 model_key=model_key,
                 method=method,
-                artifact_name=artifact_name,
+                suite=suite,
             ),
             track_progress=True,
             tqdm_kwargs={"desc": "Processing Results"},
@@ -588,7 +588,7 @@ class EndToEndResultsSingle:
         self,
         *,
         new_result_prefix: str | None = None,
-        use_artifact_name_in_prefix: bool = False,
+        use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
     ):
         """Vend this method as an :class:`InMemoryMethodMetadata` (metadata + in-memory results).
@@ -597,7 +597,7 @@ class EndToEndResultsSingle:
         ``extra_methods=`` so the method is registered at init and flows through
         ``compare`` and the leaderboard/website machinery like a cached baseline.
 
-        ``use_artifact_name_in_prefix`` / ``use_model_results`` mirror
+        ``use_suite_in_prefix`` / ``use_model_results`` mirror
         :meth:`get_results` (forwarded through :meth:`InMemoryMethodMetadata.from_results_single`).
         """
         from tabarena.models._in_memory_method_metadata import InMemoryMethodMetadata
@@ -605,14 +605,14 @@ class EndToEndResultsSingle:
         return InMemoryMethodMetadata.from_results_single(
             self,
             new_result_prefix=new_result_prefix,
-            use_artifact_name_in_prefix=use_artifact_name_in_prefix,
+            use_suite_in_prefix=use_suite_in_prefix,
             use_model_results=use_model_results,
         )
 
     def get_results(
         self,
         new_result_prefix: str | None = None,
-        use_artifact_name_in_prefix: bool = False,
+        use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
         fillna: bool = False,
     ) -> pd.DataFrame:
@@ -627,10 +627,10 @@ class EndToEndResultsSingle:
 
         df_results = copy.deepcopy(self.model_results) if use_model_results else copy.deepcopy(self.hpo_results)
 
-        if use_artifact_name_in_prefix:
+        if use_suite_in_prefix:
             if new_result_prefix is None:
                 new_result_prefix = ""
-            new_result_prefix = new_result_prefix + f"[{self.method_metadata.artifact_name}] "
+            new_result_prefix = new_result_prefix + f"[{self.method_metadata.suite}] "
         if new_result_prefix is not None:
             df_results = self.add_prefix_to_results(results=df_results, prefix=new_result_prefix, inplace=True)
 
@@ -767,7 +767,7 @@ def _process_result_list(
     name_suffix: str | None = None,
     model_key: str | None = None,
     method: str | None = None,
-    artifact_name: str | None = None,
+    suite: str | None = None,
 ) -> EndToEndResultsSingle:
     results_lst = load_all_artifacts(
         file_paths=file_paths_method,
@@ -786,7 +786,7 @@ def _process_result_list(
         name_suffix=name_suffix,
         model_key=model_key,
         method=method,
-        artifact_name=artifact_name,
+        suite=suite,
         backend="native",
         verbose=False,
     )

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -188,7 +188,7 @@ class TabArenaEvaluator:
             self.method_metadata_info = self.method_metadata_info.rename(
                 columns={
                     "method": "ta_name",
-                    "artifact_name": "ta_suite",
+                    "suite": "ta_suite",
                 }
             )
             self.method_metadata_info = self.method_metadata_info.drop(columns=["method_type"])

--- a/scripts/run_process_local_raw_data.py
+++ b/scripts/run_process_local_raw_data.py
@@ -21,7 +21,7 @@ submission yourself), and there is **no download and no upload**. The remaining 
 
 Two ways to specify each method (see ``RawMethod``):
   * Pass a fully-specified ``method_metadata`` (e.g. imported from a model's ``info.py``), or
-  * leave it ``None`` and give ``name`` / ``artifact_name`` / ``model_key`` hints so the
+  * leave it ``None`` and give ``name`` / ``suite`` / ``model_key`` hints so the
     metadata is inferred from the raw data during processing.
 """
 
@@ -54,9 +54,9 @@ class RawMethod:
         already-present raw data; nothing is downloaded.
     method_metadata
         A fully-specified ``MethodMetadata`` (e.g. ``from tabarena.models.tabpfn_3.info import
-        tabpfn_3_method_metadata``). If given, it is used as-is and ``name`` / ``artifact_name`` /
+        tabpfn_3_method_metadata``). If given, it is used as-is and ``name`` / ``suite`` /
         ``model_key`` below are ignored (their values are taken from the metadata).
-    name, artifact_name, model_key
+    name, suite, model_key
         Used only when ``method_metadata is None``: naming hints forwarded to
         ``EndToEndSingle.from_path_raw`` so the metadata is inferred from the raw data. Leaving
         all of them ``None`` lets the method name / artifact / model_key be inferred too.
@@ -65,7 +65,7 @@ class RawMethod:
     path_raw: Path
     method_metadata: MethodMetadata | None = None
     name: str | None = None
-    artifact_name: str | None = None
+    suite: str | None = None
     model_key: str | None = None
 
     def __post_init__(self) -> None:
@@ -80,10 +80,10 @@ class RawMethod:
         return self.method_metadata.method if self.method_metadata is not None else None
 
     @property
-    def resolved_artifact_name(self) -> str | None:
-        if self.artifact_name is not None:
-            return self.artifact_name
-        return self.method_metadata.artifact_name if self.method_metadata is not None else None
+    def resolved_suite(self) -> str | None:
+        if self.suite is not None:
+            return self.suite
+        return self.method_metadata.suite if self.method_metadata is not None else None
 
     @property
     def resolved_model_key(self) -> str | None:
@@ -204,8 +204,8 @@ def _print_method_metadata_snippet(
         ("has_processed", True),
         ("has_results", True),
     ]
-    if method.resolved_artifact_name is not None:
-        snippet_fields.append(("artifact_name", method.resolved_artifact_name))
+    if method.resolved_suite is not None:
+        snippet_fields.append(("suite", method.resolved_suite))
 
     slug = re.sub(r"[^a-z0-9]", "", str(snippet_method).lower()) or "method"
     print("[raw-info]   Suggested MethodMetadata (copy-paste; fill in the manual fields):")
@@ -340,7 +340,7 @@ def process_raw(
     """Process the already-present raw data into cached method artifacts (no upload).
 
     Builds the processed ``EvaluationRepository`` and per-task results and caches them under the
-    TabArena cache root (``~/.cache/tabarena/artifacts/{artifact_name}/methods/{method}/``):
+    TabArena cache root (``~/.cache/tabarena/artifacts/{suite}/methods/{method}/``):
     ``metadata.yaml`` + ``processed/`` + ``results/``.
 
     Parameters
@@ -359,7 +359,7 @@ def process_raw(
         method_metadata=method.method_metadata,
         name=method.resolved_name,
         model_key=method.resolved_model_key,
-        artifact_name=method.resolved_artifact_name,
+        suite=method.resolved_suite,
         cache=True,
         cache_raw=cache_raw,
         cache_hpo_trajectories=cache_hpo_trajectories,
@@ -384,7 +384,7 @@ if __name__ == "__main__":
     #     RawMethod(
     #         path_raw=Path("local_data/leaderboard_submissions/data_SomeNewModel"),
     #         name="SomeNewModel_GPU",
-    #         artifact_name="tabarena-2026-06-22",
+    #         suite="tabarena-2026-06-22",
     #         model_key="SOMENEWMODEL_GPU",
     #     )
     #

--- a/scripts/run_upload_results.py
+++ b/scripts/run_upload_results.py
@@ -23,7 +23,7 @@ required credentials are missing.
 
 Specify the methods to upload either by importing a ``MethodMetadata`` from a model's ``info.py``,
 or by loading one from the local cache with
-``MethodMetadata.from_yaml(method=..., artifact_name=...)``.
+``MethodMetadata.from_yaml(method=..., suite=...)``.
 """
 
 from __future__ import annotations
@@ -98,9 +98,8 @@ def plan_and_verify_upload(method_metadata: MethodMetadata, *, upload_raw: bool 
 
     if problems:
         raise FileNotFoundError(
-            f"Refusing to upload '{method_metadata.method}' (artifact_name="
-            f"{method_metadata.artifact_name!r}); {len(problems)} artifact check(s) failed:\n  - "
-            + "\n  - ".join(problems)
+            f"Refusing to upload '{method_metadata.method}' (suite="
+            f"{method_metadata.suite!r}); {len(problems)} artifact check(s) failed:\n  - " + "\n  - ".join(problems)
         )
     return parts
 
@@ -139,7 +138,7 @@ def upload_method(
 
     if dry_run:
         print(
-            f"[dry-run] '{method_metadata.method}' (artifact={method_metadata.artifact_name}) "
+            f"[dry-run] '{method_metadata.method}' (artifact={method_metadata.suite}) "
             f"verified OK; would upload parts={parts} -> {_destination(method_metadata)} "
             f"(cache_type={method_metadata.cache_type})"
         )
@@ -152,7 +151,7 @@ def upload_method(
 
     uploader = method_metadata.method_uploader()
     print(
-        f"Uploading '{method_metadata.method}' (artifact={method_metadata.artifact_name}) "
+        f"Uploading '{method_metadata.method}' (artifact={method_metadata.suite}) "
         f"to s3://{uploader.bucket}/{uploader.prefix} | cache_type={method_metadata.cache_type} | parts={parts}"
     )
     uploader.upload_metadata()
@@ -177,10 +176,10 @@ if __name__ == "__main__":
     # Methods to upload. Either import a fully-specified MethodMetadata from a model's info.py:
     #     from tabarena.models.tabpfn_3.info import tabpfn_3_method_metadata
     #     methods = [tabpfn_3_method_metadata]
-    # or load one from the local cache by (method, artifact_name):
-    #     MethodMetadata.from_yaml(method="TabPFN-3", artifact_name="tabarena-2026-05-13")
+    # or load one from the local cache by (method, suite):
+    #     MethodMetadata.from_yaml(method="TabPFN-3", suite="tabarena-2026-05-13")
     methods: list[MethodMetadata] = [
-        # MethodMetadata.from_yaml(method="...", artifact_name="..."),
+        # MethodMetadata.from_yaml(method="...", suite="..."),
     ]
 
     if len(methods) == 0:

--- a/tests/integration/test_async_tabarena_api.py
+++ b/tests/integration/test_async_tabarena_api.py
@@ -157,7 +157,7 @@ def _comparison_baseline(collection: TaskMetadataCollection) -> InMemoryMethodMe
     return InMemoryMethodMetadata(
         results=pd.DataFrame(rows),
         method="ToyBaseline",
-        artifact_name="ToyBaseline",
+        suite="ToyBaseline",
         method_type="config",
         model_key="ToyBaseline",
     )

--- a/tests/tabarena/evaluation/context/test_beyond_arena_context.py
+++ b/tests/tabarena/evaluation/context/test_beyond_arena_context.py
@@ -40,9 +40,7 @@ class TestPresets:
         ctx = BeyondArenaContext()
         method_names = {m.method for m in ctx.method_metadata_collection.method_metadata_lst}
         assert {"LinearModel", "RandomForest", "CatBoost", "TA-TabM", "TA-TabPFN-2.6"} <= method_names
-        assert all(
-            m.artifact_name == "beyond_iid_benchmark_2026" for m in ctx.method_metadata_collection.method_metadata_lst
-        )
+        assert all(m.suite == "beyond_iid_benchmark_2026" for m in ctx.method_metadata_collection.method_metadata_lst)
         assert len(ctx.task_metadata_collection) > 0
 
     def test_only_beyondarena_preset_supported(self):

--- a/tests/tabarena/evaluation/test_benchmark_eval.py
+++ b/tests/tabarena/evaluation/test_benchmark_eval.py
@@ -113,11 +113,11 @@ def test_run_eval_orchestration(tmp_path, monkeypatch):
     assert len(post_calls) == 1
     assert post_calls[0]["name_prefix_raw"] == "AG_A"
     assert post_calls[0]["method"] == "AG_A"
-    assert post_calls[0]["artifact_name"] == "bench"
+    assert post_calls[0]["suite"] == "bench"
     assert post_calls[0]["name_suffix"] == " [Rerun]"
     assert Path(post_calls[0]["path_raw"]) == cfg.path_raw
 
-    # Phase 2: every method is re-loaded from cache as (ag_name, artifact_name), exactly once.
+    # Phase 2: every method is re-loaded from cache as (ag_name, suite), exactly once.
     assert from_cache_calls == [[("AG_A", "bench"), ("AG_B", "bench")]]
 
     # The context is built once, with the run's vended methods registered via extra_methods=.

--- a/tests/tabarena/models/test_in_memory_method_metadata.py
+++ b/tests/tabarena/models/test_in_memory_method_metadata.py
@@ -122,7 +122,7 @@ class TestFromResultsSinglePrefixIdentity:
     def _results_single(self) -> EndToEndResultsSingle:
         base = MethodMetadata(
             method="MyModel",
-            artifact_name="MyModel",
+            suite="MyModel",
             method_type="config",
             ag_key="MM",
             model_key="MM",
@@ -134,17 +134,17 @@ class TestFromResultsSinglePrefixIdentity:
     def test_prefix_applied_to_identity_fields(self):
         im = self._results_single().to_method_metadata(new_result_prefix="[New] ")
         assert im.method == "[New] MyModel"
-        assert im.artifact_name == "[New] MyModel"
+        assert im.suite == "[New] MyModel"
         assert im.display_name == "[New] MyModel"
         assert im.config_type == "[New] MM"  # model_key was prefixed too
 
     def test_frame_and_identity_share_the_website_merge_key(self):
         # leaderboard_to_website_format merges leaderboard <-> info on (ta_name, ta_suite),
-        # where info's ta_name/ta_suite == method/artifact_name. They must equal the frame's.
+        # where info's ta_name/ta_suite == method/suite. They must equal the frame's.
         im = self._results_single().to_method_metadata(new_result_prefix="[New] ")
         frame = im.load_results()
         assert list(frame["ta_name"].unique()) == [im.method]
-        assert list(frame["ta_suite"].unique()) == [im.artifact_name]
+        assert list(frame["ta_suite"].unique()) == [im.suite]
         assert list(frame["method"].unique()) == ["[New] MM (default)"]
 
     def test_no_prefix_is_identity(self):
@@ -161,7 +161,7 @@ class TestContextRegistration:
         return InMemoryMethodMetadata(
             results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
             method=method,
-            artifact_name=method,
+            suite=method,
             method_type="config",
             model_key=method,
         )
@@ -170,7 +170,7 @@ class TestContextRegistration:
         return _DiskBackedMethod(
             results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
             method=method,
-            artifact_name=method,
+            suite=method,
             method_type="config",
             model_key=method,
         )
@@ -204,7 +204,7 @@ class TestResolveOnlyValidTasks:
         return InMemoryMethodMetadata(
             results=_results_frame("NewA (default)", datasets=("d1",), ta_name="NewA", ta_suite="NewA"),
             method="NewA",
-            artifact_name="NewA",
+            suite="NewA",
             method_type="config",
             model_key="NewA",
         )
@@ -263,7 +263,7 @@ class TestInitOnlyValidTasks:
         return InMemoryMethodMetadata(
             results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
             method=method,
-            artifact_name=method,
+            suite=method,
             method_type="config",
             model_key=method,
         )
@@ -296,7 +296,7 @@ class TestInitOnlyValidTasks:
         disk = _DiskBackedMethod(
             results=_results_frame("Disk (default)", datasets=("d1",), ta_name="Disk", ta_suite="Disk"),
             method="Disk",
-            artifact_name="Disk",
+            suite="Disk",
             method_type="config",
             model_key="Disk",
         )
@@ -342,7 +342,7 @@ class TestFromNewMethodsFactory:
         return InMemoryMethodMetadata(
             results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
             method=method,
-            artifact_name=method,
+            suite=method,
             method_type="config",
             model_key=method,
         )
@@ -388,7 +388,7 @@ class TestRegister:
         return InMemoryMethodMetadata(
             results=_results_frame(f"{method} (default)", datasets=datasets, ta_name=method, ta_suite=method),
             method=method,
-            artifact_name=method,
+            suite=method,
             method_type="config",
             model_key=method,
         )

--- a/tests/tabarena/models/test_registry.py
+++ b/tests/tabarena/models/test_registry.py
@@ -18,11 +18,11 @@ class _DummyModel:
     pass
 
 
-def _make_info(method: str, artifact_name: str | None = None) -> ModelInfo:
+def _make_info(method: str, suite: str | None = None) -> ModelInfo:
     return ModelInfo(
         model_cls=_DummyModel,
         search_space=lambda: None,
-        method_metadata=MethodMetadata(method=method, artifact_name=artifact_name),
+        method_metadata=MethodMetadata(method=method, suite=suite),
     )
 
 
@@ -174,7 +174,7 @@ def test_discover_models_raises_on_duplicate_method_key(patched_discovery):
 
 
 def test_register_model_info_adds_new_entry(patched_discovery):
-    info = _make_info("NewMethod", artifact_name="art-1")
+    info = _make_info("NewMethod", suite="art-1")
 
     register_model_info(info)
 
@@ -190,9 +190,9 @@ def test_register_model_info_is_idempotent_for_same_object(patched_discovery):
     assert get_model_registry()["SameObject"] is info
 
 
-def test_register_model_info_disambiguates_duplicate_with_artifact_name(patched_discovery):
-    core_info = _make_info("Linear", artifact_name="tabarena-core")
-    ext_info = _make_info("Linear", artifact_name="extension-rerun")
+def test_register_model_info_disambiguates_duplicate_with_suite(patched_discovery):
+    core_info = _make_info("Linear", suite="tabarena-core")
+    ext_info = _make_info("Linear", suite="extension-rerun")
     patched_discovery["submodules"] = [("core", True)]
     patched_discovery["info_modules"] = {"core": _info_module(core=core_info)}
 
@@ -204,9 +204,9 @@ def test_register_model_info_disambiguates_duplicate_with_artifact_name(patched_
 
 
 def test_register_model_info_raises_on_conflicting_composite_key(patched_discovery):
-    core_info = _make_info("Linear", artifact_name="tabarena-core")
-    ext_info_v1 = _make_info("Linear", artifact_name="rerun")
-    ext_info_v2 = _make_info("Linear", artifact_name="rerun")
+    core_info = _make_info("Linear", suite="tabarena-core")
+    ext_info_v1 = _make_info("Linear", suite="rerun")
+    ext_info_v2 = _make_info("Linear", suite="rerun")
     patched_discovery["submodules"] = [("core", True)]
     patched_discovery["info_modules"] = {"core": _info_module(core=core_info)}
 

--- a/tests/tabarena/nips2025_utils/test_end_to_end_single.py
+++ b/tests/tabarena/nips2025_utils/test_end_to_end_single.py
@@ -80,7 +80,7 @@ def _e2e_single_for_config(config_default: str, *, method: str = "TA-TabPFN-3") 
     """
     method_metadata = MethodMetadata(
         method=method,
-        artifact_name=method,
+        suite=method,
         method_type="config",
         config_default=config_default,
         can_hpo=False,


### PR DESCRIPTION
## Summary

Renames the `artifact_name` field on `MethodMetadata` to **`suite`** — the term already used for this concept everywhere downstream (the `ta_suite` results column / the website merge key `(ta_name, ta_suite)`). `suite` is the dated artifact set a method's artifacts are grouped under in the cache/S3 path (`artifacts/<suite>/methods/<method>/`), e.g. `"tabarena-2026-05-13"`. The old name read as "the name of one artifact" when it actually names a *collection* of artifacts shared by many methods; this makes the Python field and the serialized/results surface finally agree.

Done in two commits:

1. **Core + direct callers** — the field, `__post_init__` defaulting, all factory methods (`config`/`baseline`/`from_raw`/`_from_raw_*`/`tabarena_legacy_s3`/`from_yaml`), the `path` property and error messages, plus every direct constructor/accessor: the metadata collection, in-memory metadata, registry, simulator, artifact up/downloader path comments, all model `info.py`, `baselines/info.py`, the per-date artifact-metadata definitions, and the `add-model` skill template.
2. **Remaining usages** — `end_to_end` / `end_to_end_single` / `abstract_arena_context`, the evaluation layer (`MethodArtifact`, `benchmark_eval`, `beyond_arena_eval`), the `field -> ta_suite` rename map in `tabarena_evaluator`, scripts, archived examples, and the affected tests. Also renames the derived identifiers for consistency: `use_artifact_name_in_prefix` -> `use_suite_in_prefix`, `default_artifact_name` -> `default_suite`, `resolved_artifact_name` -> `resolved_suite`.

## Backwards compatibility

The Python `artifact_name` API is renamed outright (no alias). The **one** back-compat shim is in `MethodMetadata._migrate_legacy_kwargs`: a legacy `artifact_name:` key in an on-disk `metadata.yaml` is folded onto `suite`, so metadata written before this rename still loads (and never clobbers an explicit `suite`). The only `artifact_name` token left in the tree is that loader handling.

Downstream code that passes `artifact_name=` to `MethodMetadata` / `from_yaml` or reads `.artifact_name` will need to switch to `suite` — only the on-disk YAML key is shimmed, not Python kwargs.

## Verification

- 85 unit tests + 1 integration test pass (in-memory metadata, registry, benchmark eval, end-to-end single, beyond-arena context, async API).
- Model registry discovers all 33 models (every `info.py` constructs via `suite=`).
- Back-compat checked: legacy `{artifact_name: ...}` migrates to `suite`, explicit `suite` wins.
- `ruff check` clean on all touched files; `ruff format` applied where the shorter token changed line-wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)