### PR TITLE
Host Nori artifacts on R2 (set cache_type / cache_kwargs)

### DIFF
--- a/packages/tabarena/src/tabarena/models/nori/info.py
+++ b/packages/tabarena/src/tabarena/models/nori/info.py
@@ -17,10 +17,8 @@ nori_method_metadata = MethodMetadata.config(
     reference_url="https://github.com/Synthefy/synthefy-nori",
     display_name="Nori",
     verified=False,
-    # Not yet hosted: bucket/prefix/cache_type are set by the maintainers once the result
-    # artifacts land in the official pool; until then cache_type infers "local" (no remote
-    # location set). has_raw/has_processed/has_results stay True — a config has all three
-    # artifact tiers, hosted or not.
+    cache_type="r2",
+    cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
 )
 
 nori_info = ModelInfo(


### PR DESCRIPTION
## Summary

Sets the Nori method metadata (`packages/tabarena/src/tabarena/models/nori/info.py`) to use the R2 backend so its artifacts resolve to / can be uploaded to the official TabArena store:

```python
cache_type="r2",
cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
```

This replaces the placeholder "Not yet hosted" comment now that Nori's results are being processed and uploaded. With `cache_type="r2"` + `bucket`/`prefix` set, the metadata passes `MethodMetadata.__post_init__`'s remote-location validation and is accepted by `scripts/run_upload_results.py` (which is r2-only).

## Test plan
- `ruff check` + `ruff format --check` clean.
- `MethodMetadata.config(..., cache_type="r2", cache_kwargs={"bucket": "tabarena", "prefix": "cache"})` constructs without error (`__post_init__` requires bucket+prefix for r2, both present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)