### PR TITLE
Move paper_utils.py to evaluation/framework_naming.py

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/framework_naming.py
+++ b/packages/tabarena/src/tabarena/evaluation/framework_naming.py
@@ -1,3 +1,15 @@
+"""Framework / method display-name construction for the leaderboard and plots.
+
+Builds the human-facing method names the TabArena leaderboard and figures show — the
+``default`` / ``tuned`` / ``tuned + ensemble`` / ``best`` / ``holdout`` variants of each config
+family — along with the rename and plot-suffix maps that index them. ``framework_name`` /
+``time_suffix`` / ``default_ensemble_size`` are the building blocks; ``get_framework_type_method_names``,
+``get_method_rename_map`` and ``get_f_map_suffix_plots`` are the public maps consumed by
+:class:`~tabarena.paper.tabarena_evaluator.TabArenaEvaluator` and the tuning-trajectory plots.
+
+Formerly ``tabarena/paper/paper_utils.py``.
+"""
+
 from __future__ import annotations
 
 default_ensemble_size = 40

--- a/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
+++ b/packages/tabarena/src/tabarena/paper/tabarena_evaluator.py
@@ -16,7 +16,11 @@ from autogluon.common.savers import save_pd
 
 from bencheval.evaluator import BenchmarkEvaluator
 from tabarena.benchmark.task.metadata import TaskMetadataCollection, default_task_metadata_collection
-from tabarena.paper.paper_utils import get_f_map_suffix_plots, get_framework_type_method_names, get_method_rename_map
+from tabarena.evaluation.framework_naming import (
+    get_f_map_suffix_plots,
+    get_framework_type_method_names,
+    get_method_rename_map,
+)
 from tabarena.plot.dataset_analysis import plot_train_time_deep_dive
 from tabarena.plot.plot_ens_weights import create_heatmap
 from tabarena.plot.plot_pareto_frontier import (

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -13,12 +13,12 @@ from autogluon.common.loaders import load_pd
 
 from bencheval.evaluator import BenchmarkEvaluator
 from tabarena.contexts import TabArenaContext
+from tabarena.evaluation.framework_naming import get_method_rename_map
 from tabarena.nips2025_utils.compare import subset_tasks
 from tabarena.nips2025_utils.eval_all import (
     get_all_subset_combinations,
     get_website_folder_name,
 )
-from tabarena.paper.paper_utils import get_method_rename_map
 from tabarena.plot.plot_pareto_frontier import plot_optimal_arrow
 from tabarena.utils.parallel_for import parallel_for
 


### PR DESCRIPTION
## What

Renames and relocates `paper/paper_utils.py` → `evaluation/framework_naming.py`. Pure move + import updates, no behavior change. Builds on #406 (which dissolved `paper/paper_runner*.py` into `simulation/RepoSimulator`).

## Why

`paper_utils.py` is a cohesive set of **framework/method display-name** helpers: it builds the human-facing leaderboard/plot method names (`default` / `tuned` / `tuned + ensemble` / `best` / `holdout` variants of each config family) and the rename / plot-suffix maps that index them.

- **Name:** `framework_naming` describes what every symbol does — they operate on `framework_type` and emit `framework` display names. ("utils" said nothing.)
- **Home — `evaluation/`:** the primary consumer is `TabArenaEvaluator`, and `evaluation/` is the existing home for leaderboard/eval logic. Also moves it out of the vestigial `paper/` package (now down to just `tabarena_evaluator.py`).

## Kept as one module (did not split)

`framework_name` / `time_suffix` / `default_ensemble_size` are internal building blocks of `get_framework_type_method_names`. The only plot-flavored function, `get_f_map_suffix_plots`, is imported by the **evaluator** (not the plot module), so peeling it into `plot/` would fragment a one-line label dict from its sole caller and add a needless `evaluation → plot` dependency. The six symbols are one unit.

## Changes

- `evaluation/framework_naming.py` — new (moved from `paper/paper_utils.py`, + module docstring).
- Deleted `paper/paper_utils.py`.
- Updated the two importers: `paper/tabarena_evaluator.py`, `plot/tuning_trajectories/plot_pareto_over_tuning_time.py`.

## Verification

- `ruff check` / `ruff format` clean.
- No stale `paper_utils` references remain (only the historical note in the new module docstring).
- Imports load cleanly (`TabArenaEvaluator`, the pareto plot) and the helpers still produce the expected names (`framework_name('CatBoost', tuned=True) == 'CatBoost (tuned + ensemble)'`, `time_suffix(14400) == ' (4h)'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)