### PR TITLE
Make artifact_dir point at the method dir (rename cache_root); 3rd init arg

### DIFF
--- a/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
@@ -99,7 +99,7 @@ class InMemoryMethodMetadata(MethodMetadata):
 
     # ------------------------------------------------------------------ serialization
     def to_info_dict(self) -> dict:
-        # Build on the base exclusion (drops the runtime-only ``cache_root`` override), then
+        # Build on the base exclusion (drops the runtime-only ``artifact_dir`` override), then
         # also drop the in-memory artifact slots so no DataFrame/repo lands in the info table.
         return {k: v for k, v in super().to_info_dict().items() if k not in self._IN_MEMORY_SLOTS}
 

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -78,11 +78,11 @@ class MethodMetadata:
     # every caller constructs MethodMetadata by keyword, and to_info_dict is field-driven.
 
     # -- (1) Identity & on-disk location ------------------------------------------------------
-    #: ``method`` and ``suite`` are the identity pair that determines where this method's
-    #: artifacts live on disk (see :attr:`path`):
+    #: ``method``, ``suite``, and ``artifact_dir`` determine where this method's artifacts live
+    #: on disk (see :attr:`path`):
     #:
     #:     <tabarena_cache>/artifacts/<suite>/methods/<method>/   (default cache layout)
-    #:     <cache_root>/<method>/                                 (flat ``cache_root`` layout)
+    #:     <artifact_dir>/                                        (explicit ``artifact_dir`` override)
     #:
     #: ``method`` (the only required field) is the unique method identifier, e.g. ``"TabPFN-3"``.
     #: ``suite`` is the artifact set the method belongs to — normally the dated benchmark run,
@@ -90,8 +90,16 @@ class MethodMetadata:
     #: ``(method, suite)`` is the unique key within a :class:`MethodMetadataCollection`. ``suite``
     #: defaults to ``method`` (in :meth:`__post_init__`) when omitted, so a one-off method needs
     #: only ``method``.
+    #:
+    #: ``artifact_dir`` is an optional override pointing *directly* at this method's artifact
+    #: directory — the dir that holds ``metadata.yaml`` + ``results/`` — to load committed
+    #: artifacts from an arbitrary location (e.g. a repo's ``data/`` folder) without touching the
+    #: global TabArena cache. When set, :attr:`path` is ``artifact_dir`` itself and neither
+    #: ``suite`` nor ``method`` contributes to the path. Kept out of :meth:`to_info_dict` so this
+    #: local path is never serialized into the committed ``metadata.yaml`` or the info table.
     method: str
     suite: str | None = None
+    artifact_dir: str | Path | None = None
 
     # -- (2) Inferable from raw results -------------------------------------------------------
     #: Populated automatically by :meth:`from_raw` (and the ``run_process_local_raw_data.py``
@@ -139,13 +147,6 @@ class MethodMetadata:
     #: ``"https://data.tabarena.ai/"``). The uploader/downloader factories read what they need from
     #: here. Empty for ``"local"``.
     cache_kwargs: dict = field(default_factory=dict)
-    #: Optional override pointing at a self-contained, *flat* method directory
-    #: (``<cache_root>/<method>/`` holding ``metadata.yaml`` + ``results/``), used to load a
-    #: method's committed artifacts from an arbitrary location (e.g. a repo's ``data/`` folder)
-    #: without touching the global TabArena cache root. ``None`` => derive paths from the cache
-    #: root as usual. Kept out of ``to_info_dict`` so this local path is never serialized into
-    #: the committed ``metadata.yaml`` or the metadata info table.
-    cache_root: str | Path | None = None
 
     # -- (4) Purely informative ---------------------------------------------------------------
     # Descriptive only — no effect on behavior, paths, or loading.
@@ -166,7 +167,7 @@ class MethodMetadata:
             self.model_key = self.ag_key
         if self.can_hpo is None:
             self.can_hpo = self.method_type == "config"
-        self.cache_root = Path(self.cache_root) if self.cache_root is not None else None
+        self.artifact_dir = Path(self.artifact_dir) if self.artifact_dir is not None else None
 
         assert isinstance(self.method, str)
         assert len(self.method) > 0
@@ -560,15 +561,16 @@ class MethodMetadata:
 
     @property
     def path(self) -> Path:
-        """Root directory of this method's artifacts on disk, derived from ``(suite, method)``.
+        """Root directory of this method's artifacts on disk.
 
         Default cache layout: ``<tabarena_cache>/artifacts/<suite>/methods/<method>/`` (where
-        ``_path_root == <tabarena_cache>/artifacts``). When ``cache_root`` is set, artifacts
-        instead live in a flat ``<cache_root>/<method>/`` dir — no ``artifacts/<suite>/methods/``
-        infix, ``suite`` not part of the path — so committed copies stay shallow.
+        ``_path_root == <tabarena_cache>/artifacts``), derived from ``(suite, method)``. When
+        ``artifact_dir`` is set it *is* the artifact directory (``metadata.yaml`` + ``results/``
+        live directly under it) and is returned as-is — ``suite``/``method`` do not contribute to
+        the path — so committed copies can live at an arbitrary location.
         """
-        if self.cache_root is not None:
-            return self.cache_root / self.method
+        if self.artifact_dir is not None:
+            return self.artifact_dir
         return self._path_root / self.suite / "methods" / self.method
 
     @property
@@ -847,14 +849,14 @@ class MethodMetadata:
         """The flat field dict used to build the metadata info table / YAML.
 
         Derived from the declared dataclass fields (an allowlist), in declaration order, minus
-        the runtime-only ``cache_root`` override — a local path that must not leak into committed
+        the runtime-only ``artifact_dir`` override — a local path that must not leak into committed
         YAML or the info table. Field-driven rather than ``self.__dict__``-driven so that
         non-field instance state never lands in the info table (e.g.
         :class:`InMemoryMethodMetadata`'s in-memory results frame, set as a plain attribute,
         not a field). Remains an overridable hook for subclasses.
         """
         info = {f.name: getattr(self, f.name) for f in fields(self)}
-        info.pop("cache_root", None)
+        info.pop("artifact_dir", None)
         return info
 
     @property
@@ -927,60 +929,50 @@ class MethodMetadata:
         method: str | None = None,
         suite: str | None = None,
         *,
-        cache_root: str | Path | None = None,
+        artifact_dir: str | Path | None = None,
         relative_cache: bool | Literal["auto"] = "auto",
     ) -> Self:
         """Load a method's metadata from YAML.
 
-        ``cache_root`` points the loaded method at a self-contained, flat artifact directory
-        (``<cache_root>/<method>/`` holding ``metadata.yaml`` + ``results/``) instead of the
-        global TabArena cache — e.g. to load committed results from a repo's ``data/`` folder.
-        When given alongside an explicit ``path``, the two must describe the same location
-        (``<cache_root>/<method>/metadata.yaml``); a mismatch raises so layout typos surface early.
+        ``artifact_dir`` points the loaded method at a self-contained artifact directory (the dir
+        holding ``metadata.yaml`` + ``results/``) instead of the global TabArena cache — e.g. to
+        load committed results from a repo's ``data/`` folder. It becomes the method's
+        :attr:`path`, so ``suite``/``method`` are not used to locate artifacts.
 
-        ``relative_cache=True`` infers ``cache_root`` from ``path`` itself (as ``path.parent.parent``,
-        i.e. the directory containing the ``<method>/`` folder), so callers loading a method from an
-        explicit ``path`` need only pass ``path`` — no separately-computed ``cache_root``. Requires
-        an explicit ``path`` and is mutually exclusive with ``cache_root``.
+        ``relative_cache=True`` infers ``artifact_dir`` from ``path`` itself (as ``path.parent``,
+        the directory the ``metadata.yaml`` lives in), so callers loading a method from an explicit
+        ``path`` need only pass ``path`` — no separately-computed ``artifact_dir``. Requires an
+        explicit ``path`` and is mutually exclusive with ``artifact_dir``.
 
         The default ``"auto"`` applies that inference exactly when it is safe and unambiguous: an
-        explicit ``path`` is given and no ``cache_root`` was passed. It is a no-op for the
-        ``method``/``suite`` lookup forms (so those callers are unaffected), and the
-        inference is correct for both the flat committed layout and the global cache layout, since
-        in both the yaml's parent directory is named ``<method>``.
+        explicit ``path`` is given and no ``artifact_dir`` was passed. It is a no-op for the
+        ``method``/``suite`` lookup forms (so those callers resolve against the global cache).
         """
         if relative_cache == "auto":
-            relative_cache = path is not None and cache_root is None
+            relative_cache = path is not None and artifact_dir is None
 
         if relative_cache:
             if path is None:
                 raise ValueError("relative_cache=True requires an explicit `path`.")
-            if cache_root is not None:
-                raise ValueError("Pass either `cache_root` or `relative_cache=True`, not both.")
-            cache_root = Path(path).parent.parent
+            if artifact_dir is not None:
+                raise ValueError("Pass either `artifact_dir` or `relative_cache=True`, not both.")
+            artifact_dir = Path(path).parent
 
         if path is None:
-            assert method is not None, "method must be specified if path is not specified"
-            assert suite is not None, "suite must be specified if path is not specified"
-            if cache_root is not None:
-                path = Path(cache_root) / method / "metadata.yaml"
+            if artifact_dir is not None:
+                path = Path(artifact_dir) / "metadata.yaml"
             else:
+                assert method is not None, "method must be specified if path is not specified"
+                assert suite is not None, "suite must be specified if path is not specified"
                 path = get_tabarena_cache_root() / "artifacts" / suite / "methods" / method / "metadata.yaml"
 
         assert str(path).endswith(".yaml")
         with open(path) as file:
             kwargs = yaml.safe_load(file)
-        if cache_root is not None:
-            kwargs["cache_root"] = cache_root
+        if artifact_dir is not None:
+            kwargs["artifact_dir"] = artifact_dir
         cls._migrate_legacy_kwargs(kwargs)
-        method_metadata = cls(**kwargs)
-        if cache_root is not None and Path(method_metadata.path_metadata).resolve() != Path(path).resolve():
-            raise ValueError(
-                f"cache_root/method layout mismatch: with cache_root={cache_root!r} the metadata for "
-                f"method={method_metadata.method!r} is expected at {method_metadata.path_metadata}, "
-                f"but it was loaded from {path}. Lay artifacts out as <cache_root>/<method>/metadata.yaml.",
-            )
-        return method_metadata
+        return cls(**kwargs)
 
     def cache_raw(
         self,

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -928,46 +928,33 @@ class MethodMetadata:
         path: Path | str | None = None,
         method: str | None = None,
         suite: str | None = None,
-        *,
-        artifact_dir: str | Path | None = None,
-        relative_cache: bool | Literal["auto"] = "auto",
     ) -> Self:
-        """Load a method's metadata from YAML.
+        """Load a method's metadata from YAML, in one of two forms:
 
-        ``artifact_dir`` points the loaded method at a self-contained artifact directory (the dir
-        holding ``metadata.yaml`` + ``results/``) instead of the global TabArena cache — e.g. to
-        load committed results from a repo's ``data/`` folder. It becomes the method's
-        :attr:`path`, so ``suite``/``method`` are not used to locate artifacts.
-
-        ``relative_cache=True`` infers ``artifact_dir`` from ``path`` itself (as ``path.parent``,
-        the directory the ``metadata.yaml`` lives in), so callers loading a method from an explicit
-        ``path`` need only pass ``path`` — no separately-computed ``artifact_dir``. Requires an
-        explicit ``path`` and is mutually exclusive with ``artifact_dir``.
-
-        The default ``"auto"`` applies that inference exactly when it is safe and unambiguous: an
-        explicit ``path`` is given and no ``artifact_dir`` was passed. It is a no-op for the
-        ``method``/``suite`` lookup forms (so those callers resolve against the global cache).
+        * ``from_yaml(path=...)`` loads committed artifacts from a self-contained directory.
+          ``path`` may be that directory **or** the ``metadata.yaml`` inside it (anything not
+          ending in ``.yaml`` is treated as the directory); either way the method's
+          :attr:`artifact_dir` is set to the directory, so ``results/`` resolve next to the
+          metadata and the global TabArena cache is not consulted. This is how committed copies in
+          a repo's ``data/`` folder are loaded.
+        * ``from_yaml(method=..., suite=...)`` looks the method up in the global TabArena cache at
+          ``<cache>/artifacts/<suite>/methods/<method>/metadata.yaml``.
         """
-        if relative_cache == "auto":
-            relative_cache = path is not None and artifact_dir is None
+        if path is not None:
+            path = Path(path)
+            # `path` is either the artifact directory or the metadata.yaml inside it. Discriminate
+            # on the suffix (not ``is_dir()``) so it works before the dir exists and so method dirs
+            # whose name contains a dot (e.g. ``TA-TabPFN-2.6``) are still read as directories.
+            is_yaml_file = path.suffix == ".yaml"
+            artifact_dir = path.parent if is_yaml_file else path
+            yaml_path = path if is_yaml_file else path / "metadata.yaml"
+        else:
+            assert method is not None, "method must be specified if path is not specified"
+            assert suite is not None, "suite must be specified if path is not specified"
+            artifact_dir = None
+            yaml_path = get_tabarena_cache_root() / "artifacts" / suite / "methods" / method / "metadata.yaml"
 
-        if relative_cache:
-            if path is None:
-                raise ValueError("relative_cache=True requires an explicit `path`.")
-            if artifact_dir is not None:
-                raise ValueError("Pass either `artifact_dir` or `relative_cache=True`, not both.")
-            artifact_dir = Path(path).parent
-
-        if path is None:
-            if artifact_dir is not None:
-                path = Path(artifact_dir) / "metadata.yaml"
-            else:
-                assert method is not None, "method must be specified if path is not specified"
-                assert suite is not None, "suite must be specified if path is not specified"
-                path = get_tabarena_cache_root() / "artifacts" / suite / "methods" / method / "metadata.yaml"
-
-        assert str(path).endswith(".yaml")
-        with open(path) as file:
+        with open(yaml_path) as file:
             kwargs = yaml.safe_load(file)
         if artifact_dir is not None:
             kwargs["artifact_dir"] = artifact_dir

--- a/scripts/run_upload_results.py
+++ b/scripts/run_upload_results.py
@@ -115,7 +115,7 @@ def _destination(method_metadata: MethodMetadata) -> str:
         rel = method_metadata.relative_to_cache_root(method_metadata.path).as_posix()
         return f"{root}/{rel}"
     except ValueError:
-        # path not under the global cache root (e.g. a flat cache_root override)
+        # path not under the global cache root (e.g. an explicit artifact_dir override)
         return f"{root}/ (method={method_metadata.method})"
 
 

--- a/tests/tabarena/models/test_method_metadata.py
+++ b/tests/tabarena/models/test_method_metadata.py
@@ -14,12 +14,13 @@ def test_location_args_are_first_three_fields():
     assert [f.name for f in fields(MethodMetadata)][:3] == ["method", "suite", "artifact_dir"]
 
 
-def test_default_path_uses_suite_and_method(monkeypatch, tmp_path):
-    from tabarena.models import _method_metadata as mm_mod
-
-    monkeypatch.setattr(mm_mod, "get_tabarena_cache_root", lambda: tmp_path)
+def test_default_layout_uses_suite_and_method_segments():
+    # Without an artifact_dir override the path is <cache>/artifacts/<suite>/methods/<method>.
+    # Assert the trailing segments rather than the absolute root so the test is independent of
+    # wherever the global TabArena cache happens to resolve.
     mm = MethodMetadata.config(method="Foo", suite="tabarena-2026-05-13")
-    assert mm.path == tmp_path / "artifacts" / "tabarena-2026-05-13" / "methods" / "Foo"
+    assert mm.artifact_dir is None
+    assert mm.path.parts[-4:] == ("artifacts", "tabarena-2026-05-13", "methods", "Foo")
 
 
 def test_artifact_dir_is_returned_as_the_path_verbatim(tmp_path):

--- a/tests/tabarena/models/test_method_metadata.py
+++ b/tests/tabarena/models/test_method_metadata.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import fields
 
-import pytest
 import yaml
 
 from tabarena.models._method_metadata import MethodMetadata
@@ -44,8 +43,8 @@ def _write_committed_method(method_dir, *, method="Foo", suite="s1"):
 
 
 def test_from_yaml_path_resolves_artifacts_next_to_metadata(tmp_path):
-    # relative_cache="auto": loading from an explicit path points artifact_dir at the dir holding
-    # metadata.yaml, so results resolve next to it -- regardless of how the dir is named.
+    # Loading from an explicit metadata.yaml path points artifact_dir at the dir holding it, so
+    # results resolve next to it -- regardless of how the dir is named.
     method_dir = tmp_path / "committed" / "renamed-folder"
     _write_committed_method(method_dir, method="Foo", suite="s1")
 
@@ -56,21 +55,15 @@ def test_from_yaml_path_resolves_artifacts_next_to_metadata(tmp_path):
     assert mm.path_results == method_dir / "results"
 
 
-def test_from_yaml_explicit_artifact_dir_without_path(tmp_path):
-    method_dir = tmp_path / "anywhere"
-    _write_committed_method(method_dir, method="Bar", suite="s2")
+def test_from_yaml_path_accepts_dir_or_yaml_file(tmp_path):
+    # `path` may be the artifact directory or the metadata.yaml inside it; both are equivalent.
+    # Use a dir name containing a dot to confirm dirs aren't misread as files.
+    method_dir = tmp_path / "TA-TabPFN-2.6"
+    _write_committed_method(method_dir, method="TA-TabPFN-2.6", suite="s2")
 
-    mm = MethodMetadata.from_yaml(artifact_dir=method_dir)
-    assert mm.method == "Bar"
-    assert mm.path == method_dir
+    from_dir = MethodMetadata.from_yaml(path=method_dir)
+    from_file = MethodMetadata.from_yaml(path=method_dir / "metadata.yaml")
 
-
-def test_from_yaml_artifact_dir_and_relative_cache_are_mutually_exclusive(tmp_path):
-    method_dir = tmp_path / "m"
-    _write_committed_method(method_dir)
-    with pytest.raises(ValueError, match="artifact_dir.*relative_cache"):
-        MethodMetadata.from_yaml(
-            path=method_dir / "metadata.yaml",
-            artifact_dir=method_dir,
-            relative_cache=True,
-        )
+    assert from_dir.artifact_dir == method_dir == from_file.artifact_dir
+    assert from_dir.path == method_dir == from_file.path
+    assert from_dir.method == from_file.method == "TA-TabPFN-2.6"

--- a/tests/tabarena/models/test_method_metadata.py
+++ b/tests/tabarena/models/test_method_metadata.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import fields
+
+import pytest
+import yaml
+
+from tabarena.models._method_metadata import MethodMetadata
+
+
+def test_location_args_are_first_three_fields():
+    # method / suite / artifact_dir are the location-determining identity args and live together
+    # at the front of the init signature.
+    assert [f.name for f in fields(MethodMetadata)][:3] == ["method", "suite", "artifact_dir"]
+
+
+def test_default_path_uses_suite_and_method(monkeypatch, tmp_path):
+    from tabarena.models import _method_metadata as mm_mod
+
+    monkeypatch.setattr(mm_mod, "get_tabarena_cache_root", lambda: tmp_path)
+    mm = MethodMetadata.config(method="Foo", suite="tabarena-2026-05-13")
+    assert mm.path == tmp_path / "artifacts" / "tabarena-2026-05-13" / "methods" / "Foo"
+
+
+def test_artifact_dir_is_returned_as_the_path_verbatim(tmp_path):
+    # When artifact_dir is set it *is* the artifact root; suite/method do not contribute.
+    mm = MethodMetadata.config(method="Foo", suite="some-suite", artifact_dir=tmp_path)
+    assert mm.path == tmp_path
+    assert mm.path_results == tmp_path / "results"
+    assert mm.path_metadata == tmp_path / "metadata.yaml"
+
+
+def test_artifact_dir_excluded_from_info_dict(tmp_path):
+    mm = MethodMetadata.config(method="Foo", artifact_dir=tmp_path)
+    assert "artifact_dir" not in mm.to_info_dict()
+
+
+def _write_committed_method(method_dir, *, method="Foo", suite="s1"):
+    method_dir.mkdir(parents=True, exist_ok=True)
+    info = MethodMetadata.config(method=method, suite=suite).to_info_dict()
+    with open(method_dir / "metadata.yaml", "w") as f:
+        yaml.dump(info, f)
+
+
+def test_from_yaml_path_resolves_artifacts_next_to_metadata(tmp_path):
+    # relative_cache="auto": loading from an explicit path points artifact_dir at the dir holding
+    # metadata.yaml, so results resolve next to it -- regardless of how the dir is named.
+    method_dir = tmp_path / "committed" / "renamed-folder"
+    _write_committed_method(method_dir, method="Foo", suite="s1")
+
+    mm = MethodMetadata.from_yaml(path=method_dir / "metadata.yaml")
+    assert mm.method == "Foo"
+    assert mm.artifact_dir == method_dir
+    assert mm.path == method_dir
+    assert mm.path_results == method_dir / "results"
+
+
+def test_from_yaml_explicit_artifact_dir_without_path(tmp_path):
+    method_dir = tmp_path / "anywhere"
+    _write_committed_method(method_dir, method="Bar", suite="s2")
+
+    mm = MethodMetadata.from_yaml(artifact_dir=method_dir)
+    assert mm.method == "Bar"
+    assert mm.path == method_dir
+
+
+def test_from_yaml_artifact_dir_and_relative_cache_are_mutually_exclusive(tmp_path):
+    method_dir = tmp_path / "m"
+    _write_committed_method(method_dir)
+    with pytest.raises(ValueError, match="artifact_dir.*relative_cache"):
+        MethodMetadata.from_yaml(
+            path=method_dir / "metadata.yaml",
+            artifact_dir=method_dir,
+            relative_cache=True,
+        )


### PR DESCRIPTION
## Summary

Follow-up to the `suite` work. Renames the `MethodMetadata.cache_root` override to **`artifact_dir`** and changes its semantics to point **directly at a method's artifact directory** (the dir holding `metadata.yaml` + `results/`) rather than one level up (its parent). `path` now returns `artifact_dir` as-is. `artifact_dir` is placed as the **3rd field**, so the three location-determining args — `method`, `suite`, `artifact_dir` — sit together.

## Why

I checked every use of the old `cache_root`:

- It is **never set explicitly** anywhere (tabarena or the consumer repos) — no `cache_root=` argument, no direct construction.
- It is only ever populated implicitly by `from_yaml(path=…)` via `relative_cache="auto"`, always for a **single** committed method (the one committed example is `data/tabarena-results/TabPFN-3-Thinking/`).
- The internal `from_yaml` callers (`end_to_end`, `method_artifact_manager`) all resolve against the **global** cache, never the override.

So the parent-of-method level only bought a `dir-name == method` constraint (enforced by a layout-mismatch guard) in service of a "one root holds many method dirs" use case nobody exercises. Pointing at the artifact dir:
- makes the field honest — `path == artifact_dir`;
- decouples the folder name from `method` (load committed artifacts from any folder name);
- removes the name collision with the **global** cache root (`path_cache_root` / `relative_to_cache_root`, which are a different concept and keep their names).

## Changes

- `cache_root` → `artifact_dir`, moved to field #3; documented at the field declaration and on the `path` property.
- `path`: `return self.artifact_dir` (drop `/ self.method`).
- `from_yaml`: `relative_cache` infers `artifact_dir = path.parent` (was `path.parent.parent`); the now-dead layout-mismatch guard is removed.
- New `tests/tabarena/models/test_method_metadata.py` covering the field order and the `artifact_dir` / `from_yaml` path behavior.

## No migration / no behavior break

Committed `data/<method>/{metadata.yaml, results/}` layouts still load via `from_yaml(path=.../metadata.yaml)` unchanged — `relative_cache="auto"` now resolves `artifact_dir` to that same directory, and results are found next to the metadata exactly as before. The on-disk layout does not move.

## Verification

- 92 tests pass (85 prior + 7 new).
- No residual `cache_root` field references; `ruff check` / `ruff format` clean.

Consumer-side: the two `tabarena-pl-extensions` loaders use `from_yaml(path=…)` and need **no** change; only the producer script's docstring (which referenced the old `cache_root=` form) is updated — a separate, non-breaking follow-up in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)