### PR TITLE
Stop re-exporting TabArenaContext from the root package

### DIFF
--- a/packages/tabarena/src/tabarena/__init__.py
+++ b/packages/tabarena/src/tabarena/__init__.py
@@ -1,3 +1,1 @@
 from __future__ import annotations
-
-from .contexts import TabArenaContext


### PR DESCRIPTION
## What

`tabarena/__init__.py` re-exported `TabArenaContext` at the root, so `import tabarena` eagerly imported the (heavy) `contexts` subpackage. **Nothing uses the root path** — every call site already imports `from tabarena.contexts import TabArenaContext` (24 sites), and there are zero `from tabarena import TabArenaContext` / `tabarena.TabArenaContext` references. So the re-export is dead; this removes it.

`import tabarena` is now side-effect-free (just `from __future__ import annotations`); the canonical path is `tabarena.contexts.TabArenaContext`.

## Why

Completes the root-init slimming (after the `Evaluator` #409 and `EvaluationRepository[Collection]` #415 unexports). `import tabarena` no longer drags in the contexts/repository/evaluation stack.

## Verification
- Zero consumers of the root path (verified across packages/tests/run_scripts/examples).
- `import tabarena` no longer exposes `TabArenaContext`; `from tabarena.contexts import TabArenaContext` works.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)