### PR TITLE
feat(beyondarena): add dim_above_500 subset predicate

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
@@ -92,6 +92,9 @@ class BeyondArenaContext(AbstractArenaContext):
         "high-dim": SubsetPredicate(
             lambda df: df["num_cols_after_preprocessing"] > 100, ("num_cols_after_preprocessing",)
         ),
+        "dim_above_500": SubsetPredicate(
+            lambda df: df["num_cols_after_preprocessing"] > 500, ("num_cols_after_preprocessing",)
+        ),
         "text": SubsetPredicate(lambda df: df["num_text_cols"] > 0, ("num_text_cols",)),
         "high-cardinality": SubsetPredicate(
             lambda df: df["num_high_cardinality_cats"] > 0, ("num_high_cardinality_cats",)

--- a/tests/tabarena/contexts/test_beyond_arena_context.py
+++ b/tests/tabarena/contexts/test_beyond_arena_context.py
@@ -85,6 +85,12 @@ class TestSubsetPredicates:
         assert (grouped == (lpg | lps)).all()
         assert lpg.any() and lps.any()
 
+    def test_dim_above_500_is_subset_of_high_dim(self, ctx):
+        grid = ctx.task_metadata_collection.task_grid()
+        preds = ctx.subset_predicates
+        above = preds["dim_above_500"].evaluate(grid, name="dim_above_500")
+        assert (above <= preds["high-dim"](grid)).all()
+
     def test_lite_keys_on_split(self, ctx):
         # "lite" == split 0 == (fold 0, repeat 0): one row per dataset on the grid.
         grid = ctx.task_metadata_collection.task_grid()


### PR DESCRIPTION
## What

Adds a `dim_above_500` BeyondArena subset predicate: `num_cols_after_preprocessing > 500`.

## Why

`high-dim` (>100 preprocessed columns) is a broad bucket. `dim_above_500` isolates
the genuinely wide datasets for separate leaderboard scoring.

## Changes

- `BeyondArenaContext.SUBSET_PREDICATES`: add `dim_above_500`. It reads
  `num_cols_after_preprocessing`, already exposed on the predicate grid, so no
  `task_grid` change is required.

## Tests

- New: `dim_above_500` is a subset of `high-dim` (>500 implies >100) and evaluates
  cleanly on the task grid.

`ruff check` / `ruff format` clean.