### PR TITLE
Add hc_nolarge / hc_nolarge_lite subset shortcuts to BeyondArena

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
+++ b/packages/tabarena/src/tabarena/contexts/abstract_arena_context.py
@@ -88,10 +88,11 @@ class AbstractArenaContext:
         "lite": SubsetPredicate(lambda df: df["split"] == 0, ("split",)),
     }
 
-    #: Named shortcuts for standard subslices, each a list of :attr:`SUBSET_PREDICATES` names
-    #: AND-ed together (the same form ``compare`` / ``build_jobs`` accept as a ``subset``). Lets
+    #: Named shortcuts for standard subslices, each a list of subset expressions AND-ed together
+    #: (the same form ``compare`` / ``build_jobs`` accept as a ``subset``: atoms are
+    #: :attr:`SUBSET_PREDICATES` names, a leading ``!`` negates an atom, ``|`` is a union). Lets
     #: callers refer to a reusable slice (e.g. ``"high_dim"`` -> ``["core", "high-dim"]``) by name
-    #: instead of respelling the predicate list. Base context defines none; subclasses override.
+    #: instead of respelling the expression list. Base context defines none; subclasses override.
     #: Read via :attr:`subset_shortcuts` so subclass overrides take effect.
     SUBSET_SHORTCUTS: dict[str, list[str]] = {}
 
@@ -582,20 +583,21 @@ class AbstractArenaContext:
 
     @property
     def subset_shortcuts(self) -> dict[str, list[str]]:
-        """Named shortcuts for standard subslices (shortcut name -> list of subset-predicate
-        names AND-ed together). Reads from ``type(self).SUBSET_SHORTCUTS`` so subclass overrides
-        take effect.
+        """Named shortcuts for standard subslices (shortcut name -> list of subset expressions
+        AND-ed together; atoms are subset-predicate names, ``!`` negates, ``|`` unions). Reads
+        from ``type(self).SUBSET_SHORTCUTS`` so subclass overrides take effect.
         """
         return type(self).SUBSET_SHORTCUTS
 
     @classmethod
     def subset_shortcut_name(cls, subset: str | list[str] | None) -> str | None:
-        """Reverse of :attr:`subset_shortcuts`: the shortcut name whose predicate list
+        """Reverse of :attr:`subset_shortcuts`: the shortcut name whose expression list
         matches ``subset`` (order-insensitive), or ``None`` if none does.
 
         ``subset`` takes the AND-list forms a single :class:`TaskSubset` view accepts — a lone
-        predicate name (``"core"``), a list (``["core", "high-dim"]``), or ``None``/``[]`` — and is
-        compared as a set, so ``["high-dim", "core"]`` still resolves to ``"high_dim"``.
+        expression (``"core"``), a list (``["core", "high-dim"]``, ``["core", "!large"]``), or
+        ``None``/``[]`` — and is compared as a set of expression strings, so
+        ``["high-dim", "core"]`` still resolves to ``"high_dim"``.
         """
         if subset is None:
             subset = []

--- a/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/beyondarena/context.py
@@ -108,10 +108,10 @@ class BeyondArenaContext(AbstractArenaContext):
         "core": SubsetPredicate(lambda df: _core_subset_predicate().predicate(df), ("dataset", "split")),
     }
 
-    #: Shortcuts for the standard BeyondArena subslices: each name maps to a list of
-    #: :attr:`SUBSET_PREDICATES` names AND-ed together. Every shortcut is intersected with
-    #: ``"core"`` so the standard slices share the committed core task set. Read via
-    #: :attr:`subset_shortcuts`.
+    #: Shortcuts for the standard BeyondArena subslices: each name maps to a list of subset
+    #: expressions AND-ed together (atoms are :attr:`SUBSET_PREDICATES` names; a leading ``!``
+    #: negates one). Every shortcut is intersected with ``"core"`` so the standard slices share
+    #: the committed core task set. Read via :attr:`subset_shortcuts`.
     SUBSET_SHORTCUTS: dict[str, list[str]] = {
         "large": ["core", "large"],
         "high_dim": ["core", "high-dim"],
@@ -122,6 +122,9 @@ class BeyondArenaContext(AbstractArenaContext):
         "iid": ["core", "iid"],
         "random": ["core", "random"],
         "text": ["core", "text"],
+        # high-cardinality slice with the large size bucket removed (all splits / lite split 0)
+        "hc_nolarge": ["core", "high-cardinality", "!large"],
+        "hc_nolarge_lite": ["core", "lite", "high-cardinality", "!large"],
     }
 
     def __init__(

--- a/tests/tabarena/contexts/test_beyond_arena.py
+++ b/tests/tabarena/contexts/test_beyond_arena.py
@@ -34,3 +34,28 @@ def test_subset_predicates_cover_beyond_subsets():
         "lite",
     }
     assert expected <= set(BeyondArenaContext.SUBSET_PREDICATES)
+
+
+def test_subset_shortcuts_resolve_on_task_grid():
+    """Every shortcut's expression list (including negated atoms like ``"!large"``) evaluates
+    against the task grid and selects a non-empty, strictly smaller slice than the full grid.
+    """
+    from tabarena.benchmark.task.metadata import BeyondArenaTaskMetadataCollection
+    from tabarena.nips2025_utils.compare import _evaluate_subset_expression
+
+    grid = BeyondArenaTaskMetadataCollection().task_grid()
+    predicates = BeyondArenaContext.SUBSET_PREDICATES
+    for name, expressions in BeyondArenaContext.SUBSET_SHORTCUTS.items():
+        selected = grid
+        for expression in expressions:
+            mask = _evaluate_subset_expression(expression, selected, predicates=predicates)
+            selected = selected[mask.values]
+        assert 0 < len(selected) < len(grid), name
+
+
+def test_subset_shortcut_name_matches_negated_expressions():
+    assert BeyondArenaContext.subset_shortcut_name(["core", "high-cardinality", "!large"]) == "hc_nolarge"
+    # order-insensitive
+    assert BeyondArenaContext.subset_shortcut_name(["!large", "core", "lite", "high-cardinality"]) == "hc_nolarge_lite"
+    assert BeyondArenaContext.subset_shortcut_name(["core", "high-cardinality"]) == "high_cardinality"
+    assert BeyondArenaContext.subset_shortcut_name(["core", "!large"]) is None


### PR DESCRIPTION
## What

Registers the high-cardinality-without-large views in `BeyondArenaContext.SUBSET_SHORTCUTS`:

```python
"hc_nolarge": ["core", "high-cardinality", "!large"],
"hc_nolarge_lite": ["core", "lite", "high-cardinality", "!large"],
```

No new machinery needed — the subset-expression evaluator already supports negated atoms (`!large`), and the shortcut registry (#430) stores plain expression lists, so these flow through `subset=` unchanged. On the current grid: `hc_nolarge` selects 27 splits / 17 datasets, `hc_nolarge_lite` 17 splits / 17 datasets (out of 3722 / 142).

## Also

- Docstrings on `SUBSET_SHORTCUTS` / `subset_shortcuts` / `subset_shortcut_name` now say entries are subset **expressions** (atoms may be negated with `!` or unioned with `|`), not just predicate names.
- Tests: every registered shortcut evaluates on the real BeyondArena task grid to a non-empty strict subset; `subset_shortcut_name` reverse lookup matches negated lists order-insensitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)