### PR TITLE
Add TabArena subset shortcuts

### DIFF
--- a/packages/tabarena/src/tabarena/contexts/tabarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/context.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 #: 50 splits the TabArena v0.1 suite into 36 low-cat and 15 high-cat datasets.
 CAT_FRACTION_THRESHOLD = 50.0
 
+#: Inclusive boundary on the native feature count separating ``low_features`` (at or below it)
+#: from ``high_features`` (above it). TabArena v0.1 does not carry the after-preprocessing feature
+#: count used by BeyondArena's dimensionality predicates, so these variants use ``n_features``.
+FEATURE_COUNT_THRESHOLD = 500
+
 
 @lru_cache(maxsize=1)
 def _datasets_by_cat_fraction() -> tuple[frozenset[str], frozenset[str]]:
@@ -81,6 +86,15 @@ class TabArenaContext(AbstractArenaContext):
         "medium": SubsetPredicate(lambda df: df["max_train_rows"].between(10_001, 100_000), ("max_train_rows",)),
         "small": SubsetPredicate(lambda df: df["max_train_rows"] <= 10_000, ("max_train_rows",)),
         "tiny": SubsetPredicate(lambda df: df["max_train_rows"] <= 2_000, ("max_train_rows",)),
+        # native feature-count buckets (v0.1 has no after-preprocessing feature count)
+        "low_features": SubsetPredicate(
+            lambda df: df["n_features"] <= FEATURE_COUNT_THRESHOLD,
+            ("n_features",),
+        ),
+        "high_features": SubsetPredicate(
+            lambda df: df["n_features"] > FEATURE_COUNT_THRESHOLD,
+            ("n_features",),
+        ),
         # foundation-model compatibility (operates on tabarena task_metadata columns)
         "tabpfn": SubsetPredicate(
             lambda df: (df["max_train_rows"] <= 10_000) & (df["n_features"] <= 500) & (df["n_classes"] <= 10),
@@ -100,6 +114,18 @@ class TabArenaContext(AbstractArenaContext):
         # "split" column (see TaskMetadataCollection.task_grid); a results frame's "fold" is the
         # split, so this maps to fold == 0 there.
         "lite": SubsetPredicate(lambda df: df["split"] == 0, ("split",)),
+    }
+
+    #: Standard TabArena v0.1 variants. ``full`` applies no filtering and ``lite`` keeps split 0
+    #: only. The categorical variants divide datasets by categorical-feature fraction, not
+    #: category cardinality (v0.1's committed metadata has no cardinality counts).
+    SUBSET_SHORTCUTS: dict[str, list[str]] = {
+        "full": [],
+        "lite": ["lite"],
+        "low_cats": ["low_cats"],
+        "high_cats": ["high_cats"],
+        "low_features": ["low_features"],
+        "high_features": ["high_features"],
     }
 
     def __init__(

--- a/tests/tabarena/contexts/test_tabarena_context.py
+++ b/tests/tabarena/contexts/test_tabarena_context.py
@@ -5,6 +5,7 @@ import pytest
 
 from tabarena.benchmark.task.metadata import TaskMetadataCollection, TaskSubset
 from tabarena.contexts import AbstractArenaContext, TabArenaContext
+from tabarena.contexts.tabarena.context import FEATURE_COUNT_THRESHOLD
 
 
 def _ctx() -> TabArenaContext:
@@ -287,6 +288,47 @@ class TestCatFractionPredicates:
         high = preds["high_cats"].evaluate(grid, name="high_cats")
         assert grid.loc[low, "dataset"].nunique() == 36
         assert grid.loc[high, "dataset"].nunique() == 15
+
+
+class TestStandardSubsetVariants:
+    """TabArena exposes explicit lite and categorical-fraction variant definitions."""
+
+    def test_shortcuts_are_registered(self):
+        assert TabArenaContext.SUBSET_SHORTCUTS == {
+            "full": [],
+            "lite": ["lite"],
+            "low_cats": ["low_cats"],
+            "high_cats": ["high_cats"],
+            "low_features": ["low_features"],
+            "high_features": ["high_features"],
+        }
+
+    @pytest.mark.parametrize(
+        ("subset", "name"),
+        [
+            (None, "full"),
+            ([], "full"),
+            ("lite", "lite"),
+            ("low_cats", "low_cats"),
+            ("high_cats", "high_cats"),
+            ("low_features", "low_features"),
+            ("high_features", "high_features"),
+        ],
+    )
+    def test_shortcut_reverse_lookup(self, subset, name):
+        assert TabArenaContext.subset_shortcut_name(subset) == name
+
+    def test_feature_buckets_partition_task_grid(self):
+        grid = TaskMetadataCollection.from_preset("TabArena-v0.1").task_grid()
+        predicates = TabArenaContext.SUBSET_PREDICATES
+        low = predicates["low_features"].evaluate(grid, name="low_features")
+        high = predicates["high_features"].evaluate(grid, name="high_features")
+
+        assert not (low & high).any()
+        assert (low | high).all()
+        assert (grid.loc[low, "n_features"] <= FEATURE_COUNT_THRESHOLD).all()
+        assert (grid.loc[high, "n_features"] > FEATURE_COUNT_THRESHOLD).all()
+        assert low.any() and high.any()
 
 
 class TestComparePlotOnlyForwarding:


### PR DESCRIPTION
## Summary
- define standard TabArena shortcuts for full, lite, and categorical-feature subsets
- add low/high native feature-count predicates with a 500-feature boundary
- test shortcut lookup and complementary feature-bucket coverage

## Tests
- ruff check packages/tabarena/src/tabarena/contexts/tabarena/context.py tests/tabarena/contexts/test_tabarena_context.py
- ruff format --check packages/tabarena/src/tabarena/contexts/tabarena/context.py tests/tabarena/contexts/test_tabarena_context.py
- .venv/bin/python -m pytest -q tests/tabarena/contexts/test_tabarena_context.py (35 passed)