### PR TITLE
Use stable 'from tabarena.contexts import …' imports

### DIFF
--- a/examples/!experimental/run_async_tabarena_api.py
+++ b/examples/!experimental/run_async_tabarena_api.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from tabarena.benchmark.experiment import Job, TabArenaV0pt1ExperimentBundle
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.models import TabPFN3Model
 from tabarena.utils.config_utils import ConfigGenerator
 

--- a/examples/!experimental/run_beyondarena_tabpfn3_custom_checkpoint.py
+++ b/examples/!experimental/run_beyondarena_tabpfn3_custom_checkpoint.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tabarena.benchmark.experiment import BeyondArenaExperimentBundle
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 from tabarena.models import TabPFN3Model
 from tabarena.utils.config_utils import ConfigGenerator
 

--- a/examples/!experimental/run_generate_beyondarena_leaderboard.py
+++ b/examples/!experimental/run_generate_beyondarena_leaderboard.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 
 if __name__ == "__main__":
     output_dir = "output_beyondarena_leaderboard"  # folder to save all figures and tables

--- a/examples/!experimental/run_quickstart_beyondarena.py
+++ b/examples/!experimental/run_quickstart_beyondarena.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from autogluon.core.models import AbstractModel
 
 from tabarena.benchmark.experiment import BeyondArenaExperimentBundle
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 from tabarena.utils.config_utils import ConfigGenerator
 
 if TYPE_CHECKING:

--- a/examples/!experimental/run_quickstart_beyondarena_without_bagging.py
+++ b/examples/!experimental/run_quickstart_beyondarena_without_bagging.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from autogluon.core.models import AbstractModel
 
 from tabarena.benchmark.experiment import BeyondArenaExperimentBundle
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 from tabarena.utils.config_utils import ConfigGenerator
 
 if TYPE_CHECKING:

--- a/examples/!experimental/run_scratch_add_calibration_logic.py
+++ b/examples/!experimental/run_scratch_add_calibration_logic.py
@@ -8,7 +8,7 @@ import pandas as pd
 from autogluon.common import TabularDataset
 
 from tabarena import EvaluationRepository
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.contexts.tabarena.methods import tabarena_method_metadata_collection
 from tabarena.models._method_simulator import MethodSimulator
 from tabarena.simulation.ensemble_scorer_calibrated import EnsembleScorerCalibrated, EnsembleScorerCalibratedCV

--- a/examples/!old/run_quickstart_tabarena_custom_autogluon.py
+++ b/examples/!old/run_quickstart_tabarena_custom_autogluon.py
@@ -10,7 +10,7 @@ from tabarena.benchmark.exec_models import AGWrapper
 from tabarena.benchmark.experiment import Experiment, ExperimentBatchRunner
 from tabarena.benchmark.result import ExperimentResults
 from tabarena.benchmark.task.metadata import TaskMetadataCollection, default_task_metadata_collection
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 
 
 class MyCustomAGWrapper(AGWrapper):

--- a/examples/advanced/run_any_openml_task.py
+++ b/examples/advanced/run_any_openml_task.py
@@ -13,7 +13,7 @@ from tabarena.benchmark.experiment import (
     TabArenaV0pt1ExperimentBundle,
     build_jobs,
 )
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 from tabarena.nips2025_utils.end_to_end import EndToEnd
 from tabarena.nips2025_utils.fetch_metadata import task_metadata_collection_from_openml
 

--- a/examples/advanced/run_quickstart_tabarena_model_without_bagging.py
+++ b/examples/advanced/run_quickstart_tabarena_model_without_bagging.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.models import TabICLv2Model
 from tabarena.utils.config_utils import ConfigGenerator
 

--- a/examples/advanced/run_tabarena_tabpfn3_custom_checkpoint.py
+++ b/examples/advanced/run_tabarena_tabpfn3_custom_checkpoint.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.models import TabPFN3Model
 from tabarena.utils.config_utils import ConfigGenerator
 

--- a/examples/benchmarking/run_quickstart_tabarena.py
+++ b/examples/benchmarking/run_quickstart_tabarena.py
@@ -17,7 +17,7 @@ from autogluon.core.models import AbstractModel
 from autogluon.features import LabelEncoderFeatureGenerator
 
 from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/examples/benchmarking/run_quickstart_tabarena_custom_datasets.py
+++ b/examples/benchmarking/run_quickstart_tabarena_custom_datasets.py
@@ -27,7 +27,7 @@ from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
 from tabarena.benchmark.task import UserTask
 from tabarena.benchmark.task.metadata import TabArenaTaskMetadata, TaskMetadataCollection
 from tabarena.benchmark.task.user_task import from_sklearn_splits_to_user_task_splits
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 
 
 def _toy_frame(*, classification: bool) -> pd.DataFrame:

--- a/examples/meta/run_download_all_artifacts.py
+++ b/examples/meta/run_download_all_artifacts.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 
 if TYPE_CHECKING:
     from tabarena.models._method_metadata import MethodMetadata

--- a/examples/plots/run_end_to_end_from_raw.py
+++ b/examples/plots/run_end_to_end_from_raw.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.nips2025_utils.artifacts.download_utils import download_and_extract_zip
 from tabarena.nips2025_utils.end_to_end_single import EndToEndSingle
 

--- a/examples/plots/run_generate_main_leaderboard.py
+++ b/examples/plots/run_generate_main_leaderboard.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 
 if __name__ == "__main__":
     save_path = "output_leaderboard"  # folder to save all figures and tables

--- a/examples/reproducibility/run_generate_main_leaderboard_neurips2025.py
+++ b/examples/reproducibility/run_generate_main_leaderboard_neurips2025.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.contexts.tabarena.methods import (
     tabarena_method_metadata_2025_06_12_collection_main,
 )

--- a/examples/reproducibility/run_generate_paper_figures_neurips2025.py
+++ b/examples/reproducibility/run_generate_paper_figures_neurips2025.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories
 
 if __name__ == "__main__":

--- a/packages/tabarena/src/tabarena/__init__.py
+++ b/packages/tabarena/src/tabarena/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .contexts.tabarena.context import TabArenaContext
+from .contexts import TabArenaContext
 from .evaluation.evaluator import Evaluator
 from .repository.evaluation_repository import EvaluationRepository
 from .repository.evaluation_repository_collection import EvaluationRepositoryCollection

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
@@ -37,7 +37,7 @@ def _preset_subset_predicates_provider(
     if suite_name == "BeyondArena":
 
         def _beyond() -> dict[str, SubsetPredicate]:
-            from tabarena.contexts.beyondarena.context import BeyondArenaContext
+            from tabarena.contexts import BeyondArenaContext
 
             return BeyondArenaContext.SUBSET_PREDICATES
 
@@ -45,7 +45,7 @@ def _preset_subset_predicates_provider(
     if suite_name == "TabArena-v0.1":
 
         def _tabarena() -> dict[str, SubsetPredicate]:
-            from tabarena.contexts.tabarena.context import TabArenaContext
+            from tabarena.contexts import TabArenaContext
 
             return TabArenaContext.SUBSET_PREDICATES
 

--- a/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 from tabarena.nips2025_utils.subset_predicate import SubsetPredicate, tasks_in_frame
 
 if TYPE_CHECKING:

--- a/packages/tabarena/src/tabarena/contexts/tabarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/context.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 from tabarena.contexts.tabarena.methods import tabarena_method_metadata_collection
 from tabarena.nips2025_utils.eval_all import evaluate_all
 from tabarena.nips2025_utils.subset_predicate import SubsetPredicate

--- a/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
@@ -141,7 +141,7 @@ def run_eval(config: TabArenaEvalConfig) -> dict[str, pd.DataFrame]:
     # Register the run's methods on a TabArena-v0.1 context (extra_methods=), so they flow through
     # `compare` against the paper baselines exactly like cached methods (fill of missing tasks is
     # handled by the context's fillna_method, as the old compare_on_tabarena did via get_results).
-    from tabarena.contexts.tabarena.context import TabArenaContext
+    from tabarena.contexts import TabArenaContext
 
     context = TabArenaContext(extra_methods=results.to_method_metadata_lst())
 

--- a/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
@@ -235,8 +235,7 @@ def evaluate_beyond_subsets(
     """
     import json
 
-    from tabarena.contexts.beyondarena.context import BeyondArenaContext
-    from tabarena.contexts.tabarena.context import TabArenaContext
+    from tabarena.contexts import BeyondArenaContext, TabArenaContext
     from tabarena.evaluation._eval_common import save_leaderboard, subset_label
     from tabarena.nips2025_utils.compare import compare, get_subsets_per_dataset, subset_tasks_data_foundry
     from tabarena.website.website_format import format_leaderboard

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.nips2025_utils.subset_predicate import SubsetPredicate
 from tabarena.paper.tabarena_evaluator import TabArenaEvaluator
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -9,7 +9,7 @@ from autogluon.common.savers import save_pd
 
 from tabarena.benchmark.result import BaselineResult, ConfigResult
 from tabarena.benchmark.task.metadata import TaskMetadataCollection
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._method_simulator import MethodSimulator
 from tabarena.nips2025_utils.fetch_metadata import task_metadata_collection_from_openml

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -12,7 +12,7 @@ import seaborn as sns
 from autogluon.common.loaders import load_pd
 
 from bencheval.evaluator import BenchmarkEvaluator
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.nips2025_utils.compare import subset_tasks
 from tabarena.nips2025_utils.eval_all import (
     get_all_subset_combinations,

--- a/packages/tabflow_slurm/experiments/run_setup_beyondarena.py
+++ b/packages/tabflow_slurm/experiments/run_setup_beyondarena.py
@@ -10,7 +10,7 @@ datasets into local OpenML tasks on this head node. Scope a chosen subset with
 from __future__ import annotations
 
 from tabarena.benchmark.experiment import BeyondArenaExperimentBundle
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 from tabflow_slurm import (
     BeyondArenaResourcesSetup,
     GCPSlurmSetup,

--- a/packages/tabflow_slurm/experiments/run_setup_beyondarena_local.py
+++ b/packages/tabflow_slurm/experiments/run_setup_beyondarena_local.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from tabarena.benchmark.experiment import BeyondArenaExperimentBundle
 from tabarena.benchmark.task.metadata import TaskSubset
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 from tabflow_slurm import (
     BeyondArenaResourcesSetup,
     LocalSequentialSetup,

--- a/packages/tabflow_slurm/experiments/run_setup_tabarena_v0pt1.py
+++ b/packages/tabflow_slurm/experiments/run_setup_tabarena_v0pt1.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
 from tabarena.benchmark.task.metadata import TaskSubset
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabflow_slurm import (
     GCPSlurmSetup,
     ModelJob,

--- a/packages/tabflow_slurm/experiments/run_setup_tabarena_v0pt1_local.py
+++ b/packages/tabflow_slurm/experiments/run_setup_tabarena_v0pt1_local.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
 from tabarena.benchmark.task.metadata import TaskSubset
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabflow_slurm import (
     LocalSequentialSetup,
     ModelJob,

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/benchmark.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/benchmark.py
@@ -17,7 +17,7 @@ from tabarena.utils.ray_utils import ray_map_list, to_batch_list
 if TYPE_CHECKING:
     from tabarena.benchmark.experiment import Job, TabArenaExperimentBundle
     from tabarena.benchmark.task.metadata import TaskMetadataCollection
-    from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+    from tabarena.contexts import AbstractArenaContext
     from tabflow_slurm.setup.paths import PathSetup
     from tabflow_slurm.setup.resources import ResourcesSetup
     from tabflow_slurm.setup.scheduler import SchedulerSetup

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/plan.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/plan.py
@@ -21,14 +21,14 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from tabarena.benchmark.experiment import BeyondArenaExperimentBundle, Experiment
 from tabarena.benchmark.task.metadata import TaskSubset
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 from tabflow_slurm.setup.benchmark import TabArenaBenchmarkSetup
 from tabflow_slurm.setup.resources import BeyondArenaResourcesSetup
 from tabflow_slurm.setup.scheduler import GCPSlurmSetup
 
 if TYPE_CHECKING:
     from tabarena.benchmark.experiment import TabArenaExperimentBundle
-    from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+    from tabarena.contexts import AbstractArenaContext
     from tabflow_slurm.setup.paths import PathSetup
     from tabflow_slurm.setup.resources import ResourcesSetup
     from tabflow_slurm.setup.scheduler import SchedulerSetup

--- a/scripts/run_generate_website_artifacts.py
+++ b/scripts/run_generate_website_artifacts.py
@@ -56,7 +56,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import TabArenaContext
 from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_tuning_trajectories_all
 from tabarena.website.process_artifacts_to_website import process_one_folder
 from tabarena.website.process_pngs import process_png_bulk

--- a/tests/integration/test_async_tabarena_api.py
+++ b/tests/integration/test_async_tabarena_api.py
@@ -33,7 +33,7 @@ from tabarena.benchmark.experiment import Job, TabArenaV0pt1ExperimentBundle
 from tabarena.benchmark.task import UserTask
 from tabarena.benchmark.task.metadata import TabArenaTaskMetadata, TaskMetadataCollection
 from tabarena.benchmark.task.user_task import from_sklearn_splits_to_user_task_splits
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 from tabarena.models._in_memory_method_metadata import InMemoryMethodMetadata
 from tabarena.utils.config_utils import ConfigGenerator
 

--- a/tests/tabarena/benchmark/task/test_collection_subset_tasks.py
+++ b/tests/tabarena/benchmark/task/test_collection_subset_tasks.py
@@ -288,7 +288,7 @@ class TestSubsetPredicateFilter:
         assert {t.dataset_name for t in result} == {"bin_small", "reg_big"}
 
     def test_list_of_lists_unions_at_split_level(self):
-        from tabarena.contexts.beyondarena.context import BeyondArenaContext
+        from tabarena.contexts import BeyondArenaContext
 
         coll = _collection(
             [
@@ -311,13 +311,13 @@ class TestSubsetPredicateFilter:
             self._coll().subset_tasks(subset="nope", predicates=self._custom_predicates())
 
     def test_beyond_arena_predicates_shorthand(self):
-        from tabarena.contexts.beyondarena.context import BeyondArenaContext
+        from tabarena.contexts import BeyondArenaContext
 
         result = self._coll().subset_tasks(subset="regression", predicates=BeyondArenaContext.SUBSET_PREDICATES)
         assert [t.dataset_name for t in result] == ["reg_big"]
 
     def test_split_level_lite_predicate_keeps_first_split(self):
-        from tabarena.contexts.beyondarena.context import BeyondArenaContext
+        from tabarena.contexts import BeyondArenaContext
 
         coll = _collection([_task_meta(dataset_name="a", n_splits=3, problem_type="binary", n_train=500)])
         result = coll.subset_tasks(subset="lite", predicates=BeyondArenaContext.SUBSET_PREDICATES)

--- a/tests/tabarena/contexts/test_beyond_arena.py
+++ b/tests/tabarena/contexts/test_beyond_arena.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 
 
 def test_init_resolves_source_name_to_native_collection():

--- a/tests/tabarena/contexts/test_beyond_arena_context.py
+++ b/tests/tabarena/contexts/test_beyond_arena_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 
 
 @pytest.fixture(scope="module")

--- a/tests/tabarena/contexts/test_tabarena_context.py
+++ b/tests/tabarena/contexts/test_tabarena_context.py
@@ -4,8 +4,7 @@ import pandas as pd
 import pytest
 
 from tabarena.benchmark.task.metadata import TaskMetadataCollection, TaskSubset
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
-from tabarena.contexts.tabarena.context import TabArenaContext
+from tabarena.contexts import AbstractArenaContext, TabArenaContext
 
 
 def _ctx() -> TabArenaContext:

--- a/tests/tabarena/evaluation/test_beyond_metadata.py
+++ b/tests/tabarena/evaluation/test_beyond_metadata.py
@@ -9,7 +9,7 @@ per-dataset frame.
 from __future__ import annotations
 
 from tabarena.benchmark.task.metadata import TaskMetadataCollection
-from tabarena.contexts.beyondarena.context import BeyondArenaContext
+from tabarena.contexts import BeyondArenaContext
 from tabarena.evaluation.beyond_metadata import load_beyond_task_metadata_collection
 
 

--- a/tests/tabarena/models/test_in_memory_method_metadata.py
+++ b/tests/tabarena/models/test_in_memory_method_metadata.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from tabarena.benchmark.task.metadata import TaskMetadataCollection
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 from tabarena.models._in_memory_method_metadata import InMemoryMethodMetadata
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._method_metadata_collection import MethodMetadataCollection

--- a/tests/tabflow_slurm/test_plan.py
+++ b/tests/tabflow_slurm/test_plan.py
@@ -11,7 +11,7 @@ import pytest
 
 from tabarena.benchmark.experiment import TabArenaExperimentBundle
 from tabarena.benchmark.task.metadata import TaskMetadataCollection, TaskSubset
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 
 # Import a real submodule (see test_setup.py for why a bare namespace won't skip).
 pytest.importorskip("tabflow_slurm.setup", reason="tabflow_slurm is not installed")

--- a/tests/tabflow_slurm/test_setup.py
+++ b/tests/tabflow_slurm/test_setup.py
@@ -19,7 +19,7 @@ import pytest
 
 from tabarena.benchmark.experiment import TabArenaExperimentBundle
 from tabarena.benchmark.task.metadata import TaskMetadataCollection
-from tabarena.contexts.abstract_arena_context import AbstractArenaContext
+from tabarena.contexts import AbstractArenaContext
 
 # Import a real submodule (not the bare `tabflow_slurm` namespace): when the package
 # is not installed, the repo-root workspace dir is importable as an empty namespace


### PR DESCRIPTION
## Summary

Switches in-repo importers of the context classes from the verbose internal submodule paths to the package-level re-export:

```python
# before
from tabarena.contexts.tabarena.context import TabArenaContext
from tabarena.contexts.beyondarena.context import BeyondArenaContext
from tabarena.contexts.abstract_arena_context import AbstractArenaContext
# after
from tabarena.contexts import TabArenaContext, BeyondArenaContext, AbstractArenaContext
```

Less verbose, and **stable across internal context-module reshuffles** — the last few PRs each churned every one of these imports (`nips2025_utils` → `contexts` → per-family subpackages). Going forward, internal moves touch only `contexts/__init__.py`'s re-export map, not every call site.

The re-export is lazy (PEP 562 `__getattr__`), so this stays cycle-safe.

## Left as submodule (deliberately)
- `CORE_TASKS_CSV` — a constant with no package-level export.
- `import tabarena.contexts.tabarena.context as tc` in `test_benchmark_eval` — it `monkeypatch.setattr`s the **defining** module, so it must reference it directly.
- `contexts/` internal wiring (a subpackage importing its own base).
- Docstring `:class:` cross-refs — they point at the defining module so Sphinx resolves them.

## Verification
- `import tabarena` + package-level imports resolve; **265 tests pass**, including the monkeypatch-based `run_eval` test (the lazy `__getattr__` reads the patched attribute at call time, so the patch still takes effect through the package-level import).
- `ruff check`/`format` clean (the one flagged example was already unformatted on `main`; only its import line changed).

## Consumer repos
Updating `tabarena-pl-extensions` / `tabarena-slurm-setup` to the same `from tabarena.contexts import …` form alongside this (separately landed), so they're robust to future internal moves too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)