### PR TITLE
Stop re-exporting EvaluationRepository[Collection] from the root package

### DIFF
--- a/examples/!experimental/run_scratch_add_calibration_logic.py
+++ b/examples/!experimental/run_scratch_add_calibration_logic.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from autogluon.common import TabularDataset
 
-from tabarena import EvaluationRepository
 from tabarena.contexts import TabArenaContext
 from tabarena.contexts.tabarena.methods import tabarena_method_metadata_collection
 from tabarena.models._method_simulator import MethodSimulator
+from tabarena.repository import EvaluationRepository
 from tabarena.simulation.ensemble_scorer_calibrated import EnsembleScorerCalibrated, EnsembleScorerCalibratedCV
 from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer
 

--- a/examples/meta/inspect_processed_data.py
+++ b/examples/meta/inspect_processed_data.py
@@ -51,7 +51,7 @@ import pandas as pd
 from tabarena.contexts.tabarena.methods import tabarena_method_metadata_collection
 
 if TYPE_CHECKING:
-    from tabarena import EvaluationRepository
+    from tabarena.repository import EvaluationRepository
 
 
 if __name__ == "__main__":

--- a/packages/tabarena/src/tabarena/__init__.py
+++ b/packages/tabarena/src/tabarena/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import annotations
 
 from .contexts import TabArenaContext
-from .repository.evaluation_repository import EvaluationRepository
-from .repository.evaluation_repository_collection import EvaluationRepositoryCollection

--- a/tests/tabarena/predictions/test_impute.py
+++ b/tests/tabarena/predictions/test_impute.py
@@ -4,9 +4,9 @@ import tempfile
 
 import numpy as np
 
-from tabarena import EvaluationRepository
 from tabarena.predictions import TabularPredictionsMemmap
 from tabarena.predictions.tabular_predictions import TabularModelPredictions
+from tabarena.repository import EvaluationRepository
 from tabarena.simulation.context_artificial import load_context_artificial
 from tabarena.utils.test_utils import generate_artificial_dict
 

--- a/tests/tabarena/repository/test_repository.py
+++ b/tests/tabarena/repository/test_repository.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
-from tabarena import EvaluationRepository, EvaluationRepositoryCollection
+from tabarena.repository import EvaluationRepository, EvaluationRepositoryCollection
 from tabarena.simulation.context_artificial import load_repo_artificial
 
 if TYPE_CHECKING:

--- a/tests/tabarena/repository/test_repository_collection.py
+++ b/tests/tabarena/repository/test_repository_collection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from tabarena import EvaluationRepositoryCollection
+from tabarena.repository import EvaluationRepositoryCollection
 from tabarena.simulation.context_artificial import load_repo_artificial
 
 from .test_repository import verify_equivalent_repository


### PR DESCRIPTION
## What

`tabarena/__init__.py` re-exported `EvaluationRepository` and `EvaluationRepositoryCollection` at the root, so `import tabarena` eagerly imported the repository subpackage. Those classes already live in `tabarena.repository` (`repository/__init__.py` exports them), so this drops the redundant root re-export. The root package now exposes only `TabArenaContext`.

Consumers are repointed to the canonical path:
`from tabarena.repository import EvaluationRepository[, EvaluationRepositoryCollection]` — 3 tests + 2 examples. No internal package code used the root path.

## Why

Keeps `import tabarena` lighter and gives these classes a single, unambiguous import location (`tabarena.repository`) rather than two. Mirrors the earlier `Evaluator` unexport (#409).

## Changes
- `tabarena/__init__.py` — remove the two repository re-exports (keep `TabArenaContext`).
- `tests/tabarena/{predictions/test_impute,repository/test_repository,repository/test_repository_collection}.py` and `examples/{meta/inspect_processed_data,!experimental/run_scratch_add_calibration_logic}.py` — import from `tabarena.repository`.

## Verification
- No remaining `from tabarena import EvaluationRepository` / `tabarena.EvaluationRepository` references anywhere.
- `import tabarena` exposes `TabArenaContext` and no longer `EvaluationRepository[Collection]`; `from tabarena.repository import EvaluationRepository, EvaluationRepositoryCollection, EvaluationRepositoryZeroshot` works.
- `ruff check`/`format` clean; `tests/tabarena/repository/` + `tests/tabarena/predictions/test_impute.py` pass (20 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)