### PR TITLE
Refine RepoMetrics/RepoSimulator: move zeroshot_portfolio, finish rename, add tests

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -1523,7 +1523,7 @@ class AbstractArenaContext:
             configs = self._get_config_defaults()
 
         simulator = RepoSimulator(repo=repo, backend=self.backend)
-        simulator.evaluator.compute_avg_config_prediction_delta(configs=configs)
+        simulator.repo_metrics.compute_avg_config_prediction_delta(configs=configs)
 
     # FIXME: WIP
     def _get_config_defaults(self):

--- a/packages/tabarena/src/tabarena/evaluation/repo_metrics.py
+++ b/packages/tabarena/src/tabarena/evaluation/repo_metrics.py
@@ -6,9 +6,7 @@ import numpy as np
 import pandas as pd
 
 from tabarena.evaluation._fillna import fillna_metrics
-from tabarena.portfolio.greedy_portfolio_generator import zeroshot_results
 from tabarena.repository.repo_utils import convert_time_infer_s_from_sample_to_batch
-from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels
 
 if TYPE_CHECKING:
     from tabarena.repository import EvaluationRepository, EvaluationRepositoryCollection
@@ -280,61 +278,3 @@ class RepoMetrics:
         plt.savefig("pca_projection_test")
 
         return delta_avg_abs_mean, delta_avg_std
-
-    # TODO: WIP
-    # TODO: Add a non-loo version
-    # TODO: Rename
-    # FIXME: Make it work with framework_types + max_models_per_type
-    def zeroshot_portfolio(
-        self,
-        configs: list[str] | None = None,
-        n_portfolios: int = 200,  # FIXME
-        n_ensemble: int | None = None,
-        time_limit: float | None = 14400,
-        engine: str = "ray",
-        rename_columns: bool = True,  # TODO: Align them automatically so this isn't needed
-        n_ensemble_in_name: bool = True,
-        n_max_models_per_type: int | str | None = None,
-        n_eval_folds: int | None = None,
-        ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
-        ensemble_kwargs: dict | None = None,
-        patience_callback: list | None = None,
-    ) -> pd.DataFrame:
-        repo = self.repo
-
-        if configs is None:
-            configs = repo.configs()
-
-        if n_eval_folds is None:
-            n_eval_folds = repo.n_folds()
-
-        a = zeroshot_results(
-            repo=repo,
-            dataset_names=repo.datasets(),
-            n_portfolios=[n_portfolios],
-            n_ensembles=[n_ensemble],
-            max_runtimes=[time_limit],
-            n_ensemble_in_name=n_ensemble_in_name,
-            n_max_models_per_type=[n_max_models_per_type],
-            n_eval_folds=n_eval_folds,
-            configs=configs,
-            engine=engine,
-            ensemble_cls=ensemble_cls,
-            ensemble_kwargs=ensemble_kwargs,
-            patience_callback=patience_callback,
-        )
-
-        df_zeroshot_portfolio = pd.DataFrame(a)
-
-        if rename_columns:
-            df_zeroshot_portfolio = df_zeroshot_portfolio.rename(
-                columns={
-                    "metadata": "method_metadata",
-                }
-            )
-            datasets_info = repo.datasets_info()
-
-            df_zeroshot_portfolio["problem_type"] = df_zeroshot_portfolio["dataset"].map(datasets_info["problem_type"])
-            df_zeroshot_portfolio["metric"] = df_zeroshot_portfolio["dataset"].map(datasets_info["metric"])
-
-        return df_zeroshot_portfolio

--- a/packages/tabarena/src/tabarena/simulation/repo_simulator.py
+++ b/packages/tabarena/src/tabarena/simulation/repo_simulator.py
@@ -19,6 +19,8 @@ import numpy as np
 import pandas as pd
 
 from tabarena.evaluation.repo_metrics import RepoMetrics
+from tabarena.portfolio.greedy_portfolio_generator import zeroshot_results
+from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer, EnsembleScorerMaxModels
 
 if TYPE_CHECKING:
     from tabarena.repository import EvaluationRepository
@@ -29,7 +31,7 @@ class RepoSimulator:
         self, repo: EvaluationRepository, output_dir: str | None = None, backend: Literal["ray", "native"] = "ray"
     ):
         self.repo = repo
-        self.evaluator = RepoMetrics(repo=self.repo)
+        self.repo_metrics = RepoMetrics(repo=self.repo)
         self.output_dir = output_dir
         self.backend = backend
         assert self.backend in ["ray", "native"]
@@ -221,6 +223,64 @@ class RepoSimulator:
 
         return df_results
 
+    # TODO: WIP
+    # TODO: Add a non-loo version
+    # TODO: Rename
+    # FIXME: Make it work with framework_types + max_models_per_type
+    def zeroshot_portfolio(
+        self,
+        configs: list[str] | None = None,
+        n_portfolios: int = 200,  # FIXME
+        n_ensemble: int | None = None,
+        time_limit: float | None = 14400,
+        engine: str = "ray",
+        rename_columns: bool = True,  # TODO: Align them automatically so this isn't needed
+        n_ensemble_in_name: bool = True,
+        n_max_models_per_type: int | str | None = None,
+        n_eval_folds: int | None = None,
+        ensemble_cls: type[EnsembleScorer] = EnsembleScorerMaxModels,
+        ensemble_kwargs: dict | None = None,
+        patience_callback: list | None = None,
+    ) -> pd.DataFrame:
+        repo = self.repo
+
+        if configs is None:
+            configs = repo.configs()
+
+        if n_eval_folds is None:
+            n_eval_folds = repo.n_folds()
+
+        a = zeroshot_results(
+            repo=repo,
+            dataset_names=repo.datasets(),
+            n_portfolios=[n_portfolios],
+            n_ensembles=[n_ensemble],
+            max_runtimes=[time_limit],
+            n_ensemble_in_name=n_ensemble_in_name,
+            n_max_models_per_type=[n_max_models_per_type],
+            n_eval_folds=n_eval_folds,
+            configs=configs,
+            engine=engine,
+            ensemble_cls=ensemble_cls,
+            ensemble_kwargs=ensemble_kwargs,
+            patience_callback=patience_callback,
+        )
+
+        df_zeroshot_portfolio = pd.DataFrame(a)
+
+        if rename_columns:
+            df_zeroshot_portfolio = df_zeroshot_portfolio.rename(
+                columns={
+                    "metadata": "method_metadata",
+                }
+            )
+            datasets_info = repo.datasets_info()
+
+            df_zeroshot_portfolio["problem_type"] = df_zeroshot_portfolio["dataset"].map(datasets_info["problem_type"])
+            df_zeroshot_portfolio["metric"] = df_zeroshot_portfolio["dataset"].map(datasets_info["metric"])
+
+        return df_zeroshot_portfolio
+
     def run_zs(
         self,
         n_portfolios: int = 200,
@@ -230,7 +290,7 @@ class RepoSimulator:
         time_limit: float | None = 14400,
         **kwargs,
     ) -> pd.DataFrame:
-        df_zeroshot_portfolio = self.evaluator.zeroshot_portfolio(
+        df_zeroshot_portfolio = self.zeroshot_portfolio(
             n_portfolios=n_portfolios,
             n_ensemble=n_ensemble,
             n_ensemble_in_name=n_ensemble_in_name,
@@ -240,23 +300,25 @@ class RepoSimulator:
             **kwargs,
         )
         df_zeroshot_portfolio["method_type"] = "portfolio"
-        # df_zeroshot_portfolio = self.evaluator.assemble_metrics(results_df=df_zeroshot_portfolio, configs=[], baselines=[])
+        # df_zeroshot_portfolio = self.repo_metrics.assemble_metrics(results_df=df_zeroshot_portfolio, configs=[], baselines=[])
         return df_zeroshot_portfolio
 
     def run_zs_from_types(self, config_types: list[str], **kwargs):
-        configs = self.evaluator.repo.configs(config_types=config_types)
+        configs = self.repo.configs(config_types=config_types)
         return self.run_zs(configs=configs, **kwargs)
 
     def run_baselines(self) -> pd.DataFrame | None:
         if not self.repo.baselines():
             return None
-        df_results_baselines = self.evaluator.assemble_metrics(configs=[], include_metric_error_val=True).reset_index()
+        df_results_baselines = self.repo_metrics.assemble_metrics(
+            configs=[], include_metric_error_val=True
+        ).reset_index()
         df_results_baselines["method_type"] = "baseline"
         return df_results_baselines
 
     def run_config_family(self, config_type: str) -> pd.DataFrame:
         configs = self.repo.configs(config_types=[config_type])
-        df_results_configs = self.evaluator.assemble_metrics(
+        df_results_configs = self.repo_metrics.assemble_metrics(
             configs=configs, baselines=[], include_metric_error_val=True
         ).reset_index()
         df_results_configs["method_type"] = "config"
@@ -369,7 +431,7 @@ class RepoSimulator:
 
     def run_config(self, config: str) -> pd.DataFrame:
         configs = [config]
-        return self.evaluator.assemble_metrics(
+        return self.repo_metrics.assemble_metrics(
             configs=configs,
             baselines=[],
             include_metric_error_val=True,

--- a/tests/tabarena/evaluation/test_repo_metrics.py
+++ b/tests/tabarena/evaluation/test_repo_metrics.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from tabarena.evaluation.repo_metrics import RepoMetrics
+
+# Standard metric columns assemble_metrics keeps.
+_COLS = ["metric_error", "time_train_s", "time_infer_s", "metric", "problem_type"]
+
+
+def _df_configs() -> pd.DataFrame:
+    # c1 on both folds; c2 only on fold 0 (so it is missing on (d1, fold 1)).
+    rows = [
+        ("d1", 0, "c1", 0.10, 1.0, 0.1, "acc", "binary", 0.15),
+        ("d1", 1, "c1", 0.30, 1.0, 0.1, "acc", "binary", 0.35),
+        ("d1", 0, "c2", 0.20, 2.0, 0.2, "acc", "binary", 0.25),
+    ]
+    return pd.DataFrame(rows, columns=["dataset", "fold", "framework", *_COLS, "metric_error_val"])
+
+
+def _df_baselines() -> pd.DataFrame:
+    rows = [
+        ("d1", 0, "RF", 0.50, 0.5, 0.05, "acc", "binary"),
+        ("d1", 1, "RF", 0.60, 0.5, 0.05, "acc", "binary"),
+    ]
+    return pd.DataFrame(rows, columns=["dataset", "fold", "framework", *_COLS])
+
+
+class _FakeZeroshotContext:
+    def __init__(self, df_configs: pd.DataFrame, df_baselines: pd.DataFrame | None):
+        self.df_configs = df_configs
+        self.df_baselines = df_baselines
+
+
+class _FakeRepo:
+    """Minimal duck-typed repo exposing only what ``assemble_metrics`` reads."""
+
+    def __init__(self, df_configs, df_baselines, config_fallback=None):
+        self._zeroshot_context = _FakeZeroshotContext(df_configs, df_baselines)
+        self._config_fallback = config_fallback
+        self.task_metadata = None
+
+    def datasets(self):
+        return list(self._zeroshot_context.df_configs["dataset"].unique())
+
+
+def _metrics(config_fallback=None) -> RepoMetrics:
+    return RepoMetrics(repo=_FakeRepo(_df_configs(), _df_baselines(), config_fallback=config_fallback))
+
+
+def test_assemble_metrics_concatenates_configs_and_baselines():
+    out = _metrics().assemble_metrics()
+    assert list(out.index.names) == ["dataset", "fold", "framework"]
+    assert set(out.columns) == set(_COLS)  # no fillna -> no imputed column
+    # 3 config rows (c1 x2, c2 x1) + 2 baseline rows (RF x2)
+    assert len(out) == 5
+    assert set(out.index.get_level_values("framework")) == {"c1", "c2", "RF"}
+    assert out.loc[("d1", 0, "c1"), "metric_error"] == 0.10
+
+
+def test_include_metric_error_val_adds_column_and_nans_baselines():
+    out = _metrics().assemble_metrics(include_metric_error_val=True)
+    assert "metric_error_val" in out.columns
+    assert out.loc[("d1", 0, "c1"), "metric_error_val"] == 0.15
+    # baselines carry no validation error -> filled with NaN
+    assert np.isnan(out.loc[("d1", 0, "RF"), "metric_error_val"])
+
+
+def test_configs_and_baselines_filters():
+    # baselines=[] drops the baseline rows
+    only_configs = _metrics().assemble_metrics(baselines=[])
+    assert "RF" not in set(only_configs.index.get_level_values("framework"))
+    # configs=["c1"] keeps only that config (baselines still included)
+    out = _metrics().assemble_metrics(configs=["c1"])
+    frameworks = set(out.index.get_level_values("framework"))
+    assert "c1" in frameworks and "c2" not in frameworks and "RF" in frameworks
+
+
+def test_fillna_auto_imputes_missing_config_from_fallback():
+    # fillna defaults to "auto" -> enabled because a config_fallback is set.
+    out = _metrics(config_fallback="c1").assemble_metrics()
+    assert "imputed" in out.columns
+    # c2 was missing on (d1, fold 1): imputed from c1's (d1, fold 1) row (metric_error 0.30).
+    assert bool(out.loc[("d1", 1, "c2"), "imputed"])
+    assert out.loc[("d1", 1, "c2"), "metric_error"] == 0.30
+    assert out.loc[("d1", 1, "c2"), "impute_method"] == "c1"
+    # present rows are not imputed
+    assert not bool(out.loc[("d1", 0, "c1"), "imputed"])


### PR DESCRIPTION
## What

Three cohesive refinements to the `RepoMetrics` / `RepoSimulator` pair (no behavior change):

1. **Move `zeroshot_portfolio` `RepoMetrics` → `RepoSimulator`.** It's pure portfolio *simulation* (builds a zeroshot portfolio via `zeroshot_results`), and its only caller was `RepoSimulator.run_zs`. It now lives next to the other `run_*`/`evaluate_*` simulation methods instead of on the metrics-table assembler. Its `zeroshot_results` / `EnsembleScorer*` imports move with it; `run_zs` calls `self.zeroshot_portfolio(...)`.
2. **Finish the `Evaluator` → `RepoMetrics` rename** (started in #410): the `RepoSimulator.evaluator` attribute is renamed to `repo_metrics`, along with the one external access (`simulator.evaluator.…` in `AbstractArenaContext`). Also simplifies `self.evaluator.repo` → `self.repo` (same object) in `run_zs_from_types`.
3. **Unit-test `RepoMetrics.assemble_metrics`** (addresses the class's standing `# TODO: Add unit tests`): configs+baselines assembly + index/columns, `include_metric_error_val`, `configs`/`baselines` filters, and the `fillna="auto"` fallback-imputation path. Uses a lightweight duck-typed repo (assemble_metrics only reads `datasets()`, `_zeroshot_context.df_configs/df_baselines`, `task_metadata`, `_config_fallback`), so no heavy `EvaluationRepository` fixture is needed.

## Verification
- No remaining `self.evaluator` / `simulator.evaluator` references; `zeroshot_portfolio` is on `RepoSimulator`, gone from `RepoMetrics`.
- `ruff check` / `ruff format` clean.
- New `test_repo_metrics.py` (4) + existing `test_fillna.py` (4) pass; imports of `RepoMetrics`, `RepoSimulator`, `abstract_arena_context` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)