### PR TITLE
Make tabarena collection the paper set built from info.py; derive complete from it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ TabArena uses five independent caches. Configure them all at once with `tabarena
 
 ### Processing & uploading method artifacts (maintainers)
 
-Turn a benchmark run's already-present raw `results.pkl` files into cached (and hosted) TabArena artifacts with two single-method CLIs — no download, no auto-generation. Full flag reference lives in each script's module docstring.
+Turn a benchmark run's already-present raw `results.pkl` files into cached, hosted, and registered TabArena artifacts — no download, no auto-generation. Steps 1–2 are single-method CLIs (full flag reference in each script's module docstring); step 3 is a small code change.
 
 1. **Author + process** — `scripts/run_process_method.py` (logic in `tabarena.tools.process_local_raw_data`):
    - Inspect the raw dir for a suggested metadata snippet: `python scripts/run_process_method.py <run_dir>/data` (recursive; prints the inferred fields + a `MethodMetadata.config/.baseline/.portfolio(...)` snippet). Paste it into `packages/tabarena/src/tabarena/models/<model>/info.py` and fill in `suite` (required, must differ from `method`) + the manual fields.
@@ -129,6 +129,7 @@ Turn a benchmark run's already-present raw `results.pkl` files into cached (and 
 2. **Upload to r2** — `scripts/run_upload_results.py`:
    - Dry-run (default) verifies each part exists locally and prints what/where: `python scripts/run_upload_results.py --method-metadata tabarena.models.<model>.info:<x>_method_metadata` (or `--from-cache METHOD SUITE` to load from the local cache).
    - Real upload: add `--no-dry-run` with `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` set in the environment (never as flags). **r2 only** — the metadata needs `cache_type="r2"` + `cache_kwargs={"bucket", "prefix"}`; the dry-run prints the exact `--no-dry-run` command and, when the creds are unset, how to obtain them (`MethodMetadata.r2_credentials_help()`). `raw` uploads by default (`--no-upload-raw` to skip).
+3. **Register in the appropriate context's collection** — add the method so it appears in the benchmark. For TabArena, import the model's `info.py` `method_metadata` and add it to `tabarena_method_metadata_collection` in `packages/tabarena/src/tabarena/contexts/tabarena/methods.py` (the collection lists each model's `info.py` metadata directly, and is itself the paper method set used by `TabArenaContext`). It flows into `tabarena_method_metadata_complete_collection` automatically. Other arena contexts register in their own collection.
 
 ## Conventions
 

--- a/packages/tabarena/src/tabarena/contexts/tabarena/_tabarena_method_metadata_2025_06_12.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/_tabarena_method_metadata_2025_06_12.py
@@ -18,8 +18,9 @@ from tabarena.models.tabicl.info import tabicl_method_metadata
 from tabarena.models.tabm.info import tabm_gpu_method_metadata, tabm_method_metadata
 from tabarena.models.xgboost.info import xgboost_method_metadata
 
-# Models that own their MethodMetadata via per-model `info.py` modules. The
-# factory loop below skips these; they are seeded into `methods_2025_06_12` here.
+# Models that own their MethodMetadata via per-model `info.py` modules — seeded directly into
+# `methods_2025_06_12`. The factory loop below builds only the remaining 2025-06-12 methods that
+# have no per-model `info.py` (the maps/lists in this file are therefore keyed by just those).
 _per_model_metadata = [
     catboost_method_metadata,
     extra_trees_method_metadata,
@@ -35,7 +36,6 @@ _per_model_metadata = [
     tabm_gpu_method_metadata,
     xgboost_method_metadata,
 ]
-_migrated_method_names = {m.method for m in _per_model_metadata}
 
 methods_2025_06_12 = list(_per_model_metadata)
 
@@ -56,160 +56,81 @@ gpu_kwargs = dict(
     **common_kwargs,
 )
 
-# Methods in this list will upload s3 artifacts privately (useful for storing results for unreleased models)
-# If a method is not in this list, it will be public when uploaded.
-
-
-# If the method should not be tuned/tuned+enesmbled in the simulator, for example, due to having only 1 config
-methods_no_hpo = [
-    "TabICL_GPU",
-    "TabDPT_GPU",
-]
-
-# If the method was fit with bagging (8-fold)
-# If not present in this list, the model could instead have been refit on the full data, ex: TabPFNv2
-methods_is_bag = [
-    "CatBoost",
-    "Dummy",
-    "ExplainableBM",
-    "ExtraTrees",
-    # "KNeighbors",
-    "LightGBM",
-    "LinearModel",
-    "ModernNCA",
-    "NeuralNetFastAI",
-    "NeuralNetTorch",
-    "RandomForest",
-    "RealMLP",
-    "TabM",
-    "XGBoost",
-    "ModernNCA_GPU",
-    "RealMLP_GPU",
-    # "TabDPT_GPU",
-    # "TabICL_GPU",
-    "TabM_GPU",
-    # "TabPFNv2_GPU",
-]
-
-
-methods_ag_key_map = {
-    "CatBoost": "CAT",
-    "Dummy": "DUMMY",
-    "ExplainableBM": "EBM",
-    "ExtraTrees": "XT",
-    "KNeighbors": "KNN",
-    "LightGBM": "GBM",
-    "LinearModel": "LR",
-    "ModernNCA": "MNCA",
-    "NeuralNetFastAI": "FASTAI",
-    "NeuralNetTorch": "NN_TORCH",
-    "RandomForest": "RF",
-    "RealMLP": "REALMLP",
-    "TabM": "TABM",
-    "XGBoost": "XGB",
-    "ModernNCA_GPU": "MNCA",
-    "RealMLP_GPU": "REALMLP",
-    "TabDPT_GPU": "TABDPT",
-    "TabICL_GPU": "TABICL",
-    "TabM_GPU": "TABM",
-    "TabPFNv2_GPU": "TABPFNV2",
-}
-
-
-methods_display_name_map = {
-    "CatBoost": "CatBoost",
-    "Dummy": "Dummy",
-    "ExplainableBM": "EBM",
-    "ExtraTrees": "ExtraTrees",
-    "KNeighbors": "KNN",
-    "LightGBM": "LightGBM",
-    "LinearModel": "Linear",
-    "ModernNCA": "ModernNCA (CPU)",
-    "NeuralNetFastAI": "FastaiMLP",
-    "NeuralNetTorch": "TorchMLP",
-    "RandomForest": "RandomForest",
-    "RealMLP": "RealMLP (CPU)",
-    "TabM": "TabM (CPU)",
-    "XGBoost": "XGBoost",
-    "ModernNCA_GPU": "ModernNCA",
-    "RealMLP_GPU": "RealMLP",
-    "TabDPT_GPU": "TabDPT",
-    "TabICL_GPU": "TabICL",
-    "TabM_GPU": "TabM",
-    "TabPFNv2_GPU": "TabPFNv2",
-}
-
-
-methods_config_default_map = {
-    "CatBoost": "CatBoost_c1_BAG_L1",
-    "Dummy": "Dummy_c1_BAG_L1",
-    "ExplainableBM": "ExplainableBM_c1_BAG_L1",
-    "ExtraTrees": "ExtraTrees_c1_BAG_L1",
-    "KNeighbors": "KNeighbors_c1_BAG_L1",
-    "LightGBM": "LightGBM_c1_BAG_L1",
-    "LinearModel": "LinearModel_c1_BAG_L1",
-    "ModernNCA": "ModernNCA_c1_BAG_L1",
-    "NeuralNetFastAI": "NeuralNetFastAI_c1_BAG_L1",
-    "NeuralNetTorch": "NeuralNetTorch_c1_BAG_L1",
-    "RandomForest": "RandomForest_c1_BAG_L1",
-    "RealMLP": "RealMLP_c1_BAG_L1",
-    "TabM": "TabM_c1_BAG_L1",
-    "XGBoost": "XGBoost_c1_BAG_L1",
-    "ModernNCA_GPU": "ModernNCA_GPU_c1_BAG_L1",
-    "RealMLP_GPU": "RealMLP_GPU_c1_BAG_L1",
-    "TabDPT_GPU": "TabDPT_GPU_c1_BAG_L1",
-    "TabICL_GPU": "TabICL_GPU_c1_BAG_L1",
-    "TabM_GPU": "TabM_GPU_c1_BAG_L1",
-    "TabPFNv2_GPU": "TabPFNv2_GPU_c1_BAG_L1",
-}
-
-
-methods_compute_map = {
-    "CatBoost": "cpu",
-    "Dummy": "cpu",
-    "ExplainableBM": "cpu",
-    "ExtraTrees": "cpu",
-    "KNeighbors": "cpu",
-    "LightGBM": "cpu",
-    "LinearModel": "cpu",
-    "ModernNCA": "cpu",
-    "NeuralNetFastAI": "cpu",
-    "NeuralNetTorch": "cpu",
-    "RandomForest": "cpu",
-    "RealMLP": "cpu",
-    "TabM": "cpu",
-    "XGBoost": "cpu",
-    "ModernNCA_GPU": "gpu",
-    "RealMLP_GPU": "gpu",
-    "TabDPT_GPU": "gpu",
-    "TabICL_GPU": "gpu",
-    "TabM_GPU": "gpu",
-    "TabPFNv2_GPU": "gpu",
-}
-
+# The 2025-06-12 methods that have no per-model `info.py`; built from the maps below.
 methods = [
-    "CatBoost",
     "Dummy",
     "ExplainableBM",
-    "ExtraTrees",
     "KNeighbors",
-    "LightGBM",
     "LinearModel",
-    "ModernNCA",
-    "NeuralNetFastAI",
-    "NeuralNetTorch",
-    "RandomForest",
-    "RealMLP",
-    "TabM",
-    "XGBoost",
-    "ModernNCA_GPU",
     "RealMLP_GPU",
     "TabDPT_GPU",
-    "TabICL_GPU",
-    "TabM_GPU",
     "TabPFNv2_GPU",
 ]
 
+# Methods that should not be tuned/tuned+ensembled in the simulator (e.g. only 1 config).
+methods_no_hpo = [
+    "TabDPT_GPU",
+]
+
+# Methods fit with bagging (8-fold); if absent, the model could instead have been refit on full data.
+methods_is_bag = [
+    "Dummy",
+    "ExplainableBM",
+    "LinearModel",
+    "RealMLP_GPU",
+]
+
+methods_ag_key_map = {
+    "Dummy": "DUMMY",
+    "ExplainableBM": "EBM",
+    "KNeighbors": "KNN",
+    "LinearModel": "LR",
+    "RealMLP_GPU": "REALMLP",
+    "TabDPT_GPU": "TABDPT",
+    "TabPFNv2_GPU": "TABPFNV2",
+}
+
+methods_display_name_map = {
+    "Dummy": "Dummy",
+    "ExplainableBM": "EBM",
+    "KNeighbors": "KNN",
+    "LinearModel": "Linear",
+    "RealMLP_GPU": "RealMLP",
+    "TabDPT_GPU": "TabDPT",
+    "TabPFNv2_GPU": "TabPFNv2",
+}
+
+methods_config_default_map = {
+    "Dummy": "Dummy_c1_BAG_L1",
+    "ExplainableBM": "ExplainableBM_c1_BAG_L1",
+    "KNeighbors": "KNeighbors_c1_BAG_L1",
+    "LinearModel": "LinearModel_c1_BAG_L1",
+    "RealMLP_GPU": "RealMLP_GPU_c1_BAG_L1",
+    "TabDPT_GPU": "TabDPT_GPU_c1_BAG_L1",
+    "TabPFNv2_GPU": "TabPFNv2_GPU_c1_BAG_L1",
+}
+
+methods_compute_map = {
+    "Dummy": "cpu",
+    "ExplainableBM": "cpu",
+    "KNeighbors": "cpu",
+    "LinearModel": "cpu",
+    "RealMLP_GPU": "gpu",
+    "TabDPT_GPU": "gpu",
+    "TabPFNv2_GPU": "gpu",
+}
+
+methods_to_url_map = {
+    "ExplainableBM": "https://www.cs.cornell.edu/~yinlou/papers/lou-kdd13.pdf",
+    "KNeighbors": "https://scikit-learn.org/stable/modules/neighbors.html",
+    "LinearModel": "https://scikit-learn.org/stable/modules/linear_model.html",
+    "RealMLP_GPU": "https://arxiv.org/abs/2407.04491",
+    "TabDPT_GPU": "https://arxiv.org/abs/2410.18164",
+    "TabPFNv2_GPU": "https://www.nature.com/articles/s41586-024-08328-6",
+}
+
+# Curated name lists (consumed by the 2025-06-12 collections in `methods.py`); these span the full
+# 2025-06-12 method set, including the per-model-`info.py` models seeded above.
 methods_main_paper = [
     "CatBoost",
     "ExplainableBM",
@@ -237,48 +158,7 @@ methods_gpu_ablation = [
     "RealMLP_GPU",
 ]
 
-verified_methods = [
-    "ExplainableBM",
-    "ModernNCA",
-    "NeuralNetFastAI",
-    "NeuralNetTorch",
-    "RealMLP",
-    "TabM",
-    "ModernNCA_GPU",
-    "RealMLP_GPU",
-    "TabDPT_GPU",
-    "TabICL_GPU",
-    "TabM_GPU",
-    "TabPFNv2_GPU",
-]
-
-methods_to_url_map = {
-    "RealMLP_GPU": "https://arxiv.org/abs/2407.04491",
-    "RealMLP": "https://arxiv.org/abs/2407.04491",
-    "TabDPT_GPU": "https://arxiv.org/abs/2410.18164",
-    "TabM_GPU": "https://arxiv.org/abs/2410.24210",
-    "TabM": "https://arxiv.org/abs/2410.24210",
-    "LightGBM": "https://papers.nips.cc/paper_files/paper/2017/hash/6449f44a102fde848669bdd9eb6b76fa-Abstract.html",
-    "CatBoost": "https://arxiv.org/abs/1706.09516",
-    "ModernNCA_GPU": "https://arxiv.org/abs/2407.03257",
-    "ModernNCA": "https://arxiv.org/abs/2407.03257",
-    "XGBoost": "https://arxiv.org/abs/1603.02754",
-    "TabPFNv2_GPU": "https://www.nature.com/articles/s41586-024-08328-6",
-    "TabICL_GPU": "https://arxiv.org/abs/2502.05564",
-    "NeuralNetTorch": "https://arxiv.org/abs/2003.06505",
-    "NeuralNetFastAI": "https://arxiv.org/abs/2003.06505",
-    "ExplainableBM": "https://www.cs.cornell.edu/~yinlou/papers/lou-kdd13.pdf",
-    "RandomForest": "https://link.springer.com/article/10.1023/A:1010933404324",
-    "KNeighbors": "https://scikit-learn.org/stable/modules/neighbors.html",
-    "ExtraTrees": "https://link.springer.com/article/10.1007/s10994-006-6226-1",
-    "LinearModel": "https://scikit-learn.org/stable/modules/linear_model.html",
-}
-
-tabarena_method_metadata_map_2025_06_12: dict[str, MethodMetadata] = {}
-
 for method in methods:
-    if method in _migrated_method_names:
-        continue
     compute_type = methods_compute_map[method]
     ag_key = methods_ag_key_map[method]
     config_default = methods_config_default_map[method]

--- a/packages/tabarena/src/tabarena/contexts/tabarena/_tabarena_method_metadata_2025_09_03.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/_tabarena_method_metadata_2025_09_03.py
@@ -4,8 +4,7 @@
 models with no tabarena-side wrapper class (results were produced by external
 code), and `TabPFNv2_GPU` similarly has no wrapper here. They're kept as
 standalone `MethodMetadata` instances rather than `ModelInfo`. `ag_140_metadata`
-is an AutoGluon baseline. `limix_metadata` is the deprecated GPU-named entry
-(the active LimiX metadata lives in `tabarena.models.limix.info`).
+is an AutoGluon baseline.
 """
 
 from __future__ import annotations
@@ -24,21 +23,6 @@ ag_140_metadata = MethodMetadata.tabarena_legacy_s3(
     compute="gpu",
     date="2025-09-03",
     reference_url="https://arxiv.org/abs/2003.06505",
-    **_common_kwargs,
-)
-limix_metadata = MethodMetadata.tabarena_legacy_s3(
-    method="LimiX_GPU",
-    method_type="config",
-    display_name="LimiX",
-    compute="gpu",
-    date="2025-09-03",
-    ag_key="LIMIX",
-    model_key="LIMIX_GPU",
-    config_default="LimiX_GPU_c1_BAG_L1",
-    can_hpo=False,
-    is_bag=False,
-    verified=False,
-    reference_url="https://arxiv.org/abs/2509.03505",
     **_common_kwargs,
 )
 tabflex_metadata = MethodMetadata.tabarena_legacy_s3(

--- a/packages/tabarena/src/tabarena/contexts/tabarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/context.py
@@ -17,47 +17,6 @@ if TYPE_CHECKING:
     from tabarena.caching import CacheConfig
     from tabarena.models._method_metadata import MethodMetadata
 
-_methods_paper = [
-    "AutoGluon_v140_bq_4h8c",
-    # "AutoGluon_v140_eq_4h8c",
-    "AutoGluon_v150_eq_4h8c",
-    # "Portfolio-N200-4h",
-    "CatBoost",
-    # "Dummy",
-    "ExplainableBM",
-    "ExtraTrees",
-    "KNeighbors",
-    "LightGBM",
-    "LinearModel",
-    # "ModernNCA",
-    "NeuralNetFastAI",
-    "NeuralNetTorch",
-    "RandomForest",
-    # "RealMLP",
-    # "TabM",
-    "XGBoost",
-    "Mitra_GPU",
-    "ModernNCA_GPU",
-    "RealMLP_GPU",
-    "TabDPT_GPU",
-    "TabICL_GPU",
-    "TabM_GPU",
-    "TabPFNv2_GPU",
-    "xRFM_GPU",
-    "BetaTabPFN_GPU",
-    "TabFlex_GPU",
-    "RealTabPFN-v2.5",
-    "SAP-RPT-OSS",
-    "TabICLv2",
-    "TabSTAR",
-    "PerpetualBooster",
-    "TabPFN-v2.6",
-    "LimiX",
-    "OrionMSP",
-    "TabPFN-3",
-    "iLTM",
-]
-
 
 class TabArenaContext(AbstractArenaContext):
     """Reference arena context: TabArena v0.1 task/method presets + the paper workflow.
@@ -131,14 +90,8 @@ class TabArenaContext(AbstractArenaContext):
     def _resolve_methods_preset(self, name: str) -> list[MethodMetadata]:
         if name != "tabarena":
             raise ValueError(f"Unknown methods preset '{name}'.")
-        methods = copy.deepcopy(_methods_paper)
-        method_metadata_lst: list[MethodMetadata] = copy.deepcopy(
-            tabarena_method_metadata_collection.method_metadata_lst,
-        )
-        method_metadata_lst = [m for m in method_metadata_lst if m.method in methods]
-        method_metadata_name_set = {m.method for m in method_metadata_lst}
-        methods = [m for m in methods if m in method_metadata_name_set]
-        return [m for m in method_metadata_lst if m.method in set(methods)]
+        # `tabarena_method_metadata_collection` already holds exactly the paper method set.
+        return copy.deepcopy(tabarena_method_metadata_collection.method_metadata_lst)
 
     @property
     def _default_subsets(self):

--- a/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
@@ -17,7 +17,6 @@ from tabarena.contexts.tabarena._tabarena_method_metadata_2025_10_20 import (
 )
 from tabarena.contexts.tabarena._tabarena_method_metadata_2025_11_01 import (
     ag_140_bq_4h8c_metadata,
-    ag_140_eq_4h8c_metadata,
     methods_2025_11_01_ag,
 )
 from tabarena.contexts.tabarena._tabarena_method_metadata_2025_12_18 import ag_150_eq_4h8c_metadata
@@ -33,27 +32,36 @@ from tabarena.contexts.tabarena._tabarena_method_metadata_misc import (
 )
 from tabarena.models._method_metadata_collection import MethodMetadataCollection
 
-# Per-model `info.py` is the canonical source for each migrated model's
-# `MethodMetadata`. Aliased here under the historical name so the rest of
-# the aggregator (and downstream collections) keeps working unchanged.
+# Per-model `info.py` is the canonical source for each method's `MethodMetadata`; the collection
+# below references these directly. (Some keep their historical alias, used by the per-suite full
+# lists / downstream collections.)
+from tabarena.models.catboost.info import catboost_method_metadata
 from tabarena.models.ebm.info import ebm_method_metadata as ebm_metadata
+from tabarena.models.extra_trees.info import extra_trees_method_metadata
+from tabarena.models.fastai.info import fastai_method_metadata
 from tabarena.models.iltm.info import iltm_method_metadata
 from tabarena.models.knn.info import knn_method_metadata as knn_metadata
+from tabarena.models.lightgbm.info import lightgbm_method_metadata
 from tabarena.models.limix.info import limix_method_metadata as limix_metadata
 from tabarena.models.lr.info import lr_method_metadata as lr_metadata
 from tabarena.models.mitra.info import mitra_method_metadata as mitra_metadata
+from tabarena.models.modernnca.info import modernnca_gpu_method_metadata
+from tabarena.models.nn_torch.info import nn_torch_method_metadata
 from tabarena.models.orionmsp.info import orionmsp_method_metadata as orionmsp_metadata
 from tabarena.models.perpetual_booster.info import (
     perpetual_booster_method_metadata as perpetualbooster_metadata,
 )
+from tabarena.models.random_forest.info import random_forest_method_metadata
 from tabarena.models.realmlp.info import realmlp_method_metadata as realmlp_gpu_metadata
 from tabarena.models.sap_rpt_oss.info import (
     sap_rpt_oss_method_metadata as contexttab_metadata,
 )
 from tabarena.models.tabdpt.info import tabdpt_method_metadata as tabdpt_metadata
 from tabarena.models.tabicl.info import (
+    tabicl_method_metadata,
     tabiclv2_method_metadata as tabiclv2_metadata,
 )
+from tabarena.models.tabm.info import tabm_gpu_method_metadata
 from tabarena.models.tabpfn_3.info import (
     tabpfn_3_method_metadata as tabpfnv3_method_metadata,
 )
@@ -62,11 +70,16 @@ from tabarena.models.tabpfnv2_5.info import (
     tabpfnv26_method_metadata as tabpfn26_metadata,
 )
 from tabarena.models.tabstar.info import tabstar_method_metadata as tabstar_metadata
+from tabarena.models.xgboost.info import xgboost_method_metadata
 from tabarena.models.xrfm.info import xrfm_method_metadata as xrfm_metadata
 
 if TYPE_CHECKING:
     from tabarena.models._method_metadata import MethodMetadata
 
+# TabPFNv2_GPU has no per-model info.py (it is built by the 2025-06-12 factory); pull it out by name.
+tabpfnv2_gpu_metadata = next(m for m in methods_2025_06_12 if m.method == "TabPFNv2_GPU")
+
+# Per-suite full lists — feed the complete (historical) collection below.
 methods_2025_09_03: list[MethodMetadata] = [
     ag_140_metadata,
     ebm_metadata,
@@ -78,29 +91,10 @@ methods_2025_09_03: list[MethodMetadata] = [
     tabflex_metadata,
 ]
 
-methods_2025_09_03_keep: list[MethodMetadata] = [
-    ebm_metadata,
-    limix_metadata,
-    mitra_metadata,
-    realmlp_gpu_metadata,
-    xrfm_metadata,
-    betatabpfn_metadata,
-    tabflex_metadata,
-]
-
-methods_2025_11_01_keep: list[MethodMetadata] = [
-    ag_140_bq_4h8c_metadata,
-    ag_140_eq_4h8c_metadata,
-]
-
 methods_2025_10_20: list[MethodMetadata] = [
     lr_metadata,
     knn_metadata,
     portfolio_metadata_paper_cr,
-]
-
-methods_2025_12_18: list[MethodMetadata] = [
-    ag_150_eq_4h8c_metadata,
 ]
 
 methods_misc: list[MethodMetadata] = [
@@ -115,81 +109,77 @@ methods_tabprep = [
     tabprep_tabm_metadata,  # only first 3 splits
 ]
 
-replaced_methods = [
-    "ExplainableBM",
-    "RealMLP_GPU",
-    "TabDPT_GPU",
-    "AutoGluon_v130",
-]
 updated_methods_camera_ready = [
     "LinearModel",
     "KNeighbors",
     "Portfolio-N200-4h",
 ]
-replaced_methods += updated_methods_camera_ready
-removed_cpu_methods = [
-    "ModernNCA",
-    "TabM",
-    "RealMLP",
-]
-# Present in a run but not part of the paper method set, so kept out of `collection`.
-non_paper_methods = [
-    "Dummy",
-]
-
-# Per-suite "keep" lists = the entries that survive into the latest paper `collection`; everything
-# else from each suite (replaced/CPU-only/non-paper variants) lives only in the complete collection.
-methods_2025_06_12_keep = [
-    m
-    for m in methods_2025_06_12
-    if m.method not in replaced_methods and m.method not in removed_cpu_methods and m.method not in non_paper_methods
-]
-methods_2025_10_20_keep = [lr_metadata, knn_metadata]  # drop Portfolio-N200-4h (not in the paper set)
-methods_2025_11_01_keep = [ag_140_bq_4h8c_metadata]  # AutoGluon_v140_eq_4h8c is not in the paper set
 methods_2025_10_20_camera_ready = [
     m for m in methods_2025_06_12 if m.method not in updated_methods_camera_ready
 ] + methods_2025_10_20
 
 
 # The latest results for each method — exactly the methods in the TabArena paper (one per method),
-# so consumers (e.g. TabArenaContext) can use this directly without a separate name allowlist.
+# each referencing its per-model `info.py` MethodMetadata directly. TabArenaContext uses this
+# collection as-is (no separate name allowlist). To add a newly processed/uploaded method, import its
+# `info.py` metadata above and add it here under the appropriate group.
 tabarena_method_metadata_collection = MethodMetadataCollection(
     method_metadata_lst=[
-        *methods_2025_06_12_keep,
-        *methods_2025_09_03_keep,
-        *methods_2025_10_20_keep,
-        *methods_2025_11_01_keep,
-        *methods_2025_12_18,
+        # AutoGluon
+        ag_140_bq_4h8c_metadata,
+        ag_150_eq_4h8c_metadata,
+        # Default tabular models (CPU)
+        catboost_method_metadata,
+        ebm_metadata,
+        extra_trees_method_metadata,
+        knn_metadata,
+        lightgbm_method_metadata,
+        lr_metadata,
+        fastai_method_metadata,
+        nn_torch_method_metadata,
+        random_forest_method_metadata,
+        xgboost_method_metadata,
+        # Neural / GPU / foundation models
+        mitra_metadata,
+        modernnca_gpu_method_metadata,
+        realmlp_gpu_metadata,
         tabdpt_metadata,
+        tabicl_method_metadata,
+        tabm_gpu_method_metadata,
+        tabpfnv2_gpu_metadata,
+        xrfm_metadata,
+        betatabpfn_metadata,
+        tabflex_metadata,
         realtabpfn25_metadata,
         contexttab_metadata,
         tabiclv2_metadata,
         tabstar_metadata,
         perpetualbooster_metadata,
         tabpfn26_metadata,
-        tabpfnv3_method_metadata,
+        limix_metadata,
         orionmsp_metadata,
+        tabpfnv3_method_metadata,
         iltm_method_metadata,
     ],
 )
 
-# Historical / superseded variants kept only in the complete collection: each is either replaced by
-# a newer entry in `collection` above, CPU-only, an extra AutoGluon preset, or otherwise not in the
-# paper set. Derived from each suite's full list minus its "keep" subset.
-methods_2025_06_12_historical = [m for m in methods_2025_06_12 if m not in methods_2025_06_12_keep]
-methods_2025_09_03_historical = [m for m in methods_2025_09_03 if m not in methods_2025_09_03_keep]
-methods_2025_10_20_historical = [m for m in methods_2025_10_20 if m not in methods_2025_10_20_keep]
-methods_2025_11_01_historical = [m for m in methods_2025_11_01_ag if m not in methods_2025_11_01_keep]
-
-# All historical results for each method = the latest collection + every superseded variant.
-tabarena_method_metadata_complete_collection = tabarena_method_metadata_collection.with_additional_methods(
-    [
-        *methods_2025_06_12_historical,
-        *methods_2025_09_03_historical,
-        *methods_2025_10_20_historical,
-        *methods_2025_11_01_historical,
+# All historical results for each method = the latest collection + every superseded variant: the
+# replaced / CPU-only / extra-AutoGluon-preset / non-paper entries from the dated suite lists (and
+# misc) that the collection above does not keep.
+_collection_methods = tabarena_method_metadata_collection.method_metadata_lst
+methods_historical = [
+    m
+    for m in [
+        *methods_2025_06_12,
+        *methods_2025_09_03,
+        *methods_2025_10_20,
+        *methods_2025_11_01_ag,
         *methods_misc,
-    ],
+    ]
+    if m not in _collection_methods
+]
+tabarena_method_metadata_complete_collection = tabarena_method_metadata_collection.with_additional_methods(
+    methods_historical,
 )
 
 # All historical results for each method

--- a/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
@@ -132,53 +132,64 @@ removed_cpu_methods = [
     "TabM",
     "RealMLP",
 ]
-
-methods_2025_06_12_keep = [
-    m for m in methods_2025_06_12 if m.method not in replaced_methods and m.method not in removed_cpu_methods
+# Present in a run but not part of the paper method set, so kept out of `collection`.
+non_paper_methods = [
+    "Dummy",
 ]
+
+# Per-suite "keep" lists = the entries that survive into the latest paper `collection`; everything
+# else from each suite (replaced/CPU-only/non-paper variants) lives only in the complete collection.
+methods_2025_06_12_keep = [
+    m
+    for m in methods_2025_06_12
+    if m.method not in replaced_methods and m.method not in removed_cpu_methods and m.method not in non_paper_methods
+]
+methods_2025_10_20_keep = [lr_metadata, knn_metadata]  # drop Portfolio-N200-4h (not in the paper set)
+methods_2025_11_01_keep = [ag_140_bq_4h8c_metadata]  # AutoGluon_v140_eq_4h8c is not in the paper set
 methods_2025_10_20_camera_ready = [
     m for m in methods_2025_06_12 if m.method not in updated_methods_camera_ready
 ] + methods_2025_10_20
 
 
-# The latest results for each method
+# The latest results for each method — exactly the methods in the TabArena paper (one per method),
+# so consumers (e.g. TabArenaContext) can use this directly without a separate name allowlist.
 tabarena_method_metadata_collection = MethodMetadataCollection(
-    method_metadata_lst=methods_2025_06_12_keep
-    + methods_2025_09_03_keep
-    + methods_2025_10_20
-    + methods_2025_11_01_keep
-    + methods_2025_12_18
-    + [tabdpt_metadata]
-    + [realtabpfn25_metadata]
-    + [contexttab_metadata]
-    + [tabiclv2_metadata]
-    + [tabstar_metadata]
-    + [perpetualbooster_metadata]
-    + [tabpfn26_metadata]
-    + [tabpfnv3_method_metadata]
-    + [orionmsp_metadata]
-    + [iltm_method_metadata]
-    + methods_misc,
+    method_metadata_lst=[
+        *methods_2025_06_12_keep,
+        *methods_2025_09_03_keep,
+        *methods_2025_10_20_keep,
+        *methods_2025_11_01_keep,
+        *methods_2025_12_18,
+        tabdpt_metadata,
+        realtabpfn25_metadata,
+        contexttab_metadata,
+        tabiclv2_metadata,
+        tabstar_metadata,
+        perpetualbooster_metadata,
+        tabpfn26_metadata,
+        tabpfnv3_method_metadata,
+        orionmsp_metadata,
+        iltm_method_metadata,
+    ],
 )
 
-# All historical results for each method
-tabarena_method_metadata_complete_collection = MethodMetadataCollection(
-    method_metadata_lst=methods_2025_06_12
-    + methods_2025_09_03
-    + methods_2025_10_20
-    + methods_2025_11_01_ag
-    + methods_2025_12_18
-    + [tabdpt_metadata]
-    + [realtabpfn25_metadata]
-    + [contexttab_metadata]
-    + [tabiclv2_metadata]
-    + [tabstar_metadata]
-    + [perpetualbooster_metadata]
-    + [tabpfn26_metadata]
-    + [tabpfnv3_method_metadata]
-    + [orionmsp_metadata]
-    + [iltm_method_metadata]
-    + methods_misc,
+# Historical / superseded variants kept only in the complete collection: each is either replaced by
+# a newer entry in `collection` above, CPU-only, an extra AutoGluon preset, or otherwise not in the
+# paper set. Derived from each suite's full list minus its "keep" subset.
+methods_2025_06_12_historical = [m for m in methods_2025_06_12 if m not in methods_2025_06_12_keep]
+methods_2025_09_03_historical = [m for m in methods_2025_09_03 if m not in methods_2025_09_03_keep]
+methods_2025_10_20_historical = [m for m in methods_2025_10_20 if m not in methods_2025_10_20_keep]
+methods_2025_11_01_historical = [m for m in methods_2025_11_01_ag if m not in methods_2025_11_01_keep]
+
+# All historical results for each method = the latest collection + every superseded variant.
+tabarena_method_metadata_complete_collection = tabarena_method_metadata_collection.with_additional_methods(
+    [
+        *methods_2025_06_12_historical,
+        *methods_2025_09_03_historical,
+        *methods_2025_10_20_historical,
+        *methods_2025_11_01_historical,
+        *methods_misc,
+    ],
 )
 
 # All historical results for each method

--- a/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
+++ b/packages/tabarena/src/tabarena/models/_method_metadata_collection.py
@@ -12,6 +12,15 @@ class MethodMetadataCollection:
     def __init__(self, method_metadata_lst: list[MethodMetadata]):
         self.method_metadata_lst = method_metadata_lst
 
+    def with_additional_methods(self, method_metadata_lst: list[MethodMetadata]) -> MethodMetadataCollection:
+        """Return a new collection: this collection's methods followed by ``method_metadata_lst``.
+
+        Lets a superset collection be derived from a base one by appending extra ``MethodMetadata``
+        (e.g. a complete/historical collection from the latest collection) without rebuilding the
+        base list. The base collection is left unchanged.
+        """
+        return MethodMetadataCollection(method_metadata_lst=[*self.method_metadata_lst, *method_metadata_lst])
+
     def get_method_metadata(
         self,
         method: str,


### PR DESCRIPTION
## Summary

Reworks the TabArena method-metadata collections so the **collection is the paper method set, built directly from per-model `info.py` metadata**, and the **complete collection derives from it** — and removes the now-redundant `_methods_paper` allowlist.

### `MethodMetadataCollection`
- New `with_additional_methods(method_metadata_lst)`: returns a new collection = base methods + extras, leaving the base unchanged. The primitive for deriving a superset collection.

### `contexts/tabarena/methods.py`
- `tabarena_method_metadata_collection` now holds **exactly the 32 paper methods (one per method)**, listed **flat**, each referencing its model's `info.py` `method_metadata` directly (e.g. `catboost_method_metadata`, `nn_torch_method_metadata`, …) instead of splatting per-suite `*_keep` lists. The four non-paper entries (`Dummy`, `Portfolio-N200-4h`, `AutoGluon_v140_eq_4h8c`, `LightGBM_aio_0808`) are no longer in the collection.
  - `TabPFNv2_GPU` is the only collection method without a per-model `info.py` (it's built by the 2025-06-12 factory); it's pulled from the suite list by name.
- `tabarena_method_metadata_complete_collection` now **derives** from the collection: `collection.with_additional_methods(historical)`, where `historical` = the dated suite lists + misc **minus** the collection (the replaced / CPU-only / extra-AutoGluon-preset / non-paper variants). The per-suite `*_keep` lists are removed.

### `contexts/tabarena/context.py`
- Deleted `_methods_paper`; `_resolve_methods_preset` now returns `deepcopy(tabarena_method_metadata_collection.method_metadata_lst)` directly, since the collection *is* the paper set.

### `AGENTS.md`
- Added **step 3** to the process/upload maintainer workflow: register the new method in the appropriate context's collection (for TabArena, import its `info.py` metadata and add it to `tabarena_method_metadata_collection`; it flows into the complete collection automatically).

## Behavior (verified against a pre-change baseline)
- Collection method names **== the paper set** (32; nothing extra or missing).
- Complete collection **unchanged**: same 55 `(method, suite)` pairs (none added/dropped), no duplicates.
- The methods preset resolves to the same set; `_methods_paper` removed.

Per maintainer note, no backwards-compat was kept for scripts importing `tabarena_method_metadata_collection` directly — it's now the trimmed paper set.

## Test plan
- `ruff check` + `ruff format --check` clean on all changed files.
- `pytest tests/tabarena/contexts/test_tabarena_context.py tests/tabarena/models/test_in_memory_method_metadata.py` → 73 passed.
- Baseline diff script confirms collection == paper and complete == old complete (55, no dups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
