### PR TITLE
refactor TabArena cache setup and usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,14 @@ Raw predictions → EvaluationRepository → Simulation/Portfolio → Results Da
 
 ### Data caching
 
-Artifacts download to `~/.cache/tabarena/` by default; override with `TABARENA_CACHE`. Three tiers per method: raw data (~100 GB), processed predictions (~10 GB), results DataFrames (<1 MB).
+TabArena uses four independent caches. Configure them all at once with `tabarena.caching.CacheConfig` — the single, documented surface (`TabArenaContext(cache_config=CacheConfig.from_root(...))`; the context applies it on construction and re-applies it inside `run_jobs`, so distributed workers inherit it). The SLURM path uses the **same** object: the setup embeds `context.cache_config` in the `JobBatch`, and each worker applies it (no `--openml_cache_dir` wiring). See the `CacheConfig` docstring for the authoritative per-cache reference.
+
+| Cache | `CacheConfig` field | Holds | Set via | Default |
+|---|---|---|---|---|
+| OpenML (most important) | `openml` | Materialized datasets + CV splits + all TabArena-derived task artifacts (`tabarena_tasks/`, `tabarena_text_cache/`, `tabarena_metadata_cache/`, `local/datasets/`) | `openml.config.set_root_cache_directory` (no env var) | `~/.cache/openml` |
+| HuggingFace | `huggingface` | Foundation-model weights **and** the one-time raw dataset download (data_foundry/BeyondArena), later materialized into the OpenML cache | `HF_HOME` | `~/.cache/huggingface/hub` |
+| TabArena | `tabarena` | Results / baselines / leaderboard artifacts (~100 GB raw, ~10 GB processed, <1 MB results per method) | `set_tabarena_cache_root` / `TABARENA_CACHE` | `~/.cache/tabarena` |
+| Results (run output) | `results` | The runner's `expname` (`{expname}/data/{method}/{task}/{repeat}_{fold}/results.pkl`) | `run_jobs(expname=...)` | throwaway temp dir |
 
 ## Conventions
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,7 @@ on OpenML, and no-bagging foundation-model setups.
   - `run_autogluon_on_openml_task.py` - Run AutoGluon on any OpenML task.
   - `run_autogluon_on_openml_task_with_hpo_configs.py` - Run AutoGluon on an OpenML task using TabArena's model search spaces.
   - `run_get_tabarena_datasets_from_openml.py` - Get the data used by TabArena from OpenML, without the TabArena framework.
+  - `run_configure_caches.py` - Declare *where* TabArena caches datasets, model weights, and results — once, via `CacheConfig` — and let the context propagate it to every worker.
 
 ### 🗃️ Analysing Metadata and Meta-Learning
 

--- a/examples/advanced/run_configure_caches.py
+++ b/examples/advanced/run_configure_caches.py
@@ -1,0 +1,71 @@
+"""How to configure *where* TabArena caches everything — one object, set once.
+
+TabArena reads and writes four independent caches. By default they live under your home
+directory, which is usually the wrong disk for benchmarking (model weights and datasets are
+large, and on a cluster every worker needs to see the same files). Instead of exporting a
+handful of environment variables on every machine, declare the locations once with a
+``CacheConfig`` and hand it to the context — it points the driver at them immediately and
+re-applies them on every worker that runs a job.
+
+The four caches (see ``tabarena.caching.CacheConfig`` for the authoritative reference):
+
+  * ``openml``      — THE important one. The materialized datasets + their cross-validation
+                      splits, plus all TabArena-derived task artifacts, live here. Point this
+                      at a large, ideally shared, disk.
+  * ``huggingface`` — foundation-model weights (TabPFN / Mitra / LimiX / ...) AND the one-time
+                      raw dataset download for data_foundry / BeyondArena (which is then
+                      converted into the OpenML cache). Sets ``HF_HOME``.
+  * ``tabarena``    — TabArena's own results / baselines / leaderboard artifacts.
+  * ``results``     — the per-run output cache (the runner's ``expname``). Optional; if unset a
+                      throwaway temp dir is used unless you pass ``expname=`` explicitly.
+
+Run it:
+
+    python examples/benchmarking/run_configure_caches.py
+"""
+
+from __future__ import annotations
+
+from tabarena.caching import CacheConfig
+from tabarena.contexts import TabArenaContext
+
+if __name__ == "__main__":
+    # Option A — put every cache under one parent directory (the common case: one big disk).
+    #   /data/tabarena-caches/openml, /huggingface, /tabarena, /results
+    cache_config = CacheConfig.from_root("/data/tabarena-caches")
+
+    # Option B — set each location explicitly (e.g. datasets on shared storage, weights local).
+    #   Any field left out stays at its current env var / library default.
+    cache_config = CacheConfig(
+        openml="/shared/openml-cache",
+        huggingface="/shared/hf-cache",
+        tabarena="/shared/tabarena-cache",
+        results="/scratch/tabarena-results",
+    )
+
+    # Hand it to the context once. The context calls cache_config.apply() now (configuring THIS
+    # process) and again inside run_jobs (so any distributed worker that runs the context inherits
+    # the same locations) — no per-worker setup, no environment-variable juggling.
+    context = TabArenaContext(cache_config=cache_config)
+
+    # From here, everything — build_jobs(pre_materialize=...), run_jobs / build_and_run_jobs,
+    # compare — reads and writes the directories you declared above. For example:
+    #
+    #     experiments = TabArenaV0pt1ExperimentBundle(models=[("Linear", 0)]).build_experiments()
+    #     context.build_and_run_jobs(experiments, expname=None, subset="lite")  # expname falls
+    #                                                                            # back to results
+    #
+    # You can also apply a CacheConfig directly in any process you control (e.g. a custom
+    # distributed worker's entrypoint) without a context:
+    #
+    #     CacheConfig.from_root("/data/tabarena-caches").apply()
+    #
+    # If you already use OpenML elsewhere and don't want TabArena to permanently change its
+    # global cache location, set scope_openml=True on the CacheConfig: TabArena points OpenML at
+    # cache_config.openml only for the duration of each run and restores your previous
+    # openml.config afterwards. (apply_on_run=False is the other policy flag — it stops the
+    # context re-applying the config inside run_jobs.)
+    #
+    #     cache_config = CacheConfig(openml="/shared/openml-cache", scope_openml=True)
+    #     context = TabArenaContext(cache_config=cache_config)
+    print("Configured caches for context:", context.cache_config)

--- a/packages/tabarena/src/tabarena/benchmark/experiment/job.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/job.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from tabarena.benchmark.experiment.experiment_constructor import Experiment
     from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection
     from tabarena.benchmark.task.metadata.schema import SplitMetadata, TabArenaTaskMetadata
+    from tabarena.caching import CacheConfig
 
 
 @dataclass(frozen=True)
@@ -202,6 +203,7 @@ def filter_jobs_by_constraints(
 _EXPERIMENTS_FILE = "experiments.yaml"
 _TASK_METADATA_FILE = "task_metadata.csv"
 _JOBS_FILE = "jobs.json"
+_CACHE_CONFIG_FILE = "cache_config.json"
 
 
 @dataclass
@@ -221,9 +223,12 @@ class JobBatch:
       dataset names / task ids / shapes identically to the authoring side.
     * ``jobs.json`` — the (tiny) job list: ``(experiment name, dataset, fold, repeat)``
       coordinates only.
+    * ``cache_config.json`` — the optional :class:`~tabarena.caching.CacheConfig` (only written
+      when set), so the compute node configures the same OpenML / HuggingFace / TabArena cache
+      locations the run was set up with, with no out-of-band wiring.
 
     Loading a saved directory needs nothing else — ``JobBatch.load(path)`` reconstructs
-    the ``list[Job]`` plus the collection, ready for
+    the ``list[Job]`` plus the collection (and the ``cache_config`` if present), ready for
     :meth:`ExperimentBatchRunner.run_jobs`. This is the artifact a head node ships to
     compute nodes (each array task runs a slice of ``jobs``), and the user-facing way to
     serialize a sweep and re-run it later. Construction validates the batch is
@@ -232,6 +237,9 @@ class JobBatch:
 
     jobs: list[Job]
     task_metadata: TaskMetadataCollection
+    cache_config: CacheConfig | None = None
+    """Optional cache locations (OpenML / HuggingFace / TabArena) the run was configured with.
+    Persisted to ``cache_config.json`` and applied by the runner on the compute node."""
 
     def __post_init__(self) -> None:
         """Validate name-uniqueness and that every job's split exists in the collection.
@@ -289,6 +297,9 @@ class JobBatch:
         ]
         with (path / _JOBS_FILE).open("w") as f:
             json.dump({"jobs": job_records}, f)
+        if self.cache_config is not None:
+            with (path / _CACHE_CONFIG_FILE).open("w") as f:
+                json.dump(self.cache_config.to_dict(), f)
         return path
 
     @classmethod
@@ -301,6 +312,14 @@ class JobBatch:
         experiments = YamlExperimentSerializer.from_yaml(path=str(path / _EXPERIMENTS_FILE))
         experiment_by_name = {experiment.name: experiment for experiment in experiments}
         task_metadata = TaskMetadataCollection.from_source(path / _TASK_METADATA_FILE)
+
+        cache_config = None
+        cache_config_path = path / _CACHE_CONFIG_FILE
+        if cache_config_path.exists():
+            from tabarena.caching import CacheConfig
+
+            with cache_config_path.open() as f:
+                cache_config = CacheConfig.from_dict(json.load(f))
 
         with (path / _JOBS_FILE).open() as f:
             job_records = json.load(f)["jobs"]
@@ -316,4 +335,4 @@ class JobBatch:
             jobs.append(
                 Job.create(experiment, record["dataset"], fold=record["fold"], repeat=record["repeat"]),
             )
-        return cls(jobs=jobs, task_metadata=task_metadata)
+        return cls(jobs=jobs, task_metadata=task_metadata, cache_config=cache_config)

--- a/packages/tabarena/src/tabarena/caching.py
+++ b/packages/tabarena/src/tabarena/caching.py
@@ -1,0 +1,220 @@
+"""A single place to declare every cache directory TabArena uses.
+
+TabArena reads and writes four independent caches. Historically each was process-global
+state a user had to configure by hand on *every* process — the driver and every distributed
+worker — because the runner API exposed no cache parameter. :class:`CacheConfig` collapses
+that into one object you declare once and :meth:`CacheConfig.apply` wherever a process needs
+it; :class:`~tabarena.contexts.TabArenaContext` does the applying for you (on construction and
+again inside ``run_jobs``), and the SLURM worker setup reuses the same object.
+
+See :class:`CacheConfig` for the authoritative description of each cache and its role.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["CacheConfig"]
+
+# The path-valued fields (vs. the policy flags `apply_on_run` / `scope_openml`); used by
+# `from_root` to lay each cache out under a single parent directory.
+_LOCATION_FIELDS = ("openml", "huggingface", "tabarena", "results")
+# All constructor fields; used by `from_dict` to ignore any unknown keys.
+_CONFIG_FIELDS = (*_LOCATION_FIELDS, "apply_on_run", "scope_openml")
+
+
+@dataclass(frozen=True)
+class CacheConfig:
+    """Declarative configuration for every cache directory TabArena uses.
+
+    Construct one and hand it to :class:`~tabarena.contexts.TabArenaContext`
+    (``TabArenaContext(cache_config=CacheConfig(...))``); the context calls
+    :meth:`apply` on construction so the driver process is configured, and again inside
+    ``run_jobs`` so any worker that runs the context inherits the same locations. You can
+    also call :meth:`apply` directly in a process you control (e.g. a custom distributed
+    worker's entrypoint).
+
+    A field left ``None`` is *not touched* — the existing environment variable / library
+    default stays in effect. :meth:`apply` is idempotent and creates no directories (the
+    underlying libraries create them lazily on first write).
+
+    The four caches and their roles:
+
+    openml:
+        **The most important cache.** OpenML's root cache directory, set via
+        ``openml.config.set_root_cache_directory`` (no environment variable is honored by
+        the code). It holds the materialized datasets and their cross-validation splits, and
+        — because TabArena hangs its derived artifacts off this root at runtime — also
+        ``tabarena_tasks/`` (materialized task specs), ``tabarena_text_cache/`` (text-feature
+        embeddings), ``tabarena_metadata_cache/`` (data-foundry reference manifests) and
+        ``local/datasets/`` (local dataset payloads). Point this at a large disk; the library
+        default is ``~/.cache/openml``. :meth:`apply` sets this on the (global) ``openml.config``;
+        set ``scope_openml=True`` (or use :meth:`scoped_openml`) to point TabArena at it only for
+        the duration of a run and restore any pre-existing ``openml.config`` location after.
+    huggingface:
+        The HuggingFace Hub cache, set via the ``HF_HOME`` environment variable. It has two
+        roles: (a) foundation-model **weights** — TabPFN / Mitra / LimiX / OrionMSP / SAP-RPT
+        call ``hf_hub_download`` with no explicit ``cache_dir``, so the weights land under
+        ``HF_HOME``; and (b) the one-time **raw dataset download** for data-foundry /
+        BeyondArena collections, which is then materialized (converted) *into* the OpenML
+        cache above. Setting this controls both — the data-foundry download honors ``HF_HOME``
+        because :meth:`apply` runs before any materialization. (For per-source control of just
+        the data-foundry download, pass ``cache_dir=`` to ``DataFoundrySource`` directly.) The
+        library default is ``~/.cache/huggingface/hub``.
+    tabarena:
+        TabArena's own artifact cache — the benchmark results, baselines and leaderboard data
+        downloaded by ``load_results`` and friends. Set via
+        ``tabarena.loaders.set_tabarena_cache_root`` (equivalently the ``$TABARENA_CACHE``
+        environment variable). Default ``~/.cache/tabarena``.
+    results:
+        The benchmark *run-output* cache, used as the default ``expname`` for ``run_jobs`` —
+        under which the runner writes ``{expname}/data/{method}/{task}/{repeat}_{fold}/results.pkl``
+        (``cache_mode`` controls resume/skip). Unlike the other three this is **not** global
+        process state, so :meth:`apply` does not touch it. It is used *only* when ``run_jobs`` is
+        called without an ``expname`` argument; it does not change the meaning of an explicit
+        ``expname=None`` (still a throwaway temp dir). ``None`` here means "no default" (``run_jobs``
+        then requires an explicit ``expname``, as before).
+
+    Besides the locations, two flags describe *how* the config is applied by a context (the
+    location fields are plain data; these are policy):
+
+    apply_on_run:
+        When ``True`` (default), the context re-applies this config at the start of each
+        ``run_jobs`` / ``build_jobs(pre_materialize=True)`` — so a distributed worker that
+        reconstructed the context inherits the same cache locations. Set ``False`` if the
+        process is already configured and you don't want the runner touching it.
+    scope_openml:
+        When ``True``, the OpenML root is set only for the duration of each data operation and
+        the pre-existing ``openml.config`` location is restored afterwards (via
+        :meth:`scoped_openml`); the TabArena/HuggingFace caches stay applied. Use this to run
+        against a dedicated OpenML
+        cache without permanently changing an ambient ``openml.config`` the rest of your process
+        relies on. When ``False`` (default), :meth:`apply` sets the OpenML root for the process.
+    """
+
+    openml: str | Path | None = None
+    huggingface: str | Path | None = None
+    tabarena: str | Path | None = None
+    results: str | Path | None = None
+    apply_on_run: bool = True
+    scope_openml: bool = False
+
+    @classmethod
+    def from_root(cls, root: str | Path, **overrides) -> CacheConfig:
+        """Put every cache under a single parent directory ``root``.
+
+        ``CacheConfig.from_root("/scratch/me")`` resolves to ``/scratch/me/openml``,
+        ``/scratch/me/huggingface``, ``/scratch/me/tabarena`` and ``/scratch/me/results``.
+        Handy when one large/shared disk should hold everything. Any field can be pinned via
+        a keyword override (e.g. ``from_root(root, results=None)`` to keep run outputs in a
+        throwaway temp dir, or ``from_root(root, scope_openml=True)`` to set a policy flag).
+        """
+        root = Path(root)
+        base: dict = {name: root / name for name in _LOCATION_FIELDS}
+        base.update(overrides)
+        return cls(**base)
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain JSON-able dict (``Path`` location fields rendered as ``str``).
+
+        Used to persist the config alongside a sweep (e.g. in a ``JobBatch``) so a compute node
+        can reconstruct and :meth:`apply` it. Round-trips with :meth:`from_dict`.
+        """
+        return {
+            "openml": None if self.openml is None else str(self.openml),
+            "huggingface": None if self.huggingface is None else str(self.huggingface),
+            "tabarena": None if self.tabarena is None else str(self.tabarena),
+            "results": None if self.results is None else str(self.results),
+            "apply_on_run": self.apply_on_run,
+            "scope_openml": self.scope_openml,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> CacheConfig:
+        """Reconstruct a :class:`CacheConfig` from its :meth:`to_dict` form."""
+        return cls(**{field: data[field] for field in data if field in _CONFIG_FIELDS})
+
+    def apply(self, *, openml: bool = True) -> None:
+        """Point the current process at these caches (idempotent; ``None`` fields are no-ops).
+
+        Applies ``openml`` via ``openml.config.set_root_cache_directory``, ``tabarena`` via
+        ``tabarena.loaders.set_tabarena_cache_root``, and ``huggingface`` via the ``HF_HOME``
+        environment variable (see :meth:`_apply_huggingface` for the import-timing handling).
+        ``results`` is intentionally not applied — it is a ``run_jobs`` default, not global
+        state.
+
+        Args:
+            openml: When ``False``, skip the OpenML field. Used by callers that want to set the
+                TabArena/HuggingFace caches now but defer the OpenML root to a temporary
+                :meth:`scoped_openml` override (so the ambient ``openml.config`` is left untouched
+                between operations).
+        """
+        if openml and self.openml is not None:
+            import openml as openml_lib
+
+            openml_lib.config.set_root_cache_directory(str(Path(self.openml).expanduser()))
+        if self.tabarena is not None:
+            from tabarena.loaders import set_tabarena_cache_root
+
+            set_tabarena_cache_root(Path(self.tabarena).expanduser())
+        if self.huggingface is not None:
+            self._apply_huggingface(Path(self.huggingface).expanduser())
+
+    @contextlib.contextmanager
+    def scoped_openml(self) -> Iterator[None]:
+        """Apply the caches for the duration of the block, then restore *only* the OpenML root.
+
+        Unlike :meth:`apply` (which sets the OpenML root permanently), this saves the current
+        ``openml.config`` root cache directory, applies this config, and restores that saved value
+        on exit. Use it to run TabArena against a dedicated OpenML cache *X* without disturbing an
+        ambient ``openml.config`` the rest of the process relies on — outside the block OpenML keeps
+        reading its original location.
+
+        Scoping is deliberately OpenML-only (hence the name):
+
+        * **OpenML** re-reads ``openml.config._root_cache_directory`` on every call, so a
+          save/restore reliably redirects it for the block and reverts afterwards.
+        * **HuggingFace** *cannot* be scoped reliably: ``huggingface_hub`` freezes its cache paths
+          into module constants at import time, and that import happens during the fit (inside the
+          block). Restoring ``HF_HOME`` afterwards would not redirect later HF use in the same
+          process, so ``huggingface`` is left applied rather than promising a restore it can't keep.
+        * **TabArena** is private state (nothing outside TabArena reads ``set_tabarena_cache_root``)
+          and ``compare`` needs it to persist, so it is left applied. ``results`` is never global.
+        """
+        import openml as openml_lib
+
+        saved_openml_root = openml_lib.config._root_cache_directory
+        self.apply()
+        try:
+            yield
+        finally:
+            openml_lib.config.set_root_cache_directory(str(saved_openml_root))
+
+    @staticmethod
+    def _apply_huggingface(path: Path) -> None:
+        """Point the HuggingFace Hub cache at ``path`` via ``HF_HOME``.
+
+        ``huggingface_hub`` is only ever imported lazily inside model fits, so in a fresh
+        process setting ``HF_HOME`` before the first fit is sufficient. We also clear the
+        more specific ``HF_HUB_CACHE`` / ``HUGGINGFACE_HUB_CACHE`` env vars so a stale value
+        cannot shadow ``HF_HOME``. Finally, if ``huggingface_hub.constants`` is *already*
+        imported (its cache paths are frozen at import time), we repoint those constants too —
+        but we never force-import the module, keeping it lazy and dependency-light.
+        """
+        os.environ["HF_HOME"] = str(path)
+        os.environ.pop("HF_HUB_CACHE", None)
+        os.environ.pop("HUGGINGFACE_HUB_CACHE", None)
+
+        constants = sys.modules.get("huggingface_hub.constants")
+        if constants is not None:
+            hub_cache = str(path / "hub")
+            if hasattr(constants, "HF_HOME"):
+                constants.HF_HOME = str(path)
+            for attr in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"):
+                if hasattr(constants, attr):
+                    setattr(constants, attr, hub_cache)

--- a/packages/tabarena/src/tabarena/contexts/__init__.py
+++ b/packages/tabarena/src/tabarena/contexts/__init__.py
@@ -14,12 +14,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+# CacheConfig lives in the lightweight top-level `tabarena.caching` module (only `os` + deferred
+# imports), so re-exporting it here is cheap and does not pull in the heavy context modules.
+from tabarena.caching import CacheConfig
+
 if TYPE_CHECKING:
     from .abstract_arena_context import AbstractArenaContext
     from .beyondarena.context import BeyondArenaContext
     from .tabarena.context import TabArenaContext
 
-__all__ = ["AbstractArenaContext", "BeyondArenaContext", "TabArenaContext"]
+__all__ = ["AbstractArenaContext", "BeyondArenaContext", "CacheConfig", "TabArenaContext"]
 
 _EXPORTS = {
     "AbstractArenaContext": "abstract_arena_context",

--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -23,9 +23,11 @@ and :attr:`_default_subsets` to declare arena-specific subset filters.
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import functools
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self
 
@@ -47,7 +49,13 @@ if TYPE_CHECKING:
     from tabarena.benchmark.experiment import Experiment, Job
     from tabarena.benchmark.result import BaselineResult
     from tabarena.benchmark.task.metadata.schema import TabArenaTaskMetadata
+    from tabarena.caching import CacheConfig
     from tabarena.repository.abstract_repository import AbstractRepository
+
+# Sentinel default for `run_jobs`/`build_and_run_jobs` `expname`, distinguishing "caller omitted
+# expname" (fall back to `cache_config.results`, else error) from an explicit `expname=None`
+# (always a throwaway temp dir). Keeps the original "expname is required; None means throwaway" API.
+_EXPNAME_UNSET: Any = object()
 
 
 class AbstractArenaContext:
@@ -88,7 +96,23 @@ class AbstractArenaContext:
         fillna_method: str | None = None,
         calibration_method: str | None = None,
         only_valid_tasks: bool = False,
+        cache_config: CacheConfig | None = None,
     ):
+        # Configure the caches first: `cache_config.apply()` points this (driver) process at
+        # the declared OpenML / HuggingFace / TabArena locations, so resolving + materializing
+        # task metadata below — and any later `build_jobs(pre_materialize=...)` / `compare()` —
+        # reads and writes the right directories. `cache_config.apply_on_run` re-applies the same
+        # config inside `run_jobs`, so a worker that runs this context inherits it too. Stored
+        # before resolving the collection so preset hooks can honor it.
+        #
+        # `cache_config.scope_openml=True` keeps the ambient `openml.config` untouched: we apply
+        # only the TabArena/HuggingFace caches here (the TabArena cache is needed by `compare`, and
+        # is private to us), and point OpenML at `cache_config.openml` *only* for the duration of
+        # each data operation (see `_cache_scope`), restoring the prior OpenML location after.
+        self.cache_config = cache_config
+        if cache_config is not None:
+            cache_config.apply(openml=not cache_config.scope_openml)
+
         # A TaskMetadataCollection is the single source of truth; the legacy `task_metadata`
         # DataFrame view is derived from it on demand (see the `task_metadata` cached_property).
         self.task_metadata_collection = self._resolve_task_metadata_collection(task_metadata)
@@ -188,6 +212,26 @@ class AbstractArenaContext:
         self._register_methods(new_methods, scope_to_valid_tasks=scope_to_valid_tasks)
         return new_methods
 
+    @contextlib.contextmanager
+    def _cache_scope(self) -> Iterator[None]:
+        """Ensure the configured caches are active for the wrapped cache-touching operation.
+
+        No-op when there is no ``cache_config`` or its ``apply_on_run`` is off. With
+        ``cache_config.scope_openml=True`` the OpenML root is set only for the duration of the
+        block and the prior location is restored afterwards (so an ambient ``openml.config`` is
+        preserved); otherwise the config is applied to the process (re-applying covers a worker
+        that reconstructed this context).
+        """
+        cfg = self.cache_config
+        if cfg is None or not cfg.apply_on_run:
+            yield
+        elif cfg.scope_openml:
+            with cfg.scoped_openml():
+                yield
+        else:
+            cfg.apply()
+            yield
+
     def build_jobs(
         self,
         experiments: list[Experiment],
@@ -223,7 +267,10 @@ class AbstractArenaContext:
         predicates = subset_kwargs.pop("predicates", self.subset_predicates)
         collection = self.task_metadata_collection.subset_tasks(task_subset, predicates=predicates, **subset_kwargs)
         if pre_materialize:
-            collection.materialize()
+            # Materializing downloads into the OpenML/HF caches; make sure this process is
+            # pointed at the configured locations first (covers a context built/used on a worker).
+            with self._cache_scope():
+                collection.materialize()
         return build_jobs_grid(experiments, collection)
 
     def metadata_for_jobs(self, jobs: list[Job]) -> list[TabArenaTaskMetadata]:
@@ -242,7 +289,7 @@ class AbstractArenaContext:
         self,
         jobs: list[Job],
         *,
-        expname: str | Path | None,
+        expname: str | Path | None = _EXPNAME_UNSET,
         register: bool = True,
         new_result_prefix: str | None = None,
         **runner_kwargs,
@@ -260,30 +307,50 @@ class AbstractArenaContext:
 
         ``expname`` is the runner's results-cache directory (a real path), or ``None`` to cache to
         a throwaway temp dir (cleaned up after) when you only want the returned results and don't
-        need a persistent / resumable cache. There is no default; pass a path or ``None``. Extra
-        ``**runner_kwargs`` (e.g. ``debug_mode``, ``cache_mode``) reach :class:`ExperimentBatchRunner`.
-        Returns the raw per-split result dicts (also registered when ``register`` is True).
+        need a persistent / resumable cache. It is required: pass a path or ``None`` — *unless*
+        this context's ``cache_config.results`` is set, which is used as the default only when
+        ``expname`` is omitted entirely. An explicit ``expname`` (including ``None``) always wins,
+        so ``expname=None`` is still a throwaway temp dir even when ``cache_config.results`` is set.
+        Extra ``**runner_kwargs`` (e.g. ``debug_mode``, ``cache_mode``) reach
+        :class:`ExperimentBatchRunner`. Returns the raw per-split result dicts (also registered
+        when ``register`` is True).
         """
         from tabarena.benchmark.experiment import ExperimentBatchRunner
 
         if not jobs:
             return []
-        # Scope-then-materialize: only the tasks the jobs actually touch are downloaded, and
-        # the collection itself is the single source of truth for what the runner resolves.
-        collection = self.task_metadata_collection.subset_to_jobs(jobs).materialize()
-        # `expname=None` -> a throwaway cache: the returned result dicts are in memory, so the
-        # cache dir is only needed while the runner runs and is discarded right after.
-        tmp_expname = tempfile.TemporaryDirectory() if expname is None else None
-        try:
-            runner = ExperimentBatchRunner(
-                expname=str(tmp_expname.name if tmp_expname is not None else expname),
-                task_metadata=collection,
-                **runner_kwargs,
-            )
-            results = runner.run_jobs(jobs)
-        finally:
-            if tmp_expname is not None:
-                tmp_expname.cleanup()
+        if expname is _EXPNAME_UNSET:
+            # Omitted entirely: fall back to the cache_config default, else preserve the original
+            # "expname is required" contract with a clear error (rather than a missing-arg TypeError).
+            if self.cache_config is not None and self.cache_config.results is not None:
+                expname = self.cache_config.results
+            else:
+                raise TypeError(
+                    "run_jobs() is missing required keyword 'expname': pass a path (a persistent, "
+                    "resumable results cache) or None (a throwaway temp dir). Alternatively, set "
+                    "`cache_config.results` to provide a default expname.",
+                )
+        # `_cache_scope` points this process at the configured caches for the materialize + fit
+        # (a distributed worker may have reconstructed this context). `materialize()` downloads
+        # into the OpenML cache, so the scope must wrap it. With `cache_config.scope_openml=True`
+        # the OpenML root is restored to its prior value once the run finishes.
+        with self._cache_scope():
+            # Scope-then-materialize: only the tasks the jobs actually touch are downloaded, and
+            # the collection itself is the single source of truth for what the runner resolves.
+            collection = self.task_metadata_collection.subset_to_jobs(jobs).materialize()
+            # `expname=None` -> a throwaway cache: the returned result dicts are in memory, so the
+            # cache dir is only needed while the runner runs and is discarded right after.
+            tmp_expname = tempfile.TemporaryDirectory() if expname is None else None
+            try:
+                runner = ExperimentBatchRunner(
+                    expname=str(tmp_expname.name if tmp_expname is not None else expname),
+                    task_metadata=collection,
+                    **runner_kwargs,
+                )
+                results = runner.run_jobs(jobs)
+            finally:
+                if tmp_expname is not None:
+                    tmp_expname.cleanup()
         if register:
             self.register(results, new_result_prefix=new_result_prefix)
         return results
@@ -296,7 +363,7 @@ class AbstractArenaContext:
         self,
         experiments: list[Experiment],
         *,
-        expname: str | Path | None,
+        expname: str | Path | None = _EXPNAME_UNSET,
         task_subset: TaskSubset | dict | None = None,
         subset: str | list[str] | None = None,
         register: bool = True,

--- a/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
@@ -33,6 +33,7 @@ from tabarena.contexts import AbstractArenaContext
 
 if TYPE_CHECKING:
     from tabarena.benchmark.task.metadata import TaskMetadataCollection
+    from tabarena.caching import CacheConfig
     from tabarena.models._method_metadata import MethodMetadata
 
 #: Committed CSV of the BeyondArena "core" subset's valid ``(dataset, split)`` tasks: the first
@@ -103,6 +104,7 @@ class BeyondArenaContext(AbstractArenaContext):
         fillna_method: str | None = "RF (default)",
         calibration_method: str | None = "XGB (default)",
         only_valid_tasks: bool = False,
+        cache_config: CacheConfig | None = None,
     ) -> None:
         """Build a BeyondArena context.
 
@@ -118,6 +120,12 @@ class BeyondArenaContext(AbstractArenaContext):
             calibration_method: Calibration-method name forwarded to :class:`AbstractArenaContext`.
             only_valid_tasks: Forwarded to :class:`AbstractArenaContext`; when ``True``,
                 pre-filter ``task_metadata`` to the registered in-memory methods' tasks.
+            cache_config: Optional :class:`~tabarena.caching.CacheConfig` declaring the OpenML /
+                HuggingFace / TabArena cache locations (and how to apply them — see its
+                ``apply_on_run`` / ``scope_openml`` flags). Applied on construction and re-applied
+                inside ``run_jobs``. Relevant here because BeyondArena's ``materialize()``
+                downloads its raw datasets from HuggingFace (honoring ``cache_config.huggingface``)
+                before converting them into the OpenML cache.
         """
         super().__init__(
             methods=methods,
@@ -127,6 +135,7 @@ class BeyondArenaContext(AbstractArenaContext):
             fillna_method=fillna_method,
             calibration_method=calibration_method,
             only_valid_tasks=only_valid_tasks,
+            cache_config=cache_config,
         )
 
     def _resolve_task_metadata_preset(self, name: str) -> TaskMetadataCollection:

--- a/packages/tabarena/src/tabarena/contexts/tabarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/context.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection
+    from tabarena.caching import CacheConfig
     from tabarena.models._method_metadata import MethodMetadata
 
 _methods_paper = [
@@ -106,6 +107,7 @@ class TabArenaContext(AbstractArenaContext):
         fillna_method: str | None = "RF (default)",
         calibration_method: str | None = "RF (default)",
         only_valid_tasks: bool = False,
+        cache_config: CacheConfig | None = None,
     ):
         super().__init__(
             methods=methods,
@@ -115,6 +117,7 @@ class TabArenaContext(AbstractArenaContext):
             fillna_method=fillna_method,
             calibration_method=calibration_method,
             only_valid_tasks=only_valid_tasks,
+            cache_config=cache_config,
         )
 
     def _resolve_task_metadata_preset(self, name: str) -> TaskMetadataCollection:

--- a/packages/tabarena/src/tabarena/evaluation/_eval_common.py
+++ b/packages/tabarena/src/tabarena/evaluation/_eval_common.py
@@ -17,8 +17,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tabarena.loaders import set_tabarena_cache_root
-
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -48,16 +46,29 @@ class MethodArtifact:
     """If True, skip raw->cache post-processing and load the existing cache instead."""
 
 
-def init_caches(tabarena_cache_path: str | None = None, openml_cache_path: str | None = None) -> None:
-    """Point TabArena/OpenML at the configured caches (resolved lazily, so order-independent)."""
+def init_caches(
+    tabarena_cache_path: str | None = None,
+    openml_cache_path: str | None = None,
+    huggingface_cache_path: str | None = None,
+) -> None:
+    """Point TabArena/OpenML/HuggingFace at the configured caches (order-independent).
+
+    Thin wrapper over :meth:`tabarena.caching.CacheConfig.apply` kept for the evaluation
+    runners' existing call sites; each ``None`` path leaves that cache untouched.
+    """
+    from tabarena.caching import CacheConfig
+
     if tabarena_cache_path is not None:
-        set_tabarena_cache_root(tabarena_cache_path)
         print("Set TabArena cache root to:", tabarena_cache_path)
     if openml_cache_path is not None:
-        import openml
-
-        openml.config.set_root_cache_directory(str(Path(openml_cache_path).expanduser()))
         print("Set OpenML cache root to:", openml_cache_path)
+    if huggingface_cache_path is not None:
+        print("Set HuggingFace cache root to:", huggingface_cache_path)
+    CacheConfig(
+        tabarena=tabarena_cache_path,
+        openml=openml_cache_path,
+        huggingface=huggingface_cache_path,
+    ).apply()
 
 
 def init_aux_metric_env(aux_metric_map: dict[str, str] | None) -> None:

--- a/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import pandas as pd
 
+    from tabarena.caching import CacheConfig
+
 
 @dataclass
 class EvalMethod:
@@ -68,10 +70,14 @@ class TabArenaEvalConfig:
     benchmark. ``None`` is treated as ``[[]]`` (full only)."""
     num_cpus: int | None = None
     """CPUs for raw-result post-processing (None = all available)."""
+    cache_config: CacheConfig | None = None
+    """Cache locations (OpenML / HuggingFace / TabArena). Pass the SAME
+    :class:`~tabarena.caching.CacheConfig` used to run the benchmark. When set it takes
+    precedence over the ``*_cache_path`` fields below."""
     tabarena_cache_path: str | None = None
-    """If set, used as the TabArena cache root (via ``set_tabarena_cache_root``)."""
+    """Legacy: TabArena cache root (via ``set_tabarena_cache_root``). Prefer ``cache_config``."""
     openml_cache_path: str | None = None
-    """If set, used as the OpenML root cache (for fetching task metadata)."""
+    """Legacy: OpenML root cache (for fetching task metadata). Prefer ``cache_config``."""
     save_leaderboards: bool = True
     """If True, save each subset's leaderboard CSV under ``figure_output_dir``."""
 
@@ -85,7 +91,14 @@ class TabArenaEvalConfig:
         return self.subsets if self.subsets is not None else [[]]
 
     def init_caches(self) -> None:
-        """Point TabArena/OpenML at the configured caches (resolved lazily, so order-independent)."""
+        """Point TabArena/OpenML/HF at the configured caches (resolved lazily, order-independent).
+
+        Prefers ``cache_config`` (the unified surface) when set; otherwise falls back to the
+        legacy ``tabarena_cache_path`` / ``openml_cache_path`` fields.
+        """
+        if self.cache_config is not None:
+            self.cache_config.apply()
+            return
         from tabarena.evaluation._eval_common import init_caches
 
         init_caches(self.tabarena_cache_path, self.openml_cache_path)

--- a/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/beyond_arena_eval.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from tabarena.benchmark.task.metadata import TaskMetadataCollection
+    from tabarena.caching import CacheConfig
 
 #: Internal config-type -> display-name fixups for BeyondArena methods, applied on top of the
 #: TabArena rename map. Mirrors the hardcoded map in the legacy ``run_eval.py``.
@@ -88,6 +89,10 @@ class BeyondArenaEvalConfig:
     """BeyondArena source name (committed package CSV) or a path to a ``*_tasks_metadata.csv``."""
     subsets_to_evaluate: list[list[str]] | None = None
     """Each entry is a subset spec (e.g. ``["regression"]``); ``[]`` = full. ``None`` = full only."""
+    cache_config: CacheConfig | None = None
+    """Cache locations (OpenML / HuggingFace / TabArena). Pass the SAME
+    :class:`~tabarena.caching.CacheConfig` used to run the benchmark; takes precedence over the
+    legacy ``*_cache_path`` fields below."""
     tabarena_cache_path: str | None = None
     openml_cache_path: str | None = None
     compute_aux_metric: bool = False
@@ -142,7 +147,11 @@ def run_beyond_arena_eval(config: BeyondArenaEvalConfig) -> dict[str, pd.DataFra
     )
     from tabarena.evaluation.beyond_metadata import load_beyond_task_metadata_collection
 
-    init_caches(config.tabarena_cache_path, config.openml_cache_path)
+    # Prefer the unified CacheConfig surface; fall back to the legacy cache-path fields.
+    if config.cache_config is not None:
+        config.cache_config.apply()
+    else:
+        init_caches(config.tabarena_cache_path, config.openml_cache_path)
     # Passing None also clears a stale env var, so a previous run can't silently re-enable it.
     init_aux_metric_env(config.effective_aux_metric_map())
 

--- a/packages/tabflow_slurm/AGENTS.md
+++ b/packages/tabflow_slurm/AGENTS.md
@@ -24,7 +24,7 @@ tabflow_slurm/                      ← this folder (docs, examples, history, py
     ├── __init__.py                 ← re-exports the public API
     ├── run_tabarena_experiment.py  ← runner: fits ONE item on a node (bundled script)
     ├── submit_template.sh          ← sbatch array script (parses job JSON via jq, calls runner)
-    ├── slurm_utils.py              ← setup_slurm_job(): per-node OpenML cache + Ray init
+    ├── slurm_utils.py              ← setup_slurm_job(): per-node Ray init (caches via JobBatch.cache_config)
     └── setup/                      ← the building blocks
         ├── plan.py                 ← TabArenaBenchmarkPlan (ENTRY POINT), ModelJob, SingleModel
         ├── benchmark.py            ← TabArenaBenchmarkSetup (INTERNAL per-run engine)
@@ -86,9 +86,10 @@ Then: `sbatch … submit_template.sh <job.json>` → array task picks `jobs[SLUR
 - **The Ray cache check pickles plain `(method, task_id_str, fold, repeat)` tuples** to workers
   (never live experiments) and runs tabarena core's writer-aligned `job_cache_exists_batch` — don't
   re-derive the cache key/normalization in this package.
-- **OpenML cache must be shared** between the head node (setup materializes tasks there) and workers
-  (`--openml_cache_dir`). `PathSetup.ensure_runtime_dirs()` points the ambient cache at it during
-  setup.
+- **Caches are configured via `CacheConfig` on the context**, not `PathSetup`. The setup embeds
+  `context.cache_config` in the `JobBatch`; the head node applies it before materializing tasks and
+  each worker applies it (in `run_experiment`) before fitting — so point `CacheConfig.openml` at
+  shared storage and the head node + workers resolve the same OpenML cache.
 - **Ray on a shared filesystem:** `setup_slurm_job(setup_ray_for_slurm_shared_resources_environment=
   True)` gives each job a unique temp dir + plasma sizing; required when fold-fitting isn't
   sequential-local, else workers collide semi-randomly.

--- a/packages/tabflow_slurm/README.md
+++ b/packages/tabflow_slurm/README.md
@@ -152,7 +152,11 @@ workspace it creates and uses:
 | `output/<benchmark_name>/` | benchmark result artifacts (the cache the runner writes / eval reads) |
 | `slurm_out/<benchmark_name>/` | SLURM `.out` logs |
 | `setup_out/<benchmark_name>/` | generated `JobBatch` artifact(s) + job JSON |
-| `.openml-cache/` | OpenML cache (unless `openml_cache` overridden; `"auto"` uses OpenML's default) |
+
+Cache locations (OpenML / HuggingFace / TabArena) are **not** part of `PathSetup` — configure them
+on the arena context via `TabArenaContext(cache_config=CacheConfig.from_root(...))`, exactly as in
+the sequential/async API. The plan embeds that `CacheConfig` in the `JobBatch`, and each worker
+applies it automatically (see `tabarena.caching.CacheConfig`).
 
 `run_script` / `submit_script` default to the scripts **bundled with this package**
 (`get_run_script_path()` / `get_submit_script_path()`), so nothing hardcodes a checkout path.
@@ -200,9 +204,10 @@ collection to the jobs' tasks and `materialize()` them (download only those) →
   `output/<benchmark_name>/`.
 - **`submit_template.sh`** — the `sbatch` array script. Reads `defaults` + the array index's `items`
   from the job JSON (with `jq`) and runs the runner once per item.
-- **`slurm_utils.py::setup_slurm_job`** — per-node setup: points OpenML at the right cache and
-  initializes Ray for a **shared-filesystem** SLURM environment (unique temp dir, plasma store
-  sizing, forkserver) so parallel workers don't collide.
+- **`slurm_utils.py::setup_slurm_job`** — per-node setup: initializes Ray for a **shared-filesystem**
+  SLURM environment (unique temp dir, plasma store sizing, forkserver) so parallel workers don't
+  collide. (Caches are configured separately, by `run_experiment` applying the `JobBatch`'s
+  `cache_config`.)
 
 ---
 
@@ -215,7 +220,6 @@ collection to the jobs' tasks and `materialize()` them (download only those) →
   "defaults": {
     "python": "/shared/venv/bin/python",
     "run_script": ".../run_tabarena_experiment.py",
-    "openml_cache_dir": ".../.openml-cache",
     "job_batch_dir": ".../job_batch_<name>",
     "output_dir": ".../output/<benchmark_name>",
     "num_cpus": 8, "num_gpus": 0, "memory_limit": 32,
@@ -249,7 +253,8 @@ using `defaults` for everything shared.
   OpenML cache), checks the cache, and prefetches foundation weights — all locally — before any
   `sbatch`.
 - **The OpenML cache must be shared.** Tasks materialized during setup must be visible to the
-  workers; they configure the same cache via `--openml_cache_dir`.
+  workers. Point `CacheConfig.openml` at shared storage (via `TabArenaContext(cache_config=...)`);
+  the config is embedded in the `JobBatch` and applied identically on the head node and every worker.
 - **Grouping is by *effective* settings.** Two `ModelJob`s with the same resources/scheduler/tasks/
   experiment merge into one run (one `JobBatch`, one array). Different `num_gpus` (or any override)
   splits them — that's how GPU vs CPU models become separate `sbatch` commands.

--- a/packages/tabflow_slurm/experiments/run_eval_tabarena_v0pt1.py
+++ b/packages/tabflow_slurm/experiments/run_eval_tabarena_v0pt1.py
@@ -14,9 +14,10 @@ from tabarena.evaluation import EvalMethod, TabArenaEvalConfig, run_eval
 from tabflow_slurm import PathSetup
 
 BENCHMARK_NAME = "example_tabarena_v0pt1_29052026"
+WORKSPACE = "/home/lennart_priorlabs_ai/workspace/benchmarking/tabarena_workspace"
 
 path_setup = PathSetup(
-    workspace="/home/lennart_priorlabs_ai/workspace/benchmarking/tabarena_workspace",
+    workspace=WORKSPACE,
     python_path="/home/lennart_priorlabs_ai/.venvs/beyondarena_27052026/bin/python",
 )
 
@@ -31,6 +32,10 @@ config = TabArenaEvalConfig(
     subsets=[
         ["lite"],
     ],
+    # Caches default to the library locations (~/.cache/...). If the run used a relocated cache
+    # (see run_setup_tabarena_v0pt1.py), pass the SAME object so eval reads the same baselines:
+    #     from tabarena.caching import CacheConfig
+    #     cache_config=CacheConfig.from_root("/shared/tabarena-caches"),
 )
 
 run_eval(config)

--- a/packages/tabflow_slurm/experiments/run_setup_tabarena_v0pt1.py
+++ b/packages/tabflow_slurm/experiments/run_setup_tabarena_v0pt1.py
@@ -29,6 +29,13 @@ benchmark_plan = TabArenaBenchmarkPlan(
     ],
     # The TabArena-v0.1 context owns the task metadata + subset predicates; `task_subset`
     # scopes `context.build_jobs` (here `subset="lite"` keeps each dataset's first split).
+    #
+    # Caches use their library defaults (OpenML `~/.cache/openml`, HuggingFace
+    # `~/.cache/huggingface/hub`, TabArena `~/.cache/tabarena`). To relocate them — e.g. onto
+    # shared cluster storage so the head node and every worker resolve the same files — pass a
+    # CacheConfig to the context (the plan embeds it in the JobBatch; reuse it in the eval script):
+    #     from tabarena.caching import CacheConfig
+    #     context=TabArenaContext(cache_config=CacheConfig.from_root("/shared/tabarena-caches")),
     context=TabArenaContext(),
     task_subset=TaskSubset(subset="lite"),
     experiment_bundle=TabArenaV0pt1ExperimentBundle(),

--- a/packages/tabflow_slurm/src/tabflow_slurm/run_local.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/run_local.py
@@ -66,8 +66,6 @@ def _build_item_command(defaults: dict, item: dict) -> list[str]:
         str(item["fold"]),
         "--repeat",
         str(item["repeat"]),
-        "--openml_cache_dir",
-        str(defaults["openml_cache_dir"]),
         "--output_dir",
         str(defaults["output_dir"]),
         "--num_cpus",
@@ -90,18 +88,17 @@ def _run_item_subprocess(defaults: dict, item: dict, env: dict) -> int:
 
 
 def _setup_in_process(defaults: dict) -> None:
-    """One-time setup for `in_process` mode: OpenML cache + telemetry env.
+    """One-time setup for `in_process` mode: Ray + telemetry env.
 
-    Subprocess mode does this per child via ``run_tabarena_experiment``'s
-    ``__main__``; in-process we must do it once before the first fit. We reuse
-    ``setup_slurm_job`` with the SLURM shared-resources Ray setup disabled, so it
-    only points the OpenML cache (its numeric args are unused in that branch).
+    Subprocess mode does this per child via ``run_tabarena_experiment``'s ``__main__``; in-process
+    we must do it once before the first fit. We reuse ``setup_slurm_job`` with the SLURM
+    shared-resources Ray setup disabled. Cache configuration is not done here — each item's
+    ``run_experiment`` applies the ``JobBatch``'s ``cache_config`` before its fit.
     """
     from tabflow_slurm.slurm_utils import setup_slurm_job
 
     os.environ.setdefault("TABPFN_DISABLE_TELEMETRY", "1")
     setup_slurm_job(
-        openml_cache_dir=str(defaults["openml_cache_dir"]),
         num_cpus=defaults["num_cpus"],
         num_gpus=defaults["num_gpus"],
         memory_limit=defaults["memory_limit"],

--- a/packages/tabflow_slurm/src/tabflow_slurm/run_tabarena_experiment.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/run_tabarena_experiment.py
@@ -58,6 +58,11 @@ def run_experiment(
     from tabarena.benchmark.experiment import ExperimentBatchRunner, JobBatch
 
     batch = JobBatch.load(job_batch_dir)
+    # Point this worker at the caches the run was configured with (OpenML / HuggingFace /
+    # TabArena), before the task is loaded and the model fit (which lazily imports HF). The
+    # config was embedded in the batch at setup time; absent => use library defaults.
+    if batch.cache_config is not None:
+        batch.cache_config.apply()
     # The coordinates are a lookup key into the batch's serialized job list — the job
     # that runs is the one loaded from disk, and coordinates that don't name a job of
     # the batch (e.g. a stale job JSON against a regenerated batch) fail loudly here.
@@ -155,12 +160,6 @@ if __name__ == "__main__":
     )
     # Experiment environment settings
     parser.add_argument(
-        "--openml_cache_dir",
-        type=str,
-        help="Path to the OpenML cache directory or 'auto'.",
-        default="auto",
-    )
-    parser.add_argument(
         "--output_dir",
         type=str,
         help="Path to the output directory where the results will be saved.",
@@ -209,7 +208,6 @@ if __name__ == "__main__":
         print(f"Memory limit not provided, using detected memory size: {memory_limit} GB")
 
     ray_temp_dir = setup_slurm_job(
-        openml_cache_dir=args.openml_cache_dir,
         setup_ray_for_slurm_shared_resources_environment=args.setup_ray_for_slurm_shared_resources_environment,
         num_cpus=num_cpus,
         num_gpus=args.num_gpus,

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/benchmark.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/benchmark.py
@@ -112,6 +112,11 @@ class TabArenaBenchmarkSetup:
         largest bundle observed and is used to budget the per-task time limit.
         """
         self.path_setup.ensure_runtime_dirs(self.benchmark_name)
+        # Point this (dedicated) setup process at the context's configured caches, so any
+        # setup-time downloads (e.g. data_foundry/BeyondArena materialization below) land in the
+        # right place. The same config is embedded in the JobBatch and re-applied on each worker.
+        if self.context.cache_config is not None:
+            self.context.cache_config.apply()
         experiments = self.experiment_bundle.build_experiments(
             time_limit=self.resources_setup.time_limit,
             num_cpus=self.resources_setup.num_cpus,
@@ -181,7 +186,11 @@ class TabArenaBenchmarkSetup:
         previous invocation so the setup output always reflects this run.
         """
         if jobs:
-            JobBatch(jobs=jobs, task_metadata=collection).save(self._job_batch_dir)
+            JobBatch(
+                jobs=jobs,
+                task_metadata=collection,
+                cache_config=self.context.cache_config,
+            ).save(self._job_batch_dir)
         else:
             shutil.rmtree(self._job_batch_dir, ignore_errors=True)
 
@@ -207,7 +216,6 @@ class TabArenaBenchmarkSetup:
         return {
             "python": self.path_setup.python_path,
             "run_script": self.path_setup.run_script_path,
-            "openml_cache_dir": self.path_setup.openml_cache_path,
             "job_batch_dir": self._job_batch_dir,
             "output_dir": self.path_setup.get_output_path(self.benchmark_name),
             "num_cpus": self.resources_setup.num_cpus,

--- a/packages/tabflow_slurm/src/tabflow_slurm/setup/paths.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/setup/paths.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
-
-import openml
 
 # The runner script and submit template live at the package root, one level
 # up from this `setup/` subpackage.
@@ -38,8 +35,12 @@ class PathSetup:
 
     The user must provide a `workspace` directory and the `python_path` to use
     for the SLURM jobs. `run_script` and `submit_script` default to the scripts
-    bundled with this package (see `get_run_script_path` /
-    `get_submit_script_path`), and `openml_cache` is optional.
+    bundled with this package (see `get_run_script_path` / `get_submit_script_path`).
+
+    Cache locations (OpenML / HuggingFace / TabArena) are NOT configured here — set them on
+    the arena context via `TabArenaContext(cache_config=CacheConfig(...))` (the same surface
+    used by the sequential/async API). The setup embeds that config in the `JobBatch`, and each
+    worker applies it automatically (see `tabarena.caching.CacheConfig`).
 
     The workspace is a persistent directory that all SLURM jobs can access. We
     create and use the following structure inside it:
@@ -50,13 +51,11 @@ class PathSetup:
                                    (one `benchmark_name` subfolder each)
             - setup_out         -- generated configs YAML + SLURM job JSON
                                    (one `benchmark_name` subfolder each)
-            - .openml-cache     -- the OpenML cache (unless overridden)
     """
 
     workspace: str | Path
     """Persistent workspace directory that all jobs can access. Holds the
-    `output/`, `slurm_out/`, and `setup_out/` folders, and (by default) the
-    OpenML cache."""
+    `output/`, `slurm_out/`, and `setup_out/` folders."""
     python_path: str | Path
     """Python executable to use for the SLURM jobs. Should point to the cluster
     venv (e.g. pass `sys.executable` if this setup runs inside that venv)."""
@@ -68,13 +67,6 @@ class PathSetup:
     """Path to the SLURM (array) submit script invoked by `sbatch`.
     Defaults to the `submit_template.sh` bundled with this package
     (see `get_submit_script_path`)."""
-    openml_cache: str | Path | Literal["auto"] | None = "auto"
-    """OpenML cache directory, used to store dataset and task data from OpenML.
-
-        - If None (default), use `<workspace>/.openml-cache`.
-        - If "auto", use OpenML's own default cache location.
-        - Otherwise, the given path is used as a custom OpenML cache folder.
-    """
 
     @property
     def _workspace(self) -> Path:
@@ -89,15 +81,6 @@ class PathSetup:
     def submit_script_path(self) -> str:
         """SLURM (array) submit script invoked by `sbatch`."""
         return str(self.submit_script)
-
-    @property
-    def openml_cache_path(self) -> str:
-        """Resolved OpenML cache directory ("auto" or an absolute path)."""
-        if self.openml_cache == "auto":
-            return "auto"
-        if self.openml_cache is None:
-            return str(self._workspace / ".openml-cache")
-        return str(self.openml_cache)
 
     def get_setup_out_path(self, benchmark_name: str) -> Path:
         """Directory holding the generated job-batch artifact + SLURM job JSON."""
@@ -127,17 +110,12 @@ class PathSetup:
         return str(self._workspace / "slurm_out" / benchmark_name)
 
     def ensure_runtime_dirs(self, benchmark_name: str) -> None:
-        """Create the output, log, setup, and (optional) OpenML cache directories.
+        """Create the output, log, and setup directories for this benchmark.
 
-        Also points the ambient OpenML cache at ``openml_cache_path`` when it is
-        not ``"auto"``, so any task artifacts materialized during setup (e.g.
-        data_foundry ``UserTask`` pickles) land where the SLURM workers resolve
-        them — the workers configure the same cache via ``--openml_cache_dir``.
+        Cache directories are not created here: the OpenML / HuggingFace / TabArena caches are
+        configured via the context's ``CacheConfig`` (embedded in the ``JobBatch``) and the
+        underlying libraries create their cache dirs lazily on first write.
         """
-        if self.openml_cache_path != "auto":
-            Path(self.openml_cache_path).mkdir(parents=True, exist_ok=True)
-            print(f"Setting OpenML cache directory to: {self.openml_cache_path}")
-            openml.config.set_root_cache_directory(root_cache_directory=self.openml_cache_path)
         Path(self.get_output_path(benchmark_name)).mkdir(parents=True, exist_ok=True)
         Path(self.get_slurm_log_output_path(benchmark_name)).mkdir(parents=True, exist_ok=True)
         self.get_setup_out_path(benchmark_name).mkdir(parents=True, exist_ok=True)

--- a/packages/tabflow_slurm/src/tabflow_slurm/slurm_utils.py
+++ b/packages/tabflow_slurm/src/tabflow_slurm/slurm_utils.py
@@ -4,23 +4,22 @@ from __future__ import annotations
 
 import logging
 
-import openml
-
 
 def setup_slurm_job(
     *,
-    openml_cache_dir: str,
     num_cpus: int,
     num_gpus: int,
     memory_limit: int,
     setup_ray_for_slurm_shared_resources_environment: bool,
 ) -> None | str:
-    """Ensure correct caching and usage of directories for OpenML and TabRepo.
+    """Set up Ray (and silence loky logs) for executing a single benchmark job on a node.
+
+    Cache configuration (OpenML / HuggingFace / TabArena) is no longer done here — it travels with
+    the run inside the ``JobBatch`` and is applied by ``run_experiment`` (see
+    ``tabarena.caching.CacheConfig``).
 
     Parameters
     ----------
-    openml_cache_dir : str
-        The path to the OpenML cache directory, or "auto" to use the default OpenML cache directory.
     num_cpus : int
         The number of CPUs to use for the experiment (needed for proper Ray setup).
     num_gpus : int
@@ -34,12 +33,6 @@ def setup_slurm_job(
     """
     # Silence loky resource tracker clean up logs
     logging.getLogger("loky.backend.resource_tracker").setLevel(logging.CRITICAL)
-
-    if openml_cache_dir == "auto":
-        print("Using the default OpenML cache directory.")
-    else:
-        print(f"Setting OpenML cache directory to: {openml_cache_dir}")
-        openml.config.set_root_cache_directory(root_cache_directory=openml_cache_dir)
 
     # SLURM save Ray setup in a shared resource system
     ray_dir = None

--- a/packages/tabflow_slurm/src/tabflow_slurm/submit_template.sh
+++ b/packages/tabflow_slurm/src/tabflow_slurm/submit_template.sh
@@ -26,7 +26,6 @@ echo "Selected Job Index: $J"
 # Read defaults
 PYTHON_PATH=$(jq -r '.defaults.python' "$JSON_FILE")
 RUNSCRIPT=$(jq -r '.defaults.run_script' "$JSON_FILE")
-OPENML_CACHE_DIR=$(jq -r '.defaults.openml_cache_dir' "$JSON_FILE")
 JOB_BATCH_DIR=$(jq -r '.defaults.job_batch_dir' "$JSON_FILE")
 OUTPUT_DIR=$(jq -r '.defaults.output_dir' "$JSON_FILE")
 NUM_CPUS=$(jq -r '.defaults.num_cpus' "$JSON_FILE")
@@ -37,7 +36,6 @@ IGNORE_CACHE=$(jq -r '.defaults.ignore_cache' "$JSON_FILE")
 
 echo "Python Path: $PYTHON_PATH"
 echo "Run Script: $RUNSCRIPT"
-echo "OpenML Cache Directory: $OPENML_CACHE_DIR"
 echo "Job Batch Dir: $JOB_BATCH_DIR"
 echo "Output Directory: $OUTPUT_DIR"
 echo "Number of CPUs: $NUM_CPUS"
@@ -59,7 +57,6 @@ run_one() {
         --fold $FOLD \
         --repeat $REPEAT \
         --job_batch_dir "$JOB_BATCH_DIR" \
-        --openml_cache_dir $OPENML_CACHE_DIR \
         --output_dir $OUTPUT_DIR \
         --num_cpus $NUM_CPUS \
         --num_gpus $NUM_GPUS \

--- a/tests/tabarena/benchmark/experiment/test_job_batch.py
+++ b/tests/tabarena/benchmark/experiment/test_job_batch.py
@@ -243,6 +243,18 @@ class TestJobBatch:
         exp_a_jobs = [j for j in loaded.jobs if j.experiment.name == "exp_a"]
         assert all(j.experiment is exp_a_jobs[0].experiment for j in exp_a_jobs)
 
+    def test_cache_config_round_trip(self, tmp_path):
+        from tabarena.caching import CacheConfig
+
+        cfg = CacheConfig(openml="/o", huggingface="/hf", tabarena="/t", scope_openml=True)
+        batch = JobBatch(jobs=self._batch().jobs, task_metadata=self._batch().task_metadata, cache_config=cfg)
+        loaded = JobBatch.load(batch.save(tmp_path / "batch"))
+        assert loaded.cache_config == cfg  # str-valued config round-trips equal
+
+    def test_no_cache_config_loads_as_none(self, tmp_path):
+        loaded = JobBatch.load(self._batch().save(tmp_path / "batch"))
+        assert loaded.cache_config is None
+
     def test_load_with_unknown_experiment_reference_raises(self, tmp_path):
         batch = self._batch()
         path = batch.save(tmp_path / "batch")

--- a/tests/tabarena/contexts/test_cache_config_wiring.py
+++ b/tests/tabarena/contexts/test_cache_config_wiring.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tabarena.benchmark.task.metadata import TaskMetadataCollection
+from tabarena.caching import CacheConfig
+from tabarena.contexts import TabArenaContext
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_state():
+    """Reset the TabArena cache-root holder and the OpenML root cache around each test."""
+    import openml
+
+    from tabarena.loaders import set_tabarena_cache_root
+
+    saved_openml_root = openml.config._root_cache_directory
+    try:
+        yield
+    finally:
+        set_tabarena_cache_root(None)
+        openml.config.set_root_cache_directory(str(saved_openml_root))
+
+
+def _make_ctx(**kwargs) -> TabArenaContext:
+    """A light context (no method-metadata load) over a 2-dataset / 2-fold native collection."""
+    df = pd.DataFrame(
+        {
+            "tid": [0, 1],
+            "dataset": ["small_ds", "big_ds"],
+            "name": ["small_ds", "big_ds"],
+            "problem_type": ["binary", "regression"],
+            "n_folds": [2, 2],
+            "n_repeats": [1, 1],
+            "n_features": [10, 10],
+            "n_classes": [2, 0],
+            "NumberOfInstances": [150, 75_000],
+            "n_samples_train_per_fold": [100, 50_000],
+            "n_samples_test_per_fold": [50, 25_000],
+            "target_feature": ["t", "t"],
+        },
+    )
+    return TabArenaContext(methods=[], task_metadata=TaskMetadataCollection.from_legacy_df(df), **kwargs)
+
+
+class _StubExperiment:
+    """Stand-in for an Experiment: build_jobs only reads ``.name`` / ``.model_constraints``."""
+
+    model_constraints = None
+
+    def __init__(self, name: str = "exp"):
+        self.name = name
+
+
+def _stub_runner(record: dict):
+    """A fake ExperimentBatchRunner that records its ``expname`` and runs nothing."""
+
+    class _FakeRunner:
+        def __init__(self, *, expname, task_metadata, **kwargs):
+            record["expname"] = expname
+
+        def run_jobs(self, jobs):
+            return []
+
+    return _FakeRunner
+
+
+def test_apply_on_init_configures_constructing_process(tmp_path):
+    from tabarena.loaders import get_tabarena_cache_root
+
+    _make_ctx(cache_config=CacheConfig(tabarena=tmp_path / "tab"))
+    assert get_tabarena_cache_root() == tmp_path / "tab"
+
+
+def test_run_jobs_reapplies_cache_config(monkeypatch, tmp_path):
+    import tabarena.benchmark.experiment as exp_mod
+    from tabarena.loaders import get_tabarena_cache_root, set_tabarena_cache_root
+
+    monkeypatch.setattr(exp_mod, "ExperimentBatchRunner", _stub_runner({}))
+    ctx = _make_ctx(cache_config=CacheConfig(tabarena=tmp_path / "tab"))
+    jobs = ctx.build_jobs([_StubExperiment()], subset="lite")
+
+    set_tabarena_cache_root(None)  # clear what __init__ applied; run_jobs must re-apply it
+    ctx.run_jobs(jobs, expname=str(tmp_path / "exp"), register=False)
+    assert get_tabarena_cache_root() == tmp_path / "tab"
+
+
+def test_run_jobs_does_not_reapply_when_disabled(monkeypatch, tmp_path):
+    import tabarena.benchmark.experiment as exp_mod
+    from tabarena.loaders import get_tabarena_cache_root, set_tabarena_cache_root
+
+    monkeypatch.setattr(exp_mod, "ExperimentBatchRunner", _stub_runner({}))
+    ctx = _make_ctx(cache_config=CacheConfig(tabarena=tmp_path / "tab", apply_on_run=False))
+    jobs = ctx.build_jobs([_StubExperiment()], subset="lite")
+
+    set_tabarena_cache_root(None)
+    ctx.run_jobs(jobs, expname=str(tmp_path / "exp"), register=False)
+    assert get_tabarena_cache_root() != tmp_path / "tab"  # holder was not re-set
+
+
+def test_run_jobs_omitted_expname_defaults_from_results(monkeypatch, tmp_path):
+    import tabarena.benchmark.experiment as exp_mod
+
+    record: dict = {}
+    monkeypatch.setattr(exp_mod, "ExperimentBatchRunner", _stub_runner(record))
+    ctx = _make_ctx(cache_config=CacheConfig(results=tmp_path / "res"))
+    jobs = ctx.build_jobs([_StubExperiment()], subset="lite")
+
+    ctx.run_jobs(jobs, register=False)  # expname omitted entirely -> falls back to results
+    assert record["expname"] == str(tmp_path / "res")
+
+
+def test_run_jobs_explicit_none_is_throwaway_even_with_results(monkeypatch, tmp_path):
+    import tabarena.benchmark.experiment as exp_mod
+
+    record: dict = {}
+    monkeypatch.setattr(exp_mod, "ExperimentBatchRunner", _stub_runner(record))
+    ctx = _make_ctx(cache_config=CacheConfig(results=tmp_path / "res"))
+    jobs = ctx.build_jobs([_StubExperiment()], subset="lite")
+
+    ctx.run_jobs(jobs, expname=None, register=False)  # explicit None -> throwaway temp dir, NOT results
+    assert record["expname"] != str(tmp_path / "res")
+
+
+def test_run_jobs_requires_expname_without_results(tmp_path):
+    ctx = _make_ctx()  # no cache_config -> no results default
+    jobs = ctx.build_jobs([_StubExperiment()], subset="lite")
+    with pytest.raises(TypeError, match="expname"):
+        ctx.run_jobs(jobs, register=False)  # omitted and no default -> required
+
+
+def test_explicit_expname_overrides_results_default(monkeypatch, tmp_path):
+    import tabarena.benchmark.experiment as exp_mod
+
+    record: dict = {}
+    monkeypatch.setattr(exp_mod, "ExperimentBatchRunner", _stub_runner(record))
+    ctx = _make_ctx(cache_config=CacheConfig(results=tmp_path / "res"))
+    jobs = ctx.build_jobs([_StubExperiment()], subset="lite")
+
+    ctx.run_jobs(jobs, expname=str(tmp_path / "explicit"), register=False)
+    assert record["expname"] == str(tmp_path / "explicit")
+
+
+def test_scope_openml_init_leaves_ambient_openml_untouched(tmp_path):
+    import openml
+
+    from tabarena.loaders import get_tabarena_cache_root
+
+    openml.config.set_root_cache_directory(str(tmp_path / "ambient"))
+    _make_ctx(cache_config=CacheConfig(openml=tmp_path / "x", tabarena=tmp_path / "tab", scope_openml=True))
+    # OpenML stays at the ambient location; the TabArena cache (needed by compare) is applied.
+    assert Path(openml.config._root_cache_directory) == tmp_path / "ambient"
+    assert get_tabarena_cache_root() == tmp_path / "tab"
+
+
+def test_scope_openml_run_jobs_uses_x_then_restores_openml(monkeypatch, tmp_path):
+    import openml
+
+    import tabarena.benchmark.experiment as exp_mod
+
+    record: dict = {}
+
+    class _OpenmlCapturingRunner:
+        def __init__(self, *, expname, task_metadata, **kwargs):
+            # Constructed inside the cache scope -> records the OpenML root active during the run.
+            record["openml_in_scope"] = str(openml.config._root_cache_directory)
+
+        def run_jobs(self, jobs):
+            return []
+
+    monkeypatch.setattr(exp_mod, "ExperimentBatchRunner", _OpenmlCapturingRunner)
+    openml.config.set_root_cache_directory(str(tmp_path / "ambient"))
+    ctx = _make_ctx(cache_config=CacheConfig(openml=tmp_path / "x", tabarena=tmp_path / "tab", scope_openml=True))
+    jobs = ctx.build_jobs([_StubExperiment()], subset="lite")
+
+    ctx.run_jobs(jobs, expname=str(tmp_path / "exp"), register=False)
+    assert record["openml_in_scope"] == str(tmp_path / "x")  # X active during the run
+    assert Path(openml.config._root_cache_directory) == tmp_path / "ambient"  # restored after

--- a/tests/tabarena/evaluation/test_benchmark_eval.py
+++ b/tests/tabarena/evaluation/test_benchmark_eval.py
@@ -48,6 +48,20 @@ class TestConfig:
         finally:
             set_tabarena_cache_root(None)
 
+    def test_init_caches_prefers_cache_config(self, tmp_path):
+        from tabarena.caching import CacheConfig
+
+        try:
+            # cache_config wins over the legacy *_cache_path field.
+            _config(
+                tmp_path,
+                cache_config=CacheConfig(tabarena="/from_config"),
+                tabarena_cache_path="/legacy",
+            ).init_caches()
+            assert get_tabarena_cache_root() == Path("/from_config")
+        finally:
+            set_tabarena_cache_root(None)
+
 
 def test_run_eval_orchestration(tmp_path, monkeypatch):
     import tabarena.contexts.tabarena.context as tc

--- a/tests/tabarena/evaluation/test_eval_common.py
+++ b/tests/tabarena/evaluation/test_eval_common.py
@@ -3,14 +3,63 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
-from tabarena.evaluation._eval_common import init_aux_metric_env, subset_label
+import pytest
+
+from tabarena.evaluation._eval_common import init_aux_metric_env, init_caches, subset_label
 
 
 def test_subset_label_full_and_sorted():
     assert subset_label([]) == "full"
     assert subset_label(["regression"]) == "regression"
     assert subset_label(["b", "a"]) == "a_b"  # sorted + joined
+
+
+@pytest.fixture
+def _isolate_caches():
+    """Snapshot + restore the cache state init_caches mutates (HF env, OpenML root, holder)."""
+    import openml
+
+    from tabarena.loaders import set_tabarena_cache_root
+
+    saved_hf = os.environ.get("HF_HOME")
+    saved_openml_root = openml.config._root_cache_directory
+    try:
+        yield
+    finally:
+        if saved_hf is None:
+            os.environ.pop("HF_HOME", None)
+        else:
+            os.environ["HF_HOME"] = saved_hf
+        openml.config.set_root_cache_directory(str(saved_openml_root))
+        set_tabarena_cache_root(None)
+
+
+@pytest.mark.usefixtures("_isolate_caches")
+def test_init_caches_delegates_to_cache_config(tmp_path):
+    import openml
+
+    from tabarena.loaders import get_tabarena_cache_root
+
+    os.environ.pop("HF_HOME", None)
+    init_caches(
+        tabarena_cache_path=str(tmp_path / "tab"),
+        openml_cache_path=str(tmp_path / "openml"),
+        huggingface_cache_path=str(tmp_path / "hf"),
+    )
+    assert get_tabarena_cache_root() == tmp_path / "tab"
+    assert Path(openml.config._root_cache_directory) == tmp_path / "openml"
+    assert os.environ["HF_HOME"] == str(tmp_path / "hf")
+
+
+@pytest.mark.usefixtures("_isolate_caches")
+def test_init_caches_two_arg_call_leaves_huggingface_untouched(tmp_path):
+    # Backward compatibility: the historical two-positional-arg call must still work and not
+    # introduce an HF_HOME (huggingface_cache_path defaults to None).
+    os.environ.pop("HF_HOME", None)
+    init_caches(str(tmp_path / "tab"), str(tmp_path / "openml"))
+    assert "HF_HOME" not in os.environ
 
 
 def test_init_aux_metric_env_sets_and_clears():

--- a/tests/tabarena/test_caching.py
+++ b/tests/tabarena/test_caching.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from tabarena.caching import CacheConfig
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_state():
+    """Snapshot + restore the global cache state each test mutates.
+
+    ``apply()`` writes process-global state (``HF_HOME`` env vars, the OpenML root cache, the
+    TabArena cache-root holder), so we snapshot all of it up front and restore it afterwards to
+    keep tests independent.
+    """
+    import openml
+
+    from tabarena.loaders import set_tabarena_cache_root
+
+    hf_keys = ("HF_HOME", "HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE")
+    saved_env = {k: os.environ.get(k) for k in hf_keys}
+    saved_openml_root = openml.config._root_cache_directory
+    constants_present = "huggingface_hub.constants" in sys.modules
+    saved_constants = sys.modules.get("huggingface_hub.constants")
+    try:
+        yield
+    finally:
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        openml.config.set_root_cache_directory(str(saved_openml_root))
+        set_tabarena_cache_root(None)
+        if constants_present:
+            sys.modules["huggingface_hub.constants"] = saved_constants
+        else:
+            sys.modules.pop("huggingface_hub.constants", None)
+
+
+def test_apply_sets_openml_root(tmp_path):
+    import openml
+
+    CacheConfig(openml=tmp_path / "openml").apply()
+    assert Path(openml.config._root_cache_directory) == tmp_path / "openml"
+
+
+def test_apply_sets_tabarena_root(tmp_path):
+    from tabarena.loaders import get_tabarena_cache_root
+
+    CacheConfig(tabarena=tmp_path / "tab").apply()
+    assert get_tabarena_cache_root() == tmp_path / "tab"
+
+
+def test_apply_sets_hf_home_and_clears_more_specific_vars(tmp_path):
+    os.environ["HF_HUB_CACHE"] = "/stale/hub"  # a stale value must not shadow the new HF_HOME
+    CacheConfig(huggingface=tmp_path / "hf").apply()
+    assert os.environ["HF_HOME"] == str(tmp_path / "hf")
+    assert "HF_HUB_CACHE" not in os.environ
+    assert "HUGGINGFACE_HUB_CACHE" not in os.environ
+
+
+def test_apply_patches_already_imported_hf_constants(tmp_path):
+    # When huggingface_hub.constants is already imported its paths are frozen, so apply() must
+    # repoint them in place (otherwise the env var alone would be ignored).
+    fake = types.SimpleNamespace(HF_HOME="/old", HF_HUB_CACHE="/old/hub", HUGGINGFACE_HUB_CACHE="/old/hub")
+    sys.modules["huggingface_hub.constants"] = fake
+    CacheConfig(huggingface=tmp_path / "hf").apply()
+    expected_home = str(tmp_path / "hf")
+    expected_hub = str(tmp_path / "hf" / "hub")
+    # `expected == fake.ATTR` ordering keeps ruff's SIM300 happy (all-caps attrs read as constants).
+    assert expected_home == fake.HF_HOME
+    assert expected_hub == fake.HF_HUB_CACHE
+    assert expected_hub == fake.HUGGINGFACE_HUB_CACHE
+
+
+def test_none_fields_are_noops(tmp_path):
+    import openml
+
+    before_openml = openml.config._root_cache_directory
+    os.environ.pop("HF_HOME", None)
+    CacheConfig().apply()
+    assert openml.config._root_cache_directory == before_openml
+    assert "HF_HOME" not in os.environ
+
+
+def test_results_field_is_not_applied_globally(tmp_path):
+    # `results` is the run_jobs default expname, not global state — apply() must ignore it.
+    import openml
+
+    before_openml = openml.config._root_cache_directory
+    os.environ.pop("HF_HOME", None)
+    CacheConfig(results=tmp_path / "res").apply()
+    assert openml.config._root_cache_directory == before_openml
+    assert "HF_HOME" not in os.environ
+
+
+def test_from_root_lays_out_subdirs(tmp_path):
+    cfg = CacheConfig.from_root(tmp_path)
+    assert cfg.openml == tmp_path / "openml"
+    assert cfg.huggingface == tmp_path / "huggingface"
+    assert cfg.tabarena == tmp_path / "tabarena"
+    assert cfg.results == tmp_path / "results"
+
+
+def test_from_root_override_pins_field(tmp_path):
+    cfg = CacheConfig.from_root(tmp_path, results=None)
+    assert cfg.results is None
+    assert cfg.openml == tmp_path / "openml"  # the rest still derive from root
+
+
+def test_scoped_openml_restores_openml_root_but_keeps_other_caches(tmp_path):
+    import openml
+
+    from tabarena.loaders import get_tabarena_cache_root
+
+    openml.config.set_root_cache_directory(str(tmp_path / "ambient"))
+    cfg = CacheConfig(openml=tmp_path / "x", tabarena=tmp_path / "tab", huggingface=tmp_path / "hf")
+    with cfg.scoped_openml():
+        # Inside the block everything points at the configured caches.
+        assert Path(openml.config._root_cache_directory) == tmp_path / "x"
+        assert get_tabarena_cache_root() == tmp_path / "tab"
+        assert os.environ["HF_HOME"] == str(tmp_path / "hf")
+    # On exit the OpenML root is restored to the ambient location; HF + TabArena stay applied.
+    assert Path(openml.config._root_cache_directory) == tmp_path / "ambient"
+    assert get_tabarena_cache_root() == tmp_path / "tab"
+    assert os.environ["HF_HOME"] == str(tmp_path / "hf")
+
+
+def test_apply_openml_false_skips_openml(tmp_path):
+    import openml
+
+    from tabarena.loaders import get_tabarena_cache_root
+
+    openml.config.set_root_cache_directory(str(tmp_path / "ambient"))
+    CacheConfig(openml=tmp_path / "x", tabarena=tmp_path / "tab").apply(openml=False)
+    assert Path(openml.config._root_cache_directory) == tmp_path / "ambient"  # untouched
+    assert get_tabarena_cache_root() == tmp_path / "tab"  # the rest is still applied
+
+
+def test_to_dict_from_dict_round_trips_str_config():
+    cfg = CacheConfig(
+        openml="/o", huggingface="/hf", tabarena="/t", results="/r", apply_on_run=False, scope_openml=True
+    )
+    assert CacheConfig.from_dict(cfg.to_dict()) == cfg
+
+
+def test_to_dict_renders_paths_as_str_and_is_value_stable(tmp_path):
+    d = CacheConfig.from_root(tmp_path).to_dict()
+    assert d["openml"] == str(tmp_path / "openml")
+    assert isinstance(d["openml"], str)
+    # re-serializing the reconstructed config yields the same dict (value-stable round-trip)
+    assert CacheConfig.from_dict(d).to_dict() == d
+
+
+def test_from_dict_ignores_unknown_keys():
+    cfg = CacheConfig.from_dict({"openml": "/o", "unknown": "x"})
+    assert cfg.openml == "/o"
+
+
+def test_apply_is_idempotent(tmp_path):
+    import openml
+
+    from tabarena.loaders import get_tabarena_cache_root
+
+    cfg = CacheConfig(openml=tmp_path / "o", huggingface=tmp_path / "hf", tabarena=tmp_path / "t")
+    cfg.apply()
+    cfg.apply()
+    assert Path(openml.config._root_cache_directory) == tmp_path / "o"
+    assert os.environ["HF_HOME"] == str(tmp_path / "hf")
+    assert get_tabarena_cache_root() == tmp_path / "t"

--- a/tests/tabflow_slurm/test_run_tabarena_experiment.py
+++ b/tests/tabflow_slurm/test_run_tabarena_experiment.py
@@ -177,34 +177,17 @@ class TestRunExperimentResolution:
 
 
 class TestSetupSlurmJob:
-    def test_auto_openml_cache_returns_none(self):
+    def test_returns_none_without_ray(self):
         result = setup_slurm_job(
-            openml_cache_dir="auto",
             num_cpus=1,
             num_gpus=0,
             memory_limit=4,
             setup_ray_for_slurm_shared_resources_environment=False,
         )
         assert result is None
-
-    def test_custom_openml_cache_sets_directory(self, tmp_path):
-        import openml
-
-        cache_dir = str(tmp_path / "oml_cache")
-        result = setup_slurm_job(
-            openml_cache_dir=cache_dir,
-            num_cpus=1,
-            num_gpus=0,
-            memory_limit=4,
-            setup_ray_for_slurm_shared_resources_environment=False,
-        )
-        assert result is None
-        # Verify the OpenML cache was pointed at the custom directory.
-        assert str(openml.config.get_cache_directory()).startswith(cache_dir)
 
     def test_no_ray_setup_skips_ray(self, capsys):
         result = setup_slurm_job(
-            openml_cache_dir="auto",
             num_cpus=2,
             num_gpus=0,
             memory_limit=8,
@@ -214,3 +197,48 @@ class TestSetupSlurmJob:
         captured = capsys.readouterr()
         # Should NOT mention Ray setup when skipping it.
         assert "Ray" not in captured.out
+
+
+class TestRunExperimentAppliesCacheConfig:
+    """The runner applies the JobBatch's embedded CacheConfig before fitting (no CLI wiring)."""
+
+    def test_applies_batch_cache_config(self, monkeypatch, tmp_path):
+        import types
+
+        import tabarena.benchmark.experiment as exp_mod
+        from tabarena.caching import CacheConfig
+        from tabarena.loaders import get_tabarena_cache_root, set_tabarena_cache_root
+
+        job = types.SimpleNamespace(
+            experiment=types.SimpleNamespace(name="exp"),
+            task=types.SimpleNamespace(as_triple=lambda: ("ds", 0, 0)),
+        )
+        fake_batch = types.SimpleNamespace(
+            jobs=[job],
+            task_metadata=object(),
+            cache_config=CacheConfig(tabarena=tmp_path / "tab"),
+        )
+        monkeypatch.setattr(exp_mod, "JobBatch", types.SimpleNamespace(load=lambda _dir: fake_batch))
+
+        class _FakeRunner:
+            def __init__(self, **kwargs):
+                pass
+
+            def run_jobs(self, jobs):
+                return [{"metric_error": 0.1}]
+
+        monkeypatch.setattr(exp_mod, "ExperimentBatchRunner", _FakeRunner)
+        try:
+            out = run_experiment(
+                job_batch_dir="x",
+                experiment_name="exp",
+                dataset="ds",
+                fold=0,
+                repeat=0,
+                output_dir=str(tmp_path / "out"),
+                ignore_cache=False,
+            )
+            assert out == [{"metric_error": 0.1}]
+            assert get_tabarena_cache_root() == tmp_path / "tab"  # batch's cache_config was applied
+        finally:
+            set_tabarena_cache_root(None)

--- a/tests/tabflow_slurm/test_setup.py
+++ b/tests/tabflow_slurm/test_setup.py
@@ -49,22 +49,6 @@ class TestPathSetup:
         ps = PathSetup(workspace="/ws", python_path="/py", run_script="/custom/run.py")
         assert ps.run_script_path == "/custom/run.py"
 
-    def test_openml_cache_path_auto(self):
-        ps = PathSetup(workspace="/ws", python_path="/py", openml_cache="auto")
-        assert ps.openml_cache_path == "auto"
-
-    def test_openml_cache_path_defaults_to_auto(self):
-        ps = PathSetup(workspace="/ws", python_path="/py")
-        assert ps.openml_cache_path == "auto"
-
-    def test_openml_cache_path_none_is_under_workspace(self):
-        ps = PathSetup(workspace="/ws", python_path="/py", openml_cache=None)
-        assert ps.openml_cache_path == "/ws/.openml-cache"
-
-    def test_openml_cache_path_custom(self):
-        ps = PathSetup(workspace="/ws", python_path="/py", openml_cache="/data/cache")
-        assert ps.openml_cache_path == "/data/cache"
-
     def test_get_job_batch_dir_contains_safe_name(self):
         ps = PathSetup(workspace="/ws", python_path="/py")
         path = ps.get_job_batch_dir(benchmark_name="bench", safe_benchmark_name="bench_p1")
@@ -94,13 +78,12 @@ class TestPathSetup:
         assert str(ps.get_setup_out_path("my_bench")) == "/ws/setup_out/my_bench"
 
     def test_ensure_runtime_dirs_creates_directories(self, tmp_path):
-        # openml_cache=None -> the cache dir is created under the workspace too.
-        ps = PathSetup(workspace=tmp_path, python_path="/py", openml_cache=None)
+        # Only the output/log/setup dirs are created; caches are configured via CacheConfig.
+        ps = PathSetup(workspace=tmp_path, python_path="/py")
         ps.ensure_runtime_dirs("bench")
         assert (tmp_path / "output" / "bench").is_dir()
         assert (tmp_path / "slurm_out" / "bench").is_dir()
         assert (tmp_path / "setup_out" / "bench").is_dir()
-        assert (tmp_path / ".openml-cache").is_dir()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Title

Unify cache configuration via a single CacheConfig surface

## Body

## What
Adds `tabarena.caching.CacheConfig` — one object that declares every cache location
(OpenML, HuggingFace, TabArena results, run-output `expname`) — and wires it through the
whole stack so caches are configured the same way everywhere.

## Why
Previously caches were process-global state set ad hoc, and the SLURM path configured them
a *separate* way (`PathSetup` → JSON defaults → `jq` → `--openml_cache_dir` CLI flags). Now
you declare locations once and the system propagates them.

## Highlights
- `TabArenaContext(cache_config=CacheConfig.from_root(...))` — applied on construction and
  re-applied inside `run_jobs`, so distributed/async workers inherit it.
- `scope_openml=True` runs against a dedicated OpenML cache **without** clobbering an ambient
  `openml.config` (restored after each op); `apply_on_run` toggles the re-apply.
- SLURM: the `CacheConfig` rides inside the `JobBatch` and the worker applies it — removed
  `PathSetup.openml_cache`/`huggingface_cache`, the `defaults` cache entries, the `jq` lines,
  and the runner CLI flags. `setup_slurm_job` is now Ray-only.
- Eval configs (`TabArenaEvalConfig` / `BeyondArenaEvalConfig`) accept the same `CacheConfig`.
- **No behavior change by default**: omitting `cache_config` (`None`) uses the library defaults
  (`~/.cache/openml`, `~/.cache/huggingface/hub`, `~/.cache/tabarena`) — same as the old
  `openml_cache="auto"`.

Docs (`AGENTS.md`, READMEs) and a new `examples/advanced/run_configure_caches.py` included.
Tests: ruff clean; cache/context/eval + full `tabflow_slurm` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
