### PR TITLE
Make locally-produced/pooled results registerable + cacheable methods

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -37,6 +37,7 @@ import pandas as pd
 from tabarena.benchmark.task.metadata.collection import TaskMetadataCollection, TaskSubset
 from tabarena.benchmark.task.subset_predicate import SubsetPredicate
 from tabarena.evaluation.leaderboard_reporter import LeaderboardReporter
+from tabarena.models._in_memory_method_metadata import InMemoryMethodMetadata
 from tabarena.models._method_metadata import MethodMetadata
 from tabarena.models._method_metadata_collection import MethodMetadataCollection
 from tabarena.models._method_simulator import MethodSimulator
@@ -1382,10 +1383,21 @@ class AbstractArenaContext:
         fit_order: Literal["original", "random"] = "original",
         default_always_first: bool = True,
         seed: int = 0,
-    ) -> pd.DataFrame:
-        """Perform HPO across multiple methods.
+    ) -> InMemoryMethodMetadata:
+        """Perform HPO across multiple methods, pooling all of their configs into one family.
 
-        Returns default, tuned, and tuned + ensembled results.
+        ``methods`` may be registered method names (resolved to their ``config_type``) and/or
+        raw ``config_type`` strings; ``run_hpo`` selects the configs of every named family from
+        ``repo`` (defaulting to ``self.load_repo(methods=methods)``) and tunes/ensembles over the
+        union. ``method_default`` (the first method if unset) supplies the always-first default
+        config.
+
+        Returns the pooled family as an :class:`InMemoryMethodMetadata` (method/config_type
+        ``new_config_type``, suite ``ta_suite``) whose in-memory results hold the default / tuned
+        / tuned+ensemble rows. Register it via ``extra_methods=`` / :meth:`register` so it flows
+        through :meth:`compare` and the leaderboard like any method (e.g.
+        ``ContextCls(extra_methods=[combined], only_valid_tasks=True).compare(...)``); call
+        ``.load_results()`` for the raw frame.
         """
         if method_default is None:
             method_default = methods[0]
@@ -1438,13 +1450,28 @@ class AbstractArenaContext:
         tuned_ens["config_type"] = new_config_type
         tuned_ens["method"] = f"{new_config_type} (tuned + ensemble)"
 
-        return pd.concat(
+        results = pd.concat(
             [
                 default,
                 tuned,
                 tuned_ens,
             ],
             ignore_index=True,
+        )
+        # `method_metadata` is a per-row dict of run knobs (n_iterations/n_configs/...) that the
+        # leaderboard never reads and parquet can't serialize; drop it so the family's results
+        # frame is a clean, persistable results artifact.
+        results = results.drop(columns=["method_metadata"], errors="ignore")
+        # No repo is attached: the pooled family's configs belong to the *constituent* families
+        # (the config_types in `methods`), not to `new_config_type`, so there is no coherent
+        # processed repo for it — it is a results-only method. Attaching the merged repo would
+        # mislead repo-backed MethodMetadata logic (e.g. MethodSimulator.get_config_default keyed
+        # on this family's config_type, which the merged repo does not contain).
+        return InMemoryMethodMetadata.from_results_df(
+            results,
+            method=new_config_type,
+            suite=ta_suite,
+            config_type=new_config_type,
         )
 
     def run_hpo(

--- a/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_in_memory_method_metadata.py
@@ -13,7 +13,10 @@ operations (``load_raw``, ``generate_repo``, ``method_downloader`` / ``method_up
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Self
+
+import yaml
 
 from tabarena.models._method_metadata import MethodMetadata
 
@@ -22,6 +25,14 @@ if TYPE_CHECKING:
 
     from tabarena.nips2025_utils.end_to_end_single import EndToEndResultsSingle
     from tabarena.repository.evaluation_repository import EvaluationRepository
+
+# Results filename by method_type, mirroring MethodMetadata.load_results' dispatch, so a
+# directory written by to_dir is also loadable by the disk-backed MethodMetadata.from_yaml(path=).
+_RESULTS_FILENAME_BY_TYPE = {
+    "config": "hpo_results.parquet",
+    "baseline": "model_results.parquet",
+    "portfolio": "portfolio_results.parquet",
+}
 
 
 class InMemoryMethodMetadata(MethodMetadata):
@@ -97,12 +108,112 @@ class InMemoryMethodMetadata(MethodMetadata):
 
         return cls(results=results, repo=results_single_repo(results_single), **kwargs)
 
+    @classmethod
+    def from_results_df(
+        cls,
+        results: pd.DataFrame,
+        *,
+        method: str,
+        suite: str,
+        config_type: str | None = None,
+        method_type: str = "config",
+        repo: EvaluationRepository | None = None,
+        display_name: str | None = None,
+        can_hpo: bool = True,
+    ) -> Self:
+        """Wrap an already-computed results frame as a registerable in-memory method.
+
+        The DataFrame-first complement to :meth:`from_results_single`, for results produced
+        directly as a frame rather than via an ``EndToEndResultsSingle`` — e.g. the
+        default / tuned / tuned+ensemble frame returned by
+        :meth:`~tabarena.contexts.abstract_arena_context.AbstractArenaContext.combine_hpo`.
+        The frame is returned verbatim by :meth:`load_results`, so it must already carry the
+        leaderboard columns (``method`` / ``dataset`` / ``fold`` / ``metric_error`` / ...).
+
+        For a ``"config"`` method, ``config_type`` is the family key: it becomes ``model_key``
+        (hence :attr:`MethodMetadata.config_type`), matching the frame's ``config_type`` column
+        and the ``"<config_type> (tuned)"`` style method names so the leaderboard renders them as
+        one tunable family. Config-only fields are not accepted for other ``method_type`` values.
+        """
+        # A frame-built method never has a raw artifact, and only has a "processed" repo when one
+        # is supplied (and must genuinely belong to this method — i.e. hold its config_type's
+        # configs). These flags are descriptive (not used to gate loading), but kept accurate so
+        # ``load_processed`` raising for ``repo=None`` matches ``has_processed=False``.
+        has_processed = repo is not None
+        if method_type == "config":
+            return cls(
+                results=results,
+                repo=repo,
+                method=method,
+                suite=suite,
+                method_type="config",
+                ag_key=config_type,
+                model_key=config_type,
+                can_hpo=can_hpo,
+                display_name=display_name,
+                has_raw=False,
+                has_processed=has_processed,
+            )
+        return cls(
+            results=results,
+            repo=repo,
+            method=method,
+            suite=suite,
+            method_type=method_type,
+            display_name=display_name,
+            has_raw=False,
+            has_processed=has_processed,
+        )
+
     # ------------------------------------------------------------------ serialization
     def to_info_dict(self) -> dict:
         # Build on the base exclusion (drops the runtime-only ``artifact_dir`` / ``cache_root``
         # overrides), then
         # also drop the in-memory artifact slots so no DataFrame/repo lands in the info table.
         return {k: v for k, v in super().to_info_dict().items() if k not in self._IN_MEMORY_SLOTS}
+
+    # ------------------------------------------------------------------ persist / cache to disk
+    def to_dir(self, path: str | Path) -> Path:
+        """Persist this in-memory method to a self-contained artifact directory.
+
+        Writes ``metadata.yaml`` + ``results/<...>.parquet`` (and ``processed/`` when a repo is
+        held) in the standard :class:`MethodMetadata` on-disk layout, so the result is reloadable
+        both by :meth:`from_dir` (back into an ``InMemoryMethodMetadata``) and by the disk-backed
+        :meth:`MethodMetadata.from_yaml` (``path=``). Lets an expensive computation (e.g.
+        :meth:`~tabarena.contexts.abstract_arena_context.AbstractArenaContext.combine_hpo`) be
+        cached once and reloaded on later runs instead of recomputed. Returns the directory.
+        """
+        if self.method_type not in _RESULTS_FILENAME_BY_TYPE:
+            raise ValueError(
+                f"Cannot persist method_type={self.method_type!r}; "
+                f"expected one of {sorted(_RESULTS_FILENAME_BY_TYPE)}.",
+            )
+        path = Path(path)
+        results_dir = path / "results"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        # to_info_dict already omits the in-memory slots + runtime-only path overrides, leaving
+        # exactly the dataclass fields from_dir feeds back into the constructor.
+        with open(path / "metadata.yaml", "w") as f:
+            yaml.dump(self.to_info_dict(), f, default_flow_style=False)
+        self._results.to_parquet(results_dir / _RESULTS_FILENAME_BY_TYPE[self.method_type], index=False)
+        if self._repo is not None:
+            self._repo.to_dir(path / "processed")
+        return path
+
+    @classmethod
+    def from_dir(cls, path: str | Path, *, prediction_format: str = "memmap") -> Self:
+        """Reconstruct an ``InMemoryMethodMetadata`` previously written by :meth:`to_dir`.
+
+        Loads the directory as a disk-backed :class:`MethodMetadata` (via
+        :meth:`MethodMetadata.from_yaml`) and lifts its artifacts into memory — reusing that
+        method's own ``load_results`` (results parquet, dispatched by ``method_type``) and
+        ``load_processed`` (the ``processed/`` repo, if present, with ``prediction_format``)
+        rather than re-reading the yaml / parquet / repo by hand. ``to_info_dict`` drops the
+        runtime-only ``artifact_dir``/``cache_root``, so the rebuilt method is fully in-memory.
+        """
+        base = MethodMetadata.from_yaml(path=path)
+        repo = base.load_processed(prediction_format=prediction_format) if base.path_processed_exists else None
+        return cls(results=base.load_results(), repo=repo, **base.to_info_dict())
 
     # ------------------------------------------------------------------ in-memory artifacts
     def load_results(self) -> pd.DataFrame:

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -353,6 +353,7 @@ class MethodMetadata:
         suite: str | None = None,
         config_default: str | None = None,
         compute: Literal["cpu", "gpu"] | None = None,
+        artifact_dir: str | Path | None = None,
     ) -> Self:
         result_lst_dict = []
 
@@ -372,6 +373,7 @@ class MethodMetadata:
                 suite=suite,
                 config_default=config_default,
                 compute=compute,
+                artifact_dir=artifact_dir,
             )
         elif method_type == "baseline":
             method_metadata = cls._from_raw_baseline(
@@ -379,6 +381,7 @@ class MethodMetadata:
                 method=method,
                 suite=suite,
                 compute=compute,
+                artifact_dir=artifact_dir,
             )
         else:
             raise ValueError(f"Unknown method_type: {method_type}")
@@ -392,6 +395,7 @@ class MethodMetadata:
         method: str | None = None,
         suite: str | None = None,
         compute: Literal["cpu", "gpu"] | None = None,
+        artifact_dir: str | Path | None = None,
     ) -> Self:
         unique_method_types = result_df["method_type"].unique()
         assert len(unique_method_types) == 1
@@ -418,6 +422,7 @@ class MethodMetadata:
             method=method,
             suite=suite,
             compute=compute,
+            artifact_dir=artifact_dir,
         )
 
     @classmethod
@@ -468,6 +473,7 @@ class MethodMetadata:
         suite: str | None = None,
         config_default: str | None = None,
         compute: Literal["cpu", "gpu"] | None = None,
+        artifact_dir: str | Path | None = None,
     ) -> Self:
         unique_method_types = result_df["method_type"].unique()
         assert len(unique_method_types) == 1
@@ -533,6 +539,7 @@ class MethodMetadata:
             model_key=model_key,
             can_hpo=can_hpo,
             is_bag=is_bag,
+            artifact_dir=artifact_dir,
         )
 
     @classmethod

--- a/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/end_to_end_single.py
@@ -163,6 +163,7 @@ class EndToEndSingle:
         model_key: str | None = None,
         method: str | None = None,
         suite: str | None = None,
+        artifact_dir: str | Path | None = None,
         backend: Literal["ray", "native"] = "ray",
         verbose: bool = True,
     ) -> Self:
@@ -220,6 +221,12 @@ class EndToEndSingle:
             The name of the upper directory in the cache:
                 ~/.cache/tabarena/artifacts/{suite}/methods/{method}/
             If unspecified, will default to ``{method}``
+        artifact_dir : str | Path or None = None
+            If specified (and ``method_metadata`` is inferred), the inferred method's artifacts are
+            cached directly under this directory (``metadata.yaml`` + ``processed/`` + ``results/``)
+            instead of the ``{suite}/methods/{method}`` layout under the global cache root — useful
+            for keeping a run's artifacts self-contained in a workspace. Reload with
+            ``MethodMetadata.from_yaml(path=artifact_dir)``. Ignored if ``method_metadata`` is given.
         backend : "ray" or "native" = "ray"
             If "ray", will parallelize the calculation of hpo_results and model_results.
             If "native", will sequentially compute hpo_results and model_results.
@@ -250,6 +257,7 @@ class EndToEndSingle:
                 results_lst=results_lst,
                 method=method,
                 suite=suite,
+                artifact_dir=artifact_dir,
             )
 
         log(
@@ -325,6 +333,7 @@ class EndToEndSingle:
         model_key: str | None = None,
         method: str | None = None,
         suite: str | None = None,
+        artifact_dir: str | Path | None = None,
         name_prefix_raw: str | None = None,
         backend: Literal["ray", "native"] = "ray",
         num_cpus: int | None = None,
@@ -377,6 +386,7 @@ class EndToEndSingle:
             model_key=model_key,
             method=method,
             suite=suite,
+            artifact_dir=artifact_dir,
             backend=backend,
             verbose=verbose,
         )

--- a/tests/tabarena/models/test_in_memory_method_metadata.py
+++ b/tests/tabarena/models/test_in_memory_method_metadata.py
@@ -705,3 +705,46 @@ class TestTempDir:
         ctx.run_jobs(_jobs(), expname=None)
         assert seen["existed_during"] is True
         assert not os.path.isdir(seen["expname"])  # cleaned up after the run
+
+
+def test_from_results_df_keys_config_family_and_flags():
+    """``from_results_df`` vends a registerable config family: ``config_type`` drives
+    ``model_key``/``config_type``, ``has_raw`` is False, ``has_processed`` reflects whether a repo
+    was attached, and ``load_results`` returns the frame verbatim.
+    """
+    df = _results_frame("Fam (default)", config_type="FAM")
+    m = InMemoryMethodMetadata.from_results_df(df, method="MyFam", suite="s", config_type="FAM")
+
+    assert m.method == "MyFam"
+    assert m.method_type == "config"
+    assert m.config_type == "FAM"
+    assert m.has_raw is False
+    assert m.has_processed is False  # no repo attached
+    pd.testing.assert_frame_equal(m.load_results(), df)
+
+
+def test_to_dir_from_dir_round_trip_results_only(tmp_path):
+    """``to_dir`` persists a results-only method in the standard layout; ``from_dir`` lifts it back
+    into memory (no ``processed/`` => ``repo`` is None), and the same dir loads as a disk-backed
+    ``MethodMetadata`` too.
+    """
+    df = _results_frame("Fam (default)", config_type="FAM")
+    m = InMemoryMethodMetadata.from_results_df(df, method="MyFam", suite="s", config_type="FAM")
+
+    out = m.to_dir(tmp_path / "fam")
+    assert (out / "metadata.yaml").exists()
+    assert (out / "results" / "hpo_results.parquet").exists()
+    assert not (out / "processed").exists()  # no repo => no processed/
+
+    reloaded = InMemoryMethodMetadata.from_dir(out)
+    assert isinstance(reloaded, InMemoryMethodMetadata)
+    assert reloaded.method == "MyFam"
+    assert reloaded.config_type == "FAM"
+    assert reloaded._repo is None
+    pd.testing.assert_frame_equal(reloaded.load_results(), df, check_dtype=False)
+
+    # standard layout => also loadable as a disk-backed MethodMetadata
+    disk = MethodMetadata.from_yaml(path=out)
+    assert type(disk) is MethodMetadata
+    assert disk.config_type == "FAM"
+    pd.testing.assert_frame_equal(disk.load_results(), df, check_dtype=False)

--- a/tests/tabarena/models/test_method_metadata.py
+++ b/tests/tabarena/models/test_method_metadata.py
@@ -164,3 +164,19 @@ def test_from_raw_config_keys_off_model_type_not_ag_key(model_type, ag_key):
     assert mm.model_key == model_type
     assert mm.config_type == model_type
     assert mm.ag_key == ag_key
+
+
+def test_from_raw_config_artifact_dir_pins_artifact_location(tmp_path):
+    """``artifact_dir`` threads through ``from_raw`` so an inferred method's artifacts resolve
+    directly under it (instead of the ``{suite}/methods/{method}`` layout under the cache root).
+    """
+    df = _config_result_df(
+        model_type="GBM",
+        ag_key="GBM",
+        frameworks=["Model_c1_BAG_L1", "Model_c2_BAG_L1"],
+    )
+    mm = MethodMetadata._from_raw_config(result_df=df, method="M", suite="s", artifact_dir=tmp_path)
+    assert mm.artifact_dir == tmp_path
+    assert mm.path == tmp_path
+    assert mm.path_results == tmp_path / "results"
+    assert mm.path_processed == tmp_path / "processed"


### PR DESCRIPTION
## Summary

Turns in-memory and freshly-inferred results into first-class, registerable `MethodMetadata`, so locally-produced results flow through `compare()` / the leaderboard like cached baselines and can be cached to a chosen location.

### `AbstractArenaContext.combine_hpo` → `InMemoryMethodMetadata`
Previously returned a tidy DataFrame. It now wraps the default / tuned / tuned+ensemble results in an `InMemoryMethodMetadata`, so the pooled family can be registered (`extra_methods=` / `register`) and compared like any method; `.load_results()` recovers the frame. The pooled family is **results-only** (`repo=None`): its configs belong to the *constituent* `config_type`s, not `new_config_type`, so attaching a repo would mislead repo-backed logic (e.g. `MethodSimulator.get_config_default`).

### `InMemoryMethodMetadata.from_results_df(...)`
Wrap an already-computed results frame as a registerable method — the DataFrame-first complement to `from_results_single`. For a `config` method, `config_type` becomes the family key (`model_key`/`config_type`), matching the frame's `config_type` column.

### `InMemoryMethodMetadata.to_dir(...)` / `from_dir(...)`
Persist/reload an in-memory method to a self-contained directory (`metadata.yaml` + `results/<...>.parquet`, plus `processed/` when a repo is held), in the standard `MethodMetadata` layout — so the directory is also loadable via the disk-backed `MethodMetadata.from_yaml(path=...)`. Lets an expensive computation be cached once and reloaded on later runs. `from_dir` delegates to `from_yaml` + the method's own `load_results` / `load_processed`.

### `from_raw` / `from_path_raw` `artifact_dir=`
A pass-through that pins where an inferred method's artifacts are cached (surfacing the existing `MethodMetadata.artifact_dir` field), so `cache=True` writes a self-contained directory instead of the `{suite}/methods/{method}` layout under the global cache root. Ignored when an explicit `method_metadata` is passed.

## Tests
- `from_results_df` config-family keying + `has_raw` / `has_processed` flags.
- `to_dir` / `from_dir` round trip (results-only), incl. disk-backed `from_yaml` load of the same directory.
- `artifact_dir` plumbing through `from_raw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
