### PR TITLE
Vectorize GroupAggregationFeatureGenerator fit-time scan

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
@@ -48,6 +48,15 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         drop the group column(s).
     n_top_features:
         Maximum number of aggregation columns to retain.
+    agg_chunk_mb:
+        Approximate memory budget (in MB) for the per-chunk column slice during
+        the fit-time variance scan.  Columns are aggregated in chunks sized so
+        each slice holds at most ~``agg_chunk_mb`` of data
+        (``n_rows * chunk_cols * 8`` bytes).  This bounds peak memory regardless
+        of table width while still aggregating many columns per ``groupby`` call.
+        A very long+wide table gets smaller chunks (RAM-safe); a short+wide table
+        gets larger chunks (fast).  At the limit (one column exceeds the budget)
+        it degrades to one column at a time.
     """
 
     _NUM_AGGS = ("mean", "std", "min", "max", "last")
@@ -60,6 +69,7 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         generate_index_features: bool = True,
         n_top_features: int = 50,
         group_time_on: str | None = None,
+        agg_chunk_mb: float = 256.0,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -67,6 +77,7 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         self.generate_features = generate_index_features
         self.n_top_features = n_top_features
         self.group_time_on = group_time_on
+        self.agg_chunk_mb = agg_chunk_mb
         self._selected_features: list[str] = []
         # Maps kept for efficient test-time aggregation:
         # {source_col: [agg_func, ...]} for each feature type.
@@ -101,32 +112,41 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         variance: dict[str, float] = {}
         feature_source: dict[str, tuple[str, str, bool]] = {}
 
-        def _batched_agg(cols: list[str], aggs: list[str]) -> pd.DataFrame | None:
-            """Aggregate all ``cols`` in a single groupby (one call, not one per column)."""
-            if not cols:
-                return None
-            slice_cols = list(dict.fromkeys(self.group_col + time_cols + cols))
-            X_s = self._sort_by_time(X[slice_cols])
-            agg_df = X_s.groupby(self._build_group_key(X_s), observed=True)[cols].agg(aggs)
-            agg_df.columns = [f"{c}_{a}" for c, a in agg_df.columns]
-            return agg_df
+        # Sort the row order once (it depends only on the group + time columns)
+        # and reuse it for every chunk, rather than re-sorting per column.
+        sorted_order = self._time_sorted_index(X)
 
-        for cols, is_num, aggs in (
+        # Aggregate columns in chunks sized to ``agg_chunk_mb`` so each slice copy
+        # stays bounded (≈ n_rows * chunk_cols * 8 bytes).  This keeps peak memory
+        # flat regardless of table width while still batching many columns into a
+        # single groupby call.
+        chunk = max(1, int(self.agg_chunk_mb * 1e6 / (max(len(X), 1) * 8)))
+        col_groups = [
             (num_cols, True, list(self._NUM_AGGS)),
             (cat_cols, False, list(self._CAT_AGGS)),
-        ):
-            agg_df = _batched_agg(cols, aggs)
-            if agg_df is None:
-                continue
-            for feat in tqdm(agg_df.columns, desc="Computing groupby aggregations", unit="col"):
-                s = group_key.map(agg_df[feat])
-                if not pd.api.types.is_numeric_dtype(s):
-                    s = s.astype("category").cat.codes.astype(float)
-                    s[s < 0] = np.nan
-                variance[feat] = float(s.var())
-            for col in cols:
-                for agg in aggs:
-                    feature_source[f"{col}_{agg}"] = (col, agg, is_num)
+        ]
+        n_chunks = sum((len(cols) + chunk - 1) // chunk for cols, _, _ in col_groups if cols)
+
+        with tqdm(total=n_chunks, desc="Computing groupby aggregations", unit="chunk") as pbar:
+            for cols, is_num, aggs in col_groups:
+                for start in range(0, len(cols), chunk):
+                    block = cols[start : start + chunk]
+                    slice_cols = list(dict.fromkeys(self.group_col + time_cols + block))
+                    X_s = X[slice_cols]
+                    if sorted_order is not None:
+                        X_s = X_s.loc[sorted_order]
+                    agg_df = X_s.groupby(self._build_group_key(X_s), observed=True)[block].agg(aggs)
+                    agg_df.columns = [f"{c}_{a}" for c, a in agg_df.columns]
+                    for feat in agg_df.columns:
+                        s = group_key.map(agg_df[feat])
+                        if not pd.api.types.is_numeric_dtype(s):
+                            s = s.astype("category").cat.codes.astype(float)
+                            s[s < 0] = np.nan
+                        variance[feat] = float(s.var())
+                    for col in block:
+                        for agg in aggs:
+                            feature_source[f"{col}_{agg}"] = (col, agg, is_num)
+                    pbar.update(1)
 
         # Select top n_top_features by variance (descending), tie-break by name.
         ranked = sorted(variance.keys(), key=lambda f: (-variance[f], f))
@@ -163,20 +183,30 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         )
         return pd.concat([X, mapped], axis=1)
 
+    def _time_sorted_index(self, X: pd.DataFrame) -> pd.Index | None:
+        """Row order that sorts within each group by ``group_time_on``.
+
+        Returns ``None`` when no time column is configured.  The order depends
+        only on the group and time columns, so it is computed from a minimal
+        slice and can be reused across many feature-column chunks.
+        """
+        if self.group_time_on is None or self.group_time_on not in X.columns:
+            return None
+        cols = list(dict.fromkeys([*self.group_col, self.group_time_on]))
+        return (
+            X[cols]
+            .groupby(self.group_col, sort=False, observed=True, group_keys=False)
+            .apply(lambda g: g.sort_values(self.group_time_on), include_groups=False)
+            .index
+        )
+
     def _sort_by_time(self, X: pd.DataFrame) -> pd.DataFrame:
         """Return X with rows within each group sorted by ``group_time_on``.
 
-        Uses groupby.apply so only the within-group order changes; ``last``
-        then returns the most recent observation for each group.
+        ``last`` then returns the most recent observation for each group.
         """
-        if self.group_time_on is not None and self.group_time_on in X.columns:
-            sorted_index = (
-                X.groupby(self.group_col, sort=False, observed=True, group_keys=False)
-                .apply(lambda g: g.sort_values(self.group_time_on), include_groups=False)
-                .index
-            )
-            return X.loc[sorted_index]
-        return X
+        order = self._time_sorted_index(X)
+        return X if order is None else X.loc[order]
 
     def _compute_selected_agg_features(self, X: pd.DataFrame) -> pd.DataFrame:
         """Compute only the aggregations needed for the selected features."""

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
@@ -56,7 +56,8 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         of table width while still aggregating many columns per ``groupby`` call.
         A very long+wide table gets smaller chunks (RAM-safe); a short+wide table
         gets larger chunks (fast).  At the limit (one column exceeds the budget)
-        it degrades to one column at a time.
+        it degrades to one column at a time.  The default favors speed; lower it
+        on memory-constrained machines or very long+wide tables.
     """
 
     _NUM_AGGS = ("mean", "std", "min", "max", "last")
@@ -69,7 +70,7 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         generate_index_features: bool = True,
         n_top_features: int = 50,
         group_time_on: str | None = None,
-        agg_chunk_mb: float = 256.0,
+        agg_chunk_mb: float = 1024.0,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/group_feature_generators.py
@@ -101,22 +101,32 @@ class GroupAggregationFeatureGenerator(AbstractFeatureGenerator):
         variance: dict[str, float] = {}
         feature_source: dict[str, tuple[str, str, bool]] = {}
 
-        col_iter = [(c, True, list(self._NUM_AGGS)) for c in num_cols] + [
-            (c, False, list(self._CAT_AGGS)) for c in cat_cols
-        ]
-        for col, is_num, aggs in tqdm(col_iter, desc="Computing groupby aggregations", unit="col"):
-            slice_cols = list(dict.fromkeys(self.group_col + time_cols + [col]))
-            X_col = self._sort_by_time(X[slice_cols])
-            agg_df = X_col.groupby(self._build_group_key(X_col), observed=True)[[col]].agg(aggs)
-            agg_df.columns = [f"{col}_{a}" for a in aggs]
-            for feat in agg_df.columns:
+        def _batched_agg(cols: list[str], aggs: list[str]) -> pd.DataFrame | None:
+            """Aggregate all ``cols`` in a single groupby (one call, not one per column)."""
+            if not cols:
+                return None
+            slice_cols = list(dict.fromkeys(self.group_col + time_cols + cols))
+            X_s = self._sort_by_time(X[slice_cols])
+            agg_df = X_s.groupby(self._build_group_key(X_s), observed=True)[cols].agg(aggs)
+            agg_df.columns = [f"{c}_{a}" for c, a in agg_df.columns]
+            return agg_df
+
+        for cols, is_num, aggs in (
+            (num_cols, True, list(self._NUM_AGGS)),
+            (cat_cols, False, list(self._CAT_AGGS)),
+        ):
+            agg_df = _batched_agg(cols, aggs)
+            if agg_df is None:
+                continue
+            for feat in tqdm(agg_df.columns, desc="Computing groupby aggregations", unit="col"):
                 s = group_key.map(agg_df[feat])
                 if not pd.api.types.is_numeric_dtype(s):
                     s = s.astype("category").cat.codes.astype(float)
                     s[s < 0] = np.nan
                 variance[feat] = float(s.var())
-            for agg in aggs:
-                feature_source[f"{col}_{agg}"] = (col, agg, is_num)
+            for col in cols:
+                for agg in aggs:
+                    feature_source[f"{col}_{agg}"] = (col, agg, is_num)
 
         # Select top n_top_features by variance (descending), tie-break by name.
         ranked = sorted(variance.keys(), key=lambda f: (-variance[f], f))


### PR DESCRIPTION
## What

`GroupAggregationFeatureGenerator._fit_transform` runs an unsupervised variance scan: it generates every per-group aggregation, ranks them by variance, and keeps the top `n_top_features`. On `main` this scan runs **one `groupby().agg()` call per feature column**, so on a wide table (the motivating case had ~6.7k columns) it issues thousands of separate groupbys. Worse, when `group_time_on` is set, `_sort_by_time` ran a `groupby().apply(sort_values)` **per column**, which dominates the runtime.

This PR aggregates columns in **chunks** instead of one-at-a-time, and computes the time-sort order **once** (it depends only on the group + time columns) and reuses it across chunks.

The chunk size is derived from a memory budget, `agg_chunk_mb` (default 1 GB): each chunk's slice holds at most `~n_rows * chunk_cols * 8` bytes. The default favors speed (fewer, larger chunks); lower it on memory-constrained machines or very long+wide tables. This is deliberate — see the memory section below.

```python
chunk = max(1, int(self.agg_chunk_mb * 1e6 / (max(len(X), 1) * 8)))
for cols, is_num, aggs in (numeric_group, categorical_group):
    for start in range(0, len(cols), chunk):
        block = cols[start : start + chunk]
        X_s = X[group + time + block]
        if sorted_order is not None:
            X_s = X_s.loc[sorted_order]          # sort computed once, reused
        agg_df = X_s.groupby(key, observed=True)[block].agg(aggs)   # whole chunk in one call
        ...
```

## Why it's behavior-preserving

- Same variance per feature (still `group_key.map(...).var()`), same `feature_source` keys.
- Selection sorts by `(-variance, name)`, so chunk boundaries / column order don't affect which features are kept.
- A single full-frame sort by `group_time_on` yields the same within-group order as the old per-column sort, so `last` is identical.

Verified equivalent (identical selected features and `assert_frame_equal` on output) against the original per-column loop on synthetic data. All 27 existing group-generator tests pass (`pytest tests/tabarena/benchmark/preprocessing/test_preprocessing.py -k group`).

## Speed vs `main`

| case | main (per-column) | this PR | speedup |
|---|---|---|---|
| no `group_time_on` | 1.97s | 1.20s | **1.6×** |
| with `group_time_on` | 24.0s | 1.51s | **~16×** |

The big win with `group_time_on` is from sorting once instead of once per column.

## Peak memory vs `main` (the important part)

`main`'s per-column loop is intentionally memory-frugal: peak working set is `O(N × 1 column)` — only one column is ever materialized. Naively batching *all* columns into one groupby would raise that to `O(N × n_cols)` (~one extra full copy of the feature block), which risks OOM on tables that are both **very long and very wide**.

Chunking keeps the speedup while bounding peak memory to roughly `agg_chunk_mb`, regardless of width. The table below was measured at a conservative `agg_chunk_mb=256` to show the tight bound; the 1 GB default scales these peaks up ~4× in exchange for fewer/larger chunks. Measured peak working set above resident `X` (psutil RSS sampling, ±noise):

| case | main (per-column) | full-batch (rejected) | **this PR (chunked, 256 MB)** |
|---|---|---|---|
| narrow + very long (3M × 23) | ~220 MB | ~765 MB | **~347 MB** |
| wide (100k × 1600) | ~58 MB | ~970 MB | **~234 MB** |
| very long + wide (1M × 1k) † | ~tens of MB | ~8 GB → **OOM** | **~256 MB** |

† **Projected from the validated chunk-sizing model, not directly measured.** At 1M × 1k, `X` alone is 8 GB resident (1M × 1000 × 8 B), so the full-batch variant's second ~8 GB copy cannot even be allocated on the test box (≈1.9 GB free) — this is exactly the scenario the chunking guards against. A same-`N` proxy (1M rows, fewer columns) confirmed the model: the 256 MB budget yields a 32-column chunk, and measured peak tracked the prediction. Projected onto 1M × 1k on a 24 GB box: `main` fits but pays ~1000 group sorts when `group_time_on` is set (the ~16× slow path); full-batch needs ~16 GB and OOMs; the chunked scan adds only ~256 MB (one 32-column slice) — ~30× fewer groupbys than `main` while staying within ~0.3 GB of its footprint.

So vs `main`: **faster everywhere, with a modest and bounded increase in peak memory** (capped near the budget). The budget is tunable via `agg_chunk_mb`, and at the limit (a single column exceeds the budget) it degrades to one column at a time — i.e. back to `main`'s memory profile.

## Possible follow-up

The remaining per-feature `group_key.map(...).var()` work could be computed directly from group means + group sizes without mapping each aggregation back to full row length. Larger change with subtler numerics — left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
