### PR TITLE
Rerun ChimeraBoost with pre-compiles

### DIFF
--- a/packages/tabarena/src/tabarena/evaluation/_eval_common.py
+++ b/packages/tabarena/src/tabarena/evaluation/_eval_common.py
@@ -45,6 +45,18 @@ class MethodArtifact:
     only_load_cache: bool = False
     """If True, skip raw->cache post-processing and load the existing cache instead."""
 
+    @property
+    def method_name(self) -> str:
+        """Cache method identity: ``ag_name`` with ``result_suffix`` baked in.
+
+        The suffix is part of the method's *identity*, not just its result rows: it names the
+        cache dir (``{suite}/methods/{method_name}``), is stamped as ``ta_name``, and is the
+        name the method registers under on an arena context — so a re-run of a method that is
+        already a registered baseline (e.g. ``"ChimeraBoost"`` vs ``"ChimeraBoost [Rerun]"``)
+        does not collide with it at registration.
+        """
+        return self.ag_name + (self.result_suffix or "")
+
 
 def init_caches(
     tabarena_cache_path: str | None = None,
@@ -114,7 +126,7 @@ def post_process_to_results(
 
     1. **Cache:** for each non-``only_load_cache`` method, ``EndToEnd.from_path_raw``
        processes the raw ``results.pkl`` files into per-task results and writes them to the cache
-       (keyed by ``(suite, ag_name)``). ``task_metadata`` is a native
+       (keyed by ``(suite, method_name)``). ``task_metadata`` is a native
        :class:`~tabarena.benchmark.task.metadata.TaskMetadataCollection`, forwarded so custom (e.g.
        BeyondArena) task sets match correctly; pass ``None`` to infer it from the results.
     2. **Load:** every method is (re-)loaded from the cache via ``EndToEndResults.from_cache`` — in
@@ -132,14 +144,14 @@ def post_process_to_results(
             path_raw=ma.path_raw,
             name_prefix_raw=ma.ag_name,
             name_suffix=ma.result_suffix,
-            method=ma.ag_name,
+            method=ma.method_name,
             suite=ma.suite,
             task_metadata=task_metadata,
             num_cpus=num_cpus,
         )
 
-    # Phase 2: re-load every method from the cache (one (ag_name, suite) per artifact).
-    return EndToEndResults.from_cache(methods=[(ma.ag_name, ma.suite) for ma in method_artifacts])
+    # Phase 2: re-load every method from the cache (one (method_name, suite) per artifact).
+    return EndToEndResults.from_cache(methods=[(ma.method_name, ma.suite) for ma in method_artifacts])
 
 
 def subset_label(subset: list[str]) -> str:

--- a/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
+++ b/packages/tabarena/src/tabarena/evaluation/benchmark_eval.py
@@ -41,9 +41,12 @@ class EvalMethod:
     result_suffix: str | None = None
     """Optional suffix appended to this method's name in the leaderboard, e.g.
     `" [Rerun]"` renders ``TabPFN-3`` as ``TabPFN-3 [Rerun]``. Useful to distinguish
-    a re-run from the original TabArena baseline. Baked into the cached results at
-    post-processing time (via the engine's ``name_suffix``); for ``only_load_cache``
-    the cache must already have been built with the same suffix."""
+    a re-run from the original TabArena baseline. Part of the method's *identity*: it is
+    baked into the cached result rows (via the engine's ``name_suffix``) and into the cache
+    method name / ``ta_name`` (see ``MethodArtifact.method_name``), which is the name the
+    method registers under on the context — required for a re-run, since registering the
+    bare name of an existing baseline collides. For ``only_load_cache`` the cache must
+    already have been built with the same suffix."""
 
     @property
     def ag_name(self) -> str:

--- a/packages/tabarena/src/tabarena/models/chimeraboost/info.py
+++ b/packages/tabarena/src/tabarena/models/chimeraboost/info.py
@@ -5,6 +5,10 @@ from tabarena.models._model_info import ModelInfo
 from tabarena.models.chimeraboost.hpo import gen_chimeraboost
 from tabarena.models.chimeraboost.model import ChimeraBoostModel
 
+# Superseded 2026-06-16 run (suite ``tabarena-2026-06-30``): benchmarked before the untimed
+# environment warm-up API existed, so its fit times include ChimeraBoost's numba JIT compilation.
+# Kept so the hosted artifacts stay loadable for comparison; the warm-started rerun is described
+# by ``chimeraboost_new_method_metadata`` below.
 chimeraboost_method_metadata = MethodMetadata.config(
     method="ChimeraBoost",
     ag_key="CHIMERA",
@@ -21,9 +25,29 @@ chimeraboost_method_metadata = MethodMetadata.config(
     cache_kwargs={"bucket": "tabarena", "prefix": "cache"},  # only if uploading (s3 adds "upload_as_public": True)
 )
 
+# Rerun with the untimed environment warm-up (``ChimeraBoostModel.warmup`` pre-compiles the numba
+# kernels outside the timed fit) — the ChimeraBoost used by TabArena going forward once processed
+# and uploaded. ``(method, suite)`` is the unique artifact key, so the new suite keeps these
+# results separate from the superseded run above.
+chimeraboost_new_method_metadata = MethodMetadata.config(
+    method="ChimeraBoost",
+    ag_key="CHIMERA",
+    compute="cpu",
+    is_bag=True,
+    can_hpo=True,
+    config_default="ChimeraBoost_c1_default_BAG_L1",
+    suite="tabarena-2026-07-13",
+    date="2026-07-13",
+    reference_url="https://github.com/bbstats/chimeraboost",
+    display_name="ChimeraBoost",
+    verified=True,
+    cache_type="r2",  # one of: "local", "r2", "s3"
+    cache_kwargs={"bucket": "tabarena", "prefix": "cache"},  # only if uploading (s3 adds "upload_as_public": True)
+)
+
 chimeraboost_info = ModelInfo(
     model_cls=ChimeraBoostModel,
     search_space=gen_chimeraboost,
-    method_metadata=chimeraboost_method_metadata,
-    pip_extra=("chimeraboost>=0.14.1",),  # 0.14.1 adds chimeraboost.warmup()
+    method_metadata=chimeraboost_new_method_metadata,
+    pip_extra=("chimeraboost>=0.14.1",),
 )

--- a/packages/tabflow_slurm/BENCHMARK_LOG.md
+++ b/packages/tabflow_slurm/BENCHMARK_LOG.md
@@ -33,6 +33,56 @@ run against `main`. To reproduce an entry, check out its recorded **git SHA**.
 
 ---
 
+## 2026-07-13 — chimeraboost_13072026
+
+- **Model(s):** ChimeraBoost (all configs)
+- **Git SHA:** `99d494d3` (+ the `add_chimera_fast` metadata split: rerun recorded under
+  `chimeraboost_new_method_metadata`, suite `tabarena-2026-07-13`)
+- **Purpose:** Rerun of `benchmark_chimeraboost_16062026` with the untimed environment warm-up
+  API (#441): the original run's fit times include ChimeraBoost's numba JIT compilation (~10s per
+  cold environment). `ChimeraBoostModel.warmup` now pre-compiles the kernels untimed (warm-up is
+  on by default in the experiment runner) and numba's disk cache carries them into fold workers.
+- **Notes:** Mirrors the original run's shape for comparable timings: full task set (all splits),
+  default config + full 200-config HPO space, CPU partition `cpun416mtspotinteractive`
+  (16 vCPUs, 64 GB RAM, 0 GB VRAM), `memory_limit`/`num_cpus` left `None` so node values are
+  picked up, bundle size 10. Extra dep in the run venv: `chimeraboost>=0.14.1` (adds
+  `chimeraboost.warmup()`). New `(method, suite)` key keeps results separate from the superseded
+  suite `tabarena-2026-06-30`, which stays registered in the arena collection until the rerun is
+  processed/uploaded (the upload step swaps the registration).
+
+```python
+from tabarena.benchmark.experiment import TabArenaV0pt1ExperimentBundle
+from tabarena.benchmark.task.metadata import TaskSubset
+from tabarena.contexts import TabArenaContext
+from tabflow_slurm import (
+    GCPSlurmSetup,
+    ModelJob,
+    PathSetup,
+    TabArenaBenchmarkPlan,
+    TabArenaV0pt1ResourcesSetup,
+)
+
+plan = TabArenaBenchmarkPlan(
+    benchmark_name="chimeraboost_13072026",
+    model_jobs=[
+        ModelJob(models=("ChimeraBoost", "all"), name="cpu"),
+    ],
+    context=TabArenaContext(),
+    task_subset=TaskSubset(),  # all splits of every task (full rerun, like the original)
+    experiment_bundle=TabArenaV0pt1ExperimentBundle(model_verbosity=2),
+    path_setup=PathSetup(
+        workspace="/home/lennart_priorlabs_ai/workspace/benchmarking/tabarena_workspace",
+        python_path="/home/lennart_priorlabs_ai/.venvs/tabarena_18062026/bin/python",
+    ),
+    resources_setup=TabArenaV0pt1ResourcesSetup(num_cpus=None, memory_limit=None),
+    # Same CPU partition as the original run (16 vCPUs, 64 GB RAM) for comparable timings.
+    scheduler_setup=GCPSlurmSetup(bundle_size=10, cpu_partition="cpun416mtspotinteractive"),
+)
+plan.setup_jobs()
+```
+
+---
+
 ## 2026-07-07 — tabfmplus_07072026
 
 - **Model(s):** TabFM+ (system — single default config, 0 random)

--- a/packages/tabflow_slurm/src/tabflow_slurm/submit_template.sh
+++ b/packages/tabflow_slurm/src/tabflow_slurm/submit_template.sh
@@ -44,6 +44,13 @@ echo "Memory Limit: $MEMORY_LIMIT"
 echo "Setup Ray for SLURM Shared Resources Environment: $SETUP_RAY"
 echo "Ignore Cache: $IGNORE_CACHE"
 
+# Node-local numba JIT cache.
+export NUMBA_CACHE_DIR="${TMPDIR:-/tmp}/numba_cache_${SLURM_JOB_ID}"
+# Same treatment for the GPU JIT caches
+export TRITON_CACHE_DIR="${TMPDIR:-/tmp}/triton_cache_${SLURM_JOB_ID}"
+export CUDA_CACHE_PATH="${TMPDIR:-/tmp}/nv_cache_${SLURM_JOB_ID}"
+mkdir -p "$NUMBA_CACHE_DIR" "$TRITON_CACHE_DIR" "$CUDA_CACHE_PATH"
+
 run_one() {
     local EXPERIMENT="$1"
     local DATASET="$2"

--- a/tests/tabarena/evaluation/test_benchmark_eval.py
+++ b/tests/tabarena/evaluation/test_benchmark_eval.py
@@ -30,6 +30,18 @@ class TestEvalMethod:
         assert EvalMethod("RandomForest", ag_name_override="RF").ag_name == "RF"
 
 
+class TestMethodArtifact:
+    def test_method_name_bakes_in_result_suffix(self):
+        """The suffix is part of the cache identity, so a re-run of a registered baseline
+        registers under a distinct name instead of colliding on the bare method name.
+        """
+        from tabarena.evaluation._eval_common import MethodArtifact
+
+        kwargs = {"ag_name": "RF", "path_raw": Path("/raw"), "suite": "bench"}
+        assert MethodArtifact(**kwargs).method_name == "RF"
+        assert MethodArtifact(**kwargs, result_suffix=" [Rerun]").method_name == "RF [Rerun]"
+
+
 class TestConfig:
     def test_path_raw_is_output_dir_data(self):
         cfg = _config(Path("/base"), output_dir="/x/out/bench")
@@ -131,16 +143,18 @@ def test_run_eval_orchestration(tmp_path, monkeypatch):
     )
     out = run_eval(cfg)
 
-    # Phase 1: only the non-cache-only method is post-processed, with the suffix baked in.
+    # Phase 1: only the non-cache-only method is post-processed. The raw-folder match uses the
+    # bare ag_name; the suffix is baked into both the result rows (name_suffix) and the cache
+    # method identity (method), so a re-run registers under a distinct name from the original.
     assert len(post_calls) == 1
     assert post_calls[0]["name_prefix_raw"] == "AG_A"
-    assert post_calls[0]["method"] == "AG_A"
+    assert post_calls[0]["method"] == "AG_A [Rerun]"
     assert post_calls[0]["suite"] == "bench"
     assert post_calls[0]["name_suffix"] == " [Rerun]"
     assert Path(post_calls[0]["path_raw"]) == cfg.path_raw
 
-    # Phase 2: every method is re-loaded from cache as (ag_name, suite), exactly once.
-    assert from_cache_calls == [[("AG_A", "bench"), ("AG_B", "bench")]]
+    # Phase 2: every method is re-loaded from cache as (method_name, suite), exactly once.
+    assert from_cache_calls == [[("AG_A [Rerun]", "bench"), ("AG_B", "bench")]]
 
     # The context is built once, with the run's vended methods registered via extra_methods=,
     # and the config's only_valid_tasks forwarded through.


### PR DESCRIPTION
FYI @bbstats, I started a new run with warm-up logic. 

Here are the results for the default config compared to the old, does that make sense to you?



Leaderboard rows: 
```

##### Leaderboard [full]
|   # | Model                                             |   Elo [⬆️] | Elo 95% CI   |   Score [⬆️] |   Rank [⬇️] |   Harmonic Rank [⬇️] |   Improvability (%) [⬇️] |   Median Train Time (s/1K) [⬇️] |   Median Predict Time (s/1K) [⬇️] | Verified   |   Imputed (%) [⬇️] | Imputed   | Hardware   |
|----:|:--------------------------------------------------|-----------:|:-------------|-------------:|------------:|---------------------:|-------------------------:|--------------------------------:|----------------------------------:|:-----------|-------------------:|:----------|:-----------|

|  22 | CatBoost (default)                                |       1353 | +37/-39      |        0.23  |       30.88 |                18.57 |                   15.594 |                            6.83 |                             0.08  | Unknown    |               0    | False     | Unknown    |


|  42 | CHIMERA [NEW] (default)                           |       1251 | +43/-52      |        0.134 |       39.97 |                25.9  |                   18.682 |                           22.21 |                             0.033 | Unknown    |               0    | False     | Unknown    |
|  43 | CHIMERA (default)                                 |       1246 | +44/-54      |        0.131 |       40.47 |                26.44 |                   18.772 |                           10.45 |                             2.617 | Unknown    |               0    | False     | Unknown    |


```


It looks a bit weird to me that it takes longer to train now. Unclear where this might be coming from

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
