### PR TITLE
Fix from_raw to key config_type off model_type, not ag_key

### DIFF
--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -479,6 +479,12 @@ class MethodMetadata:
         assert len(unique_model_types) == 1, (
             f"MethodMetadata requires exactly 1 model type, found: {unique_model_types}"
         )
+        # `model_key` is the simulation/comparison family key (what the repo groups configs by via
+        # `model_type`); `ag_key` is the AutoGluon model-class key (maps back to the model impl) and
+        # may differ — e.g. after a re-key (name_prefix/model_key) that keeps the same backbone but
+        # a distinct family. Source `model_key` from `model_type`, NOT from `ag_key` (the latter
+        # would conflate the two and mis-key re-keyed families during simulate/compare).
+        model_key = unique_model_types[0]
 
         unique_num_gpus = result_df["num_gpus"].unique()
         if len(unique_num_gpus) != 1:
@@ -524,6 +530,7 @@ class MethodMetadata:
             compute=compute,
             config_default=config_default,
             ag_key=ag_key,
+            model_key=model_key,
             can_hpo=can_hpo,
             is_bag=is_bag,
         )

--- a/tests/tabarena/models/test_method_metadata.py
+++ b/tests/tabarena/models/test_method_metadata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import fields
 
+import pandas as pd
 import pytest
 import yaml
 
@@ -124,3 +125,42 @@ def test_methods_from_different_cache_roots_stay_independent(tmp_path):
     assert mm_alice.path == alice / "artifacts" / "s1" / "methods" / "Foo"
     assert mm_bob.path == bob / "artifacts" / "s1" / "methods" / "Foo"
     assert mm_alice.path != mm_bob.path
+
+
+def _config_result_df(*, model_type, ag_key, frameworks, name_prefix="Model"):
+    """Minimal per-result frame mirroring the columns ``from_raw`` infers a config method from."""
+    return pd.DataFrame(
+        {
+            "method_type": "config",
+            "model_type": model_type,
+            "ag_key": ag_key,
+            "num_gpus": 0,
+            "is_bag": True,
+            "name_prefix": name_prefix,
+            "framework": frameworks,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "ag_key"),
+    [
+        ("GBM", "GBM"),  # un-re-keyed: model_type == ag_key (no-op regression guard)
+        ("PREFIX_GBM", "GBM"),  # re-keyed family on the same model-class backbone
+    ],
+)
+def test_from_raw_config_keys_off_model_type_not_ag_key(model_type, ag_key):
+    """``model_key`` / ``config_type`` track the per-result ``model_type`` (the simulation /
+    comparison family key the repo groups by), while ``ag_key`` (the model-class key) is preserved
+    as-is. They may legitimately differ -- e.g. a re-keyed family on the same backbone -- and
+    config_type must follow ``model_type``, not ``ag_key``.
+    """
+    df = _config_result_df(
+        model_type=model_type,
+        ag_key=ag_key,
+        frameworks=["Model_c1_BAG_L1", "Model_c2_BAG_L1"],
+    )
+    mm = MethodMetadata._from_raw_config(result_df=df)
+    assert mm.model_key == model_type
+    assert mm.config_type == model_type
+    assert mm.ag_key == ag_key


### PR DESCRIPTION
## Summary

`MethodMetadata._from_raw_config` inferred a method's `model_key` (and therefore `config_type`) from `ag_key`, discarding the per-result `model_type`.

- **`ag_key`** is the AutoGluon model-class key — it maps back to the model implementation.
- **`model_key`** is the family key used for **simulation and comparison**, and is deliberately allowed to differ from `ag_key` so that variants built on the same model backbone don't key-collide.

When a family's `model_type` differs from its `ag_key`, the `config_type` inferred by `from_raw` disagreed with the processed repo's own grouping key — `ZeroshotSimulatorContext.configs_type` groups configs by `model_type` — so the method was mis-keyed in any HPO / portfolio simulation or leaderboard comparison built from raw results.

## Fix

Source `model_key` from `model_type` in `_from_raw_config`, leaving `ag_key` as the model-class key.

- **No-op** when `model_type == ag_key` (the common case).
- Corrects families where they differ.
- Also makes the `model_key=` parameter of `from_raw` / `from_path_raw` actually set the resulting method's `config_type`, as its docstring already claims (previously it moved `model_type` but left `config_type` keyed off the preserved `ag_key`).

## Test

Adds a parametrized regression test in `tests/tabarena/models/test_method_metadata.py` asserting `model_key`/`config_type` track `model_type` (with `ag_key` preserved) for both the equal and the differing case. It fails on `main` and passes with this change.

## Compatibility note

Method metadata loaded from YAML or constructed directly is unaffected (this only touches `from_raw` inference). Cached `metadata.yaml` written by the previous behavior stored `model_key == ag_key`; for any family where `model_type != ag_key`, that stored key is stale relative to its repo and would need regeneration to pick up the corrected value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
