### PR TITLE
Gate verbose eval prints behind existing verbosity settings

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
+++ b/packages/tabarena/src/tabarena/benchmark/experiment/bundle.py
@@ -425,6 +425,8 @@ class TabArenaExperimentBundle:
         return mk
 
     def _print_experiment_summary(self, method_kwargs: dict) -> None:
+        if self.verbosity <= 0:
+            return
         print(
             "Generating experiments for models...",
             f"\n\t`all` := number of configs: {self.n_random_configs}",

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/text_cache.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/text_cache.py
@@ -218,7 +218,7 @@ def use_text_cache_for_task(task_id_or_object, *, has_text: bool, mode: TextCach
             task_key = text_cache_key(task_id_or_object)
             cache_path = resolve_existing_cache_path(task_key)
             if cache_path is not None:
-                logger.debug("[TEXT CACHE] Loading embeddings for %s from %s", task_key, cache_path)
+                logger.info("[TEXT CACHE] Loading embeddings for %s from %s", task_key, cache_path)
                 SemanticTextFeatureGenerator._embedding_look_up = load_text_cache(cache_path)
                 SemanticTextFeatureGenerator.only_load_from_cache = True
             elif mode == "require":

--- a/packages/tabarena/src/tabarena/benchmark/preprocessing/text_cache.py
+++ b/packages/tabarena/src/tabarena/benchmark/preprocessing/text_cache.py
@@ -19,6 +19,7 @@ they are cached per task so a benchmark only ships/loads the caches for the task
 
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,8 @@ from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -215,7 +218,7 @@ def use_text_cache_for_task(task_id_or_object, *, has_text: bool, mode: TextCach
             task_key = text_cache_key(task_id_or_object)
             cache_path = resolve_existing_cache_path(task_key)
             if cache_path is not None:
-                print(f"[TEXT CACHE] Loading embeddings for {task_key} from {cache_path}")
+                logger.debug("[TEXT CACHE] Loading embeddings for %s from %s", task_key, cache_path)
                 SemanticTextFeatureGenerator._embedding_look_up = load_text_cache(cache_path)
                 SemanticTextFeatureGenerator.only_load_from_cache = True
             elif mode == "require":

--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/data_foundry.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/sources/data_foundry.py
@@ -157,10 +157,11 @@ class DataFoundryTaskMetadataSource(TaskMetadataSource):
             disable_progress_bars()
             restore_hf_bars = enable_progress_bars
 
-        print(
-            f"Materializing {len(splits_by_uri)} {self.collection.name} dataset(s) "
-            f"across {len(to_materialize)} split(s) (datasets + text caches)...",
-        )
+        if self.verbose:
+            print(
+                f"Materializing {len(splits_by_uri)} {self.collection.name} dataset(s) "
+                f"across {len(to_materialize)} split(s) (datasets + text caches)...",
+            )
         bar = tqdm(splits_by_uri.items(), desc=f"Materializing {self.collection.name}", unit="dataset")
         try:
             for data_foundry_uri, splits in bar:


### PR DESCRIPTION
## What

Three notices printed unconditionally during eval are gated behind verbosity settings that already exist - no new parameters, no behavior change at the default verbosity:

- **`bundle.py`** - `_print_experiment_summary` returns early when `verbosity <= 0`.
- **`data_foundry.py`** - the `Materializing N dataset(s)...` preamble prints only when `self.verbose`; the tqdm progress bar still shows regardless.
- **`text_cache.py`** - the per-task `[TEXT CACHE] Loading embeddings ...` notice becomes `logger.debug` (was a bare `print`).

## Why

When running many tasks/splits (e.g. distributed eval sharded across GPUs), these fire per experiment / per dataset / per job and flood the logs. The experiment summary reprints once per candidate rebuild, multiplying the noise. None of them respected a caller passing `verbosity=0`.

At default settings (`verbosity=2`, `verbose=False` on the data-foundry source) the only change is that the data-foundry preamble line is gone - it duplicated the tqdm bar's `Materializing {collection}` description. Everything else prints as before.

Draft for initial feedback on the approach.