### PR TITLE
feat(beyondarena): add grouped_lpg/grouped_lps subset predicates

### DIFF
--- a/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
+++ b/packages/tabarena/src/tabarena/benchmark/task/metadata/collection.py
@@ -552,8 +552,8 @@ class TaskMetadataCollection:
           train size over the dataset's splits — matches :meth:`to_legacy_df`'s
           ``n_samples_train_per_fold``), ``n_features`` (``num_features``), ``n_classes``
           (``num_classes``), ``problem_type``, and the warehouse fields ``task_type``,
-          ``num_cols_after_preprocessing``, ``num_text_cols``, ``num_high_cardinality_cats``
-          (``None`` for tasks that don't carry them, e.g. TabArena v0.1).
+          ``num_cols_after_preprocessing``, ``num_text_cols``, ``num_high_cardinality_cats``,
+          ``group_labels`` (``None`` for tasks that don't carry them, e.g. TabArena v0.1).
         """
         # Predicate-facing grid column -> TabArenaTaskMetadata attribute. Warehouse fields are
         # None for tasks that don't carry them (e.g. TabArena v0.1); BeyondArena populates them.
@@ -565,6 +565,7 @@ class TaskMetadataCollection:
             "num_cols_after_preprocessing": "num_cols_after_preprocessing",
             "num_text_cols": "num_text_cols",
             "num_high_cardinality_cats": "num_high_cardinality_cats",
+            "group_labels": "group_labels",
         }
         cols = ["dataset", "fold", "repeat", "split", "max_train_rows", *grid_col_to_field]
         n_folds_by_dataset: dict[str, int] = {}

--- a/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
@@ -6,7 +6,8 @@ nothing from ``TabArenaContext``, whose only addition over the base is the TabAr
 ``evaluate_all`` workflow). BeyondArena differs from TabArena v0.1 in three ways:
 
 * **Subset predicates** — size buckets keyed on ``max_train_rows``, plus split-regime
-  (``iid``/``temporal``/``grouped``), feature-dimensionality, text and high-cardinality subsets.
+  (``iid``/``temporal``/``grouped``, with ``grouped`` further split by label granularity into
+  ``grouped_lpg``/``grouped_lps``), feature-dimensionality, text and high-cardinality subsets.
 * **Task metadata** — the committed BeyondArena reference CSV, loaded as a
   :class:`~tabarena.benchmark.task.metadata.BeyondArenaTaskMetadataCollection` (whose tasks already
   carry the warehouse fields inline, so no separate ``warehouse_metadata.csv`` merge is needed). The
@@ -74,6 +75,16 @@ class BeyondArenaContext(AbstractArenaContext):
         "random": SubsetPredicate(lambda df: df["task_type"] == "random", ("task_type",)),
         "temporal": SubsetPredicate(lambda df: df["task_type"] == "temporal", ("task_type",)),
         "grouped": SubsetPredicate(lambda df: df["task_type"] == "grouped", ("task_type",)),
+        # grouped tasks split by label granularity: whether the group_on column carries a
+        # label per group (lpg) or per sample (lps).
+        "grouped_lpg": SubsetPredicate(
+            lambda df: (df["task_type"] == "grouped") & (df["group_labels"] == "per_group"),
+            ("task_type", "group_labels"),
+        ),
+        "grouped_lps": SubsetPredicate(
+            lambda df: (df["task_type"] == "grouped") & (df["group_labels"] == "per_sample"),
+            ("task_type", "group_labels"),
+        ),
         # feature dimensionality / type
         "low-dim": SubsetPredicate(
             lambda df: df["num_cols_after_preprocessing"] <= 100, ("num_cols_after_preprocessing",)

--- a/tests/tabarena/benchmark/task/test_task_metadata_collection.py
+++ b/tests/tabarena/benchmark/task/test_task_metadata_collection.py
@@ -121,7 +121,13 @@ class TestNativeViews:
         # TabArena v0.1) so arena-specific predicates (BeyondArena) can read them.
         c = TaskMetadataCollection(_unrolled(_task_meta(dataset_name="a")))
         grid = c.task_grid()
-        for col in ("task_type", "num_cols_after_preprocessing", "num_text_cols", "num_high_cardinality_cats"):
+        for col in (
+            "task_type",
+            "num_cols_after_preprocessing",
+            "num_text_cols",
+            "num_high_cardinality_cats",
+            "group_labels",
+        ):
             assert col in grid.columns
 
     def test_per_dataset_frame_one_row_per_dataset_native_columns(self):

--- a/tests/tabarena/contexts/test_beyond_arena_context.py
+++ b/tests/tabarena/contexts/test_beyond_arena_context.py
@@ -22,7 +22,13 @@ def test_constructs_from_native_collection(ctx):
 
 def test_task_grid_exposes_warehouse_columns(ctx):
     grid = ctx.task_metadata_collection.task_grid()
-    for col in ("task_type", "num_cols_after_preprocessing", "num_text_cols", "num_high_cardinality_cats"):
+    for col in (
+        "task_type",
+        "num_cols_after_preprocessing",
+        "num_text_cols",
+        "num_high_cardinality_cats",
+        "group_labels",
+    ):
         assert col in grid.columns
 
 
@@ -68,6 +74,16 @@ class TestSubsetPredicates:
         combined = preds["iid"](grid) | preds["temporal"](grid) | preds["grouped"](grid)
         assert combined.all()
         assert (preds["random"](grid) == preds["iid"](grid)).all()
+
+    def test_grouped_label_buckets_partition_grouped(self, ctx):
+        grid = ctx.task_metadata_collection.task_grid()
+        preds = ctx.subset_predicates
+        grouped = preds["grouped"](grid)
+        lpg = preds["grouped_lpg"].evaluate(grid, name="grouped_lpg")
+        lps = preds["grouped_lps"].evaluate(grid, name="grouped_lps")
+        assert not (lpg & lps).any()
+        assert (grouped == (lpg | lps)).all()
+        assert lpg.any() and lps.any()
 
     def test_lite_keys_on_split(self, ctx):
         # "lite" == split 0 == (fold 0, repeat 0): one row per dataset on the grid.


### PR DESCRIPTION
## What

Adds two BeyondArena subset predicates that split grouped tasks by **label granularity**:

- `grouped_lpg` — grouped tasks whose `group_on` column carries a label **per group**
- `grouped_lps` — grouped tasks whose `group_on` column carries a label **per sample**

To make this possible, `TaskMetadataCollection.task_grid()` now also exposes the
`group_labels` column. `group_labels` is already a first-class task field
(`GroupLabelTypes` on the task metadata); it just wasn't surfaced to the
subset-predicate grid, so no predicate could filter on it.

## Why

`grouped` today lumps together two materially different regimes: datasets where the
target is a per-sample property vs. a per-group property. Model behavior differs
between them, and the aggregate `grouped` number hides that. These predicates let the
leaderboard be scored separately on each.

## Changes

- `task_grid()`: add `group_labels` to the predicate-facing column set (+ docstring).
- `BeyondArenaContext.SUBSET_PREDICATES`: add `grouped_lpg` / `grouped_lps`, each
  `task_type == "grouped"` AND the corresponding `group_labels` value.

## Tests

- `task_grid` exposes `group_labels` (both the collection-level and BeyondArena-context tests).
- New: `grouped_lpg` / `grouped_lps` are disjoint, each within `grouped`, and together
  partition `grouped` exactly (verified against the committed BeyondArena metadata:
  301 per-group + 251 per-sample = 552 grouped tasks, none missing a label).

All touched tests pass; `ruff check` / `ruff format` clean.