### PR TITLE
Import EvaluationRepositoryZeroshot directly in evaluation_repository.py

### DIFF
--- a/packages/tabarena/src/tabarena/repository/evaluation_repository.py
+++ b/packages/tabarena/src/tabarena/repository/evaluation_repository.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
 
-    from tabarena import repository
     from tabarena.predictions.tabular_predictions import TabularModelPredictions
+    from tabarena.repository.evaluation_repository_zeroshot import EvaluationRepositoryZeroshot
     from tabarena.simulation.configuration_list_scorer import ConfigurationListScorer
     from tabarena.simulation.ground_truth import GroundTruth
     from tabarena.simulation.simulation_context import ZeroshotSimulatorContext
@@ -48,7 +48,7 @@ class EvaluationRepository(AbstractRepository, EnsembleMixin, GroundTruthMixin):
                 for x in self._tabular_predictions.datasets
             )
 
-    def to_zeroshot(self) -> repository.EvaluationRepositoryZeroshot:
+    def to_zeroshot(self) -> EvaluationRepositoryZeroshot:
         """Returns a version of the repository as an EvaluationRepositoryZeroshot object.
 
         :return: EvaluationRepositoryZeroshot object


### PR DESCRIPTION
## What

Replaces the package-level `from tabarena import repository` in `repository/evaluation_repository.py` (used only for the `to_zeroshot()` return annotation, `repository.EvaluationRepositoryZeroshot`) with a direct class import of `EvaluationRepositoryZeroshot`.

## Why

Both the import and the annotation are under `TYPE_CHECKING`, so this is a clarity/hygiene change: the annotation now names the class directly rather than reaching through the `tabarena.repository` package namespace (which pulls in the package `__init__`). The class is the one already imported at runtime a few lines below in `to_zeroshot` (`from .evaluation_repository_zeroshot import EvaluationRepositoryZeroshot`).

## Verification
- `ruff check` / `ruff format` clean (import re-sorted into place).
- No remaining `repository.` references; `EvaluationRepository` imports and the `to_zeroshot` return annotation resolves to `EvaluationRepositoryZeroshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)