### PR TITLE
Delegate tabarena fillna core to bencheval; add imputed flag to fillna_data

### DIFF
--- a/packages/bencheval/src/bencheval/_validation.py
+++ b/packages/bencheval/src/bencheval/_validation.py
@@ -178,6 +178,7 @@ class ResultsValidationMixin:
         data: pd.DataFrame,
         df_fillna: pd.DataFrame | None = None,
         fillna_method: str = "worst",
+        imputed_col: str | None = None,
     ) -> pd.DataFrame:
         """Fills missing (task, seed, method) rows in data with the (task, seed) row in df_fillna.
 
@@ -192,6 +193,10 @@ class ResultsValidationMixin:
             Either "worst" or the name of a method in self.method_col.
             If "worst", will fill with the result of the method with the worst error on a given task.
             Ignored if `df_fillna` is specified.
+        imputed_col : str | None, default None
+            If specified, add (or update) this boolean column: ``True`` for rows filled from
+            `df_fillna`, ``False`` for rows already present in `data`. When ``None`` (default), no
+            such column is added.
 
         Returns:
         -------
@@ -239,6 +244,11 @@ class ResultsValidationMixin:
         a = df_fillna.loc[nan_vals.droplevel(level=self.method_col)]
         a.index = nan_vals
         df_filled.loc[nan_vals] = a
-        data = df_filled
 
-        return data.reset_index(drop=False)
+        if imputed_col is not None:
+            if imputed_col not in df_filled.columns:
+                df_filled[imputed_col] = False
+            df_filled.loc[nan_vals, imputed_col] = True
+            df_filled[imputed_col] = df_filled[imputed_col].fillna(0).astype(bool)
+
+        return df_filled.reset_index(drop=False)

--- a/packages/tabarena/src/tabarena/evaluation/_fillna.py
+++ b/packages/tabarena/src/tabarena/evaluation/_fillna.py
@@ -4,17 +4,18 @@ Used by :class:`~tabarena.evaluation.repo_metrics.RepoMetrics` (keyed on ``frame
 :class:`~tabarena.contexts.abstract_arena_context.AbstractArenaContext` (keyed on ``method``,
 preserving the per-method descriptive columns).
 
-This is the tabarena-leaderboard flavor of imputation: unlike the generic
-:meth:`bencheval.evaluator.BenchmarkEvaluator.fillna_data`, it marks an ``imputed`` flag, can
-re-broadcast intrinsic per-key columns, and takes the fallback rows as an explicit ``df_fillna``.
+The grid/fill core is delegated to :meth:`bencheval.evaluator.BenchmarkEvaluator.fillna_data` (via
+its ``imputed_col`` flag); this wrapper adds the tabarena-leaderboard concern of preserving
+intrinsic per-key columns across an imputation.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-import numpy as np
-import pandas as pd
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def fillna_metrics(
@@ -37,6 +38,9 @@ def fillna_metrics(
     Both frames are flat (plain columns, not a ``MultiIndex``). ``df_fillna`` must hold exactly one
     row per ``(dataset_col, split_col)`` and is keyed on that pair; a ``key_col`` column on it, if
     present, is dropped (the fallback's own identity is irrelevant to the imputed rows).
+
+    The grid/fill is delegated to :meth:`bencheval.evaluator.BenchmarkEvaluator.fillna_data`; this
+    wrapper adds only the ``preserve_columns`` re-broadcast.
 
     Parameters
     ----------
@@ -62,6 +66,8 @@ def fillna_metrics(
     pd.DataFrame
         A flat frame with the original columns of ``df_to_fill`` plus a boolean ``imputed`` column.
     """
+    from bencheval.evaluator import BenchmarkEvaluator
+
     preserve = [c for c in preserve_columns if c in df_to_fill.columns]
     per_key: dict[str, dict] = {}
     for c in preserve:
@@ -78,38 +84,14 @@ def fillna_metrics(
         # nunique == 1 for every key, so .first() is that key's single value
         per_key[c] = groupby_key.first().to_dict()
 
-    df_to_fill = df_to_fill.set_index([dataset_col, split_col, key_col], drop=True)
-    df_fillna = df_fillna.set_index([dataset_col, split_col], drop=True)
-    if key_col in df_fillna.columns:
-        df_fillna = df_fillna.drop(columns=[key_col])
+    # Delegate the (dataset, fold) x key grid + fallback fill + imputed flag to bencheval.
+    df_filled = BenchmarkEvaluator(
+        method_col=key_col,
+        task_col=dataset_col,
+        seed_column=split_col,
+    ).fillna_data(data=df_to_fill, df_fillna=df_fillna, imputed_col="imputed")
 
-    keys = list(df_to_fill.index.unique(level=key_col))
-    df_filled = df_fillna.index.to_frame().merge(
-        pd.Series(data=keys, name=key_col),
-        how="cross",
-    )
-    df_filled = df_filled.set_index(keys=list(df_filled.columns))
-
-    # (dataset, fold, key) rows in the full grid that are missing from df_to_fill
-    nan_vals = df_filled.index.difference(df_to_fill.index)
-
-    fill_cols = list(df_to_fill.columns)
-    df_filled[fill_cols] = np.nan
-    df_filled[fill_cols] = df_filled[fill_cols].astype(df_to_fill.dtypes)
-    df_filled.loc[df_to_fill.index] = df_to_fill
-
-    df_fillna_to_use = df_fillna.loc[nan_vals.droplevel(level=key_col)].copy()
-    df_fillna_to_use.index = nan_vals
-    df_filled.loc[nan_vals] = df_fillna_to_use
-
-    if "imputed" not in df_filled.columns:
-        df_filled["imputed"] = False
-    df_filled.loc[nan_vals, "imputed"] = True
-    df_filled["imputed"] = df_filled["imputed"].fillna(0).astype(bool)
-
-    df_filled = df_filled.reset_index(drop=False)
-
-    # restore each key's own value for intrinsic columns (the fallback's value was copied in above)
+    # Restore each key's own value for intrinsic columns (the fallback's value was copied in above).
     for c in preserve:
         df_filled[c] = df_filled[key_col].map(per_key[c])
 


### PR DESCRIPTION
## What

Completes the fillna unification recommended in #410: generalize `bencheval`'s fill helper to optionally emit the `imputed` flag, then delegate tabarena's grid/fill core to it.

1. **`bencheval.BenchmarkEvaluator.fillna_data` gains an optional `imputed_col` param** (default `None` = unchanged). When set, it marks that boolean column `True` for rows filled from the fallback, `False` otherwise — the one piece tabarena needed that the generic helper lacked.
2. **`tabarena.evaluation._fillna.fillna_metrics` now delegates** its `(dataset, fold) × key` grid + fallback-fill + imputed-flag to `BenchmarkEvaluator.fillna_data(..., imputed_col="imputed")`, dropping its duplicated copy of that core loop. The wrapper retains only the tabarena-leaderboard-specific `preserve_columns` re-broadcast (so an imputed row keeps its own `method_type`/`config_type`/`ta_*` rather than the fallback's).

This removes the last duplicate of the core algorithm. Dependency direction stays correct: tabarena → bencheval (tabarena already imports `bencheval.evaluator`). The descriptive-column preservation — a leaderboard concern — deliberately stays out of the generic library.

## Why not push `preserve_columns` into bencheval too

`imputed` marking is generic and belongs in the shared helper; re-broadcasting intrinsic per-key metadata (`method_type`, `ta_suite`, …) is a tabarena-leaderboard concern and would bloat the published library's API, so it stays in the tabarena wrapper.

## Verification

- No behavior change — the shared core was already byte-identical between the two implementations.
- `tests/tabarena/evaluation/test_fillna.py` (imputed marking, both key modes, `preserve_columns`, non-constant guard) and `tests/bencheval/test_evaluator.py` pass — **67 passed** across the bencheval + tabarena-evaluation suites.
- Smoke-verified the `RepoMetrics._fillna_metrics` indexed-frame adapter still produces the right imputed rows via the delegation.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)