### PR TITLE
Refactor run_upload_results.py to a single-method r2 CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,17 @@ TabArena uses five independent caches. Configure them all at once with `tabarena
 | TabArena | `tabarena` | Results / baselines / leaderboard artifacts (~100 GB raw, ~10 GB processed, <1 MB results per method) | `set_tabarena_cache_root` / `TABARENA_CACHE` | `~/.cache/tabarena` |
 | Results (run output) | `results` | The runner's `expname` (`{expname}/data/{method}/{task}/{repeat}_{fold}/results.pkl`) | `run_jobs(expname=...)` | throwaway temp dir |
 
+### Processing & uploading method artifacts (maintainers)
+
+Turn a benchmark run's already-present raw `results.pkl` files into cached (and hosted) TabArena artifacts with two single-method CLIs — no download, no auto-generation. Full flag reference lives in each script's module docstring.
+
+1. **Author + process** — `scripts/run_process_method.py` (logic in `tabarena.tools.process_local_raw_data`):
+   - Inspect the raw dir for a suggested metadata snippet: `python scripts/run_process_method.py <run_dir>/data` (recursive; prints the inferred fields + a `MethodMetadata.config/.baseline/.portfolio(...)` snippet). Paste it into `packages/tabarena/src/tabarena/models/<model>/info.py` and fill in `suite` (required, must differ from `method`) + the manual fields.
+   - Process: append `--method-metadata tabarena.models.<model>.info:<x>_method_metadata --process`. **Processing requires an explicit `MethodMetadata`**, verified against the raw data first (method_type / compute / ag_key / `config_default` / can_hpo / is_bag must align, and `method != suite`); a `method`-name mismatch only warns, other mismatches error unless `--ignore-metadata-mismatch`. Caches `metadata.yaml` + `processed/` + `results/` (plus raw + HPO trajectories, on by default) under the TabArena cache.
+2. **Upload to r2** — `scripts/run_upload_results.py`:
+   - Dry-run (default) verifies each part exists locally and prints what/where: `python scripts/run_upload_results.py --method-metadata tabarena.models.<model>.info:<x>_method_metadata` (or `--from-cache METHOD SUITE` to load from the local cache).
+   - Real upload: add `--no-dry-run` with `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` set in the environment (never as flags). **r2 only** — the metadata needs `cache_type="r2"` + `cache_kwargs={"bucket", "prefix"}`; the dry-run prints the exact `--no-dry-run` command and, when the creds are unset, how to obtain them (`MethodMetadata.r2_credentials_help()`). `raw` uploads by default (`--no-upload-raw` to skip).
+
 ## Conventions
 
 - **Add a new model**: create one folder `packages/tabarena/src/tabarena/models/<model>/` (`model.py`, `hpo.py`, `info.py`, `__init__.py`), then edit `models/__init__.py` (lazy class entry), `models/utils.py` (name→generator map), and `packages/tabarena/pyproject.toml` (a per-model extra). The registry auto-discovers the model from its `info.py`, and `tests/tabarena/models/test_all_models.py` then fits it automatically — there is **no per-model test file**. Only add an entry to `tests/tabarena/models/smoke_configs.py` if the smoke fit needs faster toy hyperparameters or a restricted problem-type set (keyed by the model's `MethodMetadata.method`). **Use the `add-model` skill**, which encodes this and points to reference implementations (foundation / torch / sklearn).

--- a/packages/tabarena/src/tabarena/models/_method_metadata.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata.py
@@ -699,6 +699,35 @@ class MethodMetadata:
             )
         raise ValueError(f"Invalid cache_type for downloads: {cache_type}")
 
+    @staticmethod
+    def r2_credentials_help() -> str:
+        """How to obtain and set the R2 upload credentials (``R2_ACCOUNT_ID`` / ``R2_ACCESS_KEY_ID``
+        / ``R2_SECRET_ACCESS_KEY``).
+
+        Shared by :meth:`method_uploader`'s missing-credentials error and the upload script's
+        dry-run output, so the instructions live in one place.
+        """
+        return (
+            "Where to find these values in the Cloudflare R2 dashboard "
+            "(https://dash.cloudflare.com/ -> R2 Object Storage):\n"
+            "  - R2_ACCOUNT_ID: shown as 'Account ID' on the R2 overview page, "
+            "and embedded in the dashboard URL (dash.cloudflare.com/<account_id>/r2).\n"
+            "  - R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY: open 'Manage R2 API Tokens' "
+            "-> 'Create API Token', choose the required permission (e.g. Object Read & "
+            "Write) and bucket scope, then submit. Cloudflare displays both the Access "
+            "Key ID and the Secret Access Key on the success page; the secret is shown "
+            "only once, so copy it immediately. If you've lost an existing secret, "
+            "create a new token (or roll the existing one) from the same page.\n"
+            "\n"
+            "For the official TabArena R2 account, go to "
+            "https://dash.cloudflare.com/<account_id>/r2/api-tokens and create a new user "
+            "API token with Object Read & Write permissions scoped to only the 'tabarena' "
+            "bucket. If such a token already exists, use it instead and select 'Roll' to "
+            "obtain new credentials for the API token. Once viewing the credentials, use "
+            "the 'Access Key ID' and 'Secret Access Key' values for R2_ACCESS_KEY_ID and "
+            "R2_SECRET_ACCESS_KEY respectively."
+        )
+
     def method_uploader(self, cache_type: str = "auto") -> MethodUploader:
         if cache_type == "auto":
             cache_type = self.cache_type
@@ -721,18 +750,7 @@ class MethodMetadata:
                 raise OSError(
                     f"Missing required environment variable(s) for R2 uploads: {missing}.\n"
                     f"Set {', '.join(r2_env_vars)} in your shell (or a .env file) before "
-                    f"calling method_uploader() with cache_type='r2'.\n"
-                    f"\n"
-                    f"Where to find these values in the Cloudflare R2 dashboard "
-                    f"(https://dash.cloudflare.com/ -> R2 Object Storage):\n"
-                    f"  - R2_ACCOUNT_ID: shown as 'Account ID' on the R2 overview page, "
-                    f"and embedded in the dashboard URL (dash.cloudflare.com/<account_id>/r2).\n"
-                    f"  - R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY: open 'Manage R2 API Tokens' "
-                    f"-> 'Create API Token', choose the required permission (e.g. Object Read & "
-                    f"Write) and bucket scope, then submit. Cloudflare displays both the Access "
-                    f"Key ID and the Secret Access Key on the success page; the secret is shown "
-                    f"only once, so copy it immediately. If you've lost an existing secret, "
-                    f"create a new token (or roll the existing one) from the same page.",
+                    f"calling method_uploader() with cache_type='r2'.\n\n" + self.r2_credentials_help()
                 )
 
             return MethodUploaderR2(

--- a/scripts/run_upload_results.py
+++ b/scripts/run_upload_results.py
@@ -1,38 +1,130 @@
-"""Upload already-generated method artifacts to the method's configured object store.
+"""Upload one method's already-generated artifacts to its configured object store (r2).
 
-Companion to ``scripts/run_process_local_raw_data.py``: that script processes raw results into a
-local cache (``metadata.yaml`` + ``processed/`` + ``results/`` under the TabArena cache root); this
-one uploads those already-cached artifacts. It assumes the artifacts and the method's
+Companion to ``scripts/run_process_method.py``: that script processes raw results into a local cache
+(``metadata.yaml`` + ``processed/`` + ``results/`` under the TabArena cache root); this one uploads
+those already-cached artifacts for a single method. It assumes the artifacts and the method's
 ``MethodMetadata`` already exist locally — it does not generate anything.
 
-The destination backend is whatever the method's ``MethodMetadata.cache_type`` says (``"s3"`` or
-``"r2"``); this script is not specific to any one backend — it just calls
-``method_metadata.method_uploader()`` (``cache_type="auto"``).
+This script only supports the **r2** backend. ``MethodMetadata.method_uploader`` also implements
+``"s3"``; s3 support could be enabled here in the future by adding it to ``SUPPORTED_CACHE_TYPES``
+(it is intentionally left out for now). The method's ``MethodMetadata`` is verified before any work
+(see :func:`verify_upload_metadata` and :func:`plan_and_verify_upload`): its ``cache_type`` /
+``cache_kwargs`` must describe a supported remote store, and every part to be uploaded must exist
+locally and be non-empty — otherwise the upload is aborted with a clear, aggregated error, so a
+method is never partially uploaded.
 
-Before uploading, every part that will be uploaded is verified to exist locally and be non-empty
-(see ``plan_and_verify_upload``); the upload is aborted with a clear, aggregated error if anything
-is missing, so a method is never partially uploaded.
+``--dry-run`` (the default) runs the verification and prints what would be uploaded and where,
+without uploading anything and without needing credentials. Pass ``--no-dry-run`` to perform the
+real upload; r2 then reads ``R2_ACCOUNT_ID`` / ``R2_ACCESS_KEY_ID`` / ``R2_SECRET_ACCESS_KEY`` from
+the environment (``method_uploader`` raises a descriptive error if they are missing).
 
-Set ``dry_run=True`` (the default in ``__main__``) to run the verification and print what would be
-uploaded and where, without uploading anything and without needing credentials.
+Specify the method either by a dotted reference to a committed ``MethodMetadata`` (a model's
+``info.py``) or by loading one from the local cache by ``(method, suite)``:
 
-Credentials are required only for the real upload, and depend on the backend: ``"r2"`` reads
-``R2_ACCOUNT_ID`` / ``R2_ACCESS_KEY_ID`` / ``R2_SECRET_ACCESS_KEY`` from the environment, while
-``"s3"`` uses ambient AWS credentials. ``method_uploader`` raises a descriptive error if the
-required credentials are missing.
+    # dry-run (default) — verify + print what would be uploaded:
+    python scripts/run_upload_results.py --method-metadata tabarena.models.nori.info:nori_method_metadata
 
-Specify the methods to upload either by importing a ``MethodMetadata`` from a model's ``info.py``,
-or by loading one from the local cache with
-``MethodMetadata.from_yaml(method=..., suite=...)``.
+    # real upload from the local cache (raw uploaded by default; --no-upload-raw to skip):
+    python scripts/run_upload_results.py --from-cache "TabPFN-3" "tabarena-2026-05-13" --no-dry-run
 """
 
 from __future__ import annotations
 
+import argparse
+import importlib
+import os
+import shlex
+import sys
 from pathlib import Path
 
-# Imported at runtime (not under TYPE_CHECKING) so this script can be edited to build the
-# `methods` list below via `MethodMetadata.from_yaml(...)`.
-from tabarena.models._method_metadata import MethodMetadata  # noqa: TC001
+from tabarena.models._method_metadata import MethodMetadata
+
+# Backends this script will upload to. "s3" is implemented in MethodMetadata.method_uploader and can
+# be enabled here in the future by adding it below; intentionally r2-only for now.
+SUPPORTED_CACHE_TYPES = ("r2",)
+
+# R2 credentials are read from the environment by MethodMetadata.method_uploader (never passed as
+# CLI flags, which would leak secrets into shell history and the process table).
+R2_ENV_VARS = ("R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY")
+
+
+def _suggested_upload_command(args: argparse.Namespace) -> str:
+    """A copy-paste command for the real upload, with R2 credentials supplied inline as env vars.
+
+    Reconstructs this invocation with ``--no-dry-run`` and prefixes it with the three R2 env vars as
+    ``<placeholder>`` values. They are passed as a shell env-var prefix (not ``--flags``) so real
+    secrets stay out of the process ``argv``; ``export``-ing them or using a ``.env`` file (so they
+    also stay out of shell history) is preferable for repeated runs.
+    """
+    invocation = ["python", sys.argv[0]]
+    if args.method_metadata:
+        invocation += ["--method-metadata", args.method_metadata]
+    else:
+        invocation += ["--from-cache", *args.from_cache]
+    if not args.upload_raw:
+        invocation.append("--no-upload-raw")
+    invocation.append("--no-dry-run")
+    command = " ".join(shlex.quote(tok) for tok in invocation)
+    creds = " ".join(f"{var}=<{var.removeprefix('R2_').lower()}>" for var in R2_ENV_VARS)
+    return f"{creds} {command}"
+
+
+def _load_method_metadata(ref: str) -> MethodMetadata:
+    """Import a ``MethodMetadata`` from a ``module.path:attr`` (or ``module.path.attr``) reference."""
+    module_path, _, attr = ref.partition(":") if ":" in ref else ref.rpartition(".")
+    if not module_path or not attr:
+        raise ValueError(
+            f"Invalid --method-metadata reference {ref!r}; expected 'module.path:attr' "
+            f"(e.g. 'tabarena.models.nori.info:nori_method_metadata')."
+        )
+    obj = getattr(importlib.import_module(module_path), attr)
+    if not isinstance(obj, MethodMetadata):
+        raise TypeError(f"{ref!r} resolved to {type(obj).__name__}, not a MethodMetadata.")
+    return obj
+
+
+def verify_upload_metadata(method_metadata: MethodMetadata) -> None:
+    """Verify the ``MethodMetadata`` describes an upload destination this script supports.
+
+    Checks that ``cache_type`` is one of :data:`SUPPORTED_CACHE_TYPES` (``"r2"``) and that
+    ``cache_kwargs`` carries the remote location (``bucket`` + ``prefix``). ``__post_init__`` already
+    enforces the remote location for r2/s3, but this re-checks it to give a precise, actionable
+    message. Raises ``ValueError`` listing every problem at once (no partial upload is attempted).
+    """
+    problems: list[str] = []
+    cache_type = method_metadata.cache_type
+
+    if cache_type not in SUPPORTED_CACHE_TYPES:
+        if cache_type == "s3":
+            problems.append(
+                "cache_type='s3' is not supported by this script yet (only 'r2' is). s3 upload "
+                "exists in MethodMetadata.method_uploader and can be enabled by adding 's3' to "
+                "SUPPORTED_CACHE_TYPES."
+            )
+        elif cache_type in (None, "local"):
+            problems.append(
+                f"cache_type={cache_type!r} has no remote store to upload to; set cache_type='r2' "
+                f"and cache_kwargs={{'bucket': ..., 'prefix': ...}} on the MethodMetadata."
+            )
+        else:
+            problems.append(
+                f"cache_type={cache_type!r} is unsupported; this script only uploads to {SUPPORTED_CACHE_TYPES}."
+            )
+    else:
+        # Remote location is only meaningful (and required) for a supported remote backend.
+        cache_kwargs = method_metadata.cache_kwargs or {}
+        for key in ("bucket", "prefix"):
+            if not cache_kwargs.get(key):
+                problems.append(
+                    f"cache_kwargs is missing '{key}' (got cache_kwargs={cache_kwargs!r}); "
+                    f"required for a {cache_type!r} upload."
+                )
+
+    if problems:
+        raise ValueError(
+            f"Cannot upload '{method_metadata.method}' (suite={method_metadata.suite!r}); "
+            f"{len(problems)} metadata check(s) failed:\n  - " + "\n  - ".join(problems)
+        )
 
 
 def _check_file(path: Path, problems: list[str], label: str) -> None:
@@ -48,7 +140,7 @@ def _dir_has_files(path: Path) -> bool:
     return path.is_dir() and any(p.is_file() for p in path.rglob("*"))
 
 
-def plan_and_verify_upload(method_metadata: MethodMetadata, *, upload_raw: bool = False) -> list[str]:
+def plan_and_verify_upload(method_metadata: MethodMetadata, *, upload_raw: bool = True) -> list[str]:
     """Decide which parts of the method to upload and verify each is present and non-empty.
 
     Returns the ordered list of part names to upload (a subset of ``metadata``, ``results``,
@@ -85,8 +177,8 @@ def plan_and_verify_upload(method_metadata: MethodMetadata, *, upload_raw: bool 
         _check_file(method_metadata.path_results_hpo_trajectories(), problems, "hpo_trajectories")
         parts.append("hpo_trajectories")
 
-    # raw — only when explicitly requested; the dir must exist, be non-empty, and contain the
-    # per-run results.pkl files that upload_raw zips.
+    # raw — uploaded by default; the dir must exist, be non-empty, and contain the per-run
+    # results.pkl files that upload_raw zips.
     if upload_raw:
         path_raw = method_metadata.path_raw
         if not _dir_has_files(path_raw):
@@ -107,10 +199,11 @@ def plan_and_verify_upload(method_metadata: MethodMetadata, *, upload_raw: bool 
 def _destination(method_metadata: MethodMetadata) -> str:
     """The remote location this method would upload to, computed from the metadata alone (no client).
 
-    Uses ``s3://bucket/prefix`` semantics, which is what both the S3 and R2 backends use.
+    Rendered as ``<cache_type>://bucket/prefix/...`` (e.g. ``r2://...``) so the scheme reflects the
+    actual backend rather than always reading ``s3://``.
     """
     ck = method_metadata.cache_kwargs
-    root = f"s3://{ck.get('bucket')}/{ck.get('prefix')}"
+    root = f"{method_metadata.cache_type}://{ck.get('bucket')}/{ck.get('prefix')}"
     try:
         rel = method_metadata.relative_to_cache_root(method_metadata.path).as_posix()
         return f"{root}/{rel}"
@@ -122,37 +215,34 @@ def _destination(method_metadata: MethodMetadata) -> str:
 def upload_method(
     method_metadata: MethodMetadata,
     *,
-    upload_raw: bool = False,
+    upload_raw: bool = True,
     dry_run: bool = False,
 ) -> None:
-    """Verify then upload one method's cached artifacts to its configured backend.
+    """Verify then upload one method's cached artifacts to its configured r2 backend.
 
-    The backend follows ``method_metadata.cache_type`` (``method_uploader(cache_type="auto")``).
-    All local checks run first (before the client is created), so missing/empty artifacts are
-    reported without needing credentials and without starting a partial upload.
+    All verification runs first (before the client is created): :func:`verify_upload_metadata`
+    confirms the ``cache_type`` / ``cache_kwargs`` describe a supported remote store, then
+    :func:`plan_and_verify_upload` confirms every planned artifact is present and non-empty. So a
+    misconfigured or incomplete method is reported without needing credentials and without starting
+    a partial upload.
 
     ``dry_run=True`` runs the same verification and prints what *would* be uploaded and where, but
     performs no upload and does not construct the client — so it needs no credentials.
     """
+    verify_upload_metadata(method_metadata)
     parts = plan_and_verify_upload(method_metadata, upload_raw=upload_raw)
 
     if dry_run:
         print(
             f"[dry-run] '{method_metadata.method}' (artifact={method_metadata.suite}) "
-            f"verified OK; would upload parts={parts} -> {_destination(method_metadata)} "
-            f"(cache_type={method_metadata.cache_type})"
+            f"verified OK; would upload parts={parts} -> {_destination(method_metadata)}"
         )
-        if not method_metadata.has_remote_cache:
-            print(
-                f"[dry-run]   WARNING: cache_type={method_metadata.cache_type!r} has no remote store; "
-                "a real upload would fail."
-            )
         return
 
     uploader = method_metadata.method_uploader()
     print(
         f"Uploading '{method_metadata.method}' (artifact={method_metadata.suite}) "
-        f"to s3://{uploader.bucket}/{uploader.prefix} | cache_type={method_metadata.cache_type} | parts={parts}"
+        f"to {method_metadata.cache_type}://{uploader.bucket}/{uploader.prefix} | parts={parts}"
     )
     uploader.upload_metadata()
     uploader.upload_results()
@@ -165,27 +255,73 @@ def upload_method(
     print(f"\tDone: {method_metadata.method}")
 
 
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify + upload a single method's cached artifacts to its r2 store.",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--method-metadata",
+        metavar="MODULE:ATTR",
+        help="Dotted reference to a committed MethodMetadata (e.g. 'tabarena.models.nori.info:nori_method_metadata').",
+    )
+    source.add_argument(
+        "--from-cache",
+        nargs=2,
+        metavar=("METHOD", "SUITE"),
+        help="Load the MethodMetadata from the local cache via MethodMetadata.from_yaml(method, suite).",
+    )
+    parser.add_argument(
+        "--upload-raw",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Upload the raw `results.pkl` files too (on by default; pass --no-upload-raw to skip).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Verify + print what would be uploaded without uploading (on by default; "
+        "pass --no-dry-run to perform the real upload).",
+    )
+    args = parser.parse_args()
+
+    if args.method_metadata:
+        method_metadata = _load_method_metadata(args.method_metadata)
+    else:
+        method, suite = args.from_cache
+        method_metadata = MethodMetadata.from_yaml(method=method, suite=suite)
+
+    print(
+        f"{'[dry-run] ' if args.dry_run else ''}Uploading '{method_metadata.method}' "
+        f"(suite={method_metadata.suite}, upload_raw={args.upload_raw})"
+    )
+    try:
+        upload_method(method_metadata, upload_raw=args.upload_raw, dry_run=args.dry_run)
+    except OSError as e:
+        # Missing R2 credentials (raised by MethodMetadata.method_uploader, with where-to-find-them
+        # instructions). Re-surface those, then append the exact command to re-run with the
+        # credentials supplied as env vars.
+        if all(os.environ.get(var) for var in R2_ENV_VARS):
+            raise  # an unrelated OSError — leave it untouched
+        raise SystemExit(
+            f"{e}\n\nThen re-run with the credentials set as env vars:\n  {_suggested_upload_command(args)}"
+        ) from e
+
+    if args.dry_run:
+        print(
+            "\nTo upload for real, re-run with your R2 credentials set as env vars and --no-dry-run:\n"
+            f"  {_suggested_upload_command(args)}"
+        )
+        missing = [var for var in R2_ENV_VARS if not os.environ.get(var)]
+        if missing:
+            print(
+                f"\nR2 credentials are not set yet ({', '.join(missing)}). How to obtain them:\n"
+                + MethodMetadata.r2_credentials_help()
+            )
+
+
 if __name__ == "__main__":
-    # When True, verify + print what would be uploaded (and where) without uploading anything.
-    # No credentials are needed for a dry run. Flip to False to perform the real upload.
-    dry_run = True
-
-    # raw/ is large and usually not cached locally; flip on only if you intend to upload it too.
-    upload_raw = False
-
-    # Methods to upload. Either import a fully-specified MethodMetadata from a model's info.py:
-    #     from tabarena.models.tabpfn_3.info import tabpfn_3_method_metadata
-    #     methods = [tabpfn_3_method_metadata]
-    # or load one from the local cache by (method, suite):
-    #     MethodMetadata.from_yaml(method="TabPFN-3", suite="tabarena-2026-05-13")
-    methods: list[MethodMetadata] = [
-        # MethodMetadata.from_yaml(method="...", suite="..."),
-    ]
-
-    if len(methods) == 0:
-        raise AssertionError("Populate `methods` with one or more MethodMetadata to upload. Currently empty.")
-
-    print(f"{'[dry-run] ' if dry_run else ''}Uploading {len(methods)} method(s) (upload_raw={upload_raw})")
-    for i, method_metadata in enumerate(methods):
-        print(f"\n({i + 1}/{len(methods)}) {method_metadata.method}")
-        upload_method(method_metadata, upload_raw=upload_raw, dry_run=dry_run)
+    main()


### PR DESCRIPTION
## Summary

Follow-up to #426. Refactors `scripts/run_upload_results.py` into a single-method, CLI-parameterized uploader (mirroring `run_process_method.py`), restricts it to the **r2** backend with up-front verification, and centralizes the R2 credential instructions.

### `scripts/run_upload_results.py`
- **Single-method CLI** — select the method via `--method-metadata MODULE:ATTR` (dotted ref to a committed `MethodMetadata`) or `--from-cache METHOD SUITE` (loads from the local cache). Drops the edit-the-vars `methods` list/loop.
- **`verify_upload_metadata`** — verifies the method's cache config before any work: `cache_type` must be `"r2"` (`SUPPORTED_CACHE_TYPES`), and `cache_kwargs` must carry `bucket` + `prefix`, with descriptive, aggregated errors (same style as the process tool). `"s3"` is intentionally unsupported for now and reports how to enable it later; `"local"`/`None` reports that no remote store is configured.
- **`upload_raw` defaults to True** (`--upload-raw` / `--no-upload-raw`); `--dry-run` defaults on (`--no-dry-run` performs the real upload).
- **Destination scheme reflects the backend** — rendered as `r2://bucket/prefix/...` instead of a hardcoded `s3://`.
- **Credential UX (env vars only — no secret flags):**
  - dry-run prints a copy-paste `--no-dry-run` command with the R2 credentials as env-var **placeholders** (passed as a shell env prefix, not `argv` flags), and — when the env vars aren't set — prints the credential-setup instructions inline;
  - the real-upload missing-credentials error re-surfaces those instructions and appends the same re-run command.

### `packages/.../models/_method_metadata.py`
- Extracts the R2 credential instructions into `MethodMetadata.r2_credentials_help()` — a single source of truth shared by `method_uploader`'s missing-credentials error and the upload script's dry-run.
- Adds official-TabArena-account guidance: create (or `Roll`) a user API token with Object Read & Write scoped to only the `tabarena` bucket at `https://dash.cloudflare.com/<account_id>/r2/api-tokens`, and which values map to `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`.

## Test plan
- `ruff check` + `ruff format --check` clean on both files.
- Dry-run renders the `r2://` destination, the suggested `--no-dry-run` command (for both `--method-metadata` and `--from-cache` forms), and — with the R2 env vars cleared — the inline credential instructions; with the env vars set, the instructions are suppressed.
- `--no-dry-run` with credentials cleared raises before any upload, printing the credential instructions + the re-run command and exiting non-zero.
- Verification: `r2` + bucket/prefix → OK; `local`/`s3`/missing bucket|prefix → descriptive errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
