### PR TITLE
Add AbstractEnsembler interface: swappable ensemble selection for simulation

### DIFF
--- a/packages/tabarena/src/tabarena/repository/ensemble_mixin.py
+++ b/packages/tabarena/src/tabarena/repository/ensemble_mixin.py
@@ -292,7 +292,11 @@ class EnsembleMixin:
         # fit the ensemble and retrieve the metric error and ensemble weights
         results = scorer.compute_errors(configs=configs_to_use)
         metric_error = results[task]["metric_error"]
-        ensemble_weights = results[task]["ensemble_weights"]
+        # weights are None for ensemblers that are not weight-based (see AbstractEnsembler)
+        ensemble_weights = results[task].get("ensemble_weights")
+        models_used = results[task].get("ensemble_models_used")
+        if models_used is None:
+            models_used = [w != 0 for w in ensemble_weights]
         metric_error_val = results[task]["metric_error_val"]
         aux_metric_error = results[task].get("aux_metric_error")
         aux_metric_error_val = results[task].get("aux_metric_error_val")
@@ -318,8 +322,9 @@ class EnsembleMixin:
         )
         time_train_s = sum(runtimes.values())
 
-        # compute the ensemble time_infer_s by summing all considered config's time_infer_s that have non-zero weight
-        config_selected_ensemble = [config for i, config in enumerate(configs_to_use) if ensemble_weights[i] != 0]
+        # compute the ensemble time_infer_s by summing the time_infer_s of the configs the
+        # fitted ensemble needs at inference (for weighted ensembles: non-zero weight)
+        config_selected_ensemble = [config for config, used in zip(configs_to_use, models_used, strict=True) if used]
 
         config_metrics_inference = config_metrics[config_metrics["framework"].isin(config_selected_ensemble)]
 
@@ -355,6 +360,9 @@ class EnsembleMixin:
             output_dict["rank"] = [rank_list]
 
         multiindex = pd.MultiIndex.from_tuples([(dataset, fold)], names=["dataset", "fold"])
+        if ensemble_weights is None:
+            # non-weight-based ensembler: no weights to report
+            ensemble_weights = np.full(len(configs_to_use), np.nan)
         df_ensemble_weights = pd.DataFrame(data=[ensemble_weights], index=multiindex, columns=configs_to_use)
         df_out = pd.DataFrame(data=output_dict, index=multiindex)
 

--- a/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
@@ -5,11 +5,19 @@ from tabarena.simulation.ensemble.abstract_ensembler import (
     LegacyEnsemblerAdapter,
     WeightedEnsembler,
 )
+from tabarena.simulation.ensemble.basic_ensemblers import (
+    FixedWeightsEnsembler,
+    SingleBestEnsembler,
+    TopKAverageEnsembler,
+)
 from tabarena.simulation.ensemble.greedy_ensembler import GreedyEnsembler
 
 __all__ = [
     "AbstractEnsembler",
+    "FixedWeightsEnsembler",
     "GreedyEnsembler",
     "LegacyEnsemblerAdapter",
+    "SingleBestEnsembler",
+    "TopKAverageEnsembler",
     "WeightedEnsembler",
 ]

--- a/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from tabarena.simulation.ensemble.abstract_ensembler import (
+    AbstractEnsembler,
+    LegacyEnsemblerAdapter,
+    WeightedEnsembler,
+)
+from tabarena.simulation.ensemble.greedy_ensembler import GreedyEnsembler
+
+__all__ = [
+    "AbstractEnsembler",
+    "GreedyEnsembler",
+    "LegacyEnsemblerAdapter",
+    "WeightedEnsembler",
+]

--- a/packages/tabarena/src/tabarena/simulation/ensemble/abstract_ensembler.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/abstract_ensembler.py
@@ -1,0 +1,183 @@
+"""The ensembler interface used by TabArena's ensemble simulation.
+
+An *ensembler* combines the predictions of already-fitted base models on a single task.
+It is the swappable unit of :class:`~tabarena.simulation.ensemble_selection_config_scorer.EnsembleScorer`:
+implement :class:`AbstractEnsembler` (or, for weighted combinations,
+:class:`WeightedEnsembler`) and pass the class via ``ensembler_cls`` to plug an
+alternative post-hoc ensembling method into the simulation.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+import numpy as np
+from autogluon.core.utils import get_pred_from_proba
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from autogluon.core.metrics import Scorer
+
+
+class AbstractEnsembler(ABC):
+    """Fits an ensemble over base-model *predictions* (not features) for one task.
+
+    Data format
+    -----------
+    ``predictions`` is an array-like of per-model predictions, shape
+    ``(n_models, n_samples)`` or ``(n_models, n_samples, n_classes)``, in the space the
+    fit ``metric`` consumes. Note that this space can be a *metric-preprocessed view* of
+    the original problem: e.g. for log_loss the simulation feeds ground-truth-class
+    probabilities (1-D per model) with ``problem_type="binary"``. Such transformed views
+    are only valid to combine linearly, which is what the :attr:`linear` flag declares.
+
+    Lifecycle
+    ---------
+    Construct with ``(problem_type, metric, **method_kwargs)``, then ``fit`` once on the
+    optimization split and ``predict``/``predict_proba`` on any split. ``model_weights``
+    / ``models_used`` / ``info`` report the fitted ensemble back to the simulation (they
+    drive the ``ensemble_weights`` result column and the inference-time accounting).
+
+    Parameters
+    ----------
+    problem_type : str
+        The problem type the predictions are in (after any metric preprocessing).
+    metric : Scorer
+        The metric to optimize, in AutoGluon ``Scorer`` format. ``metric.error`` is the
+        lower-is-better objective.
+    """
+
+    linear: bool = True
+    """Whether :meth:`predict_proba` is a fixed linear combination of the input
+    predictions. Non-linear ensemblers (e.g. stacking) must set this to ``False``; they
+    are rejected when the simulation feeds metric-preprocessed prediction spaces, where
+    only linear combinations are meaningful."""
+
+    def __init__(self, *, problem_type: str, metric: Scorer):
+        self.problem_type = problem_type
+        self.metric = metric
+        self.n_models_: int | None = None
+
+    def fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> Self:
+        """Fit the ensemble on the optimization split. Returns ``self``."""
+        self.n_models_ = len(predictions)
+        self._fit(predictions=predictions, labels=labels, time_limit=time_limit)
+        return self
+
+    @abstractmethod
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None: ...
+
+    @abstractmethod
+    def predict_proba(self, predictions: np.ndarray) -> np.ndarray:
+        """Combined prediction, in the same space as the per-model inputs."""
+        ...
+
+    def predict(self, predictions: np.ndarray, *, problem_type: str | None = None) -> np.ndarray:
+        """Combined prediction converted to label space.
+
+        ``problem_type`` overrides the fit-time problem type: the caller may have fitted
+        on a metric-preprocessed view (e.g. ``"binary"`` ground-truth-class
+        probabilities) but need label-space predictions for the original problem.
+        """
+        y_pred_proba = self.predict_proba(predictions)
+        if problem_type is None:
+            problem_type = self.problem_type
+        return get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=problem_type)
+
+    # -------------------------
+    # Reporting surface
+    # -------------------------
+    def model_weights(self) -> np.ndarray | None:
+        """Per-model linear weights of the fitted ensemble, or ``None`` if the method is
+        not weight-based. Drives the ``ensemble_weights`` result column.
+        """
+        return None
+
+    def models_used(self) -> np.ndarray:
+        """Boolean mask of models required at inference time, aligned with the fit-time
+        model order. Drives the ensemble's ``time_infer_s`` accounting. Defaults to
+        ``model_weights() != 0``; ensemblers without weights report all models used and
+        should override when they can do better.
+        """
+        weights = self.model_weights()
+        if weights is None:
+            return np.ones(self.n_models_, dtype=bool)
+        return np.asarray(weights) != 0
+
+    def info(self) -> dict:
+        """Optional extra payload describing the fitted ensemble (surfaced as
+        ``ensemble_info`` in task results when non-empty).
+        """
+        return {}
+
+    # -------------------------
+    # Helpers for subclasses
+    # -------------------------
+    def _score_error(self, labels: np.ndarray, y_pred_proba: np.ndarray) -> float:
+        """The metric error (lower is better) of a combined prediction, converting to
+        label space first when the metric requires class predictions.
+        """
+        metric = self.metric
+        if metric.needs_pred or metric.needs_quantile:
+            y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=self.problem_type)
+            return metric.error(labels, y_pred)
+        return metric.error(labels, y_pred_proba)
+
+
+class WeightedEnsembler(AbstractEnsembler):
+    """Base class for ensemblers whose prediction is a fixed weighted sum.
+
+    Subclasses set ``self.weights_`` (one weight per model) in ``_fit``.
+    """
+
+    weights_: np.ndarray
+
+    def predict_proba(self, predictions: np.ndarray) -> np.ndarray:
+        # Identical arithmetic to AutoGluon's AbstractWeightedEnsemble.weight_pred_probas,
+        # so results are bit-for-bit interchangeable with the historical implementation.
+        preds_norm = [pred * weight for pred, weight in zip(predictions, self.weights_, strict=False) if weight != 0]
+        return np.sum(preds_norm, axis=0)
+
+    def model_weights(self) -> np.ndarray | None:
+        return np.asarray(self.weights_)
+
+
+class LegacyEnsemblerAdapter(AbstractEnsembler):
+    """Adapts a pre-interface ensemble class (AutoGluon ``AbstractWeightedEnsemble``
+    style: ``cls(problem_type=..., metric=..., **kwargs)`` with ``fit(predictions,
+    labels)``, ``predict``/``predict_proba`` reading ``self.problem_type``, and an
+    optional ``weights_`` attribute) to :class:`AbstractEnsembler`.
+
+    Kept so ``ensemble_method``-style callers (deprecated) continue to work unchanged.
+    """
+
+    def __init__(self, *, problem_type: str, metric: Scorer, ensemble_cls: type, ensemble_kwargs: dict | None = None):
+        super().__init__(problem_type=problem_type, metric=metric)
+        self._ensemble = ensemble_cls(problem_type=problem_type, metric=metric, **(ensemble_kwargs or {}))
+
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
+        # list() guard: AutoGluon's EnsembleSelection._fit mutates the sequence in place
+        # when subsampling is triggered.
+        self._ensemble.fit(predictions=list(predictions), labels=labels)
+
+    def predict_proba(self, predictions: np.ndarray) -> np.ndarray:
+        return self._ensemble.predict_proba(predictions)
+
+    def predict(self, predictions: np.ndarray, *, problem_type: str | None = None) -> np.ndarray:
+        # Legacy classes read self.problem_type inside predict; override it for the call.
+        if problem_type is None or problem_type == self._ensemble.problem_type:
+            return self._ensemble.predict(predictions)
+        original_problem_type = self._ensemble.problem_type
+        self._ensemble.problem_type = problem_type
+        try:
+            return self._ensemble.predict(predictions)
+        finally:
+            self._ensemble.problem_type = original_problem_type
+
+    def model_weights(self) -> np.ndarray | None:
+        weights = getattr(self._ensemble, "weights_", None)
+        if weights is None:
+            return None
+        return np.asarray(weights)

--- a/packages/tabarena/src/tabarena/simulation/ensemble/basic_ensemblers.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/basic_ensemblers.py
@@ -1,0 +1,73 @@
+"""Reference :class:`~tabarena.simulation.ensemble.AbstractEnsembler` implementations.
+
+These are small, useful-in-practice methods that double as templates for plugging custom
+post-hoc ensembling into the simulation: pass one via ``ensembler_cls`` (plus
+``ensembler_kwargs``) to :class:`~tabarena.simulation.ensemble_selection_config_scorer.EnsembleScorer`
+or ``repo.evaluate_ensemble(ensemble_kwargs={"ensembler_cls": ..., "ensembler_kwargs": ...})``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tabarena.simulation.ensemble.abstract_ensembler import WeightedEnsembler
+
+if TYPE_CHECKING:
+    from autogluon.core.metrics import Scorer
+
+
+class SingleBestEnsembler(WeightedEnsembler):
+    """Selects the single model with the best validation metric error (no ensembling)."""
+
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
+        errors = [self._score_error(labels, pred) for pred in predictions]
+        self.best_index_ = int(np.nanargmin(errors))
+        weights = np.zeros(len(predictions))
+        weights[self.best_index_] = 1.0
+        self.weights_ = weights
+
+    def info(self) -> dict:
+        return {"best_index": self.best_index_}
+
+
+class TopKAverageEnsembler(WeightedEnsembler):
+    """Uniform average of the ``k`` models with the best validation metric error.
+
+    Parameters
+    ----------
+    k : int, default 5
+        Number of models to average; capped at the number of available models.
+    """
+
+    def __init__(self, *, problem_type: str, metric: Scorer, k: int = 5):
+        super().__init__(problem_type=problem_type, metric=metric)
+        assert k >= 1
+        self.k = k
+
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
+        errors = np.array([self._score_error(labels, pred) for pred in predictions])
+        k = min(self.k, len(predictions))
+        top_k = np.argsort(errors, kind="stable")[:k]
+        weights = np.zeros(len(predictions))
+        weights[top_k] = 1.0 / k
+        self.weights_ = weights
+
+
+class FixedWeightsEnsembler(WeightedEnsembler):
+    """Applies user-provided per-model weights; nothing is fitted.
+
+    Parameters
+    ----------
+    weights : array-like of float
+        One weight per model, in the model order the simulation passes predictions in.
+    """
+
+    def __init__(self, *, problem_type: str, metric: Scorer, weights):
+        super().__init__(problem_type=problem_type, metric=metric)
+        self.weights_ = np.asarray(weights, dtype=np.float64)
+
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
+        if len(self.weights_) != len(predictions):
+            raise ValueError(f"FixedWeightsEnsembler got {len(self.weights_)} weights for {len(predictions)} models")

--- a/packages/tabarena/src/tabarena/simulation/ensemble/greedy_ensembler.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/greedy_ensembler.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tabarena.simulation.ensemble.abstract_ensembler import WeightedEnsembler
+
+if TYPE_CHECKING:
+    import numpy as np
+    from autogluon.core.metrics import Scorer
+
+
+class GreedyEnsembler(WeightedEnsembler):
+    """Greedy weighted ensemble selection (Caruana et al., 2004) — the default TabArena
+    post-hoc ensembling method.
+
+    Thin adapter around AutoGluon's
+    :class:`~autogluon.core.models.greedy_ensemble.ensemble_selection.EnsembleSelection`,
+    which performs the actual selection; results are identical to using that class
+    directly.
+
+    Parameters
+    ----------
+    ensemble_size : int, default 100
+        Maximum number of greedy selection iterations.
+    **ensemble_selection_kwargs
+        Forwarded to ``EnsembleSelection`` (e.g. ``tie_breaker``, ``subsample_size``,
+        ``random_state``).
+    """
+
+    def __init__(self, *, problem_type: str, metric: Scorer, ensemble_size: int = 100, **ensemble_selection_kwargs):
+        super().__init__(problem_type=problem_type, metric=metric)
+        self.ensemble_size = ensemble_size
+        self._ensemble_selection_kwargs = ensemble_selection_kwargs
+        self._selection = None
+
+    def _fit(self, *, predictions: np.ndarray, labels: np.ndarray, time_limit: float | None = None) -> None:
+        from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
+
+        self._selection = EnsembleSelection(
+            ensemble_size=self.ensemble_size,
+            problem_type=self.problem_type,
+            metric=self.metric,
+            **self._ensemble_selection_kwargs,
+        )
+        # list() guard: EnsembleSelection._fit mutates the sequence in place when
+        # subsampling is triggered.
+        self._selection.fit(predictions=list(predictions), labels=labels, time_limit=time_limit)
+        self.weights_ = self._selection.weights_

--- a/packages/tabarena/src/tabarena/simulation/ensemble_scorer_calibrated.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble_scorer_calibrated.py
@@ -142,13 +142,13 @@ class EnsembleScorerCalibrated(EnsembleScorerMaxModels):
 
         pred_val, pred_test = self.get_preds_from_models(dataset=dataset, fold=fold, models=models)
 
-        # Choose ensemble method/kwargs via hooks
-        ensemble_method = self.get_ensemble_method_for_task(dataset=dataset, fold=fold, models=models)
-        ensemble_kwargs = self.get_ensemble_method_kwargs_for_task(dataset=dataset, fold=fold, models=models)
+        # Choose ensembler via hooks
+        ensembler_cls = self.get_ensembler_cls_for_task(dataset=dataset, fold=fold, models=models)
+        ensembler_kwargs = self.get_ensembler_kwargs_for_task(dataset=dataset, fold=fold, models=models)
 
         evaluator = self.evaluator_cls(
-            ensemble_method=ensemble_method,
-            ensemble_kwargs=ensemble_kwargs,
+            ensembler_cls=ensembler_cls,
+            ensembler_kwargs=ensembler_kwargs,
             eval_metric=eval_metric,
             fit_eval_metric=fit_eval_metric,
             problem_type=problem_type,
@@ -203,13 +203,17 @@ class EnsembleScorerCalibrated(EnsembleScorerMaxModels):
         if self.return_metric_error_val:
             results["metric_error_val"] = evaluator.error(y=y_val_proc, y_pred=y_val_pred)
 
-        if hasattr(ensemble, "weights_"):
-            weights = ensemble.weights_
-            ensemble_weights_fixed = np.zeros(len(models_og), dtype=np.float64)
-            ensemble_weights_fixed[models_filtered_idx] = weights
-            results["ensemble_weights"] = ensemble_weights_fixed
+        weights = ensemble.model_weights()
+        if weights is not None:
+            results["ensemble_weights"] = weights
+        results["ensemble_models_used"] = ensemble.models_used()
+        ensemble_info = ensemble.info()
+        if ensemble_info:
+            results["ensemble_info"] = ensemble_info
 
-        return results
+        return self._remap_ensemble_results_to_models(
+            results, models_og=models_og, models_filtered_idx=models_filtered_idx
+        )
 
 
 class EnsembleScorerCalibratedCV(EnsembleScorerCalibrated):

--- a/packages/tabarena/src/tabarena/simulation/ensemble_selection_config_scorer.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble_selection_config_scorer.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from autogluon.core.metrics import Scorer, get_metric
-from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
 
 from tabarena.metrics import _fast_log_loss
+from tabarena.simulation.ensemble import AbstractEnsembler, GreedyEnsembler, LegacyEnsemblerAdapter
 from tabarena.utils import task_to_tid_fold
 from tabarena.utils.aux_metric import get_aux_metric_map
 from tabarena.utils.parallel_for import parallel_for
@@ -76,9 +76,19 @@ def get_fast_rmse() -> Scorer:
     return fast_rmse
 
 
+def _accepts_kwarg(cls: type, name: str) -> bool:
+    """Whether ``cls.__init__`` accepts a keyword argument ``name`` (directly or via **kwargs)."""
+    import inspect
+
+    parameters = inspect.signature(cls.__init__).parameters
+    if name in parameters:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+
+
 class TaskEvaluator:
     """Minimal per-task evaluator:
-      - knows how to fit an ensemble given (y_train, pred_train)
+      - knows how to fit an ensembler given (y_train, pred_train)
       - knows how to predict/score given (y, pred)
     It does NOT know anything about repo/dataset/fold/models or optimize_on.
     """
@@ -86,19 +96,18 @@ class TaskEvaluator:
     def __init__(
         self,
         *,
-        ensemble_method: type,
-        ensemble_kwargs: dict,
+        ensembler_cls: type[AbstractEnsembler],
+        ensembler_kwargs: dict | None = None,
         eval_metric: Scorer,
         fit_eval_metric: Scorer,
         problem_type: str,
         aux_eval_metric: Scorer | None = None,
     ):
-        self._ensemble_method = ensemble_method
-        self._ensemble_kwargs = ensemble_kwargs
+        self._ensembler_cls = ensembler_cls
+        self._ensembler_kwargs = ensembler_kwargs if ensembler_kwargs is not None else {}
         self._eval_metric = eval_metric
         self._fit_eval_metric = fit_eval_metric
         self._aux_eval_metric = aux_eval_metric
-        self._predict_problem_type = getattr(eval_metric, "post_problem_type", problem_type)
         self._fit_problem_type = getattr(fit_eval_metric, "post_problem_type", problem_type)
         self.problem_type = problem_type
 
@@ -108,25 +117,35 @@ class TaskEvaluator:
             y, pred = metric.preprocess_bulk(y, pred)
         return y, pred
 
-    def init_ens(self):
-        return self._ensemble_method(
+    def init_ens(self) -> AbstractEnsembler:
+        ensembler = self._ensembler_cls(
             problem_type=self._fit_problem_type,
             metric=self._fit_eval_metric,
-            **self._ensemble_kwargs,
+            **self._ensembler_kwargs,
         )
+        if not ensembler.linear:
+            # Metric-preprocessed prediction spaces (marked by `post_problem_type`, e.g.
+            # log_loss ground-truth-class probabilities) are only valid to combine
+            # linearly; a non-linear ensembler would silently operate on the wrong space.
+            for metric in (self._fit_eval_metric, self._eval_metric):
+                if getattr(metric, "post_problem_type", None) is not None:
+                    raise ValueError(
+                        f"Ensembler {type(ensembler).__name__} is non-linear (linear=False), but metric "
+                        f"{metric.name!r} preprocesses predictions into a transformed space that only "
+                        f"supports linear combination. Pass use_fast_metrics=False to feed the ensembler "
+                        f"original prediction spaces."
+                    )
+        return ensembler
 
-    def fit(self, *, pred_train: np.ndarray, y_train: np.ndarray):
+    def fit(self, *, pred_train: np.ndarray, y_train: np.ndarray) -> AbstractEnsembler:
         ensemble = self.init_ens()
 
         y_train, pred_train = self._maybe_preprocess_bulk(self._fit_eval_metric, y_train, pred_train)
         ensemble.fit(predictions=pred_train, labels=y_train)
-
-        # Ensure prediction interface aligns with the metric we ultimately evaluate with
-        ensemble.problem_type = self._predict_problem_type
         return ensemble
 
     def predict(
-        self, *, ensemble, pred: np.ndarray, y: np.ndarray, eval_metric: Scorer | None = None
+        self, *, ensemble: AbstractEnsembler, pred: np.ndarray, y: np.ndarray, eval_metric: Scorer | None = None
     ) -> tuple[np.ndarray, np.ndarray]:
         if eval_metric is None:
             eval_metric = self._eval_metric
@@ -134,15 +153,9 @@ class TaskEvaluator:
         y, pred = self._maybe_preprocess_bulk(eval_metric, y, pred)
 
         if eval_metric.needs_pred:
-            reset_problem_type = False
-            original_problem_type = ensemble.problem_type
-            new_problem_type = self.problem_type
-            if original_problem_type != new_problem_type:
-                reset_problem_type = True
-                ensemble.problem_type = new_problem_type
-            y_pred = ensemble.predict(pred)
-            if reset_problem_type:
-                ensemble.problem_type = original_problem_type
+            # Label-space predictions are for the original problem, not the (possibly
+            # metric-preprocessed) problem type the ensembler was fitted on.
+            y_pred = ensemble.predict(pred, problem_type=self.problem_type)
         else:
             y_pred = ensemble.predict_proba(pred)
         return y_pred, y
@@ -192,8 +205,13 @@ class TaskEvaluator:
                     y=y_val_proc_aux, y_pred=y_val_pred_aux, eval_metric=self._aux_eval_metric
                 )
 
-        if hasattr(ensemble, "weights_"):
-            results["ensemble_weights"] = ensemble.weights_
+        weights = ensemble.model_weights()
+        if weights is not None:
+            results["ensemble_weights"] = weights
+        results["ensemble_models_used"] = ensemble.models_used()
+        ensemble_info = ensemble.info()
+        if ensemble_info:
+            results["ensemble_info"] = ensemble_info
 
         return results, ensemble
 
@@ -204,7 +222,9 @@ class EnsembleScorer:
         repo: EvaluationRepository,
         task_metrics_metadata,
         evaluator_cls: type[TaskEvaluator] = TaskEvaluator,
-        ensemble_method: type = EnsembleSelection,
+        ensembler_cls: type[AbstractEnsembler] | None = None,
+        ensembler_kwargs: dict | None = None,
+        ensemble_method: type | None = None,
         ensemble_method_kwargs: dict | None = None,
         proxy_fit_metric_map: dict | None = None,
         use_fast_metrics: bool = True,
@@ -215,8 +235,16 @@ class EnsembleScorer:
         ----------
         repo: EvaluationRepository
         task_metrics_metadata
-        ensemble_method: Type = EnsembleSelection
+        ensembler_cls: type[AbstractEnsembler], default = None
+            The post-hoc ensembling method fitted on each task.
+            If None, defaults to `GreedyEnsembler` (greedy weighted ensemble selection).
+        ensembler_kwargs: dict, default = None
+            kwargs passed to `ensembler_cls` (e.g. `ensemble_size` for `GreedyEnsembler`).
+        ensemble_method: type, default = None
+            [Deprecated] Pre-interface ensemble class (AutoGluon `AbstractWeightedEnsemble`
+            style); wrapped in `LegacyEnsemblerAdapter`. Use `ensembler_cls` instead.
         ensemble_method_kwargs: dict, default = None
+            [Deprecated] Alias for `ensembler_kwargs`, used when `ensembler_kwargs` is None.
         proxy_fit_metric_map: dict, default = None
         use_fast_metrics: bool, default = True
         optimize_on: str, default = "val"
@@ -227,17 +255,16 @@ class EnsembleScorer:
         """
         if proxy_fit_metric_map is None:
             proxy_fit_metric_map = {}
-        if ensemble_method_kwargs is None:
-            ensemble_method_kwargs = {}
 
-        ensemble_method_kwargs = copy.deepcopy(ensemble_method_kwargs)
-        if "ensemble_size" not in ensemble_method_kwargs:
-            ensemble_method_kwargs["ensemble_size"] = 100
+        self.ensembler_cls, self.ensembler_kwargs = self._resolve_ensembler(
+            ensembler_cls=ensembler_cls,
+            ensembler_kwargs=ensembler_kwargs,
+            ensemble_method=ensemble_method,
+            ensemble_method_kwargs=ensemble_method_kwargs,
+        )
 
         self.repo = repo
         self.evaluator_cls = evaluator_cls
-        self.ensemble_method: type = ensemble_method
-        self.ensemble_method_kwargs = ensemble_method_kwargs
         self.task_metrics_metadata = task_metrics_metadata
         self.proxy_fit_metric_map = proxy_fit_metric_map
         self.use_fast_metrics = use_fast_metrics
@@ -249,17 +276,53 @@ class EnsembleScorer:
         # (dataset, fold) -> (model -> row index, pred_val, pred_test); see cache_task_preds.
         self._preds_cache: dict[tuple[str, int], tuple[dict[str, int], np.ndarray, np.ndarray]] = {}
 
+    @staticmethod
+    def _resolve_ensembler(
+        *,
+        ensembler_cls: type[AbstractEnsembler] | None,
+        ensembler_kwargs: dict | None,
+        ensemble_method: type | None,
+        ensemble_method_kwargs: dict | None,
+    ) -> tuple[type[AbstractEnsembler], dict]:
+        """Resolve the (ensembler_cls, ensembler_kwargs) pair from the new-style and
+        deprecated constructor parameters.
+        """
+        if ensembler_kwargs is None:
+            ensembler_kwargs = ensemble_method_kwargs
+        ensembler_kwargs = copy.deepcopy(ensembler_kwargs) if ensembler_kwargs is not None else {}
+
+        if ensemble_method is not None:
+            assert ensembler_cls is None, "Pass either `ensembler_cls` or the deprecated `ensemble_method`, not both"
+            if isinstance(ensemble_method, type) and issubclass(ensemble_method, AbstractEnsembler):
+                ensembler_cls = ensemble_method
+            else:
+                # Pre-interface ensemble class: preserve the historical default of
+                # ensemble_size=100 and wrap in the adapter.
+                ensembler_kwargs.setdefault("ensemble_size", 100)
+                return LegacyEnsemblerAdapter, {
+                    "ensemble_cls": ensemble_method,
+                    "ensemble_kwargs": ensembler_kwargs,
+                }
+        if ensembler_cls is None:
+            ensembler_cls = GreedyEnsembler
+        if "ensemble_size" in ensembler_kwargs and not _accepts_kwarg(ensembler_cls, "ensemble_size"):
+            # `EnsembleSelectionConfigScorer` unconditionally plumbs its greedy iteration
+            # budget in as `ensemble_size`; drop it for ensemblers that don't take one
+            # instead of forcing every alternative method to accept a greedy-specific kwarg.
+            ensembler_kwargs.pop("ensemble_size")
+        return ensembler_cls, ensembler_kwargs
+
     # -------------------------
     # Extension hooks
     # -------------------------
     def filter_models(self, dataset: str, fold: int, models: list[str]) -> list[str]:
         return models
 
-    def get_ensemble_method_for_task(self, dataset: str, fold: int, models: list[str]) -> type:
-        return self.ensemble_method
+    def get_ensembler_cls_for_task(self, dataset: str, fold: int, models: list[str]) -> type[AbstractEnsembler]:
+        return self.ensembler_cls
 
-    def get_ensemble_method_kwargs_for_task(self, dataset: str, fold: int, models: list[str]) -> dict:
-        return copy.deepcopy(self.ensemble_method_kwargs)
+    def get_ensembler_kwargs_for_task(self, dataset: str, fold: int, models: list[str]) -> dict:
+        return copy.deepcopy(self.ensembler_kwargs)
 
     def subsample_val_data(
         self,
@@ -402,12 +465,12 @@ class EnsembleScorer:
 
         y_train, pred_train = self._get_train(y_val=y_val, pred_val=pred_val, y_test=y_test, pred_test=pred_test)
 
-        ensemble_method = self.get_ensemble_method_for_task(dataset=dataset, fold=fold, models=models)
-        ensemble_kwargs = self.get_ensemble_method_kwargs_for_task(dataset=dataset, fold=fold, models=models)
+        ensembler_cls = self.get_ensembler_cls_for_task(dataset=dataset, fold=fold, models=models)
+        ensembler_kwargs = self.get_ensembler_kwargs_for_task(dataset=dataset, fold=fold, models=models)
 
         evaluator = self.evaluator_cls(
-            ensemble_method=ensemble_method,
-            ensemble_kwargs=ensemble_kwargs,
+            ensembler_cls=ensembler_cls,
+            ensembler_kwargs=ensembler_kwargs,
             eval_metric=eval_metric,
             fit_eval_metric=fit_eval_metric,
             problem_type=problem_type,
@@ -424,11 +487,25 @@ class EnsembleScorer:
             y_val=y_val,
         )
 
+        return self._remap_ensemble_results_to_models(
+            results, models_og=models_og, models_filtered_idx=models_filtered_idx
+        )
+
+    @staticmethod
+    def _remap_ensemble_results_to_models(
+        results: dict[str, object], *, models_og: list[str], models_filtered_idx: list[int]
+    ) -> dict[str, object]:
+        """Expand per-model result arrays from the filtered model order back to the
+        caller's original model order (filtered-out models get weight 0 / unused).
+        """
         if "ensemble_weights" in results:
             ensemble_weights_fixed = np.zeros(len(models_og), dtype=np.float64)
             ensemble_weights_fixed[models_filtered_idx] = results["ensemble_weights"]
             results["ensemble_weights"] = ensemble_weights_fixed
-
+        if "ensemble_models_used" in results:
+            models_used_fixed = np.zeros(len(models_og), dtype=bool)
+            models_used_fixed[models_filtered_idx] = results["ensemble_models_used"]
+            results["ensemble_models_used"] = models_used_fixed
         return results
 
     def _get_models_filtered_idx(self, models: list[str], models_filtered: list[str]) -> tuple[list[str], list[int]]:
@@ -598,7 +675,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         self.ensemble_scorer = ensemble_cls(
             repo=repo,
             task_metrics_metadata=task_metrics_metadata,
-            ensemble_method_kwargs=ensemble_selection_kwargs,
+            ensemble_method_kwargs=ensemble_selection_kwargs,  # ensembler_kwargs unless overridden via ensemble_kwargs
             proxy_fit_metric_map=proxy_fit_metric_map,
             use_fast_metrics=self.use_fast_metrics,
             **ensemble_kwargs,

--- a/tests/tabarena/simulation/test_ensembler.py
+++ b/tests/tabarena/simulation/test_ensembler.py
@@ -108,3 +108,124 @@ def test_fit_does_not_mutate_caller_predictions():
     assert all(np.array_equal(a, b) for a, b in zip(preds_list, preds_list_copy, strict=False)), (
         "GreedyEnsembler.fit mutated the caller's predictions"
     )
+
+
+# -------------------------
+# TaskEvaluator integration (stage 2)
+# -------------------------
+def _run_task_evaluator(ensembler_cls, ensembler_kwargs, *, problem_type, eval_metric, fit_eval_metric, y, preds):
+    from tabarena.simulation.ensemble_selection_config_scorer import TaskEvaluator
+
+    evaluator = TaskEvaluator(
+        ensembler_cls=ensembler_cls,
+        ensembler_kwargs=ensembler_kwargs,
+        eval_metric=eval_metric,
+        fit_eval_metric=fit_eval_metric,
+        problem_type=problem_type,
+    )
+    results, ensemble = evaluator.run(
+        pred_train=preds,
+        y_train=y,
+        pred_test=preds,
+        y_test=y,
+        return_metric_error_val=True,
+        pred_val=preds,
+        y_val=y,
+    )
+    return results, ensemble
+
+
+def _task_for_metric(metric_name):
+    if metric_name == "roc_auc":
+        from tabarena.metrics._fast_roc_auc import fast_roc_auc_cpp
+
+        y, preds = _make_binary_task()
+        return "binary", fast_roc_auc_cpp, y, preds
+    if metric_name == "log_loss":
+        from tabarena.metrics._fast_log_loss import fast_log_loss
+
+        rng = np.random.default_rng(0)
+        n_samples, n_classes, n_models = 400, 3, 6
+        y = rng.integers(0, n_classes, n_samples)
+        preds = rng.random((n_models, n_samples, n_classes))
+        preds /= preds.sum(axis=2, keepdims=True)
+        return "multiclass", fast_log_loss, y, preds.astype(np.float32)
+    if metric_name == "rmse":
+        y, preds = _make_regression_task()
+        return "regression", get_metric(metric="rmse", problem_type="regression"), y, preds
+    raise ValueError(metric_name)
+
+
+@pytest.mark.parametrize("metric_name", ["roc_auc", "log_loss", "rmse"])
+def test_task_evaluator_new_interface_matches_legacy(metric_name):
+    """TaskEvaluator with the default GreedyEnsembler must produce identical results to
+    the historical ensemble_method=EnsembleSelection path (resolved via EnsembleScorer),
+    across all three metric regimes (incl. the metric-preprocessed log_loss space and
+    the needs_pred rmse path).
+    """
+    from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer
+
+    problem_type, metric, y, preds = _task_for_metric(metric_name)
+
+    legacy_cls, legacy_kwargs = EnsembleScorer._resolve_ensembler(
+        ensembler_cls=None,
+        ensembler_kwargs=None,
+        ensemble_method=EnsembleSelection,
+        ensemble_method_kwargs={"ensemble_size": 20},
+    )
+    new_cls, new_kwargs = EnsembleScorer._resolve_ensembler(
+        ensembler_cls=None, ensembler_kwargs={"ensemble_size": 20}, ensemble_method=None, ensemble_method_kwargs=None
+    )
+    assert new_cls is GreedyEnsembler
+
+    results_legacy, _ = _run_task_evaluator(
+        legacy_cls,
+        legacy_kwargs,
+        problem_type=problem_type,
+        eval_metric=metric,
+        fit_eval_metric=metric,
+        y=y,
+        preds=preds,
+    )
+    results_new, _ = _run_task_evaluator(
+        new_cls, new_kwargs, problem_type=problem_type, eval_metric=metric, fit_eval_metric=metric, y=y, preds=preds
+    )
+
+    assert results_legacy["metric_error"] == results_new["metric_error"]
+    assert results_legacy["metric_error_val"] == results_new["metric_error_val"]
+    np.testing.assert_array_equal(results_legacy["ensemble_weights"], results_new["ensemble_weights"])
+    np.testing.assert_array_equal(results_legacy["ensemble_models_used"], results_new["ensemble_models_used"])
+    np.testing.assert_array_equal(results_new["ensemble_models_used"], results_new["ensemble_weights"] != 0)
+
+
+def test_resolve_ensembler_drops_ensemble_size_for_unsupported_cls():
+    """EnsembleSelectionConfigScorer always plumbs ensemble_size in; ensemblers that
+    don't take one must not be forced to accept it.
+    """
+    from tabarena.simulation.ensemble import AbstractEnsembler
+    from tabarena.simulation.ensemble_selection_config_scorer import EnsembleScorer
+
+    class NoSizeEnsembler(AbstractEnsembler):
+        def _fit(self, *, predictions, labels, time_limit=None):
+            pass
+
+        def predict_proba(self, predictions):
+            return predictions[0]
+
+    cls, kwargs = EnsembleScorer._resolve_ensembler(
+        ensembler_cls=NoSizeEnsembler,
+        ensembler_kwargs={"ensemble_size": 100},
+        ensemble_method=None,
+        ensemble_method_kwargs=None,
+    )
+    assert cls is NoSizeEnsembler
+    assert "ensemble_size" not in kwargs
+
+    cls, kwargs = EnsembleScorer._resolve_ensembler(
+        ensembler_cls=GreedyEnsembler,
+        ensembler_kwargs={"ensemble_size": 40},
+        ensemble_method=None,
+        ensemble_method_kwargs=None,
+    )
+    assert cls is GreedyEnsembler
+    assert kwargs == {"ensemble_size": 40}

--- a/tests/tabarena/simulation/test_ensembler.py
+++ b/tests/tabarena/simulation/test_ensembler.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from autogluon.core.metrics import get_metric
+from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
+
+from tabarena.simulation.ensemble import (
+    GreedyEnsembler,
+    LegacyEnsemblerAdapter,
+)
+
+
+def _make_binary_task(n_models=8, n_samples=500, seed=0):
+    rng = np.random.default_rng(seed)
+    y = rng.random(n_samples) < 0.4
+    preds = np.stack(
+        [np.clip(y * rng.uniform(0.3, 0.8) + rng.normal(0, 0.4, n_samples), 0, 1) for _ in range(n_models)]
+    ).astype(np.float32)
+    return y.astype(np.bool_), preds
+
+
+def _make_regression_task(n_models=8, n_samples=500, seed=0):
+    rng = np.random.default_rng(seed)
+    y = rng.normal(0, 1, n_samples)
+    preds = np.stack([y + rng.normal(0, s, n_samples) for s in rng.uniform(0.3, 1.0, n_models)]).astype(np.float32)
+    return y, preds
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "regression"])
+def test_greedy_ensembler_matches_ensemble_selection(problem_type):
+    """GreedyEnsembler must produce identical weights and predictions to using AutoGluon's
+    EnsembleSelection directly (the historical code path).
+    """
+    if problem_type == "binary":
+        y, preds = _make_binary_task()
+        metric = get_metric(metric="roc_auc", problem_type=problem_type)
+    else:
+        y, preds = _make_regression_task()
+        metric = get_metric(metric="rmse", problem_type=problem_type)
+
+    reference = EnsembleSelection(
+        ensemble_size=20, problem_type=problem_type, metric=metric, random_state=np.random.RandomState(0)
+    )
+    reference.fit(predictions=list(preds), labels=y)
+
+    ensembler = GreedyEnsembler(
+        problem_type=problem_type, metric=metric, ensemble_size=20, random_state=np.random.RandomState(0)
+    )
+    ensembler.fit(predictions=preds, labels=y)
+
+    np.testing.assert_array_equal(ensembler.model_weights(), reference.weights_)
+    np.testing.assert_array_equal(ensembler.predict_proba(preds), reference.predict_proba(preds))
+    if problem_type == "binary":
+        np.testing.assert_array_equal(ensembler.predict(preds, problem_type=problem_type), reference.predict(preds))
+    np.testing.assert_array_equal(ensembler.models_used(), reference.weights_ != 0)
+
+
+def test_legacy_adapter_matches_ensemble_selection():
+    """LegacyEnsemblerAdapter wraps a pre-interface class without changing behavior."""
+    y, preds = _make_binary_task(seed=1)
+    metric = get_metric(metric="roc_auc", problem_type="binary")
+
+    reference = EnsembleSelection(
+        ensemble_size=20, problem_type="binary", metric=metric, random_state=np.random.RandomState(0)
+    )
+    reference.fit(predictions=list(preds), labels=y)
+
+    adapted = LegacyEnsemblerAdapter(
+        problem_type="binary",
+        metric=metric,
+        ensemble_cls=EnsembleSelection,
+        ensemble_kwargs={"ensemble_size": 20, "random_state": np.random.RandomState(0)},
+    )
+    adapted.fit(predictions=preds, labels=y)
+
+    np.testing.assert_array_equal(adapted.model_weights(), reference.weights_)
+    np.testing.assert_array_equal(adapted.predict_proba(preds), reference.predict_proba(preds))
+
+
+def test_legacy_adapter_predict_problem_type_override_restores():
+    """The problem_type override in predict is applied for the call and restored after."""
+    y, preds = _make_binary_task(seed=2)
+    metric = get_metric(metric="roc_auc", problem_type="binary")
+    adapted = LegacyEnsemblerAdapter(
+        problem_type="binary",
+        metric=metric,
+        ensemble_cls=EnsembleSelection,
+        ensemble_kwargs={"ensemble_size": 5},
+    )
+    adapted.fit(predictions=preds, labels=y)
+    adapted.predict(preds, problem_type="binary")
+    assert adapted._ensemble.problem_type == "binary"
+
+
+def test_fit_does_not_mutate_caller_predictions():
+    """subsample_size triggers in-place mutation inside AutoGluon's EnsembleSelection;
+    the adapters must shield the caller's arrays/list from it.
+    """
+    y, preds = _make_binary_task(n_samples=500, seed=3)
+    metric = get_metric(metric="roc_auc", problem_type="binary")
+    preds_list = list(preds)
+    preds_list_copy = [p.copy() for p in preds_list]
+
+    ensembler = GreedyEnsembler(problem_type="binary", metric=metric, ensemble_size=5, subsample_size=100)
+    ensembler.fit(predictions=preds_list, labels=y)
+
+    assert all(np.array_equal(a, b) for a, b in zip(preds_list, preds_list_copy, strict=False)), (
+        "GreedyEnsembler.fit mutated the caller's predictions"
+    )

--- a/tests/tabarena/simulation/test_ensembler.py
+++ b/tests/tabarena/simulation/test_ensembler.py
@@ -229,3 +229,132 @@ def test_resolve_ensembler_drops_ensemble_size_for_unsupported_cls():
     )
     assert cls is GreedyEnsembler
     assert kwargs == {"ensemble_size": 40}
+
+
+# -------------------------
+# Reference ensemblers + guardrails (stage 3)
+# -------------------------
+def test_single_best_ensembler():
+    from tabarena.simulation.ensemble import SingleBestEnsembler
+
+    y, preds = _make_regression_task(n_models=5, seed=4)
+    metric = get_metric(metric="rmse", problem_type="regression")
+    per_model_errors = [metric.error(y, p) for p in preds]
+    best = int(np.argmin(per_model_errors))
+
+    ensembler = SingleBestEnsembler(problem_type="regression", metric=metric)
+    ensembler.fit(predictions=preds, labels=y)
+
+    expected = np.zeros(5)
+    expected[best] = 1.0
+    np.testing.assert_array_equal(ensembler.model_weights(), expected)
+    np.testing.assert_array_equal(ensembler.predict_proba(preds), preds[best])
+    assert ensembler.info() == {"best_index": best}
+    assert ensembler.models_used().sum() == 1
+
+
+def test_top_k_average_ensembler():
+    from tabarena.simulation.ensemble import TopKAverageEnsembler
+
+    y, preds = _make_binary_task(n_models=6, seed=5)
+    metric = get_metric(metric="roc_auc", problem_type="binary")
+    errors = np.array([metric.error(y, p) for p in preds])
+    top3 = set(np.argsort(errors, kind="stable")[:3])
+
+    ensembler = TopKAverageEnsembler(problem_type="binary", metric=metric, k=3)
+    ensembler.fit(predictions=preds, labels=y)
+
+    weights = ensembler.model_weights()
+    assert set(np.flatnonzero(weights)) == top3
+    np.testing.assert_allclose(weights[weights != 0], 1 / 3)
+    # k larger than the model count is capped
+    ensembler_all = TopKAverageEnsembler(problem_type="binary", metric=metric, k=100)
+    ensembler_all.fit(predictions=preds, labels=y)
+    np.testing.assert_allclose(ensembler_all.model_weights(), 1 / 6)
+
+
+def test_fixed_weights_ensembler():
+    from tabarena.simulation.ensemble import FixedWeightsEnsembler
+
+    y, preds = _make_binary_task(n_models=4, seed=6)
+    metric = get_metric(metric="roc_auc", problem_type="binary")
+    weights = [0.5, 0.5, 0.0, 0.0]
+
+    ensembler = FixedWeightsEnsembler(problem_type="binary", metric=metric, weights=weights)
+    ensembler.fit(predictions=preds, labels=y)
+    # use the fitted (float64) weights so dtype promotion matches predict_proba exactly
+    w = ensembler.model_weights()
+    np.testing.assert_array_equal(ensembler.predict_proba(preds), w[0] * preds[0] + w[1] * preds[1])
+    np.testing.assert_array_equal(ensembler.models_used(), [True, True, False, False])
+
+    bad = FixedWeightsEnsembler(problem_type="binary", metric=metric, weights=[1.0])
+    with pytest.raises(ValueError, match="1 weights for 4 models"):
+        bad.fit(predictions=preds, labels=y)
+
+
+def test_ensembler_swap_through_task_evaluator():
+    """Swapping the ensembling method is a single constructor argument."""
+    from tabarena.simulation.ensemble import SingleBestEnsembler, TopKAverageEnsembler
+
+    problem_type, metric, y, preds = _task_for_metric("roc_auc")
+    for ensembler_cls, ensembler_kwargs in [
+        (SingleBestEnsembler, {}),
+        (TopKAverageEnsembler, {"k": 2}),
+    ]:
+        results, ensemble = _run_task_evaluator(
+            ensembler_cls,
+            ensembler_kwargs,
+            problem_type=problem_type,
+            eval_metric=metric,
+            fit_eval_metric=metric,
+            y=y,
+            preds=preds,
+        )
+        assert np.isfinite(results["metric_error"])
+        assert len(results["ensemble_weights"]) == len(preds)
+        assert results["ensemble_models_used"].dtype == bool
+
+
+def test_nonlinear_ensembler_rejected_on_preprocessed_metric_space():
+    """A non-linear ensembler must be rejected when the metric feeds a transformed
+    (linear-only) prediction space, and accepted on untransformed spaces.
+    """
+    from tabarena.metrics._fast_log_loss import fast_log_loss
+    from tabarena.simulation.ensemble import AbstractEnsembler
+    from tabarena.simulation.ensemble_selection_config_scorer import TaskEvaluator
+
+    class NonLinearEnsembler(AbstractEnsembler):
+        linear = False
+
+        def _fit(self, *, predictions, labels, time_limit=None):
+            pass
+
+        def predict_proba(self, predictions):
+            return np.maximum.reduce(list(predictions))
+
+    problem_type, _, y, preds = _task_for_metric("log_loss")
+    evaluator = TaskEvaluator(
+        ensembler_cls=NonLinearEnsembler,
+        ensembler_kwargs={},
+        eval_metric=fast_log_loss,
+        fit_eval_metric=fast_log_loss,
+        problem_type=problem_type,
+    )
+    with pytest.raises(ValueError, match="non-linear"):
+        evaluator.init_ens()
+
+    # Untransformed metric space: allowed
+    rmse = get_metric(metric="rmse", problem_type="regression")
+    y_r, preds_r = _make_regression_task()
+    results, _ = _run_task_evaluator(
+        NonLinearEnsembler,
+        {},
+        problem_type="regression",
+        eval_metric=rmse,
+        fit_eval_metric=rmse,
+        y=y_r,
+        preds=preds_r,
+    )
+    assert np.isfinite(results["metric_error"])
+    assert "ensemble_weights" not in results  # not weight-based
+    assert results["ensemble_models_used"].all()  # conservative default: all models used


### PR DESCRIPTION
## Summary

Makes the post-hoc ensembling method a first-class, swappable component of the ensemble simulation. Previously the swap point (`ensemble_method: type` + kwargs on `EnsembleScorer`) existed but the contract was implicit and leaky — spread across `TaskEvaluator`, `EnsembleScorer`, `ensemble_mixin`, and AutoGluon's `AbstractWeightedEnsemble` — and parts of it assumed a linear weighted ensemble. Swapping is now one constructor argument:

```python
from tabarena.simulation.ensemble import TopKAverageEnsembler

EnsembleScorer(..., ensembler_cls=TopKAverageEnsembler, ensembler_kwargs={"k": 3})
# or through the repo API:
repo.evaluate_ensemble(..., ensemble_kwargs={"ensembler_cls": TopKAverageEnsembler, "ensembler_kwargs": {"k": 3}})
```

## The interface (`tabarena/simulation/ensemble/`)

`AbstractEnsembler` — fit/predict over base-model *predictions* for one task:

- `fit(predictions, labels)` / `predict_proba(predictions)` / `predict(predictions, problem_type=...)`
- Reporting surface: `model_weights()` (drives the `ensemble_weights` result column; `None` for non-weight-based methods), `models_used()` (bool mask, drives `time_infer_s` accounting), `info()` (optional payload, surfaced as `ensemble_info`).
- `linear` capability flag: metric-preprocessed prediction spaces (fast log_loss's ground-truth-class-probability view) are only valid to combine linearly. A non-linear ensembler is now rejected with a clear error pointing to `use_fast_metrics=False` instead of silently operating on the wrong space.

Implementations: `GreedyEnsembler` (default; thin adapter around AutoGluon's `EnsembleSelection`, bit-identical results), `WeightedEnsembler` (base for weighted combinations), `LegacyEnsemblerAdapter` (wraps pre-interface classes), and three reference methods that double as templates: `SingleBestEnsembler`, `TopKAverageEnsembler`, `FixedWeightsEnsembler`.

## Driver migration

`TaskEvaluator`, `EnsembleScorer`(+`Calibrated`), and `EnsembleMixin` consume only the interface:

- The post-fit `ensemble.problem_type` mutation hack is gone — label-space predictions pass the original problem type explicitly via `predict(problem_type=...)`.
- The unconditional `ensemble_size=100` kwargs injection is gone; `GreedyEnsembler` owns that default, and the greedy-specific `ensemble_size` plumbed in by `EnsembleSelectionConfigScorer` is dropped (via signature inspection) for ensemblers that don't accept one, so alternative methods aren't forced to take a greedy kwarg.
- Task results always carry `ensemble_models_used`; `time_infer_s` is computed from it instead of assuming `weight != 0`, so non-weight-based ensemblers no longer crash `evaluate_ensemble` (their weights row is NaN).
- Per-task hooks renamed to `get_ensembler_cls_for_task` / `get_ensembler_kwargs_for_task` (the old hooks had no overriders in-repo or in known extensions).

## Backwards compatibility

- `ensemble_method` / `ensemble_method_kwargs` are deprecated but still accepted: pre-interface classes are auto-wrapped in `LegacyEnsemblerAdapter` with the historical `ensemble_size=100` default preserved.
- The adapters shield AutoGluon's `EnsembleSelection._fit` in-place predictions-list mutation (triggered by `subsample_size`), so this works with released AutoGluon; a separate upstream hygiene PR fixes it at the source.

## Verification

- 14 new tests in `tests/tabarena/simulation/test_ensembler.py`: GreedyEnsembler and the legacy path produce identical weights/predictions/`TaskEvaluator.run` results across roc_auc / log_loss / rmse (including the metric-preprocessed log_loss space and the needs_pred rmse path); reference-ensembler behavior; the non-linear guardrail.
- Full default suite green (1290 passed).
- End-to-end: LightGBM HPO tuning trajectories (`MethodSimulator.generate_hpo_trajectories`, 50 datasets x 3 folds, 12 passes) are **byte-identical** to pre-refactor output at the same runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi