### PR TITLE
Move + rename TabArenaEvaluator -> evaluation/LeaderboardReporter

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -36,11 +36,11 @@ import pandas as pd
 
 from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection, TaskSubset
 from tabarena.benchmark.task.subset_predicate import SubsetPredicate
+from tabarena.evaluation.leaderboard_reporter import LeaderboardReporter
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._method_metadata_collection import MethodMetadataCollection
 from tabarena.models._method_simulator import MethodSimulator
 from tabarena.nips2025_utils.per_dataset_tables import get_per_dataset_tables
-from tabarena.paper.tabarena_evaluator import TabArenaEvaluator
 from tabarena.repository import EvaluationRepository, EvaluationRepositoryCollection
 from tabarena.simulation.repo_simulator import RepoSimulator
 from tabarena.website.website_format import format_leaderboard
@@ -909,7 +909,7 @@ class AbstractArenaContext:
             )
 
         kwargs = kwargs.copy()
-        # Plotting-only method allowlist (forwarded to the lower-level compare -> TabArenaEvaluator
+        # Plotting-only method allowlist (forwarded to the lower-level compare -> LeaderboardReporter
         # .eval, which translates it into the hidden_methods complement). Does not affect scoring.
         if plot_only is not None:
             kwargs["plot_only"] = plot_only
@@ -1793,7 +1793,7 @@ class AbstractArenaContext:
 
         deep_dive_kwargs = dict(kwargs.pop("deep_dive_kwargs", None) or {})
 
-        evaluator = TabArenaEvaluator(output_dir=save_path, task_metadata=self.task_metadata_collection)
+        evaluator = LeaderboardReporter(output_dir=save_path, task_metadata=self.task_metadata_collection)
         evaluator.generate_runtime_plot(
             df_results=df_results_configs,
             deep_dive_kwargs=deep_dive_kwargs,

--- a/packages/tabarena/src/tabarena/evaluation/framework_naming.py
+++ b/packages/tabarena/src/tabarena/evaluation/framework_naming.py
@@ -5,7 +5,7 @@ Builds the human-facing method names the TabArena leaderboard and figures show â
 family â€” along with the rename and plot-suffix maps that index them. ``framework_name`` /
 ``time_suffix`` / ``default_ensemble_size`` are the building blocks; ``get_framework_type_method_names``,
 ``get_method_rename_map`` and ``get_f_map_suffix_plots`` are the public maps consumed by
-:class:`~tabarena.paper.tabarena_evaluator.TabArenaEvaluator` and the tuning-trajectory plots.
+:class:`~tabarena.evaluation.leaderboard_reporter.LeaderboardReporter` and the tuning-trajectory plots.
 
 Formerly ``tabarena/paper/paper_utils.py``.
 """

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -33,7 +33,7 @@ MethodLabelStyle = str | Mapping[str, object]
 
 @dataclass
 class TuneMethodOverride:
-    """Extra bar style for `TabArenaEvaluator.plot_tuning_impact`.
+    """Extra bar style for `LeaderboardReporter.plot_tuning_impact`.
 
     Rows whose method name is in `methods` get retagged with `tune_method`
     (replacing whatever value `f_map_inverse` would have produced) and are
@@ -62,7 +62,7 @@ def _init_global_rcparams() -> None:
 
     Cached + lazy so that importing this module does not import ``matplotlib``/``tueplots``
     — this keeps the plotting stack off the ``TabArenaContext`` import path. Called from
-    ``TabArenaEvaluator.__init__`` (previously ran at module import time).
+    ``LeaderboardReporter.__init__`` (previously ran at module import time).
     """
     import matplotlib
     from tueplots import fontsizes
@@ -85,7 +85,7 @@ def darken_color(color_str, amount=0.5):
 
 
 # FIXME: ensemble weights can get if including `config_hyperparameters` as input
-class TabArenaEvaluator:
+class LeaderboardReporter:
     def __init__(
         self,
         *,
@@ -2749,14 +2749,6 @@ class TabArenaEvaluator:
             show=False,
             **deep_dive_kwargs,
         )
-
-
-class TabArenaEvaluator_2025_06_12(TabArenaEvaluator):
-    def get_method_rename_map(self) -> dict[str, str]:
-        method_rename_map = super().get_method_rename_map()
-        method_rename_map["REALMLP"] = "RealMLP"
-        method_rename_map["REALMLP_GPU"] = "RealMLP (GPU)"
-        return method_rename_map
 
 
 def _apply_ticklabel_styles(

--- a/packages/tabarena/src/tabarena/nips2025_utils/compare.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/compare.py
@@ -9,7 +9,7 @@ import pandas as pd
 from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection
 from tabarena.benchmark.task.subset_predicate import SubsetPredicate
 from tabarena.contexts import TabArenaContext
-from tabarena.paper.tabarena_evaluator import TabArenaEvaluator
+from tabarena.evaluation.leaderboard_reporter import LeaderboardReporter
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -57,7 +57,7 @@ def compare(
     evaluator_kwargs = {}
     if elo_ymin is not None:
         evaluator_kwargs["elo_ymin"] = elo_ymin
-    plotter = TabArenaEvaluator(
+    plotter = LeaderboardReporter(
         output_dir=output_dir,
         task_metadata=task_metadata,
         error_col=error_col,

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -465,7 +465,7 @@ class EndToEndResults:
         methods without affecting any numbers — the leaderboard / Elo / win-rates are still
         computed over the full method set, and only the plots are filtered. Pass method display
         names (e.g. ``["CustomRF", "RandomForest", "CatBoost", "TabPFN-2.6"]``); see
-        :meth:`tabarena.paper.tabarena_evaluator.TabArenaEvaluator.eval`.
+        :meth:`tabarena.evaluation.leaderboard_reporter.LeaderboardReporter.eval`.
         """
         results = self.get_results(
             new_result_prefix=new_result_prefix,
@@ -481,7 +481,7 @@ class EndToEndResults:
 
             task_metadata = default_task_metadata_collection()
 
-        # `plot_only` flows through the lower-level compare's **kwargs into TabArenaEvaluator.eval,
+        # `plot_only` flows through the lower-level compare's **kwargs into LeaderboardReporter.eval,
         # which applies it to plots only (scoring stays over the full method set).
         extra_kwargs = {} if plot_only is None else {"plot_only": plot_only}
         return compare(

--- a/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
@@ -4,7 +4,7 @@ from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tabarena.paper.tabarena_evaluator import TabArenaEvaluator
+from tabarena.evaluation.leaderboard_reporter import LeaderboardReporter
 from tabarena.utils.parallel_for import parallel_for
 
 if TYPE_CHECKING:
@@ -213,7 +213,7 @@ def evaluate_single(
     if custom_folder_name is not None:
         folder_name = custom_folder_name
 
-    plotter = TabArenaEvaluator(
+    plotter = LeaderboardReporter(
         output_dir=eval_save_path / folder_name,
         task_metadata=tabarena_context.task_metadata_collection,
         elo_bootstrap_rounds=elo_bootstrap_rounds,
@@ -234,7 +234,7 @@ def evaluate_single(
         include_norm_score=True,
         plot_times=True,
         average_seeds=average_seeds,
-        # Keep baselines out of evaluate_all's Pareto plots: TabArenaEvaluator.eval now
+        # Keep baselines out of evaluate_all's Pareto plots: LeaderboardReporter.eval now
         # defaults plot_with_baselines=True for the compare paths, but the paper-figure /
         # website-artifact outputs produced here should preserve the prior (baseline-free) plots.
         plot_with_baselines=False,

--- a/tests/tabarena/evaluation/test_leaderboard_reporter.py
+++ b/tests/tabarena/evaluation/test_leaderboard_reporter.py
@@ -1,6 +1,6 @@
-"""Tests for ``TabArenaEvaluator`` plotting helpers.
+"""Tests for ``LeaderboardReporter`` plotting helpers.
 
-Focused on :meth:`TabArenaEvaluator._plot_only_to_hidden_methods`, the pure
+Focused on :meth:`LeaderboardReporter._plot_only_to_hidden_methods`, the pure
 translation that powers the ``plot_only`` plotting allowlist (issue #306): it
 turns an allowlist of method *display names* into the ``hidden_methods``
 denylist the plot helpers already honor, so scoring (Elo / ranks) is never
@@ -9,7 +9,7 @@ touched — only the figures are filtered.
 
 from __future__ import annotations
 
-from tabarena.paper.tabarena_evaluator import TabArenaEvaluator
+from tabarena.evaluation.leaderboard_reporter import LeaderboardReporter
 
 # ``f_map_type_name`` maps a config method's *short* config_type to its long
 # display name (e.g. "GBM" -> "LightGBM"); baselines are not keys, so they map
@@ -21,7 +21,7 @@ class TestPlotOnlyToHiddenMethods:
     def test_hides_the_complement_of_plot_only(self):
         # Keep one config (LightGBM) and one baseline (TabPFN-3); everything else
         # is hidden. Display-name surface: configs via f_map_type_name, baselines as-is.
-        hidden = TabArenaEvaluator._plot_only_to_hidden_methods(
+        hidden = LeaderboardReporter._plot_only_to_hidden_methods(
             ["LightGBM", "TabPFN-3"],
             framework_types=["GBM", "CAT", "TABM"],
             baselines=["TabPFN-3", "AutoGluon 1.5 (extreme, 4h)"],
@@ -30,7 +30,7 @@ class TestPlotOnlyToHiddenMethods:
         assert hidden == sorted(["CatBoost", "TabM", "AutoGluon 1.5 (extreme, 4h)"])
 
     def test_keeping_everything_hides_nothing(self):
-        hidden = TabArenaEvaluator._plot_only_to_hidden_methods(
+        hidden = LeaderboardReporter._plot_only_to_hidden_methods(
             ["LightGBM", "CatBoost"],
             framework_types=["GBM", "CAT"],
             baselines=[],
@@ -40,7 +40,7 @@ class TestPlotOnlyToHiddenMethods:
 
     def test_unions_with_existing_hidden_methods(self):
         # A pre-existing hidden_methods denylist composes with the plot_only complement.
-        hidden = TabArenaEvaluator._plot_only_to_hidden_methods(
+        hidden = LeaderboardReporter._plot_only_to_hidden_methods(
             ["LightGBM"],
             framework_types=["GBM", "CAT"],
             baselines=[],
@@ -53,7 +53,7 @@ class TestPlotOnlyToHiddenMethods:
         # "SAP-RPT-1" matches nothing (the display name is "SAP-RPT-OSS"): it is
         # warned about and ignored — and since it is not a valid keep, SAP-RPT-OSS
         # is (correctly) hidden, which is exactly the typo-guard signal we want.
-        hidden = TabArenaEvaluator._plot_only_to_hidden_methods(
+        hidden = LeaderboardReporter._plot_only_to_hidden_methods(
             ["LightGBM", "SAP-RPT-1"],
             framework_types=["GBM", "CAT"],
             baselines=["SAP-RPT-OSS"],

--- a/tests/tabarena/paper/__init__.py
+++ b/tests/tabarena/paper/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations


### PR DESCRIPTION
## What

Moves `paper/tabarena_evaluator.py` → `evaluation/leaderboard_reporter.py`, renames the class `TabArenaEvaluator` → **`LeaderboardReporter`**, and deletes the dead `TabArenaEvaluator_2025_06_12` subclass. Pure move/rename + import updates; no behavior change. Follows #406 and #407, which dissolved the rest of the `paper/` package — `paper/` is now empty and removed.

## Why move to `evaluation/`

It *is* an evaluator: it computes the leaderboard (Elo / normalized-error / improvability, wrapping `bencheval.BenchmarkEvaluator`) and renders the paper/website figures + LaTeX tables. It belongs next to the other eval entry points (`evaluator.py`, `benchmark_eval.py`, `beyond_arena_eval.py`). Rejected `plot/` (it *depends on* `plot/`, and does more than plotting).

It is deliberately **not** added to `evaluation/__init__.py`: that file is kept light so `import tabarena.evaluation` stays cheap and matplotlib-free. Consumers import the submodule directly (as before). Verified `import tabarena.evaluation` still loads with no matplotlib.

## Why rename to `LeaderboardReporter`

The old name was misleading on both halves: **"TabArena"** is brand-specific even though the class serves any arena (it takes a `benchmark_name`), and **"Evaluator"** collided with the two metric-computing classes it is *not* — `evaluation.evaluator.Evaluator` and the `bencheval.BenchmarkEvaluator` it wraps. `LeaderboardReporter` names its actual role: the leaderboard/figure presentation layer.

## Delete `TabArenaEvaluator_2025_06_12`

A dated subclass (only overrode `get_method_rename_map` for two RealMLP labels) referenced nowhere but its own definition. Removed.

## Changes

- `evaluation/leaderboard_reporter.py` — moved from `paper/tabarena_evaluator.py`, class renamed, dead subclass removed.
- Deleted the empty `paper/` package.
- Test moved to mirror source: `tests/tabarena/evaluation/test_leaderboard_reporter.py`.
- Updated importers/docstrings: `nips2025_utils/{eval_all,compare,end_to_end}.py`, `contexts/abstract_arena_context.py`, `evaluation/framework_naming.py`.

## Verification

- `ruff check` / `ruff format` clean.
- No stale `TabArenaEvaluator` / `tabarena_evaluator` references remain (source, tests, docs).
- Imports load (`LeaderboardReporter`, `TuneMethodOverride`, all consumers); `import tabarena.evaluation` stays matplotlib-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)