### PR TITLE
fix: emit n_splits column from per_dataset_frame

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
@@ -506,24 +506,32 @@ class TaskMetadataCollection:
         """One row per dataset with the dataset-level (split-invariant) metadata.
 
         Uses native column names (``problem_type``, ``num_features``, ``num_classes``, ...)
-        plus a ``dataset`` key column and ``max_train_rows`` — the per-dataset *maximum*
+        plus a ``dataset`` key column, ``max_train_rows`` — the per-dataset *maximum*
         training-fold size over splits, which the BeyondArena size predicates key on (note
         :meth:`task_grid`'s ``max_train_rows`` is the per-dataset *mean*, matching the
-        legacy schema).
+        legacy schema) — and ``n_splits``, the total split count per dataset.
+
+        ``n_splits`` is summed across every task for a dataset because it is the
+        :class:`~tabarena.benchmark.task.metadata.schema.TabArenaTaskMetadata.n_splits`
+        *property* (``len(splits_metadata)``), which ``to_dict`` / ``asdict`` drop — only
+        declared dataclass fields survive serialization.
         """
         rows: dict[str, dict] = {}
         max_train_rows: dict[str, int] = {}
+        n_splits: dict[str, int] = {}
         for t in self._tasks:
             ds = t.tabarena_task_name
             # Static fields are dataset-level, so the first task seen per dataset wins.
             rows.setdefault(ds, t.to_dict(exclude_splits_metadata=True))
             # TODO: key into task metadata in the future?
+            n_splits[ds] = n_splits.get(ds, 0) + len(t.splits_metadata)
             for split in t.splits_metadata.values():
                 max_train_rows[ds] = max(max_train_rows.get(ds, 0), split.num_instances_train)
         frame = pd.DataFrame(list(rows.values()))
         if not frame.empty:
             frame["dataset"] = list(rows.keys())
             frame["max_train_rows"] = [max_train_rows[ds] for ds in rows]
+            frame["n_splits"] = [n_splits[ds] for ds in rows]
         return frame
 
     def task_grid(self) -> pd.DataFrame:


### PR DESCRIPTION
## Summary

The per-dataset Pareto trajectory plots (`pareto_n_configs_err_tot_train.pdf`, generated via `plot_tuning_trajectories_per_dataset`) render `Splits: ?` in the "Dataset" metadata legend instead of an integer.

**Root cause:** the legend is built by `_build_dataset_metadata_map` (`plot_pareto_over_tuning_time.py`) from `task_metadata_collection.per_dataset_frame()`, reading `row.get("n_splits")`. But `TabArenaTaskMetadata.n_splits` is a computed `@property` (`len(splits_metadata)`), **not** a dataclass field — and `per_dataset_frame()` builds its columns from `to_dict()` (`asdict(self)`), which serializes only declared fields, dropping properties. So the frame had no `n_splits` column, `.get("n_splits")` returned `None`, and `_fmt_int(None)` falls back to `"?"`.

Every other legend field (Samples, Features, Problem, Classes, Type, …) renders fine because those are real dataclass fields.

## Fix

Add an `n_splits` column to `per_dataset_frame()`, summed across all tasks for each dataset (mirroring the existing `max_train_rows` aggregation, since a dataset can span multiple task objects). The plot side needs no change — it now finds the column and formats the integer.

## Verification

- Built a collection from a legacy frame with `n_folds=3, n_repeats=2`: `per_dataset_frame()` now carries `n_splits=6`, and `_build_dataset_metadata_map` yields `Splits: 6` instead of `"?"`.
- Existing tests touching `per_dataset_frame` pass: `tests/tabarena/contexts/test_beyond_arena.py`, `tests/tabarena/nips2025_utils/test_per_dataset_tables.py`, `tests/tabarena/nips2025_utils/test_end_to_end_single.py` (14 passed).
- `ruff check` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)