### PR TITLE
Drop refactor-history narratives from docstrings

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/framework_naming.py
+++ b/packages/tabarena/src/tabarena/evaluation/framework_naming.py
@@ -6,8 +6,6 @@ family — along with the rename and plot-suffix maps that index them. ``framewo
 ``time_suffix`` / ``default_ensemble_size`` are the building blocks; ``get_framework_type_method_names``,
 ``get_method_rename_map`` and ``get_f_map_suffix_plots`` are the public maps consumed by
 :class:`~tabarena.evaluation.leaderboard_reporter.LeaderboardReporter` and the tuning-trajectory plots.
-
-Formerly ``tabarena/paper/paper_utils.py``.
 """
 
 from __future__ import annotations

--- a/packages/tabarena/src/tabarena/simulation/repo_simulator.py
+++ b/packages/tabarena/src/tabarena/simulation/repo_simulator.py
@@ -9,10 +9,6 @@ portfolios, single-config and config-family results, and baselines. The output r
 This is the repo-level engine. :class:`~tabarena.models._method_simulator.MethodSimulator` is the
 per-:class:`~tabarena.models._method_metadata.MethodMetadata` facade that drives one of these over
 a single method's processed results.
-
-Formerly ``PaperRun`` (``tabarena/paper/paper_runner.py``) plus its sole subclass
-``PaperRunTabArena`` (``paper_runner_tabarena.py``); the two were merged here — the base class was
-never instantiated on its own and there was no second subclass.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

Removes "Formerly …" / "used to live … merged here" refactor-history narratives that reference classes/modules that no longer exist, from the docstrings added during the `paper/` cleanup:

- `simulation/repo_simulator.py` — drop the "Formerly `PaperRun` / `PaperRunTabArena` … merged here" paragraph (those classes were deleted in #406).
- `evaluation/framework_naming.py` — drop the "Formerly `tabarena/paper/paper_utils.py`" line (that module was removed in #407).

## Why

The module docstrings should describe what the code **is**, not the refactor that produced it. The rename/merge history is already captured in git and the PR trail. Mentions of names that no longer exist (`PaperRun`, `PaperRunTabArena`, `paper_utils.py`) are dead references.

Left untouched: `previously …` notes that explain current behavior and reference things that still exist (e.g. `MethodMetadata`, the matplotlib import-timing note in `leaderboard_reporter.py`). The `_fillna.py` history narrative is cleaned separately in #410 (where that file lives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)