### PR TITLE
Remove EndToEndResults.model_results/hpo_results and the dead get_results fillna path

### DIFF
--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end.py
@@ -360,8 +360,8 @@ class EndToEnd:
             verbose: Whether to print progress.
 
         Returns:
-            The results DataFrame. For finer control (e.g. ``fillna``,
-            ``use_model_results``) call ``from_raw(...).to_results().get_results(...)`` directly.
+            The results DataFrame. For finer control (e.g. ``use_model_results``) call
+            ``from_raw(...).to_results().get_results(...)`` directly.
         """
         cache = not debug_mode
         backend: Literal["ray", "native"] = "native" if debug_mode else "ray"
@@ -382,24 +382,6 @@ class EndToEndResults:
         end_to_end_results_lst: list[EndToEndResultsSingle],
     ):
         self.end_to_end_results_lst = end_to_end_results_lst
-
-    @property
-    def model_results(self) -> pd.DataFrame | None:
-        model_results_lst = [e2e.model_results for e2e in self.end_to_end_results_lst]
-        model_results_lst = [model_results for model_results in model_results_lst if model_results is not None]
-        if not model_results_lst:
-            return None
-
-        return pd.concat(model_results_lst, ignore_index=True)
-
-    @property
-    def hpo_results(self) -> pd.DataFrame | None:
-        hpo_results_lst = [e2e.hpo_results for e2e in self.end_to_end_results_lst]
-        hpo_results_lst = [hpo_results for hpo_results in hpo_results_lst if hpo_results is not None]
-        if not hpo_results_lst:
-            return None
-
-        return pd.concat(hpo_results_lst, ignore_index=True)
 
     def to_method_metadata_lst(
         self,
@@ -427,7 +409,6 @@ class EndToEndResults:
         new_result_prefix: str | None = None,
         use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
-        fillna: bool = False,
     ) -> pd.DataFrame:
         df_results_lst = []
         for result in self.end_to_end_results_lst:
@@ -436,7 +417,6 @@ class EndToEndResults:
                     new_result_prefix=new_result_prefix,
                     use_suite_in_prefix=use_suite_in_prefix,
                     use_model_results=use_model_results,
-                    fillna=fillna,
                 ),
             )
         return pd.concat(df_results_lst, ignore_index=True)

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -10,7 +10,6 @@ from autogluon.common.savers import save_pd
 from tabarena.benchmark.result import BaselineResult, ConfigResult
 from tabarena.benchmark.task.metadata import TaskMetadataCollection
 from tabarena.benchmark.task.metadata.fetch_metadata import task_metadata_collection_from_openml
-from tabarena.contexts import TabArenaContext
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._method_simulator import MethodSimulator
 from tabarena.nips2025_utils.method_processor import (
@@ -101,8 +100,6 @@ class EndToEndSingle:
         Lightweight container returned by :meth:`to_results`.
     MethodMetadata
         Serialized description of a method and its artifact layout.
-    TabArenaContext
-        Simulator used internally for HPO/model selection under TabArena.
 
     Examples:
     --------
@@ -614,7 +611,6 @@ class EndToEndResultsSingle:
         new_result_prefix: str | None = None,
         use_suite_in_prefix: bool = False,
         use_model_results: bool = False,
-        fillna: bool = False,
     ) -> pd.DataFrame:
         """Get data to compare results on TabArena leaderboard.
 
@@ -634,9 +630,6 @@ class EndToEndResultsSingle:
         if new_result_prefix is not None:
             df_results = self.add_prefix_to_results(results=df_results, prefix=new_result_prefix, inplace=True)
 
-        if fillna:
-            df_results = self.fillna_results_on_tabarena(df_results=df_results)
-
         return df_results
 
     @classmethod
@@ -654,21 +647,6 @@ class EndToEndResultsSingle:
             save_pd.save(path=str(self.method_metadata.path_results_hpo()), df=self.hpo_results)
         if self.model_results is not None:
             save_pd.save(path=str(self.method_metadata.path_results_model()), df=self.model_results)
-
-    @classmethod
-    def fillna_results_on_tabarena(cls, df_results: pd.DataFrame) -> pd.DataFrame:
-        tabarena_context = TabArenaContext()
-        fillna_method = "RF (default)"
-        fillna_method_name = "RandomForest"
-
-        df_fillna = tabarena_context.load_results(methods=[fillna_method_name])
-        df_fillna = df_fillna[df_fillna["method"] == fillna_method]
-        assert not df_fillna.empty
-
-        return TabArenaContext.fillna_metrics(
-            df_to_fill=df_results,
-            df_fillna=df_fillna,
-        )
 
     @classmethod
     def concat(cls, e2e_lst: list[EndToEndResultsSingle]) -> EndToEndResultsSingle:


### PR DESCRIPTION
Stacked on #418.

## What
- Delete the `EndToEndResults.model_results` / `hpo_results` properties (plural concat-over-singles accessors).
- Remove the `fillna` parameter from `EndToEndResults.get_results` **and** `EndToEndResultsSingle.get_results`, and delete `EndToEndResultsSingle.fillna_results_on_tabarena`. Drop the now-orphaned `TabArenaContext` import + its stale "See Also"/Returns docstring references.

## Why
- The plural `model_results`/`hpo_results` properties had **no tabarena callers**; the only users were `tabarena-pl-extensions` debug-print scripts (`results.model_results.head(100)`), updated separately to `.get_results()`.
- **No caller anywhere — tabarena or pl-extensions — ever set `fillna=True`.** A repo-wide search for `fillna=True` is empty; the only `fillna` args were `EndToEndResults.get_results`'s internal `fillna=fillna` passthrough and (pre-#418) `EndToEndResults.compare`'s `fillna=False`. So the entire fillna-on-TabArena path was dead, and removing it is a no-op for every real call.

(`EndToEndResultsSingle.model_results`/`hpo_results` — the per-method instance attributes used by `get_results`/`cache`/`concat` — are untouched.)

## Verification
- `ruff check` clean (orphaned `TabArenaContext` import removed; no stale `fillna` docstring left).
- `EndToEndResults` no longer has `model_results`/`hpo_results`; neither `get_results` has a `fillna` param; `fillna_results_on_tabarena` gone.
- `_in_memory_method_metadata` and `beyond_arena_eval` (the other `get_results` callers, neither using `fillna`) import cleanly; `tests/tabarena/nips2025_utils/` passes.

## Coordination
Paired with a `tabarena-pl-extensions` PR switching 6 run-scripts from `.model_results.head(...)` to `.get_results().head(...)`. That change is backward-compatible (works against current tabarena too), so it can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)