### PR TITLE
Unify fillna_metrics into evaluation/_fillna; rename Evaluator -> RepoMetrics

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -1896,7 +1896,12 @@ class AbstractArenaContext:
 
     @classmethod
     def fillna_metrics(cls, df_to_fill: pd.DataFrame, df_fillna: pd.DataFrame) -> pd.DataFrame:
-        """Fills missing (dataset, fold, framework) rows in df_to_fill with the (dataset, fold) row in df_fillna.
+        """Fills missing (dataset, fold, method) rows in df_to_fill with the (dataset, fold) row in df_fillna.
+
+        Thin wrapper over :func:`tabarena.evaluation._fillna.fillna_metrics` (keyed on ``method``),
+        preserving the per-method descriptive columns (``method_type`` / ``method_subtype`` /
+        ``config_type`` / ``ta_name`` / ``ta_suite``) so an imputed row keeps its own identity
+        rather than the fallback method's.
 
         Parameters
         ----------
@@ -1907,68 +1912,11 @@ class AbstractArenaContext:
         -------
 
         """
-        method_col = "method"
-        split_col = "fold"
-        dataset_col = "dataset"
+        from tabarena.evaluation._fillna import fillna_metrics
 
-        columns_to_keep = [
-            "method_type",
-            "method_subtype",
-            "config_type",
-            "ta_name",
-            "ta_suite",
-        ]
-        columns_to_keep = [c for c in columns_to_keep if c in df_to_fill]
-        per_column: dict[str, dict] = {}
-        for c in columns_to_keep:
-            groupby_method = df_to_fill.groupby(method_col)[c]
-            nunique = groupby_method.nunique(dropna=False)
-            invalid = nunique[nunique != 1]
-            df_to_fill_invalid = df_to_fill[df_to_fill[method_col].isin(invalid.index)]
-            groupby_method_invalid = df_to_fill_invalid.groupby(method_col)[c]
-            if not invalid.empty:
-                raise AssertionError(
-                    f"Found a method with multiple values for column {c} (must be unique):\n"
-                    f"{groupby_method_invalid.value_counts(dropna=False)}",
-                )
-
-            # Using .first() is safe because nunique == 1 for every method
-            per_column[c] = groupby_method.first().to_dict()
-
-        df_to_fill = df_to_fill.set_index([dataset_col, split_col, method_col], drop=True)
-        df_fillna = df_fillna.set_index([dataset_col, split_col], drop=True).drop(columns=[method_col])
-
-        unique_frameworks = list(df_to_fill.index.unique(level=method_col))
-
-        df_filled = df_fillna.index.to_frame().merge(
-            pd.Series(data=unique_frameworks, name=method_col),
-            how="cross",
+        return fillna_metrics(
+            df_to_fill=df_to_fill,
+            df_fillna=df_fillna,
+            key_col="method",
+            preserve_columns=["method_type", "method_subtype", "config_type", "ta_name", "ta_suite"],
         )
-        df_filled = df_filled.set_index(keys=list(df_filled.columns))
-
-        # missing results
-        nan_vals = df_filled.index.difference(df_to_fill.index)
-
-        # fill valid values
-        fill_cols = list(df_to_fill.columns)
-        df_filled[fill_cols] = np.nan
-        df_filled[fill_cols] = df_filled[fill_cols].astype(df_to_fill.dtypes)
-        df_filled.loc[df_to_fill.index] = df_to_fill
-
-        df_fillna_to_use = df_fillna.loc[nan_vals.droplevel(level=method_col)].copy()
-        df_fillna_to_use.index = nan_vals
-        df_filled.loc[nan_vals] = df_fillna_to_use
-
-        if "imputed" not in df_filled.columns:
-            df_filled["imputed"] = False
-        df_filled.loc[nan_vals, "imputed"] = True
-        df_filled["imputed"] = df_filled["imputed"].fillna(0).astype(bool)
-
-        df_filled = df_filled.reset_index(drop=False)
-
-        # Overwrite values column-by-column while preserving order
-        for c in columns_to_keep:
-            mapping = per_column[c]
-            df_filled[c] = df_filled[method_col].map(mapping)
-
-        return df_filled

--- a/packages/tabarena/src/tabarena/evaluation/_fillna.py
+++ b/packages/tabarena/src/tabarena/evaluation/_fillna.py
@@ -1,15 +1,12 @@
 """Shared fallback-imputation for per-task metric tables.
 
-A single implementation behind the two near-identical ``fillna_metrics`` methods that used to live
-on :class:`~tabarena.evaluation.repo_metrics.RepoMetrics` (keyed on ``framework``) and
+Used by :class:`~tabarena.evaluation.repo_metrics.RepoMetrics` (keyed on ``framework``) and
 :class:`~tabarena.contexts.abstract_arena_context.AbstractArenaContext` (keyed on ``method``,
-preserving the per-method descriptive columns). Both now delegate here.
+preserving the per-method descriptive columns).
 
-This is the tabarena-leaderboard flavor of imputation; the generic
-:meth:`bencheval.evaluator.BenchmarkEvaluator.fillna_data` shares the same core grid/difference/
-fill algorithm but does not mark an ``imputed`` flag, does not preserve per-key descriptive
-columns, and additionally supports selecting the fallback rows itself (``"worst"`` / a named
-method) rather than taking them as an explicit ``df_fillna``.
+This is the tabarena-leaderboard flavor of imputation: unlike the generic
+:meth:`bencheval.evaluator.BenchmarkEvaluator.fillna_data`, it marks an ``imputed`` flag, can
+re-broadcast intrinsic per-key columns, and takes the fallback rows as an explicit ``df_fillna``.
 """
 
 from __future__ import annotations

--- a/packages/tabarena/src/tabarena/evaluation/_fillna.py
+++ b/packages/tabarena/src/tabarena/evaluation/_fillna.py
@@ -1,0 +1,119 @@
+"""Shared fallback-imputation for per-task metric tables.
+
+A single implementation behind the two near-identical ``fillna_metrics`` methods that used to live
+on :class:`~tabarena.evaluation.repo_metrics.RepoMetrics` (keyed on ``framework``) and
+:class:`~tabarena.contexts.abstract_arena_context.AbstractArenaContext` (keyed on ``method``,
+preserving the per-method descriptive columns). Both now delegate here.
+
+This is the tabarena-leaderboard flavor of imputation; the generic
+:meth:`bencheval.evaluator.BenchmarkEvaluator.fillna_data` shares the same core grid/difference/
+fill algorithm but does not mark an ``imputed`` flag, does not preserve per-key descriptive
+columns, and additionally supports selecting the fallback rows itself (``"worst"`` / a named
+method) rather than taking them as an explicit ``df_fillna``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+
+
+def fillna_metrics(
+    df_to_fill: pd.DataFrame,
+    df_fillna: pd.DataFrame,
+    *,
+    key_col: str = "method",
+    dataset_col: str = "dataset",
+    split_col: str = "fold",
+    preserve_columns: Sequence[str] = (),
+) -> pd.DataFrame:
+    """Fill missing ``(dataset, fold, key)`` rows of ``df_to_fill`` from ``df_fillna``.
+
+    For every ``key_col`` value present in ``df_to_fill``, ensures a row exists for each
+    ``(dataset_col, split_col)`` task in ``df_fillna``. Any ``(dataset, fold, key)`` row absent
+    from ``df_to_fill`` is filled with that ``(dataset, fold)`` row of ``df_fillna`` (the fallback
+    method) and flagged ``imputed=True``; rows already present keep their values and are
+    ``imputed=False``.
+
+    Both frames are flat (plain columns, not a ``MultiIndex``). ``df_fillna`` must hold exactly one
+    row per ``(dataset_col, split_col)`` and is keyed on that pair; a ``key_col`` column on it, if
+    present, is dropped (the fallback's own identity is irrelevant to the imputed rows).
+
+    Parameters
+    ----------
+    df_to_fill
+        Per-``(dataset, fold, key)`` rows to complete. Must contain ``dataset_col``, ``split_col``
+        and ``key_col`` columns.
+    df_fillna
+        Fallback rows, one per ``(dataset_col, split_col)`` task; its non-key columns are copied
+        into imputed rows.
+    key_col
+        Column naming the method / framework / config whose missing tasks are imputed.
+    dataset_col, split_col
+        The two columns that together identify a task.
+    preserve_columns
+        Columns that are intrinsic to ``key_col`` (constant per key) and must keep the key's own
+        value rather than the fallback's after an imputation — e.g. ``method_type`` /
+        ``config_type``. They are re-broadcast from each key's (unique) value after filling.
+        Columns absent from ``df_to_fill`` are ignored; a column that is not constant within a key
+        raises ``AssertionError``.
+
+    Returns:
+    -------
+    pd.DataFrame
+        A flat frame with the original columns of ``df_to_fill`` plus a boolean ``imputed`` column.
+    """
+    preserve = [c for c in preserve_columns if c in df_to_fill.columns]
+    per_key: dict[str, dict] = {}
+    for c in preserve:
+        groupby_key = df_to_fill.groupby(key_col)[c]
+        nunique = groupby_key.nunique(dropna=False)
+        invalid = nunique[nunique != 1]
+        if not invalid.empty:
+            invalid_counts = (
+                df_to_fill[df_to_fill[key_col].isin(invalid.index)].groupby(key_col)[c].value_counts(dropna=False)
+            )
+            raise AssertionError(
+                f"Found a {key_col} with multiple values for column {c} (must be unique):\n{invalid_counts}",
+            )
+        # nunique == 1 for every key, so .first() is that key's single value
+        per_key[c] = groupby_key.first().to_dict()
+
+    df_to_fill = df_to_fill.set_index([dataset_col, split_col, key_col], drop=True)
+    df_fillna = df_fillna.set_index([dataset_col, split_col], drop=True)
+    if key_col in df_fillna.columns:
+        df_fillna = df_fillna.drop(columns=[key_col])
+
+    keys = list(df_to_fill.index.unique(level=key_col))
+    df_filled = df_fillna.index.to_frame().merge(
+        pd.Series(data=keys, name=key_col),
+        how="cross",
+    )
+    df_filled = df_filled.set_index(keys=list(df_filled.columns))
+
+    # (dataset, fold, key) rows in the full grid that are missing from df_to_fill
+    nan_vals = df_filled.index.difference(df_to_fill.index)
+
+    fill_cols = list(df_to_fill.columns)
+    df_filled[fill_cols] = np.nan
+    df_filled[fill_cols] = df_filled[fill_cols].astype(df_to_fill.dtypes)
+    df_filled.loc[df_to_fill.index] = df_to_fill
+
+    df_fillna_to_use = df_fillna.loc[nan_vals.droplevel(level=key_col)].copy()
+    df_fillna_to_use.index = nan_vals
+    df_filled.loc[nan_vals] = df_fillna_to_use
+
+    if "imputed" not in df_filled.columns:
+        df_filled["imputed"] = False
+    df_filled.loc[nan_vals, "imputed"] = True
+    df_filled["imputed"] = df_filled["imputed"].fillna(0).astype(bool)
+
+    df_filled = df_filled.reset_index(drop=False)
+
+    # restore each key's own value for intrinsic columns (the fallback's value was copied in above)
+    for c in preserve:
+        df_filled[c] = df_filled[key_col].map(per_key[c])
+
+    return df_filled

--- a/packages/tabarena/src/tabarena/evaluation/repo_metrics.py
+++ b/packages/tabarena/src/tabarena/evaluation/repo_metrics.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
+from tabarena.evaluation._fillna import fillna_metrics
 from tabarena.portfolio.greedy_portfolio_generator import zeroshot_results
 from tabarena.repository.repo_utils import convert_time_infer_s_from_sample_to_batch
 from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels
@@ -15,8 +16,8 @@ if TYPE_CHECKING:
 
 # TODO: This class is WIP.
 # TODO: Add unit tests
-class Evaluator:
-    """Computes metrics and statistics to compare methods."""
+class RepoMetrics:
+    """Assembles per-``(dataset, fold, framework)`` metric tables and zeroshot portfolios from a repository."""
 
     def __init__(
         self,
@@ -164,42 +165,30 @@ class Evaluator:
     def _fillna_metrics(cls, df_metrics: pd.DataFrame, df_fillna: pd.DataFrame) -> pd.DataFrame:
         """Fills missing (dataset, fold, framework) rows in df_metrics with the (dataset, fold) row in df_fillna.
 
+        Thin adapter over :func:`tabarena.evaluation._fillna.fillna_metrics` (keyed on ``framework``)
+        that accepts and returns frames indexed by ``(dataset, fold, framework)`` /
+        ``(dataset, fold)``; the shared helper works on flat frames.
+
         Parameters
         ----------
         df_metrics
+            Per-``(dataset, fold, framework)`` metrics, indexed by that triple.
         df_fillna
+            Fallback rows indexed by ``(dataset, fold)`` (the framework level already dropped).
 
         Returns:
         -------
+        pd.DataFrame
+            ``df_metrics`` completed and indexed by ``(dataset, fold, framework)``, with an
+            ``imputed`` column.
 
         """
-        # FIXME: Include frameworks that have 0 presence?
-        #  baselines + configs
-        unique_frameworks = list(df_metrics.index.unique(level="framework"))
-
-        df_filled = df_fillna.index.to_frame().merge(
-            pd.Series(data=unique_frameworks, name="framework"),
-            how="cross",
+        df_filled = fillna_metrics(
+            df_to_fill=df_metrics.reset_index(),
+            df_fillna=df_fillna.reset_index(),
+            key_col="framework",
         )
-        df_filled = df_filled.set_index(keys=list(df_filled.columns))
-
-        # missing results
-        nan_vals = df_filled.index.difference(df_metrics.index)
-
-        # fill valid values
-        fill_cols = list(df_metrics.columns)
-        df_filled[fill_cols] = np.nan
-        df_filled[fill_cols] = df_filled[fill_cols].astype(df_metrics.dtypes)
-        df_filled.loc[df_metrics.index] = df_metrics
-
-        a = df_fillna.loc[nan_vals.droplevel(level="framework")]
-        a.index = nan_vals
-        df_filled.loc[nan_vals] = a
-
-        df_filled["imputed"] = False
-        df_filled.loc[nan_vals, "imputed"] = True
-
-        return df_filled
+        return df_filled.set_index(["dataset", "fold", "framework"])
 
     # TODO: Prototype, find a better way to do this
     # TODO: Docstring

--- a/packages/tabarena/src/tabarena/simulation/repo_simulator.py
+++ b/packages/tabarena/src/tabarena/simulation/repo_simulator.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 
-from tabarena.evaluation.evaluator import Evaluator
+from tabarena.evaluation.repo_metrics import RepoMetrics
 
 if TYPE_CHECKING:
     from tabarena.repository import EvaluationRepository
@@ -33,7 +33,7 @@ class RepoSimulator:
         self, repo: EvaluationRepository, output_dir: str | None = None, backend: Literal["ray", "native"] = "ray"
     ):
         self.repo = repo
-        self.evaluator = Evaluator(repo=self.repo)
+        self.evaluator = RepoMetrics(repo=self.repo)
         self.output_dir = output_dir
         self.backend = backend
         assert self.backend in ["ray", "native"]

--- a/tests/tabarena/evaluation/test_fillna.py
+++ b/tests/tabarena/evaluation/test_fillna.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tabarena.evaluation._fillna import fillna_metrics
+
+
+def _frames(key_col: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """``m_a`` is complete over both tasks; ``m_b`` is missing ``(d1, fold 1)``."""
+    df_to_fill = pd.DataFrame(
+        {
+            "dataset": ["d1", "d1", "d1"],
+            "fold": [0, 1, 0],
+            key_col: ["m_a", "m_a", "m_b"],
+            "metric_error": [0.1, 0.2, 0.3],
+        }
+    )
+    df_fillna = pd.DataFrame(
+        {
+            "dataset": ["d1", "d1"],
+            "fold": [0, 1],
+            key_col: ["fb", "fb"],
+            "metric_error": [0.9, 0.8],
+        }
+    )
+    return df_to_fill, df_fillna
+
+
+@pytest.mark.parametrize("key_col", ["method", "framework"])
+def test_fillna_marks_and_fills_missing_rows(key_col: str):
+    df_to_fill, df_fillna = _frames(key_col)
+    out = fillna_metrics(df_to_fill, df_fillna, key_col=key_col)
+    out = out.set_index(["dataset", "fold", key_col]).sort_index()
+
+    # every key x (dataset, fold) task now exists (2 keys x 2 tasks)
+    assert len(out) == 4
+    # the missing (d1, fold 1, m_b) row is imputed from the fallback's value (0.8)
+    assert out.loc[("d1", 1, "m_b"), "imputed"]
+    assert out.loc[("d1", 1, "m_b"), "metric_error"] == 0.8
+    # rows already present keep their own value and are not imputed
+    assert not out.loc[("d1", 0, "m_b"), "imputed"]
+    assert out.loc[("d1", 0, "m_b"), "metric_error"] == 0.3
+    assert not out["imputed"].loc[("d1", slice(None), "m_a")].any()
+
+
+def test_fillna_preserves_intrinsic_columns():
+    df_to_fill, df_fillna = _frames("method")
+    df_to_fill["method_type"] = df_to_fill["method"].map({"m_a": "config", "m_b": "baseline"})
+    df_fillna["method_type"] = "config"  # the fallback's value must NOT leak into the imputed m_b row
+
+    out = fillna_metrics(df_to_fill, df_fillna, key_col="method", preserve_columns=["method_type"])
+    out = out.set_index(["dataset", "fold", "method"])
+    # imputed row keeps m_b's own intrinsic value, not the fallback's
+    assert out.loc[("d1", 1, "m_b"), "method_type"] == "baseline"
+
+
+def test_fillna_rejects_non_constant_preserve_column():
+    df_to_fill, df_fillna = _frames("method")
+    df_to_fill["method_type"] = ["config", "baseline", "config"]  # m_a has two values -> invalid
+    with pytest.raises(AssertionError):
+        fillna_metrics(df_to_fill, df_fillna, key_col="method", preserve_columns=["method_type"])


### PR DESCRIPTION
## What

Two cohesive cleanups to the evaluation layer (no behavior change):

### 1. Unify the duplicated `fillna_metrics`
`RepoMetrics._fillna_metrics` (keyed on `framework`) and `AbstractArenaContext.fillna_metrics` (keyed on `method`, preserving the per-method descriptive columns) were near-identical copies of the same grid → `index.difference` → fill-from-fallback → mark-`imputed` algorithm. Extracted into one shared helper **`evaluation/_fillna.py::fillna_metrics`**, parametrized by `key_col` and an optional `preserve_columns` re-broadcast (the context's descriptive-column preservation is the superset and is kept, presence-guarded). Both methods now delegate.

This keeps the correct dependency direction (`contexts → evaluation`); the helper lives in `evaluation/`, which the context already imports from.

### 2. Rename `Evaluator` → `RepoMetrics`
The class assembles per-`(dataset, fold, framework)` metric tables and zeroshot portfolios from a repository — it doesn't rank/compare methods, and the bare name `Evaluator` collided with `bencheval.BenchmarkEvaluator` and `LeaderboardReporter`. Renamed the class and file (`evaluation/evaluator.py` → `evaluation/repo_metrics.py`), fixed its one-liner docstring, and updated its sole consumer (`simulation/repo_simulator.py`). (The `RepoSimulator.evaluator` attribute name is unchanged — out of scope; happy to rename if wanted.)

## Changes
- New `evaluation/_fillna.py` (shared `fillna_metrics`) + `tests/tabarena/evaluation/test_fillna.py`.
- `RepoMetrics._fillna_metrics` and `AbstractArenaContext.fillna_metrics` reduced to thin delegating wrappers.
- `evaluation/evaluator.py` → `evaluation/repo_metrics.py`; `Evaluator` → `RepoMetrics`; docstring fixed.

## Verification
- New unit test passes (`4 passed`); covers imputed-flag marking, both `key_col` modes, descriptive-column preservation, and the non-constant-column guard.
- `ruff check` / `ruff format` clean; no stale `Evaluator` / `evaluation.evaluator` references.
- `RepoMetrics`, the shared helper, `repo_simulator` and `abstract_arena_context` all import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)