### PR TITLE
Add per-instance cache_root override to MethodMetadata

### DIFF
--- a/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
@@ -99,7 +99,8 @@ class InMemoryMethodMetadata(MethodMetadata):
 
     # ------------------------------------------------------------------ serialization
     def to_info_dict(self) -> dict:
-        # Build on the base exclusion (drops the runtime-only ``artifact_dir`` override), then
+        # Build on the base exclusion (drops the runtime-only ``artifact_dir`` / ``cache_root``
+        # overrides), then
         # also drop the in-memory artifact slots so no DataFrame/repo lands in the info table.
         return {k: v for k, v in super().to_info_dict().items() if k not in self._IN_MEMORY_SLOTS}
 

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -78,10 +78,11 @@ class MethodMetadata:
     # every caller constructs MethodMetadata by keyword, and to_info_dict is field-driven.
 
     # -- (1) Identity & on-disk location ------------------------------------------------------
-    #: ``method``, ``suite``, and ``artifact_dir`` determine where this method's artifacts live
-    #: on disk (see :attr:`path`):
+    #: ``method``, ``suite``, ``artifact_dir``, and ``cache_root`` determine where this method's
+    #: artifacts live on disk (see :attr:`path`):
     #:
     #:     <tabarena_cache>/artifacts/<suite>/methods/<method>/   (default cache layout)
+    #:     <cache_root>/artifacts/<suite>/methods/<method>/       (explicit ``cache_root`` override)
     #:     <artifact_dir>/                                        (explicit ``artifact_dir`` override)
     #:
     #: ``method`` (the only required field) is the unique method identifier, e.g. ``"TabPFN-3"``.
@@ -91,15 +92,21 @@ class MethodMetadata:
     #: defaults to ``method`` (in :meth:`__post_init__`) when omitted, so a one-off method needs
     #: only ``method``.
     #:
-    #: ``artifact_dir`` is an optional override pointing *directly* at this method's artifact
-    #: directory — the dir that holds ``metadata.yaml`` + ``results/`` — to load committed
-    #: artifacts from an arbitrary location (e.g. a repo's ``data/`` folder) without touching the
-    #: global TabArena cache. When set, :attr:`path` is ``artifact_dir`` itself and neither
-    #: ``suite`` nor ``method`` contributes to the path. Kept out of :meth:`to_info_dict` so this
-    #: local path is never serialized into the committed ``metadata.yaml`` or the info table.
+    #: ``cache_root`` and ``artifact_dir`` are mutually-exclusive, runtime-only path overrides
+    #: (kept out of :meth:`to_info_dict`, so neither serializes into the committed ``metadata.yaml``
+    #: or the info table). ``cache_root`` overrides the root of the TabArena cache this method
+    #: resolves against — the dir under which ``artifacts/<suite>/methods/<method>/`` lives —
+    #: defaulting to the global :func:`get_tabarena_cache_root` when unset. Set it to read a method
+    #: from a *specific* cache (e.g. a teammate's cache on a shared drive) without mutating global
+    #: state; the loaded instance carries it, so deferred ``load_results`` / :attr:`path` keep
+    #: resolving into that cache. ``artifact_dir`` instead points *directly* at this method's
+    #: artifact directory (the dir holding ``metadata.yaml`` + ``results/``), bypassing the
+    #: ``artifacts/<suite>/methods/`` layout entirely — e.g. a committed copy in a repo's ``data/``
+    #: folder; when set, :attr:`path` is ``artifact_dir`` itself.
     method: str
     suite: str | None = None
     artifact_dir: str | Path | None = None
+    cache_root: str | Path | None = None
 
     # -- (2) Inferable from raw results -------------------------------------------------------
     #: Populated automatically by :meth:`from_raw` (and the ``run_process_local_raw_data.py``
@@ -168,6 +175,13 @@ class MethodMetadata:
         if self.can_hpo is None:
             self.can_hpo = self.method_type == "config"
         self.artifact_dir = Path(self.artifact_dir) if self.artifact_dir is not None else None
+        self.cache_root = Path(self.cache_root) if self.cache_root is not None else None
+        if self.artifact_dir is not None and self.cache_root is not None:
+            raise AssertionError(
+                "Specify at most one of `artifact_dir` (a method's exact artifact directory) and "
+                "`cache_root` (a cache root to resolve <artifacts/suite/methods/method> under); "
+                f"got both (method={self.method!r})."
+            )
 
         assert isinstance(self.method, str)
         assert len(self.method) > 0
@@ -553,21 +567,25 @@ class MethodMetadata:
 
     @property
     def _path_root(self) -> Path:
-        return get_tabarena_cache_root() / "artifacts"
+        return self.path_cache_root / "artifacts"
 
     @property
     def path_cache_root(self) -> Path:
-        return get_tabarena_cache_root()
+        """The TabArena cache root this method resolves against: its ``cache_root`` override if
+        set, else the global :func:`get_tabarena_cache_root`.
+        """
+        return self.cache_root if self.cache_root is not None else get_tabarena_cache_root()
 
     @property
     def path(self) -> Path:
         """Root directory of this method's artifacts on disk.
 
-        Default cache layout: ``<tabarena_cache>/artifacts/<suite>/methods/<method>/`` (where
-        ``_path_root == <tabarena_cache>/artifacts``), derived from ``(suite, method)``. When
-        ``artifact_dir`` is set it *is* the artifact directory (``metadata.yaml`` + ``results/``
-        live directly under it) and is returned as-is — ``suite``/``method`` do not contribute to
-        the path — so committed copies can live at an arbitrary location.
+        Default layout: ``<path_cache_root>/artifacts/<suite>/methods/<method>/``, derived from
+        ``(suite, method)`` under :attr:`path_cache_root` (the ``cache_root`` override, else the
+        global cache). When ``artifact_dir`` is set it *is* the artifact directory
+        (``metadata.yaml`` + ``results/`` live directly under it) and is returned as-is —
+        ``suite``/``method``/``cache_root`` do not contribute — so committed copies can live at an
+        arbitrary location.
         """
         if self.artifact_dir is not None:
             return self.artifact_dir
@@ -849,14 +867,15 @@ class MethodMetadata:
         """The flat field dict used to build the metadata info table / YAML.
 
         Derived from the declared dataclass fields (an allowlist), in declaration order, minus
-        the runtime-only ``artifact_dir`` override — a local path that must not leak into committed
-        YAML or the info table. Field-driven rather than ``self.__dict__``-driven so that
-        non-field instance state never lands in the info table (e.g.
-        :class:`InMemoryMethodMetadata`'s in-memory results frame, set as a plain attribute,
+        the runtime-only ``artifact_dir`` / ``cache_root`` overrides — local paths that must not
+        leak into committed YAML or the info table. Field-driven rather than
+        ``self.__dict__``-driven so that non-field instance state never lands in the info table
+        (e.g. :class:`InMemoryMethodMetadata`'s in-memory results frame, set as a plain attribute,
         not a field). Remains an overridable hook for subclasses.
         """
         info = {f.name: getattr(self, f.name) for f in fields(self)}
         info.pop("artifact_dir", None)
+        info.pop("cache_root", None)
         return info
 
     @property
@@ -928,6 +947,7 @@ class MethodMetadata:
         path: Path | str | None = None,
         method: str | None = None,
         suite: str | None = None,
+        cache_root: str | Path | None = None,
     ) -> Self:
         """Load a method's metadata from YAML, in one of two forms:
 
@@ -935,12 +955,22 @@ class MethodMetadata:
           ``path`` may be that directory **or** the ``metadata.yaml`` inside it (anything not
           ending in ``.yaml`` is treated as the directory); either way the method's
           :attr:`artifact_dir` is set to the directory, so ``results/`` resolve next to the
-          metadata and the global TabArena cache is not consulted. This is how committed copies in
-          a repo's ``data/`` folder are loaded.
-        * ``from_yaml(method=..., suite=...)`` looks the method up in the global TabArena cache at
-          ``<cache>/artifacts/<suite>/methods/<method>/metadata.yaml``.
+          metadata and no TabArena cache is consulted. This is how committed copies in a repo's
+          ``data/`` folder are loaded.
+        * ``from_yaml(method=..., suite=...)`` looks the method up in a TabArena cache at
+          ``<cache>/artifacts/<suite>/methods/<method>/metadata.yaml``. ``cache_root`` selects
+          *which* cache (e.g. a teammate's cache on a shared drive); it is stamped onto the loaded
+          instance so its deferred ``load_results`` / :attr:`path` keep resolving into that cache.
+          Omit ``cache_root`` to use the global :func:`get_tabarena_cache_root`.
+
+        ``path`` and ``cache_root`` are mutually exclusive: ``path`` already pins an exact location.
         """
         if path is not None:
+            if cache_root is not None:
+                raise ValueError(
+                    "Pass either `path` (a committed artifact dir/metadata.yaml) or `cache_root` "
+                    "(a cache root to look up `method`/`suite` under), not both."
+                )
             path = Path(path)
             # `path` is either the artifact directory or the metadata.yaml inside it. Discriminate
             # on the suffix (not ``is_dir()``) so it works before the dir exists and so method dirs
@@ -948,16 +978,17 @@ class MethodMetadata:
             is_yaml_file = path.suffix == ".yaml"
             artifact_dir = path.parent if is_yaml_file else path
             yaml_path = path if is_yaml_file else path / "metadata.yaml"
+            override = {"artifact_dir": artifact_dir}
         else:
             assert method is not None, "method must be specified if path is not specified"
             assert suite is not None, "suite must be specified if path is not specified"
-            artifact_dir = None
-            yaml_path = get_tabarena_cache_root() / "artifacts" / suite / "methods" / method / "metadata.yaml"
+            root = Path(cache_root) if cache_root is not None else get_tabarena_cache_root()
+            yaml_path = root / "artifacts" / suite / "methods" / method / "metadata.yaml"
+            override = {"cache_root": cache_root} if cache_root is not None else {}
 
         with open(yaml_path) as file:
             kwargs = yaml.safe_load(file)
-        if artifact_dir is not None:
-            kwargs["artifact_dir"] = artifact_dir
+        kwargs.update(override)
         cls._migrate_legacy_kwargs(kwargs)
         return cls(**kwargs)
 

--- a/tests/tabarena/models/test_method_metadata.py
+++ b/tests/tabarena/models/test_method_metadata.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 from dataclasses import fields
 
+import pytest
 import yaml
 
 from tabarena.models._method_metadata import MethodMetadata
 
 
-def test_location_args_are_first_three_fields():
-    # method / suite / artifact_dir are the location-determining identity args and live together
-    # at the front of the init signature.
-    assert [f.name for f in fields(MethodMetadata)][:3] == ["method", "suite", "artifact_dir"]
+def test_location_args_are_first_fields():
+    # The location-determining args live together at the front of the init signature.
+    assert [f.name for f in fields(MethodMetadata)][:4] == ["method", "suite", "artifact_dir", "cache_root"]
 
 
 def test_default_layout_uses_suite_and_method_segments():
@@ -67,3 +67,60 @@ def test_from_yaml_path_accepts_dir_or_yaml_file(tmp_path):
     assert from_dir.artifact_dir == method_dir == from_file.artifact_dir
     assert from_dir.path == method_dir == from_file.path
     assert from_dir.method == from_file.method == "TA-TabPFN-2.6"
+
+
+def test_cache_root_resolves_layered_path_under_the_override(tmp_path):
+    # cache_root keeps the standard <root>/artifacts/<suite>/methods/<method> layout, just under a
+    # chosen root instead of the global cache.
+    mm = MethodMetadata.config(method="Foo", suite="s1", cache_root=tmp_path)
+    assert mm.path_cache_root == tmp_path
+    assert mm.path == tmp_path / "artifacts" / "s1" / "methods" / "Foo"
+    assert mm.path_results == tmp_path / "artifacts" / "s1" / "methods" / "Foo" / "results"
+
+
+def test_cache_root_excluded_from_info_dict(tmp_path):
+    mm = MethodMetadata.config(method="Foo", cache_root=tmp_path)
+    assert "cache_root" not in mm.to_info_dict()
+
+
+def test_artifact_dir_and_cache_root_are_mutually_exclusive(tmp_path):
+    with pytest.raises(AssertionError, match="at most one of"):
+        MethodMetadata.config(method="Foo", artifact_dir=tmp_path, cache_root=tmp_path)
+
+
+def _write_layered_cache(cache_root, *, method, suite):
+    method_dir = cache_root / "artifacts" / suite / "methods" / method
+    method_dir.mkdir(parents=True, exist_ok=True)
+    info = MethodMetadata.config(method=method, suite=suite).to_info_dict()
+    with open(method_dir / "metadata.yaml", "w") as f:
+        yaml.dump(info, f)
+
+
+def test_from_yaml_cache_root_lookup_stamps_the_override(tmp_path):
+    cache = tmp_path / "alice" / ".cache" / "tabarena"
+    _write_layered_cache(cache, method="Foo", suite="s1")
+
+    mm = MethodMetadata.from_yaml(method="Foo", suite="s1", cache_root=cache)
+    assert mm.cache_root == cache
+    assert mm.path == cache / "artifacts" / "s1" / "methods" / "Foo"
+
+
+def test_from_yaml_path_and_cache_root_are_mutually_exclusive(tmp_path):
+    with pytest.raises(ValueError, match="not both"):
+        MethodMetadata.from_yaml(path=tmp_path / "metadata.yaml", cache_root=tmp_path)
+
+
+def test_methods_from_different_cache_roots_stay_independent(tmp_path):
+    # The shared-drive scenario: two caches loaded in one process must not interfere -- each
+    # instance retains its own cache_root for deferred path resolution.
+    alice = tmp_path / "alice"
+    bob = tmp_path / "bob"
+    _write_layered_cache(alice, method="Foo", suite="s1")
+    _write_layered_cache(bob, method="Foo", suite="s1")
+
+    mm_alice = MethodMetadata.from_yaml(method="Foo", suite="s1", cache_root=alice)
+    mm_bob = MethodMetadata.from_yaml(method="Foo", suite="s1", cache_root=bob)
+
+    assert mm_alice.path == alice / "artifacts" / "s1" / "methods" / "Foo"
+    assert mm_bob.path == bob / "artifacts" / "s1" / "methods" / "Foo"
+    assert mm_alice.path != mm_bob.path


### PR DESCRIPTION
## Summary

Lets a `MethodMetadata` resolve its (default-layout) artifacts under a **specific** TabArena cache root instead of the process-global one. `path_cache_root` is now the instance's `cache_root` if set, else `get_tabarena_cache_root()`; `path` / `_path_root` flow through it, giving `<cache_root>/artifacts/<suite>/methods/<method>/`.

## Example — one leaderboard from your own + several teammates' results

Mix your own results (your default cache) with teammates' results on a shared drive, each loaded bound to *its source* — by `(method, suite)` under a cache (`cache_root=`, omit it for your own) or straight from a committed artifact directory (`path=`) — and hand them all to one `compare`. Each method carries its own `suite` (its run). No global state; works no matter who runs it or what their own `$TABARENA_CACHE` is:

```python
from pathlib import Path
from tabarena.models._method_metadata import MethodMetadata
from tabarena.nips2025_utils.tabarena_context import TabArenaContext

shared = Path("/mnt/gcp")                  # shared drive

# Each load is stamped with where it came from, so all of them resolve into the right
# place simultaneously and keep doing so for deferred load_results()/path during compare().
extra_methods = [
    # no override: resolve (method, suite) against *your own* cache -- the global
    # get_tabarena_cache_root() (~/.cache/tabarena or $TABARENA_CACHE).
    MethodMetadata.from_yaml(method="ModelMine", suite="SuiteMine"),
    # cache_root: look (method, suite) up under a teammate's full TabArena cache.
    MethodMetadata.from_yaml(method="ModelA", suite="SuiteA", cache_root=shared / "user_a" / ".cache" / "tabarena"),
    MethodMetadata.from_yaml(method="ModelB", suite="SuiteB", cache_root=shared / "user_b" / ".cache" / "tabarena"),
    # path: point straight at a committed artifact dir (holds metadata.yaml + results/) --
    # no cache layout involved; the dir may be the dir itself or its metadata.yaml.
    MethodMetadata.from_yaml(path=shared / "user_c" / "shared_results" / "ModelC"),
]

context = TabArenaContext(extra_methods=extra_methods)
leaderboard = context.compare(output_dir="leaderboards/shared")
```

*(Illustrative: methods are constructed explicitly with `cache_root` / `path` and passed via `extra_methods` — which works with this PR. Threading `cache_root` through the context's own `from_cache` lookups is the noted follow-up.)*

## Motivation — sharing results across a shared drive

We have a shared GCP drive where each person has their own cache, e.g. `/mnt/gcp/<user>/.cache/tabarena`, each a full TabArena cache (`artifacts/<suite>/methods/<method>/…`). A script can now load any teammate's method and the loaded object stays bound to that cache:

```python
def load_shared(method, suite, user):
    return MethodMetadata.from_yaml(
        method=method, suite=suite,
        cache_root=f"/mnt/gcp/{user}/.cache/tabarena",
    )
```

This works regardless of who runs it or their own `$TABARENA_CACHE`, and methods from several people's caches can coexist in one process (e.g. mix your new local results with shared baselines in one `compare`).

Why not the existing mechanisms:
- **`set_tabarena_cache_root` (global)** is mutated in place and read lazily, so a retained `MethodMetadata` would re-resolve into whatever the global was *last* set to — you can't hold methods from two caches at once.
- **`artifact_dir`** would force every sharing script to hardcode the `artifacts/<suite>/methods/<method>` layout; `cache_root` keeps that layout encapsulated and matches the natural `(method, suite)` identity.

## Changes

- New field **`cache_root`** (4th location arg, after `artifact_dir`). Runtime-only: excluded from `to_info_dict`; **mutually exclusive** with `artifact_dir` (`__post_init__` raises if both set).
- `path_cache_root` / `_path_root` resolve the instance override first, so paths *and* `relative_to_cache_root` (S3 keys) stay consistent.
- `from_yaml(method=…, suite=…, cache_root=…)` looks the method up under that root and **stamps `cache_root` onto the loaded instance**, so deferred `load_results` / `path` keep resolving there. `path` and `cache_root` are mutually exclusive (`path` already pins a location).

Precedence: `artifact_dir` (exact dir) > `cache_root` (this instance's cache) > global `set_tabarena_cache_root` > `$TABARENA_CACHE` > `~/.cache/tabarena`.

## Verification

- New tests cover: the layered path under the override, `to_info_dict` exclusion, both mutual-exclusivity guards, the stamped-override load, and **two caches staying independent in one process** (the core scenario). All pass (incl. when run right after the `test_lazy_imports` polluter); `ruff` clean.

## Follow-up (not in this PR)

The bulk entry points (`EndToEndResults.from_cache`, `TabArenaContext(extra_methods=…)`) call `from_yaml(method, suite)` internally; threading `cache_root` through them would enable loading a whole *set* from a teammate's cache. Happy to do that next if useful — this PR delivers the per-method core the sharing script needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




