### PR TITLE
Redesign Pareto plots: family colors, focus/grey-out statics + interactive explorers

### DIFF
--- a/.claude/skills/update-leaderboard/SKILL.md
+++ b/.claude/skills/update-leaderboard/SKILL.md
@@ -85,6 +85,12 @@ cd <tabarena>/scripts
 nohup <generation_venv>/bin/python run_generate_website_artifacts.py > <scratch>/gen_website.log 2>&1 &
 ```
 
+Useful flags (defaults = the fast website-only publish run): `--skip-evaluate` /
+`--skip-trajectories` reuse the existing raw artifacts for one pipeline when only the other's
+outputs changed; `--elo-bootstrap-rounds 1` for a toy run (Elo CIs meaningless);
+`--full-figures` restores the full per-subset paper figure suite (incl. GIF animations);
+`--zip-raw` re-enables the large raw-artifacts zip (the publish flow only needs the clean zip).
+
 Monitor until the process exits, then verify outputs — **don't trust "exited" alone**:
 
 - **Harmless noise to ignore:** at the end ray tears down its workers and each logs a
@@ -104,7 +110,9 @@ Monitor until the process exits, then verify outputs — **don't trust "exited" 
     PY
     ```
   - Structural sanity in `website_data/`: **60** `website_leaderboard.csv`, **60** `n_datasets_*`
-    markers, **240** `*.png.zip`, and **0** raw `*.png` (figures are zipped, not extracted).
+    markers, **240** `*.png.zip`, **0** raw `*.png` (figures are zipped, not extracted), **120**
+    interactive `*_explorer.html` (60 Pareto + 60 trajectories) and their **120** data CSVs
+    (`pareto_front_points.csv` + `tuning_trajectories.csv`).
 
 ## Step 3: Refresh the Space repo's `data/` (the stale-PNG gotcha)
 

--- a/packages/tabarena/src/tabarena/contexts/tabarena/context.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/context.py
@@ -221,6 +221,7 @@ class TabArenaContext(AbstractArenaContext):
         evaluator_kwargs: dict | None = None,
         engine: str = "auto",
         progress_bar: bool = True,
+        website_only: bool = False,
     ):
         if df_results is None:
             df_results = self.load_results(download_results="auto")
@@ -244,4 +245,5 @@ class TabArenaContext(AbstractArenaContext):
             evaluator_kwargs=evaluator_kwargs,
             engine=engine,
             progress_bar=progress_bar,
+            website_only=website_only,
         )

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -1870,7 +1870,8 @@ class LeaderboardReporter:
                 "method": leaderboard["Method"],
                 "variant": leaderboard["Type"],
                 "family": leaderboard["Family"],
-                "x": leaderboard["median_time_infer_s_per_1K"],
+                "x_infer": leaderboard["median_time_infer_s_per_1K"],
+                "x_train": leaderboard["median_time_train_s_per_1K"],
                 "imp": leaderboard["improvability"] * 100,
                 "elo": leaderboard["elo"],
             }
@@ -1883,14 +1884,16 @@ class LeaderboardReporter:
             imputed_frac = pd.Series(0.0, index=leaderboard.index)
         points["imputed"] = imputed_frac > 0
         points["imputed_pct"] = imputed_frac * 100
-        points = points.dropna(subset=["x", "imp", "elo"]).reset_index(drop=True)
+        points = points.dropna(subset=["x_infer", "x_train", "imp", "elo"]).reset_index(drop=True)
         if points.empty:
             return
 
         save_pd.save(path=str(Path(self.output_dir) / "pareto_front_points.csv"), df=points)
         build_pareto_explorer_html(
             points=points,
-            x_label="Inference time per 1K samples (s), median — log scale",
+            # Inference time is the default view (the panel the website led
+            # with historically); train time is the toggle.
+            x_keys=["x_infer", "x_train"],
             save_path=Path(self.output_dir) / "pareto_front_explorer.html",
         )
 

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -671,8 +671,16 @@ class LeaderboardReporter:
         winrate_method_rename: dict[str, str] | None = None,
         plot_only: list[str] | None = None,
         method_color_overrides: dict[str, str] | None = None,
+        website_only: bool = False,
     ) -> pd.DataFrame:
         """Compute the leaderboard for ``df_results`` and render the TabArena figures.
+
+        ``website_only`` (default ``False``) renders only the outputs the
+        tabarena.ai website ships (leaderboard CSVs, the vertical
+        ``tuning-impact-elo`` bar plot, the win-rate matrix, and the Pareto
+        figures + interactive explorer), skipping the rest of the paper
+        figure suite (date-introduced scatters and their GIF animations,
+        LaTeX tables, the horizontal Elo bar plot).
 
         ``plot_only`` (default ``None`` -> show everything) restricts the *plots*
         to a subset of methods without affecting any numbers: the leaderboard,
@@ -914,18 +922,19 @@ class LeaderboardReporter:
         leaderboard = leaderboard.reset_index(drop=False)
         save_pd.save(path=f"{self.output_dir}/tabarena_leaderboard.csv", df=leaderboard)
 
-        # Elo vs. method introduction date (no-op unless `date_introduced` method metadata is available).
-        self.plot_elo_vs_date_introduced(leaderboard=leaderboard, show=False)
-        self.animate_elo_vs_date_introduced(leaderboard=leaderboard)
-        self.plot_improvability_vs_date_introduced(leaderboard=leaderboard, show=False)
-        self.animate_improvability_vs_date_introduced(leaderboard=leaderboard)
+        if not website_only:
+            # Elo vs. method introduction date (no-op unless `date_introduced` method metadata is available).
+            self.plot_elo_vs_date_introduced(leaderboard=leaderboard, show=False)
+            self.animate_elo_vs_date_introduced(leaderboard=leaderboard)
+            self.plot_improvability_vs_date_introduced(leaderboard=leaderboard, show=False)
+            self.animate_improvability_vs_date_introduced(leaderboard=leaderboard)
 
-        self.create_leaderboard_latex(
-            leaderboard,
-            framework_types=framework_types,
-            save_dir=self.output_dir,
-            hidden_methods=plot_tuning_kwargs.get("hidden_methods"),
-        )
+            self.create_leaderboard_latex(
+                leaderboard,
+                framework_types=framework_types,
+                save_dir=self.output_dir,
+                hidden_methods=plot_tuning_kwargs.get("hidden_methods"),
+            )
 
         n_tasks = len(df_results_rank_compare[[tabarena.task_col, tabarena.seed_column]].drop_duplicates())
 
@@ -936,23 +945,24 @@ class LeaderboardReporter:
             with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
                 print(leaderboard)
 
-        # horizontal elo barplot
-        self.plot_tuning_impact(
-            df=df_results_rank_compare,
-            df_elo=leaderboard,
-            framework_types=framework_types,
-            save_prefix=f"{self.output_dir}",
-            use_gmean=use_gmean,
-            baselines=baselines,
-            baseline_colors=baseline_colors,
-            name_suffix="-elo-horizontal",
-            imputed_names=imputed_names,
-            plot_tune_types=plot_tune_types,
-            use_y=True,
-            show=False,
-            method_color_overrides=method_color_overrides,
-            **plot_tuning_kwargs,
-        )
+        # horizontal elo barplot (the website ships only the vertical one)
+        if not website_only:
+            self.plot_tuning_impact(
+                df=df_results_rank_compare,
+                df_elo=leaderboard,
+                framework_types=framework_types,
+                save_prefix=f"{self.output_dir}",
+                use_gmean=use_gmean,
+                baselines=baselines,
+                baseline_colors=baseline_colors,
+                name_suffix="-elo-horizontal",
+                imputed_names=imputed_names,
+                plot_tune_types=plot_tune_types,
+                use_y=True,
+                show=False,
+                method_color_overrides=method_color_overrides,
+                **plot_tuning_kwargs,
+            )
 
         # vertical elo barplot
         self.plot_tuning_impact(
@@ -1891,9 +1901,9 @@ class LeaderboardReporter:
         save_pd.save(path=str(Path(self.output_dir) / "pareto_front_points.csv"), df=points)
         build_pareto_explorer_html(
             points=points,
-            # Inference time is the default view (the panel the website led
-            # with historically); train time is the toggle.
-            x_keys=["x_infer", "x_train"],
+            # Single time axis (inference, the panel the website led with
+            # historically); train time stays available in the CSV export.
+            x_keys=["x_infer"],
             save_path=Path(self.output_dir) / "pareto_front_explorer.html",
         )
 

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -22,11 +22,11 @@ from tabarena.evaluation.framework_naming import (
     get_method_rename_map,
 )
 from tabarena.plot.dataset_analysis import plot_train_time_deep_dive
+from tabarena.plot.interactive.pareto_explorer import build_pareto_explorer_html
 from tabarena.plot.plot_ens_weights import create_heatmap
-from tabarena.plot.plot_pareto_frontier import (
-    plot_pareto as _plot_pareto,
-)
+from tabarena.plot.plot_pareto_focus import plot_pareto_focus
 from tabarena.utils.normalized_scorer import NormalizedScorer
+from tabarena.website.website_format import get_model_family
 
 MethodLabelStyle = str | Mapping[str, object]
 
@@ -1690,34 +1690,34 @@ class LeaderboardReporter:
         )
         f_map_suffix = get_f_map_suffix_plots()
         leaderboard_pareto["suffix"] = leaderboard_pareto["Type"].map(f_map_suffix).fillna("")
-        method_order = None
         plot_pareto_kwargs = {}
         if plot_tuning_kwargs is not None:
             if "hidden_methods" in plot_tuning_kwargs:
                 leaderboard_pareto = leaderboard_pareto[
                     ~leaderboard_pareto["Method"].isin(plot_tuning_kwargs["hidden_methods"])
                 ]
-            if "pareto_order" in plot_tuning_kwargs:
-                method_order = plot_tuning_kwargs["pareto_order"]
             if "method_style_map" in plot_tuning_kwargs:
                 method_style_map = plot_tuning_kwargs["method_style_map"]
                 display_name_map = {m: v["display_name"] for m, v in method_style_map.items() if "display_name" in v}
                 leaderboard_pareto["Method"] = (
                     leaderboard_pareto["Method"].map(display_name_map).fillna(leaderboard_pareto["Method"])
                 )
-                if method_order is not None:
-                    method_order = [display_name_map.get(m, m) for m in method_order]
             if "title" in plot_tuning_kwargs:
                 plot_pareto_kwargs["title"] = plot_tuning_kwargs["title"]
 
-        # Per-method color overrides (display name -> matplotlib color). Pins a fixed color for
-        # specific method families instead of letting seaborn auto-assign from the palette, so a
-        # method keeps the same color across runs / subsets. Keyed by the long display name in the
-        # "Method" column (e.g. "TabM", "TabPFN-3"). A standalone arg (not a `plot_tuning_kwargs`
-        # key) because `plot_tuning_kwargs` is splatted into `plot_tuning_impact`, which would
-        # reject an unknown keyword.
-        if method_color_overrides is not None:
-            plot_pareto_kwargs["color_overrides"] = method_color_overrides
+        # Model-family classification drives point colors in the focus-style
+        # scatter (`plot_pareto_focus`); per-method colors/orders (the old
+        # `method_color_overrides` / `pareto_order` inputs) no longer apply.
+        # Prefer the raw config_type key when present (configs); baselines have
+        # NaN config_type, so fall back to the display name — `get_model_family`
+        # accepts both forms.
+        if "config_type" in leaderboard_pareto.columns:
+            leaderboard_pareto["Family"] = [
+                get_model_family(ct if not pd.isna(ct) else m)
+                for ct, m in zip(leaderboard_pareto["config_type"], leaderboard_pareto["Method"], strict=True)
+            ]
+        else:
+            leaderboard_pareto["Family"] = leaderboard_pareto["Method"].map(get_model_family)
 
         leaderboard_pareto[self.method_col] = leaderboard_pareto["Method"] + leaderboard_pareto["suffix"]
         fig_rename_dict = {
@@ -1741,171 +1741,157 @@ class LeaderboardReporter:
         if not with_baselines:
             leaderboard_pareto = leaderboard_pareto[leaderboard_pareto["Type"] != "Baseline"]
 
-        self.plot_pareto_elo_vs_time_infer(
-            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
-        )
-        self.plot_pareto_elo_vs_time_train(
-            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
-        )
-        self.plot_pareto_improvability_vs_time_infer(
-            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
-        )
-        self.plot_pareto_improvability_vs_time_train(
-            leaderboard=leaderboard_pareto, method_order=method_order, **plot_pareto_kwargs
+        self.plot_pareto_elo_vs_time_infer(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
+        self.plot_pareto_elo_vs_time_train(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
+        self.plot_pareto_improvability_vs_time_infer(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
+        self.plot_pareto_improvability_vs_time_train(leaderboard=leaderboard_pareto, **plot_pareto_kwargs)
+        self.build_pareto_explorer(leaderboard=leaderboard_pareto)
+
+    def _plot_pareto_focus_figure(
+        self,
+        leaderboard: pd.DataFrame,
+        *,
+        file_name: str,
+        x_source_col: str,
+        x_name: str,
+        y_source_col: str,
+        y_name: str,
+        max_Y: bool,
+        y_scale: float = 1.0,
+        title: str | None = None,
+        focus_methods: list[str] | None = None,
+    ):
+        """Shared body of the four ``pareto_front_*`` website figures: map the
+        leaderboard's raw columns onto display axes and render the focus-style
+        scatter (family colors, Pareto front + ``focus_methods`` emphasized,
+        every other method greyed out).
+        """
+        data = leaderboard.copy()
+        data[x_name] = data[x_source_col]
+        data[y_name] = data[y_source_col] * y_scale
+
+        plot_pareto_focus(
+            data=data,
+            x_col=x_name,
+            y_col=y_name,
+            method_col="Method",
+            variant_col="Type",
+            family_col="Family",
+            max_X=False,
+            max_Y=max_Y,
+            focus_methods=focus_methods,
+            variant_markers=self.style_markers,
+            title=title,
+            save_path=str(Path(self.output_dir) / f"{file_name}.{self.figure_file_type}"),
+            show=False,
         )
 
     def plot_pareto_elo_vs_time_train(
         self,
         leaderboard: pd.DataFrame,
-        method_order: list[str] | None = None,
         title: str | None = "auto",
-        color_overrides: dict[str, str] | None = None,
+        focus_methods: list[str] | None = None,
     ):
-        save_prefix = Path(self.output_dir)
-        save_path = str(save_prefix / f"pareto_front_elo_vs_time_train.{self.figure_file_type}")
-        y_name = "Elo"
-        x_name = "Train time per 1K samples (s) (median)"
-        if title == "auto":
-            title = "Elo vs Train Time"
-
-        data = leaderboard.copy()
-        data[x_name] = data["median_time_train_s_per_1K"]
-        data[y_name] = data["elo"]
-
-        _plot_pareto(
-            data=data,
-            x_name=x_name,
-            y_name=y_name,
-            max_X=False,
+        self._plot_pareto_focus_figure(
+            leaderboard,
+            file_name="pareto_front_elo_vs_time_train",
+            x_source_col="median_time_train_s_per_1K",
+            x_name="Train time per 1K samples (s) (median)",
+            y_source_col="elo",
+            y_name="Elo",
             max_Y=True,
-            sort_y=True,
-            hue="Method",  # color by family
-            style_col="Type",  # marker by run type
-            style_order=self.style_order,
-            style_markers=self.style_markers,
-            label_col=self.method_col,  # annotate with full method name
-            title=title,
-            save_path=save_path,
-            show=False,
-            aspect=4 / 3,
-            legend_first=method_order,
-            color_overrides=color_overrides,
+            title="Elo vs Train Time" if title == "auto" else title,
+            focus_methods=focus_methods,
         )
 
     def plot_pareto_elo_vs_time_infer(
         self,
         leaderboard: pd.DataFrame,
-        method_order: list[str] | None = None,
         title: str | None = "auto",
-        color_overrides: dict[str, str] | None = None,
+        focus_methods: list[str] | None = None,
     ):
-        save_prefix = Path(self.output_dir)
-        save_path = str(save_prefix / f"pareto_front_elo_vs_time_infer.{self.figure_file_type}")
-        y_name = "Elo"
-        x_name = "Inference time per 1K samples (s) (median)"
-        if title == "auto":
-            title = "Elo vs Inference Time"
-
-        data = leaderboard.copy()
-        data[x_name] = data["median_time_infer_s_per_1K"]
-        data[y_name] = data["elo"]
-
-        _plot_pareto(
-            data=data,
-            x_name=x_name,
-            y_name=y_name,
-            max_X=False,
+        self._plot_pareto_focus_figure(
+            leaderboard,
+            file_name="pareto_front_elo_vs_time_infer",
+            x_source_col="median_time_infer_s_per_1K",
+            x_name="Inference time per 1K samples (s) (median)",
+            y_source_col="elo",
+            y_name="Elo",
             max_Y=True,
-            sort_y=True,
-            hue="Method",  # <-- same color for same method_type
-            style_col="Type",  # <-- different marker per run_type
-            style_order=self.style_order,
-            style_markers=self.style_markers,
-            label_col=self.method_col,  # <-- annotate with full method name
-            title=title,
-            save_path=save_path,
-            show=False,
-            aspect=4 / 3,
-            legend_first=method_order,
-            color_overrides=color_overrides,
+            title="Elo vs Inference Time" if title == "auto" else title,
+            focus_methods=focus_methods,
         )
 
     def plot_pareto_improvability_vs_time_infer(
         self,
         leaderboard: pd.DataFrame,
-        method_order: list[str] | None = None,
         title: str | None = "auto",
-        color_overrides: dict[str, str] | None = None,
+        focus_methods: list[str] | None = None,
     ):
-        save_prefix = Path(self.output_dir)
-        save_path = str(save_prefix / f"pareto_front_improvability_vs_time_infer.{self.figure_file_type}")
-        y_name = "Improvability (%)"
-        x_name = "Inference time per 1K samples (s) (median)"
-        if title == "auto":
-            title = "Improvability vs Inference Time"
-
-        data = leaderboard.copy()
-        data[x_name] = data["median_time_infer_s_per_1K"]
-        data[y_name] = data["improvability"] * 100
-
-        _plot_pareto(
-            data=data,
-            x_name=x_name,
-            y_name=y_name,
-            max_X=False,
+        self._plot_pareto_focus_figure(
+            leaderboard,
+            file_name="pareto_front_improvability_vs_time_infer",
+            x_source_col="median_time_infer_s_per_1K",
+            x_name="Inference time per 1K samples (s) (median)",
+            y_source_col="improvability",
+            y_name="Improvability (%)",
+            y_scale=100,
             max_Y=False,
-            sort_y=True,
-            hue="Method",  # color by family
-            style_col="Type",  # marker by run type
-            style_order=self.style_order,
-            style_markers=self.style_markers,
-            label_col=self.method_col,  # annotate with full method name
-            # ylim=(0, None),
-            title=title,
-            save_path=save_path,
-            show=False,
-            aspect=4 / 3,
-            legend_first=method_order,
-            color_overrides=color_overrides,
+            title="Improvability vs Inference Time" if title == "auto" else title,
+            focus_methods=focus_methods,
         )
 
     def plot_pareto_improvability_vs_time_train(
         self,
         leaderboard: pd.DataFrame,
-        method_order: list[str] | None = None,
         title: str | None = "auto",
-        color_overrides: dict[str, str] | None = None,
+        focus_methods: list[str] | None = None,
     ):
-        save_prefix = Path(self.output_dir)
-        save_path = str(save_prefix / f"pareto_front_improvability_vs_time_train.{self.figure_file_type}")
-        y_name = "Improvability (%)"
-        x_name = "Train time per 1K samples (s) (median)"
-        if title == "auto":
-            title = "Improvability vs Train Time"
-
-        data = leaderboard.copy()
-        data[x_name] = data["median_time_train_s_per_1K"]
-        data[y_name] = data["improvability"] * 100
-
-        _plot_pareto(
-            data=data,
-            x_name=x_name,
-            y_name=y_name,
-            max_X=False,
+        self._plot_pareto_focus_figure(
+            leaderboard,
+            file_name="pareto_front_improvability_vs_time_train",
+            x_source_col="median_time_train_s_per_1K",
+            x_name="Train time per 1K samples (s) (median)",
+            y_source_col="improvability",
+            y_name="Improvability (%)",
+            y_scale=100,
             max_Y=False,
-            sort_y=True,
-            hue="Method",  # color by family
-            style_col="Type",  # marker by run type
-            style_order=self.style_order,
-            style_markers=self.style_markers,
-            label_col=self.method_col,  # annotate with full method name
-            # ylim=(0, None),
-            title=title,
-            save_path=save_path,
-            show=False,
-            aspect=4 / 3,
-            legend_first=method_order,
-            color_overrides=color_overrides,
+            title="Improvability vs Train Time" if title == "auto" else title,
+            focus_methods=focus_methods,
+        )
+
+    def build_pareto_explorer(self, leaderboard: pd.DataFrame):
+        """Write the self-contained interactive Pareto explorer
+        (``pareto_front_explorer.html``) and its underlying data
+        (``pareto_front_points.csv``) next to the static figures.
+        """
+        points = pd.DataFrame(
+            {
+                "method": leaderboard["Method"],
+                "variant": leaderboard["Type"],
+                "family": leaderboard["Family"],
+                "x": leaderboard["median_time_infer_s_per_1K"],
+                "imp": leaderboard["improvability"] * 100,
+                "elo": leaderboard["elo"],
+            }
+        )
+        # `imputed` is the imputed-task fraction aggregated per method-variant;
+        # older results frames may not carry it.
+        if "imputed" in leaderboard.columns:
+            imputed_frac = leaderboard["imputed"].fillna(0.0).astype(float)
+        else:
+            imputed_frac = pd.Series(0.0, index=leaderboard.index)
+        points["imputed"] = imputed_frac > 0
+        points["imputed_pct"] = imputed_frac * 100
+        points = points.dropna(subset=["x", "imp", "elo"]).reset_index(drop=True)
+        if points.empty:
+            return
+
+        save_pd.save(path=str(Path(self.output_dir) / "pareto_front_points.csv"), df=points)
+        build_pareto_explorer_html(
+            points=points,
+            x_label="Inference time per 1K samples (s), median — log scale",
+            save_path=Path(self.output_dir) / "pareto_front_explorer.html",
         )
 
     def get_method_rename_map(self) -> dict[str, str]:

--- a/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
+++ b/packages/tabarena/src/tabarena/evaluation/leaderboard_reporter.py
@@ -1904,6 +1904,8 @@ class LeaderboardReporter:
             # Single time axis (inference, the panel the website led with
             # historically); train time stays available in the CSV export.
             x_keys=["x_infer"],
+            # Mirrored against the trajectories explorer (chips right there).
+            chips_side="left",
             save_path=Path(self.output_dir) / "pareto_front_explorer.html",
         )
 

--- a/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
@@ -56,14 +56,17 @@ def evaluate_all(
     evaluator_kwargs: dict | None = None,
     engine: str = "auto",
     progress_bar: bool = True,
+    website_only: bool = False,
 ):
     if evaluator_kwargs is None:
         evaluator_kwargs = {}
 
-    # All methods are shown on the Pareto figures — weak methods are greyed
-    # out by the focus styling rather than banned.
+    # Only the baselines (KNN/LR) are banned from the Pareto figures — they sit
+    # far above every real method and stretch the improvability axis. Weak
+    # non-baseline methods stay, greyed out by the focus styling.
     evaluator_kwargs_ = {
         "use_latex": use_latex,
+        "banned_pareto_methods": ["KNN", "LR"],
     }
     evaluator_kwargs_.update(evaluator_kwargs)
     evaluator_kwargs = evaluator_kwargs_
@@ -131,6 +134,7 @@ def evaluate_all(
             "baselines": baselines,
             "baseline_colors": baseline_colors,
             "elo_bootstrap_rounds": elo_bootstrap_rounds,
+            "website_only": website_only,
         },
         engine=engine,
         progress_bar=progress_bar,
@@ -153,6 +157,7 @@ def evaluate_single(
     baseline_colors: list[str] | None = None,
     elo_bootstrap_rounds: int = 200,
     custom_folder_name: str | None = None,
+    website_only: bool = False,
 ):
     from tabarena.nips2025_utils.compare import subset_tasks
 
@@ -231,8 +236,11 @@ def evaluate_single(
     leaderboard = plotter.eval(
         df_results=df_results,
         plot_extra_barplots=False,
-        include_norm_score=True,
-        plot_times=True,
+        # The website ships neither the normalized-score bar plots nor the
+        # per-method time plots — skip them in website_only mode.
+        include_norm_score=not website_only,
+        plot_times=not website_only,
+        website_only=website_only,
         average_seeds=average_seeds,
         # Keep baselines out of evaluate_all's Pareto plots: LeaderboardReporter.eval now
         # defaults plot_with_baselines=True for the compare paths, but the paper-figure /

--- a/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
+++ b/packages/tabarena/src/tabarena/nips2025_utils/eval_all.py
@@ -59,11 +59,11 @@ def evaluate_all(
 ):
     if evaluator_kwargs is None:
         evaluator_kwargs = {}
-    banned_pareto_methods = ["KNN", "LR", "PB", "TABSTAR"]
 
+    # All methods are shown on the Pareto figures — weak methods are greyed
+    # out by the focus styling rather than banned.
     evaluator_kwargs_ = {
         "use_latex": use_latex,
-        "banned_pareto_methods": banned_pareto_methods,
     }
     evaluator_kwargs_.update(evaluator_kwargs)
     evaluator_kwargs = evaluator_kwargs_

--- a/packages/tabarena/src/tabarena/plot/interactive/__init__.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -434,7 +434,12 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
         const size = (on ? 7 : 5) * (TRAJECTORY ? 0.8 : 1);
         const op = on ? 0.95 : 0.5;
         drawMark(on ? ptsOn : ptsOff, X(p.x), Y(mval(p, metric)), p.variant, color, size, op, p.method, on);
-        if (p.imputed) drawImputedRing(on ? ptsOn : ptsOff, X(p.x), Y(mval(p, metric)), size, color, op, p.method);
+        // Imputation ring: every affected point in scatter mode; only the
+        // trajectory's end point in trajectory mode (a ring on all ~8 line
+        // points would read as beads, and the chip's ‡ already flags the line).
+        if (p.imputed && (!TRAJECTORY || p === pts[pts.length - 1])) {
+          drawImputedRing(on ? ptsOn : ptsOff, X(p.x), Y(mval(p, metric)), size, color, op, p.method);
+        }
       }
     }
 

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -163,6 +163,9 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     <label class="metricpick" id="metricpick" hidden>Y-axis
       <select id="metric-select"></select>
     </label>
+    <label class="metricpick" id="xaxispick" hidden>X-axis
+      <select id="xaxis-select"></select>
+    </label>
     <div class="btnrow">
       <button class="btn" id="btn-front">Pareto front</button>
       <button class="btn" id="btn-all">All</button>
@@ -330,19 +333,25 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
   const metricByKey = {};
   for (const m of METRICS) metricByKey[m.key] = m;
 
+  const X_AXES = CONFIG.xAxes;
+  let xKey = X_AXES[0].key;
+  const xAxisByKey = {};
+  for (const xa of X_AXES) xAxisByKey[xa.key] = xa;
+
   function mval(p, metric) { return p[metric.key]; }
 
-  function computeFront(metric) {
+  function computeFront(metric, xAxis) {
+    const xk = xAxis.key;
     const pts = [...POINTS].sort((a, b) =>
-      a.x - b.x || (metric.lowerBetter ? mval(a, metric) - mval(b, metric) : mval(b, metric) - mval(a, metric)));
+      a[xk] - b[xk] || (metric.lowerBetter ? mval(a, metric) - mval(b, metric) : mval(b, metric) - mval(a, metric)));
     const verts = [];
     const methods = new Set();
     let best = null;
     for (const p of pts) {
       const v = mval(p, metric);
       if (best === null || (metric.lowerBetter ? v < best : v > best)) {
-        if (best !== null) verts.push([p.x, best]);
-        verts.push([p.x, v]);
+        if (best !== null) verts.push([p[xk], best]);
+        verts.push([p[xk], v]);
         best = v;
         methods.add(p.method);
       }
@@ -350,18 +359,21 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     return { verts, methods };
   }
 
-  const state = { active: new Set(computeFront(metricByKey[metricKey]).methods) };
+  const state = { active: new Set(computeFront(metricByKey[metricKey], xAxisByKey[xKey]).methods) };
 
   // ---------- chart ----------
   const W = 960, H = 540, M = { l: 62, r: 18, t: 14, b: 52 };
-  const xsAll = POINTS.map(p => p.x);
-  const xmin = Math.min(...xsAll) * 0.65, xmax = Math.max(...xsAll) * 1.6;
-  const lx0 = Math.log10(xmin), lx1 = Math.log10(xmax);
-  const X = v => M.l + (Math.log10(v) - lx0) / (lx1 - lx0) * (W - M.l - M.r);
 
   function render() {
     const metric = metricByKey[metricKey];
+    const xAxis = xAxisByKey[xKey];
     svg.textContent = "";
+
+    // x scale (log), recomputed per render since the x-axis is switchable
+    const xsAll = POINTS.map(p => p[xKey]);
+    const xmin = Math.min(...xsAll) * 0.65, xmax = Math.max(...xsAll) * 1.6;
+    const lx0 = Math.log10(xmin), lx1 = Math.log10(xmax);
+    const X = v => M.l + (Math.log10(v) - lx0) / (lx1 - lx0) * (W - M.l - M.r);
 
     const vals = POINTS.map(p => mval(p, metric));
     let y0, y1;
@@ -390,14 +402,14 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     }
     el("rect", { x: M.l, y: M.t, width: W - M.l - M.r, height: H - M.t - M.b, fill: "none", stroke: "var(--line)" }, grid);
     el("text", { x: (M.l + W - M.r) / 2, y: H - 10, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)" }, grid)
-      .textContent = CONFIG.x_label;
+      .textContent = xAxis.axisLabel;
     el("text", { x: 0, y: 0, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)",
       transform: `translate(16 ${(M.t + H - M.b) / 2}) rotate(-90)` }, grid).textContent = metric.axisLabel;
 
     drawOptimalArrow(grid, metric.lowerBetter, M, W, H);
 
     // pareto front (always shown)
-    const front = computeFront(metric);
+    const front = computeFront(metric, xAxis);
     const fv = front.verts;
     if (fv.length) {
       let d = `M${X(fv[0][0])},${metric.lowerBetter ? M.t : H - M.b}`;
@@ -414,7 +426,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
       if (pts.length < 2) continue;
       const on = isOn(method);
       if (!TRAJECTORY && !on) continue; // scatter: connectors only for active methods
-      const dd = pts.map((p, i) => `${i ? "L" : "M"}${X(p.x)},${Y(mval(p, metric))}`).join(" ");
+      const dd = pts.map((p, i) => `${i ? "L" : "M"}${X(p[xKey])},${Y(mval(p, metric))}`).join(" ");
       el("path", {
         d: dd, fill: "none",
         stroke: on ? FAM_VAR[pts[0].family] : "var(--pt-muted)",
@@ -433,12 +445,12 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
         const color = on ? FAM_VAR[p.family] : "var(--pt-muted)";
         const size = (on ? 7 : 5) * (TRAJECTORY ? 0.8 : 1);
         const op = on ? 0.95 : 0.5;
-        drawMark(on ? ptsOn : ptsOff, X(p.x), Y(mval(p, metric)), p.variant, color, size, op, p.method, on);
+        drawMark(on ? ptsOn : ptsOff, X(p[xKey]), Y(mval(p, metric)), p.variant, color, size, op, p.method, on);
         // Imputation ring: every affected point in scatter mode; only the
         // trajectory's end point in trajectory mode (a ring on all ~8 line
         // points would read as beads, and the chip's ‡ already flags the line).
         if (p.imputed && (!TRAJECTORY || p === pts[pts.length - 1])) {
-          drawImputedRing(on ? ptsOn : ptsOff, X(p.x), Y(mval(p, metric)), size, color, op, p.method);
+          drawImputedRing(on ? ptsOn : ptsOff, X(p[xKey]), Y(mval(p, metric)), size, color, op, p.method);
         }
       }
     }
@@ -449,7 +461,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
       if (!isOn(method)) continue;
       const best = pts.reduce((a, b) =>
         (metric.lowerBetter ? mval(a, metric) < mval(b, metric) : mval(a, metric) > mval(b, metric)) ? a : b);
-      labels.push({ method, family: best.family, x: X(best.x) + 10, y: Y(mval(best, metric)) - 10 });
+      labels.push({ method, family: best.family, x: X(best[xKey]) + 10, y: Y(mval(best, metric)) - 10 });
     }
     labels.sort((a, b) => a.y - b.y);
     for (let i = 1; i < labels.length; i++) {
@@ -472,7 +484,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     // invisible hit targets on top (bigger than marks)
     const hits = el("g", {}, svg);
     for (const p of POINTS) {
-      const h = el("circle", { cx: X(p.x), cy: Y(mval(p, metric)), r: 12, fill: "transparent", cursor: "pointer" }, hits);
+      const h = el("circle", { cx: X(p[xKey]), cy: Y(mval(p, metric)), r: 12, fill: "transparent", cursor: "pointer" }, hits);
       h.addEventListener("mouseenter", ev => showTip(p, ev));
       h.addEventListener("mousemove", ev => tip.move(ev));
       h.addEventListener("mouseleave", () => hideTip(p.method));
@@ -502,7 +514,9 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     for (const m of METRICS) {
       html += `<div>${m.label}: <b>${fmtMetric(m, mval(p, m))}</b></div>`;
     }
-    html += `<div>${CONFIG.x_short}: <b>${fmtTime(p.x)}</b></div>`;
+    for (const xa of X_AXES) {
+      html += `<div>${xa.short}: <b>${fmtTime(p[xa.key])}</b></div>`;
+    }
     if (p.imputed) html += `<div class="t-imp">Imputed on ${p.imputed_pct.toFixed(0)}% of datasets</div>`;
     tip.show(html, ev);
   }
@@ -595,7 +609,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     render();
   }
   document.getElementById("btn-front").addEventListener("click",
-    () => setActive(computeFront(metricByKey[metricKey]).methods));
+    () => setActive(computeFront(metricByKey[metricKey], xAxisByKey[xKey]).methods));
   document.getElementById("btn-all").addEventListener("click", () => setActive([...byMethod.keys()]));
   document.getElementById("btn-none").addEventListener("click", () => setActive([]));
 
@@ -612,6 +626,23 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     }
     metricSelect.addEventListener("change", ev => {
       metricKey = ev.target.value;
+      render();
+    });
+  }
+
+  // x-axis selector (hidden when only one time axis is configured)
+  const xAxisPick = document.getElementById("xaxispick");
+  const xAxisSelect = document.getElementById("xaxis-select");
+  if (X_AXES.length > 1) {
+    xAxisPick.hidden = false;
+    for (const xa of X_AXES) {
+      const opt = document.createElement("option");
+      opt.value = xa.key;
+      opt.textContent = xa.label;
+      xAxisSelect.appendChild(opt);
+    }
+    xAxisSelect.addEventListener("change", ev => {
+      xKey = ev.target.value;
       render();
     });
   }
@@ -644,11 +675,13 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     html += TRAJECTORY ? "<th>Configs</th>" : "<th>Variant</th>";
     html += "<th>Family</th>";
     for (const m of METRICS) html += `<th>${m.label}</th>`;
-    html += `<th>${CONFIG.x_short}</th><th>Imputed</th></tr></thead><tbody>`;
+    for (const xa of X_AXES) html += `<th>${xa.short}</th>`;
+    html += "<th>Imputed</th></tr></thead><tbody>";
     for (const p of rows) {
       html += `<tr><td>${p.method}</td><td>${TRAJECTORY ? (p.n_configs != null ? p.n_configs : "—") : p.variant}</td><td>${p.family}</td>`;
       for (const m of METRICS) html += `<td>${fmtMetric(m, mval(p, m))}</td>`;
-      html += `<td>${p.x.toFixed(3)}</td><td>${p.imputed ? p.imputed_pct.toFixed(0) + "%" : "—"}</td></tr>`;
+      for (const xa of X_AXES) html += `<td>${p[xa.key].toFixed(3)}</td>`;
+      html += `<td>${p.imputed ? p.imputed_pct.toFixed(0) + "%" : "—"}</td></tr>`;
     }
     html += "</tbody></table>";
     document.getElementById("tblwrap").innerHTML = html;

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -1,0 +1,650 @@
+"""HTML/CSS/JS template for the self-contained interactive Pareto explorer.
+
+Kept as a Python string constant (rather than a package-data file) so it ships
+with the package without any build-system data-file configuration. The
+placeholders ``__PAGE_TITLE__``, ``__CONFIG_JSON__`` and ``__POINTS_JSON__``
+are substituted by :func:`tabarena.plot.interactive.pareto_explorer.build_pareto_explorer_html`.
+
+The rendered page has zero external dependencies (no plotting library, fonts,
+or CDN assets), renders in light and dark mode via ``prefers-color-scheme``,
+and offers: per-method highlight chips grouped by model family, family-level
+toggle buttons, a metric selector (e.g. Improvability vs Elo) that re-anchors
+the Pareto front, hover tooltips with exact values, dashed-ring marking of
+partially imputed methods, and a collapsible data table.
+"""
+
+from __future__ import annotations
+
+EXPLORER_TEMPLATE = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__PAGE_TITLE__</title>
+<style>
+  :root {
+    --paper: #ffffff;
+    --card: #ffffff;
+    --ink: #14161a;
+    --muted: #6d6c65;
+    --line: #e4e3db;
+    --accent: #2a78d6;
+    --chip-bg: #f2f1ec;
+    --pt-muted: #b9b8b1;
+    --fam-foundation: #2a78d6;
+    --fam-tree: #eb6834;
+    --fam-nn: #1baf7a;
+    --fam-other: #4a3aa7;
+    --fam-reference: #e87ba4;
+    --fam-baseline: #898781;
+    --optimal: #228b22;
+    --tooltip-bg: #14161a;
+    --tooltip-ink: #fbfbf9;
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #131316;
+      --card: #1b1b1f;
+      --ink: #f0efea;
+      --muted: #9b9a92;
+      --line: #2e2e33;
+      --accent: #3987e5;
+      --chip-bg: #232327;
+      --pt-muted: #55555c;
+      --fam-foundation: #3987e5;
+      --fam-tree: #d95926;
+      --fam-nn: #199e70;
+      --fam-other: #9085e9;
+      --fam-reference: #d55181;
+      --fam-baseline: #898781;
+      --optimal: #2ea043;
+      --tooltip-bg: #f0efea;
+      --tooltip-ink: #14161a;
+      color-scheme: dark;
+    }
+  }
+
+  html, body { margin: 0; background: var(--paper); }
+  body {
+    color: var(--ink);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.5;
+    padding: 10px 12px 14px;
+  }
+
+  .explorer-title { font-size: 15px; font-weight: 650; margin: 0 0 8px; }
+  .controls { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; margin-bottom: 10px; }
+  .controls .hint { font-size: 12.5px; color: var(--muted); }
+  .btnrow { display: flex; gap: 6px; flex-wrap: wrap; }
+  .btn {
+    font: 600 12.5px/1 system-ui, sans-serif; color: var(--ink);
+    background: var(--chip-bg); border: 1px solid var(--line); border-radius: 7px;
+    padding: 6px 11px; cursor: pointer;
+  }
+  .btn:hover { border-color: var(--muted); }
+  .btn:focus-visible, .chip:focus-visible, .famchip:focus-visible, select:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 2px;
+  }
+  .metricpick { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: 600; color: var(--muted); }
+  .metricpick select {
+    font: 600 12.5px/1.2 system-ui, sans-serif; color: var(--ink);
+    background: var(--chip-bg); border: 1px solid var(--line); border-radius: 7px;
+    padding: 5px 7px; cursor: pointer;
+  }
+
+  .chips { display: flex; flex-direction: column; gap: 6px; margin-bottom: 10px; }
+  .chiprow { display: flex; align-items: flex-start; gap: 9px; }
+  .famchip {
+    flex: 0 0 152px; display: inline-flex; align-items: center; gap: 6px; justify-content: flex-end;
+    font: 650 10.5px/1.3 system-ui, sans-serif; letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--muted); background: var(--chip-bg); border: 1px dashed var(--line);
+    border-radius: 999px; padding: 5px 10px; cursor: pointer; margin-top: 1px;
+  }
+  .famchip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam); flex: none; }
+  .famchip .count { font-weight: 500; letter-spacing: 0; opacity: 0.75; }
+  .famchip:hover { border-color: var(--fam); color: var(--ink); }
+  .famchip[aria-pressed="true"] {
+    border: 1px solid var(--fam);
+    background: color-mix(in srgb, var(--fam) 13%, transparent);
+    color: var(--ink);
+  }
+  .chipset { display: flex; flex-wrap: wrap; gap: 4px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 5px;
+    font: 500 12.5px/1 system-ui, sans-serif; color: var(--ink);
+    background: none; border: 1px solid var(--line); border-radius: 999px;
+    padding: 5px 10px 5px 8px; cursor: pointer;
+  }
+  .chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--pt-muted); flex: none; }
+  .chip .imp-mark { color: var(--muted); font-weight: 700; margin-left: -2px; }
+  .chip[aria-pressed="true"] { border-color: var(--fam); background: color-mix(in srgb, var(--fam) 13%, transparent); font-weight: 650; }
+  .chip[aria-pressed="true"] .dot { background: var(--fam); }
+  .chip:hover { border-color: var(--muted); }
+
+  .chartbox { position: relative; }
+  .chartbox svg { width: 100%; height: auto; display: block; }
+  .legendstrip {
+    display: flex; flex-wrap: wrap; gap: 5px 16px; align-items: center;
+    font-size: 12.5px; color: var(--muted); padding: 2px 2px 8px;
+  }
+  .legendstrip .item { display: inline-flex; align-items: center; gap: 6px; }
+
+  .tooltip {
+    position: absolute; pointer-events: none; display: none;
+    background: var(--tooltip-bg); color: var(--tooltip-ink);
+    border-radius: 8px; padding: 8px 11px; font-size: 12px; line-height: 1.45;
+    max-width: 260px; z-index: 5; font-variant-numeric: tabular-nums;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.25);
+  }
+  .tooltip .t-name { font-weight: 700; font-size: 12.5px; }
+  .tooltip .t-var { opacity: 0.75; }
+  .tooltip .t-imp { opacity: 0.85; font-style: italic; }
+
+  details.datatable { margin-top: 8px; font-size: 12.5px; }
+  details.datatable summary { cursor: pointer; color: var(--muted); font-weight: 600; }
+  details.datatable .tblwrap { overflow-x: auto; margin-top: 8px; }
+  details.datatable table { border-collapse: collapse; font-variant-numeric: tabular-nums; min-width: 560px; }
+  details.datatable th, details.datatable td {
+    text-align: left; padding: 3px 12px 3px 0; border-bottom: 1px solid var(--line);
+  }
+  details.datatable th { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); }
+
+  svg text { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .chip, .btn, .famchip { transition: border-color 120ms ease, background-color 120ms ease; }
+  }
+</style>
+</head>
+<body>
+  <p class="explorer-title" id="title"></p>
+  <div class="controls">
+    <label class="metricpick" id="metricpick" hidden>Y-axis
+      <select id="metric-select"></select>
+    </label>
+    <div class="btnrow">
+      <button class="btn" id="btn-front">Pareto front</button>
+      <button class="btn" id="btn-all">All</button>
+      <button class="btn" id="btn-none">Clear</button>
+    </div>
+    <span class="hint">Click methods or family buttons to highlight &middot; hover points for details</span>
+  </div>
+  <div class="chips" id="chips"></div>
+  <div class="legendstrip" id="legendstrip"></div>
+  <div class="chartbox" id="chartbox">
+    <svg id="chart" viewBox="0 0 960 540" role="img" aria-label="Pareto front explorer"></svg>
+    <div class="tooltip"></div>
+  </div>
+  <details class="datatable">
+    <summary>Data table</summary>
+    <div class="tblwrap" id="tblwrap"></div>
+  </details>
+
+<script>
+(function () {
+  "use strict";
+  const CONFIG = __CONFIG_JSON__;
+  const POINTS = __POINTS_JSON__;
+
+  const FAM_ORDER = ["Foundation Model", "Tree-based", "Neural Network", "Other", "Reference Pipeline", "Baseline"];
+  const FAM_VAR = {
+    "Foundation Model": "var(--fam-foundation)",
+    "Tree-based": "var(--fam-tree)",
+    "Neural Network": "var(--fam-nn)",
+    "Other": "var(--fam-other)",
+    "Reference Pipeline": "var(--fam-reference)",
+    "Baseline": "var(--fam-baseline)",
+  };
+  const NS = "http://www.w3.org/2000/svg";
+  const TRAJECTORY = CONFIG.mode === "trajectory";
+
+  const titleEl = document.getElementById("title");
+  if (CONFIG.title) titleEl.textContent = CONFIG.title; else titleEl.hidden = true;
+
+  const svg = document.getElementById("chart");
+  const box = document.getElementById("chartbox");
+  const tipEl = box.querySelector(".tooltip");
+  const tip = {
+    show(html, ev) { tipEl.innerHTML = html; tipEl.style.display = "block"; this.move(ev); },
+    move(ev) {
+      const r = box.getBoundingClientRect();
+      let tx = ev.clientX - r.left + 14, ty = ev.clientY - r.top + 12;
+      if (tx > r.width - 270) tx = ev.clientX - r.left - 274;
+      tipEl.style.left = tx + "px";
+      tipEl.style.top = ty + "px";
+    },
+    hide() { tipEl.style.display = "none"; },
+  };
+
+  // ---------- helpers ----------
+  function el(name, attrs, parent) {
+    const node = document.createElementNS(NS, name);
+    for (const k in attrs) node.setAttribute(k, attrs[k]);
+    if (parent) parent.appendChild(node);
+    return node;
+  }
+
+  // Marker glyph per variant at (cx, cy); trajectories use circles everywhere.
+  function drawMark(parent, cx, cy, variant, color, size, opacity, dataM, whiteStroke) {
+    const common = { opacity: opacity, "data-m": dataM };
+    let node;
+    if (TRAJECTORY || variant === "Default" || !variant) {
+      node = el("circle", { ...common, cx, cy, r: size, fill: color }, parent);
+    } else if (variant === "Tuned") {
+      const s = size * 1.75;
+      node = el("rect", { ...common, x: cx - s / 2, y: cy - s / 2, width: s, height: s, rx: 1.5, fill: color }, parent);
+    } else if (variant === "Tuned + Ens.") {
+      const d = size * 0.95;
+      node = el("path", {
+        ...common,
+        d: `M${cx - d},${cy - d} L${cx + d},${cy + d} M${cx - d},${cy + d} L${cx + d},${cy - d}`,
+        stroke: color, "stroke-width": size * 0.62, fill: "none", "stroke-linecap": "round",
+      }, parent);
+    } else {
+      // Any other variant (e.g. "Baseline", holdout types): diamond.
+      const s = size * 1.45;
+      node = el("rect", {
+        ...common, x: cx - s / 2, y: cy - s / 2, width: s, height: s, rx: 1,
+        fill: color, transform: `rotate(45 ${cx} ${cy})`,
+      }, parent);
+    }
+    if (whiteStroke && variant !== "Tuned + Ens.") {
+      node.setAttribute("stroke", "var(--card)");
+      node.setAttribute("stroke-width", "1");
+    }
+    return node;
+  }
+
+  function drawImputedRing(parent, cx, cy, size, color, opacity, dataM) {
+    el("circle", {
+      cx, cy, r: size + 4.5, fill: "none", stroke: color, "stroke-width": 1.4,
+      "stroke-dasharray": "3 2.5", opacity: opacity, "data-m": dataM,
+    }, parent);
+  }
+
+  // Fat green arrow pointing into the optimal corner (mirrors the static
+  // figures' "Optimal" arrow so both read the same way).
+  function drawOptimalArrow(parent, lowerBetter, M, W, H) {
+    const cornerY = lowerBetter ? H - M.b - 12 : M.t + 12;
+    const tailY = lowerBetter ? H - M.b - 64 : M.t + 64;
+    const cx = M.l + 12, tx = M.l + 64;
+    const dx = cx - tx, dy = cornerY - tailY;
+    const len = Math.hypot(dx, dy);
+    const ux = dx / len, uy = dy / len;
+    const headLen = 16;
+    const bx = cx - ux * headLen, by = cornerY - uy * headLen; // head base center
+    // line stops at the head base
+    el("line", {
+      x1: tx, y1: tailY, x2: bx, y2: by,
+      stroke: "var(--optimal)", "stroke-width": 13, "stroke-linecap": "round", opacity: 0.92,
+    }, parent);
+    const px = -uy, py = ux; // perpendicular
+    el("polygon", {
+      points: `${cx},${cornerY} ${bx + px * 11},${by + py * 11} ${bx - px * 11},${by - py * 11}`,
+      fill: "var(--optimal)", opacity: 0.92,
+    }, parent);
+    let angle = Math.atan2(dy, dx) * 180 / Math.PI;
+    if (angle > 90 || angle < -90) angle += 180;
+    const mx = (tx + bx) / 2, my = (tailY + by) / 2;
+    const t = el("text", {
+      x: mx, y: my, "text-anchor": "middle", "dominant-baseline": "middle",
+      "font-size": 10.5, "font-weight": 700, fill: "#ffffff",
+      transform: `rotate(${angle} ${mx} ${my})`,
+    }, parent);
+    t.textContent = "Optimal";
+  }
+
+  function ticks(min, max, target) {
+    const raw = (max - min) / target;
+    const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+    let step = mag;
+    for (const m of [1, 2, 5, 10]) {
+      if (mag * m >= raw) { step = mag * m; break; }
+    }
+    const out = [];
+    for (let v = Math.ceil(min / step) * step; v <= max + 1e-9; v += step) out.push(v);
+    return out;
+  }
+
+  function fmtTime(v) {
+    if (v >= 100) return v.toFixed(0) + " s";
+    if (v >= 1) return v.toFixed(1) + " s";
+    if (v >= 0.1) return v.toFixed(2) + " s";
+    return v.toFixed(3) + " s";
+  }
+
+  function fmtMetric(metric, v) {
+    return v.toFixed(metric.decimals) + (metric.suffix || "");
+  }
+
+  // ---------- data ----------
+  const byMethod = new Map();
+  for (const p of POINTS) {
+    if (!byMethod.has(p.method)) byMethod.set(p.method, []);
+    byMethod.get(p.method).push(p); // insertion order = builder's point order
+  }
+
+  const METRICS = CONFIG.metrics;
+  let metricKey = METRICS[0].key;
+  const metricByKey = {};
+  for (const m of METRICS) metricByKey[m.key] = m;
+
+  function mval(p, metric) { return p[metric.key]; }
+
+  function computeFront(metric) {
+    const pts = [...POINTS].sort((a, b) =>
+      a.x - b.x || (metric.lowerBetter ? mval(a, metric) - mval(b, metric) : mval(b, metric) - mval(a, metric)));
+    const verts = [];
+    const methods = new Set();
+    let best = null;
+    for (const p of pts) {
+      const v = mval(p, metric);
+      if (best === null || (metric.lowerBetter ? v < best : v > best)) {
+        if (best !== null) verts.push([p.x, best]);
+        verts.push([p.x, v]);
+        best = v;
+        methods.add(p.method);
+      }
+    }
+    return { verts, methods };
+  }
+
+  const state = { active: new Set(computeFront(metricByKey[metricKey]).methods) };
+
+  // ---------- chart ----------
+  const W = 960, H = 540, M = { l: 62, r: 18, t: 14, b: 52 };
+  const xsAll = POINTS.map(p => p.x);
+  const xmin = Math.min(...xsAll) * 0.65, xmax = Math.max(...xsAll) * 1.6;
+  const lx0 = Math.log10(xmin), lx1 = Math.log10(xmax);
+  const X = v => M.l + (Math.log10(v) - lx0) / (lx1 - lx0) * (W - M.l - M.r);
+
+  function render() {
+    const metric = metricByKey[metricKey];
+    svg.textContent = "";
+
+    const vals = POINTS.map(p => mval(p, metric));
+    let y0, y1;
+    if (metric.fromZero) {
+      y0 = 0; y1 = Math.max(...vals) * 1.07;
+    } else {
+      const pad = (Math.max(...vals) - Math.min(...vals)) * 0.07;
+      y0 = Math.min(...vals) - pad; y1 = Math.max(...vals) + pad;
+    }
+    const Y = v => M.t + (1 - (v - y0) / (y1 - y0)) * (H - M.t - M.b);
+
+    // grid + axes
+    const grid = el("g", {}, svg);
+    for (let e = Math.ceil(lx0); Math.pow(10, e) < xmax; e++) {
+      const gx = X(Math.pow(10, e));
+      el("line", { x1: gx, y1: M.t, x2: gx, y2: H - M.b, stroke: "var(--line)", "stroke-width": 1 }, grid);
+      const lbl = e >= 0 ? String(Math.pow(10, e)) : Math.pow(10, e).toFixed(-e);
+      el("text", { x: gx, y: H - M.b + 20, "text-anchor": "middle", "font-size": 12, fill: "var(--muted)" }, grid)
+        .textContent = lbl;
+    }
+    for (const yv of ticks(y0, y1, 6)) {
+      const gy = Y(yv);
+      el("line", { x1: M.l, y1: gy, x2: W - M.r, y2: gy, stroke: "var(--line)", "stroke-width": 1 }, grid);
+      el("text", { x: M.l - 8, y: gy + 4, "text-anchor": "end", "font-size": 12, fill: "var(--muted)" }, grid)
+        .textContent = yv;
+    }
+    el("rect", { x: M.l, y: M.t, width: W - M.l - M.r, height: H - M.t - M.b, fill: "none", stroke: "var(--line)" }, grid);
+    el("text", { x: (M.l + W - M.r) / 2, y: H - 10, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)" }, grid)
+      .textContent = CONFIG.x_label;
+    el("text", { x: 0, y: 0, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)",
+      transform: `translate(16 ${(M.t + H - M.b) / 2}) rotate(-90)` }, grid).textContent = metric.axisLabel;
+
+    drawOptimalArrow(grid, metric.lowerBetter, M, W, H);
+
+    // pareto front (always shown)
+    const front = computeFront(metric);
+    const fv = front.verts;
+    if (fv.length) {
+      let d = `M${X(fv[0][0])},${metric.lowerBetter ? M.t : H - M.b}`;
+      for (const [fx, fy] of fv) d += ` L${X(fx)},${Y(fy)}`;
+      d += ` L${W - M.r},${Y(fv[fv.length - 1][1])}`;
+      el("path", { d, fill: "none", stroke: "var(--ink)", "stroke-width": 1.6, "stroke-dasharray": "7 5", opacity: 0.85 }, svg);
+    }
+
+    const isOn = m => state.active.has(m);
+
+    // connectors: variant links (scatter) / the trajectory itself
+    const conn = el("g", {}, svg);
+    for (const [method, pts] of byMethod) {
+      if (pts.length < 2) continue;
+      const on = isOn(method);
+      if (!TRAJECTORY && !on) continue; // scatter: connectors only for active methods
+      const dd = pts.map((p, i) => `${i ? "L" : "M"}${X(p.x)},${Y(mval(p, metric))}`).join(" ");
+      el("path", {
+        d: dd, fill: "none",
+        stroke: on ? FAM_VAR[pts[0].family] : "var(--pt-muted)",
+        "stroke-width": on ? (TRAJECTORY ? 2 : 1.4) : 1,
+        opacity: on ? 0.6 : 0.35,
+        "data-m": method,
+      }, conn);
+    }
+
+    // points: inactive first, active on top
+    const ptsOff = el("g", {}, svg);
+    const ptsOn = el("g", {}, svg);
+    for (const [method, pts] of byMethod) {
+      const on = isOn(method);
+      for (const p of pts) {
+        const color = on ? FAM_VAR[p.family] : "var(--pt-muted)";
+        const size = (on ? 7 : 5) * (TRAJECTORY ? 0.8 : 1);
+        const op = on ? 0.95 : 0.5;
+        drawMark(on ? ptsOn : ptsOff, X(p.x), Y(mval(p, metric)), p.variant, color, size, op, p.method, on);
+        if (p.imputed) drawImputedRing(on ? ptsOn : ptsOff, X(p.x), Y(mval(p, metric)), size, color, op, p.method);
+      }
+    }
+
+    // labels for active methods at their best point, greedy de-overlap
+    const labels = [];
+    for (const [method, pts] of byMethod) {
+      if (!isOn(method)) continue;
+      const best = pts.reduce((a, b) =>
+        (metric.lowerBetter ? mval(a, metric) < mval(b, metric) : mval(a, metric) > mval(b, metric)) ? a : b);
+      labels.push({ method, family: best.family, x: X(best.x) + 10, y: Y(mval(best, metric)) - 10 });
+    }
+    labels.sort((a, b) => a.y - b.y);
+    for (let i = 1; i < labels.length; i++) {
+      for (let j = 0; j < i; j++) {
+        if (Math.abs(labels[i].x - labels[j].x) < 110 && Math.abs(labels[i].y - labels[j].y) < 15) {
+          labels[i].y = labels[j].y + 15;
+        }
+      }
+    }
+    const lg = el("g", {}, svg);
+    for (const l of labels) {
+      const t = el("text", {
+        x: Math.min(l.x, W - M.r - 8), y: Math.max(l.y, M.t + 12), "font-size": 13, "font-weight": 700,
+        fill: FAM_VAR[l.family], "paint-order": "stroke", stroke: "var(--card)", "stroke-width": 3.5,
+        "text-anchor": l.x > W - 120 ? "end" : "start",
+      }, lg);
+      t.textContent = l.method;
+    }
+
+    // invisible hit targets on top (bigger than marks)
+    const hits = el("g", {}, svg);
+    for (const p of POINTS) {
+      const h = el("circle", { cx: X(p.x), cy: Y(mval(p, metric)), r: 12, fill: "transparent", cursor: "pointer" }, hits);
+      h.addEventListener("mouseenter", ev => showTip(p, ev));
+      h.addEventListener("mousemove", ev => tip.move(ev));
+      h.addEventListener("mouseleave", () => hideTip(p.method));
+      h.addEventListener("click", () => toggle(p.method));
+    }
+  }
+
+  // Temporary hover emphasis without a re-render (a re-render would replace
+  // the hit node under the cursor mid-hover).
+  function emphasize(method, on) {
+    svg.querySelectorAll(`[data-m="${CSS.escape(method)}"]`).forEach(n => {
+      if (on) {
+        if (!n.dataset.save) n.dataset.save = n.getAttribute("opacity") || "1";
+        n.setAttribute("opacity", "0.95");
+      } else if (n.dataset.save) {
+        n.setAttribute("opacity", n.dataset.save);
+        delete n.dataset.save;
+      }
+    });
+  }
+
+  function showTip(p, ev) {
+    emphasize(p.method, true);
+    const sub = TRAJECTORY ? (p.n_configs != null ? `${p.n_configs} configs` : "") : (p.variant || "");
+    let html = `<div class="t-name">${p.method}` + (sub ? ` <span class="t-var">(${sub})</span>` : "") + "</div>" +
+      `<div>${p.family}</div>`;
+    for (const m of METRICS) {
+      html += `<div>${m.label}: <b>${fmtMetric(m, mval(p, m))}</b></div>`;
+    }
+    html += `<div>${CONFIG.x_short}: <b>${fmtTime(p.x)}</b></div>`;
+    if (p.imputed) html += `<div class="t-imp">Imputed on ${p.imputed_pct.toFixed(0)}% of datasets</div>`;
+    tip.show(html, ev);
+  }
+  function hideTip(method) {
+    emphasize(method, false);
+    tip.hide();
+  }
+
+  // ---------- chips ----------
+  const chipsBox = document.getElementById("chips");
+  const chipByMethod = new Map();
+  const famChips = new Map();
+  function familyMethods(fam) {
+    return [...byMethod.keys()].filter(m => byMethod.get(m)[0].family === fam);
+  }
+  function buildChips() {
+    for (const fam of FAM_ORDER) {
+      const methods = familyMethods(fam).sort();
+      if (!methods.length) continue;
+      const row = document.createElement("div");
+      row.className = "chiprow";
+      const famBtn = document.createElement("button");
+      famBtn.className = "famchip";
+      famBtn.style.setProperty("--fam", FAM_VAR[fam]);
+      famBtn.innerHTML = `<span class="dot"></span>${fam} <span class="count">&times;${methods.length}</span>`;
+      famBtn.title = `Toggle all ${methods.length} ${fam} methods`;
+      famBtn.addEventListener("click", () => toggleFamily(fam));
+      row.appendChild(famBtn);
+      famChips.set(fam, famBtn);
+      const set = document.createElement("div");
+      set.className = "chipset";
+      for (const m of methods) {
+        const b = document.createElement("button");
+        b.className = "chip";
+        b.style.setProperty("--fam", FAM_VAR[fam]);
+        const imputed = byMethod.get(m).some(p => p.imputed);
+        const label = document.createElement("span");
+        label.textContent = m;
+        b.appendChild(Object.assign(document.createElement("span"), { className: "dot" }));
+        b.appendChild(label);
+        if (imputed) {
+          const mark = document.createElement("span");
+          mark.className = "imp-mark";
+          mark.textContent = "‡";
+          b.appendChild(mark);
+        }
+        b.title = m + (imputed ? " — partially imputed" : "");
+        b.addEventListener("click", () => toggle(m));
+        set.appendChild(b);
+        chipByMethod.set(m, b);
+      }
+      row.appendChild(set);
+      chipsBox.appendChild(row);
+    }
+  }
+  function syncChips() {
+    for (const [m, b] of chipByMethod) b.setAttribute("aria-pressed", String(state.active.has(m)));
+    for (const [fam, b] of famChips) {
+      b.setAttribute("aria-pressed", String(familyMethods(fam).every(m => state.active.has(m))));
+    }
+  }
+  function toggle(m) {
+    if (state.active.has(m)) state.active.delete(m); else state.active.add(m);
+    syncChips();
+    render();
+  }
+  function toggleFamily(fam) {
+    const methods = familyMethods(fam);
+    const allOn = methods.every(m => state.active.has(m));
+    for (const m of methods) {
+      if (allOn) state.active.delete(m); else state.active.add(m);
+    }
+    syncChips();
+    render();
+  }
+  function setActive(methods) {
+    state.active = new Set(methods);
+    syncChips();
+    render();
+  }
+  document.getElementById("btn-front").addEventListener("click",
+    () => setActive(computeFront(metricByKey[metricKey]).methods));
+  document.getElementById("btn-all").addEventListener("click", () => setActive([...byMethod.keys()]));
+  document.getElementById("btn-none").addEventListener("click", () => setActive([]));
+
+  // metric selector (hidden when only one metric is configured)
+  const metricPick = document.getElementById("metricpick");
+  const metricSelect = document.getElementById("metric-select");
+  if (METRICS.length > 1) {
+    metricPick.hidden = false;
+    for (const m of METRICS) {
+      const opt = document.createElement("option");
+      opt.value = m.key;
+      opt.textContent = m.label;
+      metricSelect.appendChild(opt);
+    }
+    metricSelect.addEventListener("change", ev => {
+      metricKey = ev.target.value;
+      render();
+    });
+  }
+
+  // ---------- legend strip ----------
+  function buildLegend() {
+    const box2 = document.getElementById("legendstrip");
+    let html = "";
+    if (!TRAJECTORY) {
+      html +=
+        '<span class="item"><svg width="14" height="14" viewBox="0 0 14 14"><circle cx="7" cy="7" r="5" fill="var(--muted)"/></svg> Default</span>' +
+        '<span class="item"><svg width="14" height="14" viewBox="0 0 14 14"><rect x="2" y="2" width="10" height="10" rx="1.5" fill="var(--muted)"/></svg> Tuned</span>' +
+        '<span class="item"><svg width="14" height="14" viewBox="0 0 14 14"><path d="M3,3 L11,11 M3,11 L11,3" stroke="var(--muted)" stroke-width="2.6" stroke-linecap="round"/></svg> Tuned + Ensembled</span>';
+    } else {
+      html += '<span class="item"><svg width="26" height="8" viewBox="0 0 26 8"><line x1="0" y1="4" x2="26" y2="4" stroke="var(--muted)" stroke-width="2"/><circle cx="6" cy="4" r="2.6" fill="var(--muted)"/><circle cx="16" cy="4" r="2.6" fill="var(--muted)"/></svg> Tuning trajectory (more configs &rarr; more time)</span>';
+    }
+    html += '<span class="item"><svg width="26" height="8" viewBox="0 0 26 8"><line x1="0" y1="4" x2="26" y2="4" stroke="var(--ink)" stroke-width="1.6" stroke-dasharray="6 4"/></svg> Pareto front (always shown)</span>';
+    if (POINTS.some(p => p.imputed)) {
+      html += '<span class="item"><svg width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="4" fill="var(--muted)"/><circle cx="9" cy="9" r="7.5" fill="none" stroke="var(--muted)" stroke-width="1.3" stroke-dasharray="3 2.5"/></svg> &Dagger; partially imputed</span>';
+    }
+    box2.innerHTML = html;
+  }
+
+  // ---------- data table ----------
+  function buildTable() {
+    const m0 = metricByKey[METRICS[0].key];
+    const rows = [...POINTS].sort((a, b) =>
+      m0.lowerBetter ? mval(a, m0) - mval(b, m0) : mval(b, m0) - mval(a, m0));
+    let html = "<table><thead><tr><th>Method</th>";
+    html += TRAJECTORY ? "<th>Configs</th>" : "<th>Variant</th>";
+    html += "<th>Family</th>";
+    for (const m of METRICS) html += `<th>${m.label}</th>`;
+    html += `<th>${CONFIG.x_short}</th><th>Imputed</th></tr></thead><tbody>`;
+    for (const p of rows) {
+      html += `<tr><td>${p.method}</td><td>${TRAJECTORY ? (p.n_configs != null ? p.n_configs : "—") : p.variant}</td><td>${p.family}</td>`;
+      for (const m of METRICS) html += `<td>${fmtMetric(m, mval(p, m))}</td>`;
+      html += `<td>${p.x.toFixed(3)}</td><td>${p.imputed ? p.imputed_pct.toFixed(0) + "%" : "—"}</td></tr>`;
+    }
+    html += "</tbody></table>";
+    document.getElementById("tblwrap").innerHTML = html;
+  }
+
+  buildChips();
+  buildLegend();
+  buildTable();
+  syncChips();
+  render();
+})();
+</script>
+</body>
+</html>
+"""

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -31,12 +31,9 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     --accent: #2a78d6;
     --chip-bg: #f2f1ec;
     --pt-muted: #b9b8b1;
-    --fam-foundation: #2a78d6;
-    --fam-tree: #eb6834;
-    --fam-nn: #1baf7a;
-    --fam-other: #4a3aa7;
-    --fam-reference: #e87ba4;
-    --fam-baseline: #898781;
+    /* Family colors: injected from FAMILY_COLORS (same scheme as the
+       leaderboard tables), identical in light and dark mode. */
+__FAMILY_CSS_VARS__
     --optimal: #228b22;
     --tooltip-bg: #14161a;
     --tooltip-ink: #fbfbf9;
@@ -55,12 +52,6 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
       --accent: #3987e5;
       --chip-bg: #232327;
       --pt-muted: #55555c;
-      --fam-foundation: #3987e5;
-      --fam-tree: #d95926;
-      --fam-nn: #199e70;
-      --fam-other: #9085e9;
-      --fam-reference: #d55181;
-      --fam-baseline: #898781;
       --optimal: #2ea043;
       --tooltip-bg: #f0efea;
       --tooltip-ink: #14161a;
@@ -76,12 +67,6 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     --accent: #3987e5;
     --chip-bg: #232327;
     --pt-muted: #55555c;
-    --fam-foundation: #3987e5;
-    --fam-tree: #d95926;
-    --fam-nn: #199e70;
-    --fam-other: #9085e9;
-    --fam-reference: #d55181;
-    --fam-baseline: #898781;
     --optimal: #2ea043;
     --tooltip-bg: #f0efea;
     --tooltip-ink: #14161a;
@@ -94,6 +79,20 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
     line-height: 1.5;
     padding: 10px 12px 14px;
+  }
+  /* The [hidden] attribute must beat author display rules (e.g. the
+     inline-flex on .metricpick), else hidden controls render empty. */
+  [hidden] { display: none !important; }
+
+  /* Two-column layout: controls + chips in a side panel, chart beside it.
+     ``chips-right`` mirrors the columns. Wraps to stacked when narrow. */
+  .explorer-grid { display: flex; gap: 18px; align-items: flex-start; }
+  .explorer-grid.chips-right { flex-direction: row-reverse; }
+  .sidebox { flex: 0 0 330px; min-width: 250px; display: flex; flex-direction: column; gap: 10px; }
+  .mainbox { flex: 1 1 auto; min-width: 0; }
+  @media (max-width: 860px) {
+    .explorer-grid { flex-wrap: wrap; }
+    .sidebox { flex: 1 1 100%; }
   }
 
   .explorer-title { font-size: 15px; font-weight: 650; margin: 0 0 8px; }
@@ -116,13 +115,14 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     padding: 5px 7px; cursor: pointer;
   }
 
-  .chips { display: flex; flex-direction: column; gap: 6px; margin-bottom: 10px; }
-  .chiprow { display: flex; align-items: flex-start; gap: 9px; }
+  .chips { display: flex; flex-direction: column; gap: 9px; }
+  /* One block per family: the family toggle on top, its chips wrapping below. */
+  .chiprow { display: flex; flex-direction: column; align-items: flex-start; gap: 5px; }
   .famchip {
-    flex: 0 0 152px; display: inline-flex; align-items: center; gap: 6px; justify-content: flex-end;
+    display: inline-flex; align-items: center; gap: 6px;
     font: 650 10.5px/1.3 system-ui, sans-serif; letter-spacing: 0.06em; text-transform: uppercase;
     color: var(--muted); background: var(--chip-bg); border: 1px dashed var(--line);
-    border-radius: 999px; padding: 5px 10px; cursor: pointer; margin-top: 1px;
+    border-radius: 999px; padding: 5px 10px; cursor: pointer;
   }
   .famchip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam); flex: none; }
   .famchip .count { font-weight: 500; letter-spacing: 0; opacity: 0.75; }
@@ -145,8 +145,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
   .chip[aria-pressed="true"] .dot { background: var(--fam); }
   .chip:hover { border-color: var(--muted); }
 
-  /* Cap the chart size: at full page width the 960x540 canvas would blow up. */
-  .chartbox { position: relative; max-width: 920px; }
+  .chartbox { position: relative; }
   .chartbox svg { width: 100%; height: auto; display: block; }
   .legendstrip {
     display: flex; flex-wrap: wrap; gap: 5px 16px; align-items: center;
@@ -183,25 +182,29 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
 </head>
 <body>
   <p class="explorer-title" id="title"></p>
-  <div class="controls">
-    <label class="metricpick" id="metricpick" hidden>Y-axis
-      <select id="metric-select"></select>
-    </label>
-    <label class="metricpick" id="xaxispick" hidden>X-axis
-      <select id="xaxis-select"></select>
-    </label>
-    <div class="btnrow">
-      <button class="btn" id="btn-front">Pareto front</button>
-      <button class="btn" id="btn-all">All</button>
-      <button class="btn" id="btn-none">Clear</button>
+  <div class="explorer-grid" id="grid">
+    <div class="sidebox">
+      <div class="controls">
+        <label class="metricpick" id="metricpick" hidden>Y-axis
+          <select id="metric-select"></select>
+        </label>
+        <div class="btnrow">
+          <button class="btn" id="btn-front">Pareto front</button>
+          <button class="btn" id="btn-all">All</button>
+          <button class="btn" id="btn-none">Clear</button>
+        </div>
+        <span class="hint">Click methods or family buttons to highlight &middot; hover points for details</span>
+      </div>
+      <div class="chips" id="chips"></div>
     </div>
-    <span class="hint">Click methods or family buttons to highlight &middot; hover points for details</span>
-  </div>
-  <div class="chips" id="chips"></div>
-  <div class="legendstrip" id="legendstrip"></div>
-  <div class="chartbox" id="chartbox">
-    <svg id="chart" viewBox="0 0 960 540" role="img" aria-label="Pareto front explorer"></svg>
-    <div class="tooltip"></div>
+    <div class="mainbox">
+      <!-- Legend above the chart so readers decode the marks before the data. -->
+      <div class="legendstrip" id="legendstrip"></div>
+      <div class="chartbox" id="chartbox">
+        <svg id="chart" viewBox="0 0 960 540" role="img" aria-label="Pareto front explorer"></svg>
+        <div class="tooltip"></div>
+      </div>
+    </div>
   </div>
   <details class="datatable">
     <summary>Data table</summary>
@@ -228,6 +231,9 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
 
   const titleEl = document.getElementById("title");
   if (CONFIG.title) titleEl.textContent = CONFIG.title; else titleEl.hidden = true;
+
+  // Column order: chips/controls left of the chart, or mirrored.
+  document.getElementById("grid").classList.add(CONFIG.chipsSide === "right" ? "chips-right" : "chips-left");
 
   const svg = document.getElementById("chart");
   const box = document.getElementById("chartbox");
@@ -357,15 +363,15 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
   const metricByKey = {};
   for (const m of METRICS) metricByKey[m.key] = m;
 
-  const X_AXES = CONFIG.xAxes;
-  let xKey = X_AXES[0].key;
-  const xAxisByKey = {};
-  for (const xa of X_AXES) xAxisByKey[xa.key] = xa;
+  // Single time axis per explorer (the scatter ships inference time, the
+  // trajectories train time).
+  const X_AXIS = CONFIG.xAxes[0];
+  const xKey = X_AXIS.key;
 
   function mval(p, metric) { return p[metric.key]; }
 
-  function computeFront(metric, xAxis) {
-    const xk = xAxis.key;
+  function computeFront(metric) {
+    const xk = xKey;
     const pts = [...POINTS].sort((a, b) =>
       a[xk] - b[xk] || (metric.lowerBetter ? mval(a, metric) - mval(b, metric) : mval(b, metric) - mval(a, metric)));
     const verts = [];
@@ -383,17 +389,16 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     return { verts, methods };
   }
 
-  const state = { active: new Set(computeFront(metricByKey[metricKey], xAxisByKey[xKey]).methods) };
+  const state = { active: new Set(computeFront(metricByKey[metricKey]).methods) };
 
   // ---------- chart ----------
   const W = 960, H = 540, M = { l: 62, r: 18, t: 14, b: 52 };
 
   function render() {
     const metric = metricByKey[metricKey];
-    const xAxis = xAxisByKey[xKey];
     svg.textContent = "";
 
-    // x scale (log), recomputed per render since the x-axis is switchable
+    // x scale (log)
     const xsAll = POINTS.map(p => p[xKey]);
     const xmin = Math.min(...xsAll) * 0.65, xmax = Math.max(...xsAll) * 1.6;
     const lx0 = Math.log10(xmin), lx1 = Math.log10(xmax);
@@ -426,14 +431,14 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     }
     el("rect", { x: M.l, y: M.t, width: W - M.l - M.r, height: H - M.t - M.b, fill: "none", stroke: "var(--line)" }, grid);
     el("text", { x: (M.l + W - M.r) / 2, y: H - 10, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)" }, grid)
-      .textContent = xAxis.axisLabel;
+      .textContent = X_AXIS.axisLabel;
     el("text", { x: 0, y: 0, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)",
       transform: `translate(16 ${(M.t + H - M.b) / 2}) rotate(-90)` }, grid).textContent = metric.axisLabel;
 
     drawOptimalArrow(grid, metric.lowerBetter, M, W, H);
 
     // pareto front (always shown)
-    const front = computeFront(metric, xAxis);
+    const front = computeFront(metric);
     const fv = front.verts;
     if (fv.length) {
       let d = `M${X(fv[0][0])},${metric.lowerBetter ? M.t : H - M.b}`;
@@ -538,9 +543,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     for (const m of METRICS) {
       html += `<div>${m.label}: <b>${fmtMetric(m, mval(p, m))}</b></div>`;
     }
-    for (const xa of X_AXES) {
-      html += `<div>${xa.short}: <b>${fmtTime(p[xa.key])}</b></div>`;
-    }
+    html += `<div>${X_AXIS.short}: <b>${fmtTime(p[xKey])}</b></div>`;
     if (p.imputed) html += `<div class="t-imp">Imputed on ${p.imputed_pct.toFixed(0)}% of datasets</div>`;
     tip.show(html, ev);
   }
@@ -633,7 +636,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     render();
   }
   document.getElementById("btn-front").addEventListener("click",
-    () => setActive(computeFront(metricByKey[metricKey], xAxisByKey[xKey]).methods));
+    () => setActive(computeFront(metricByKey[metricKey]).methods));
   document.getElementById("btn-all").addEventListener("click", () => setActive([...byMethod.keys()]));
   document.getElementById("btn-none").addEventListener("click", () => setActive([]));
 
@@ -650,23 +653,6 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     }
     metricSelect.addEventListener("change", ev => {
       metricKey = ev.target.value;
-      render();
-    });
-  }
-
-  // x-axis selector (hidden when only one time axis is configured)
-  const xAxisPick = document.getElementById("xaxispick");
-  const xAxisSelect = document.getElementById("xaxis-select");
-  if (X_AXES.length > 1) {
-    xAxisPick.hidden = false;
-    for (const xa of X_AXES) {
-      const opt = document.createElement("option");
-      opt.value = xa.key;
-      opt.textContent = xa.label;
-      xAxisSelect.appendChild(opt);
-    }
-    xAxisSelect.addEventListener("change", ev => {
-      xKey = ev.target.value;
       render();
     });
   }
@@ -699,12 +685,11 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     html += TRAJECTORY ? "<th>Configs</th>" : "<th>Variant</th>";
     html += "<th>Family</th>";
     for (const m of METRICS) html += `<th>${m.label}</th>`;
-    for (const xa of X_AXES) html += `<th>${xa.short}</th>`;
-    html += "<th>Imputed</th></tr></thead><tbody>";
+    html += `<th>${X_AXIS.short}</th><th>Imputed</th></tr></thead><tbody>`;
     for (const p of rows) {
       html += `<tr><td>${p.method}</td><td>${TRAJECTORY ? (p.n_configs != null ? p.n_configs : "—") : p.variant}</td><td>${p.family}</td>`;
       for (const m of METRICS) html += `<td>${fmtMetric(m, mval(p, m))}</td>`;
-      for (const xa of X_AXES) html += `<td>${p[xa.key].toFixed(3)}</td>`;
+      html += `<td>${p[xKey].toFixed(3)}</td>`;
       html += `<td>${p.imputed ? p.imputed_pct.toFixed(0) + "%" : "—"}</td></tr>`;
     }
     html += "</tbody></table>";
@@ -713,13 +698,17 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
 
   // When embedded, report the content height so the host page can size the
   // iframe to fit (avoids an inner scrollbar). Works from a sandboxed frame.
+  // Measure the body (viewport-independent) — documentElement.scrollHeight is
+  // clamped to at least the iframe's current viewport, which turns the
+  // resize round-trip into a grow-forever feedback loop. The change guard
+  // stops re-posting once the height settles.
+  let lastPostedHeight = 0;
   function postHeight() {
-    if (window.parent !== window) {
-      window.parent.postMessage(
-        { type: "tabarena-explorer-height", height: document.documentElement.scrollHeight },
-        "*",
-      );
-    }
+    if (window.parent === window) return;
+    const height = Math.ceil(document.body.offsetHeight);
+    if (Math.abs(height - lastPostedHeight) < 3) return;
+    lastPostedHeight = height;
+    window.parent.postMessage({ type: "tabarena-explorer-height", height: height }, "*");
   }
   const _renderInner = render;
   render = function () {

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -513,9 +513,20 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
   function familyMethods(fam) {
     return [...byMethod.keys()].filter(m => byMethod.get(m)[0].family === fam);
   }
+  // Chips are listed by leaderboard rank — best Elo first when Elo is
+  // configured, otherwise best value of the primary metric.
+  const RANK_METRIC = metricByKey["elo"] || metricByKey[METRICS[0].key];
+  function bestVal(method) {
+    const vals = byMethod.get(method).map(p => mval(p, RANK_METRIC));
+    return RANK_METRIC.lowerBetter ? Math.min(...vals) : Math.max(...vals);
+  }
+  function rankSorted(methods) {
+    return [...methods].sort((a, b) =>
+      RANK_METRIC.lowerBetter ? bestVal(a) - bestVal(b) : bestVal(b) - bestVal(a));
+  }
   function buildChips() {
     for (const fam of FAM_ORDER) {
-      const methods = familyMethods(fam).sort();
+      const methods = rankSorted(familyMethods(fam));
       if (!methods.length) continue;
       const row = document.createElement("div");
       row.className = "chiprow";

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -42,6 +42,9 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     --tooltip-ink: #fbfbf9;
     color-scheme: light;
   }
+  /* Dark tokens twice: the media query follows the OS preference, and the
+     [data-theme="dark"] scope lets an embedding page (e.g. the always-dark
+     leaderboard Space) force dark regardless of the OS setting. */
   @media (prefers-color-scheme: dark) {
     :root {
       --paper: #131316;
@@ -63,6 +66,26 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
       --tooltip-ink: #14161a;
       color-scheme: dark;
     }
+  }
+  :root[data-theme="dark"] {
+    --paper: #131316;
+    --card: #1b1b1f;
+    --ink: #f0efea;
+    --muted: #9b9a92;
+    --line: #2e2e33;
+    --accent: #3987e5;
+    --chip-bg: #232327;
+    --pt-muted: #55555c;
+    --fam-foundation: #3987e5;
+    --fam-tree: #d95926;
+    --fam-nn: #199e70;
+    --fam-other: #9085e9;
+    --fam-reference: #d55181;
+    --fam-baseline: #898781;
+    --optimal: #2ea043;
+    --tooltip-bg: #f0efea;
+    --tooltip-ink: #14161a;
+    color-scheme: dark;
   }
 
   html, body { margin: 0; background: var(--paper); }
@@ -122,7 +145,8 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
   .chip[aria-pressed="true"] .dot { background: var(--fam); }
   .chip:hover { border-color: var(--muted); }
 
-  .chartbox { position: relative; }
+  /* Cap the chart size: at full page width the 960x540 canvas would blow up. */
+  .chartbox { position: relative; max-width: 920px; }
   .chartbox svg { width: 100%; height: auto; display: block; }
   .legendstrip {
     display: flex; flex-wrap: wrap; gap: 5px 16px; align-items: center;
@@ -686,6 +710,25 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
     html += "</tbody></table>";
     document.getElementById("tblwrap").innerHTML = html;
   }
+
+  // When embedded, report the content height so the host page can size the
+  // iframe to fit (avoids an inner scrollbar). Works from a sandboxed frame.
+  function postHeight() {
+    if (window.parent !== window) {
+      window.parent.postMessage(
+        { type: "tabarena-explorer-height", height: document.documentElement.scrollHeight },
+        "*",
+      );
+    }
+  }
+  const _renderInner = render;
+  render = function () {
+    _renderInner();
+    postHeight();
+  };
+  document.querySelector("details.datatable").addEventListener("toggle", postHeight);
+  window.addEventListener("resize", postHeight);
+  window.addEventListener("load", postHeight);
 
   buildChips();
   buildLegend();

--- a/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
@@ -1,0 +1,145 @@
+"""Build the self-contained interactive Pareto explorer HTML.
+
+The explorer is a single dependency-free HTML file (inline SVG + vanilla JS)
+rendered from a points DataFrame. The leaderboard website embeds one such file
+per subset in place of the static Pareto PNG; because the file is fully
+self-contained it also works as a local artifact anyone can open in a browser.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tabarena.plot.interactive._explorer_template import EXPLORER_TEMPLATE
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+#: Variant display order used to sort each method's points so the connector
+#: line runs default -> tuned -> tuned + ensembled.
+_VARIANT_ORDER = ["Default", "Tuned", "Tuned + Ens.", "Baseline", "Best"]
+
+#: Metric definitions the explorer's y-axis selector can offer, keyed by the
+#: column name expected in ``points``.
+_METRIC_SPECS: dict[str, dict] = {
+    "imp": {
+        "key": "imp",
+        "label": "Improvability (%)",
+        "axisLabel": "Improvability (%) — lower is better",
+        "lowerBetter": True,
+        "fromZero": True,
+        "decimals": 1,
+        "suffix": "%",
+    },
+    "elo": {
+        "key": "elo",
+        "label": "Elo",
+        "axisLabel": "Elo — higher is better",
+        "lowerBetter": False,
+        "fromZero": False,
+        "decimals": 0,
+        "suffix": "",
+    },
+}
+
+
+def build_pareto_explorer_html(
+    points: pd.DataFrame,
+    *,
+    save_path: str | Path,
+    mode: str = "scatter",
+    x_label: str,
+    x_short: str | None = None,
+    title: str | None = None,
+    metric_keys: list[str] | None = None,
+    page_title: str = "TabArena Pareto explorer",
+) -> Path:
+    """Render the interactive explorer HTML for a set of method points.
+
+    Parameters
+    ----------
+    points
+        One row per plotted point. Required columns: ``method`` (display
+        name), ``family`` (model family, e.g. "Foundation Model"), ``x``
+        (positive; plotted on a log axis) and at least one metric column
+        (``imp`` and/or ``elo``). Optional columns: ``variant`` (scatter
+        mode: "Default"/"Tuned"/"Tuned + Ens."), ``n_configs`` (trajectory
+        mode), ``imputed`` (bool) and ``imputed_pct`` (0-100).
+    mode
+        ``"scatter"`` (one point per method-variant, connectors link a
+        method's variants) or ``"trajectory"`` (one line per method over
+        ``n_configs``).
+    x_label
+        Full x-axis caption (e.g. "Inference time per 1K samples (s), median
+        — log scale").
+    x_short
+        Short x label used in the tooltip and data table; derived from
+        ``mode`` when omitted.
+    metric_keys
+        Which metrics of :data:`_METRIC_SPECS` to offer on the y-axis
+        selector; defaults to every metric whose column is present.
+    """
+    if mode not in ("scatter", "trajectory"):
+        raise ValueError(f"Unknown mode: {mode!r}")
+
+    if metric_keys is None:
+        metric_keys = [k for k in _METRIC_SPECS if k in points.columns]
+    missing = [k for k in metric_keys if k not in points.columns]
+    if not metric_keys or missing:
+        raise ValueError(f"points must contain at least one metric column; missing={missing}, available={metric_keys}")
+    for col in ("method", "family", "x"):
+        if col not in points.columns:
+            raise ValueError(f"points is missing required column {col!r}")
+
+    data = points.copy()
+    if "imputed" not in data.columns:
+        data["imputed"] = False
+    if "imputed_pct" not in data.columns:
+        data["imputed_pct"] = 0.0
+    data["imputed"] = data["imputed"].fillna(False).astype(bool)
+    data["imputed_pct"] = data["imputed_pct"].fillna(0.0).astype(float)
+
+    # The x-axis is logarithmic: rows without a positive x cannot be placed.
+    data = data.dropna(subset=["x", *metric_keys])
+    data = data[data["x"] > 0]
+
+    # Point order per method defines the connector/trajectory line direction.
+    if mode == "scatter":
+        variant_rank = {v: i for i, v in enumerate(_VARIANT_ORDER)}
+        if "variant" in data.columns:
+            data["_rank"] = data["variant"].map(variant_rank).fillna(len(variant_rank))
+        else:
+            data["_rank"] = len(variant_rank)
+    else:
+        data["_rank"] = data["n_configs"] if "n_configs" in data.columns else data["x"]
+    data = data.sort_values(["method", "_rank"]).drop(columns=["_rank"]).reset_index(drop=True)
+
+    keep_cols = ["method", "family", "x", *metric_keys, "imputed", "imputed_pct"]
+    for opt in ("variant", "n_configs"):
+        if opt in data.columns:
+            keep_cols.append(opt)
+    data = data[keep_cols]
+
+    if x_short is None:
+        x_short = "Inference (s/1K, median)" if mode == "scatter" else "Train time (s/1K, median)"
+
+    config = {
+        "mode": mode,
+        "title": title,
+        "x_label": x_label,
+        "x_short": x_short,
+        "metrics": [_METRIC_SPECS[k] for k in metric_keys],
+    }
+
+    html = (
+        EXPLORER_TEMPLATE.replace("__PAGE_TITLE__", page_title)
+        .replace("__CONFIG_JSON__", json.dumps(config))
+        .replace("__POINTS_JSON__", data.to_json(orient="records"))
+    )
+
+    save_path = Path(save_path)
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    save_path.write_text(html, encoding="utf-8")
+    return save_path

--- a/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
@@ -44,16 +44,33 @@ _METRIC_SPECS: dict[str, dict] = {
     },
 }
 
+#: Time-axis definitions the explorer's x-axis selector can offer, keyed by
+#: the column name expected in ``points``. All are log-scale seconds per 1K
+#: samples (median over datasets).
+_X_AXIS_SPECS: dict[str, dict] = {
+    "x_infer": {
+        "key": "x_infer",
+        "label": "Inference time",
+        "axisLabel": "Inference time per 1K samples (s), median — log scale",
+        "short": "Inference (s/1K, median)",
+    },
+    "x_train": {
+        "key": "x_train",
+        "label": "Train time",
+        "axisLabel": "Train time per 1K samples (s), median — log scale",
+        "short": "Train (s/1K, median)",
+    },
+}
+
 
 def build_pareto_explorer_html(
     points: pd.DataFrame,
     *,
     save_path: str | Path,
     mode: str = "scatter",
-    x_label: str,
-    x_short: str | None = None,
     title: str | None = None,
     metric_keys: list[str] | None = None,
+    x_keys: list[str] | None = None,
     page_title: str = "TabArena Pareto explorer",
 ) -> Path:
     """Render the interactive explorer HTML for a set of method points.
@@ -62,24 +79,23 @@ def build_pareto_explorer_html(
     ----------
     points
         One row per plotted point. Required columns: ``method`` (display
-        name), ``family`` (model family, e.g. "Foundation Model"), ``x``
-        (positive; plotted on a log axis) and at least one metric column
-        (``imp`` and/or ``elo``). Optional columns: ``variant`` (scatter
-        mode: "Default"/"Tuned"/"Tuned + Ens."), ``n_configs`` (trajectory
-        mode), ``imputed`` (bool) and ``imputed_pct`` (0-100).
+        name), ``family`` (model family, e.g. "Foundation Model"), at least
+        one x column (``x_infer`` and/or ``x_train``; positive, plotted on a
+        log axis) and at least one metric column (``imp`` and/or ``elo``).
+        Optional columns: ``variant`` (scatter mode:
+        "Default"/"Tuned"/"Tuned + Ens."), ``n_configs`` (trajectory mode),
+        ``imputed`` (bool) and ``imputed_pct`` (0-100).
     mode
         ``"scatter"`` (one point per method-variant, connectors link a
         method's variants) or ``"trajectory"`` (one line per method over
         ``n_configs``).
-    x_label
-        Full x-axis caption (e.g. "Inference time per 1K samples (s), median
-        — log scale").
-    x_short
-        Short x label used in the tooltip and data table; derived from
-        ``mode`` when omitted.
     metric_keys
         Which metrics of :data:`_METRIC_SPECS` to offer on the y-axis
         selector; defaults to every metric whose column is present.
+    x_keys
+        Which time axes of :data:`_X_AXIS_SPECS` to offer on the x-axis
+        selector (first entry is the default view); defaults to every axis
+        whose column is present.
     """
     if mode not in ("scatter", "trajectory"):
         raise ValueError(f"Unknown mode: {mode!r}")
@@ -89,7 +105,12 @@ def build_pareto_explorer_html(
     missing = [k for k in metric_keys if k not in points.columns]
     if not metric_keys or missing:
         raise ValueError(f"points must contain at least one metric column; missing={missing}, available={metric_keys}")
-    for col in ("method", "family", "x"):
+    if x_keys is None:
+        x_keys = [k for k in _X_AXIS_SPECS if k in points.columns]
+    missing_x = [k for k in x_keys if k not in points.columns]
+    if not x_keys or missing_x:
+        raise ValueError(f"points must contain at least one x column; missing={missing_x}, available={x_keys}")
+    for col in ("method", "family"):
         if col not in points.columns:
             raise ValueError(f"points is missing required column {col!r}")
 
@@ -101,9 +122,10 @@ def build_pareto_explorer_html(
     data["imputed"] = data["imputed"].fillna(False).astype(bool)
     data["imputed_pct"] = data["imputed_pct"].fillna(0.0).astype(float)
 
-    # The x-axis is logarithmic: rows without a positive x cannot be placed.
-    data = data.dropna(subset=["x", *metric_keys])
-    data = data[data["x"] > 0]
+    # The x-axes are logarithmic: rows without positive times cannot be placed.
+    data = data.dropna(subset=[*x_keys, *metric_keys])
+    for x_key in x_keys:
+        data = data[data[x_key] > 0]
 
     # Point order per method defines the connector/trajectory line direction.
     if mode == "scatter":
@@ -113,24 +135,20 @@ def build_pareto_explorer_html(
         else:
             data["_rank"] = len(variant_rank)
     else:
-        data["_rank"] = data["n_configs"] if "n_configs" in data.columns else data["x"]
+        data["_rank"] = data["n_configs"] if "n_configs" in data.columns else data[x_keys[0]]
     data = data.sort_values(["method", "_rank"]).drop(columns=["_rank"]).reset_index(drop=True)
 
-    keep_cols = ["method", "family", "x", *metric_keys, "imputed", "imputed_pct"]
+    keep_cols = ["method", "family", *x_keys, *metric_keys, "imputed", "imputed_pct"]
     for opt in ("variant", "n_configs"):
         if opt in data.columns:
             keep_cols.append(opt)
     data = data[keep_cols]
 
-    if x_short is None:
-        x_short = "Inference (s/1K, median)" if mode == "scatter" else "Train time (s/1K, median)"
-
     config = {
         "mode": mode,
         "title": title,
-        "x_label": x_label,
-        "x_short": x_short,
         "metrics": [_METRIC_SPECS[k] for k in metric_keys],
+        "xAxes": [_X_AXIS_SPECS[k] for k in x_keys],
     }
 
     html = (

--- a/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
@@ -13,9 +13,26 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tabarena.plot.interactive._explorer_template import EXPLORER_TEMPLATE
+from tabarena.plot.plot_pareto_focus import FAMILY_COLORS
 
 if TYPE_CHECKING:
     import pandas as pd
+
+#: Family display name -> the template's CSS custom property carrying its color.
+_FAMILY_CSS_TOKENS: dict[str, str] = {
+    "Foundation Model": "--fam-foundation",
+    "Neural Network": "--fam-nn",
+    "Tree-based": "--fam-tree",
+    "Reference Pipeline": "--fam-reference",
+    "Baseline": "--fam-baseline",
+    "Other": "--fam-other",
+}
+
+
+def _family_css_vars() -> str:
+    """CSS custom-property lines carrying the shared family colors."""
+    return "\n".join(f"    {token}: {FAMILY_COLORS[family]};" for family, token in _FAMILY_CSS_TOKENS.items())
+
 
 #: Variant display order used to sort each method's points so the connector
 #: line runs default -> tuned -> tuned + ensembled.
@@ -71,6 +88,7 @@ def build_pareto_explorer_html(
     title: str | None = None,
     metric_keys: list[str] | None = None,
     x_keys: list[str] | None = None,
+    chips_side: str = "left",
     page_title: str = "TabArena Pareto explorer",
 ) -> Path:
     """Render the interactive explorer HTML for a set of method points.
@@ -93,10 +111,15 @@ def build_pareto_explorer_html(
         Which metrics of :data:`_METRIC_SPECS` to offer on the y-axis
         selector; defaults to every metric whose column is present.
     x_keys
-        Which time axes of :data:`_X_AXIS_SPECS` to offer on the x-axis
-        selector (first entry is the default view); defaults to every axis
-        whose column is present.
+        Which time axis of :data:`_X_AXIS_SPECS` the chart uses (only the
+        first entry is rendered); defaults to the first axis whose column is
+        present.
+    chips_side
+        ``"left"`` places the controls + method chips left of the chart,
+        ``"right"`` mirrors the columns.
     """
+    if chips_side not in ("left", "right"):
+        raise ValueError(f"Unknown chips_side: {chips_side!r}")
     if mode not in ("scatter", "trajectory"):
         raise ValueError(f"Unknown mode: {mode!r}")
 
@@ -149,10 +172,12 @@ def build_pareto_explorer_html(
         "title": title,
         "metrics": [_METRIC_SPECS[k] for k in metric_keys],
         "xAxes": [_X_AXIS_SPECS[k] for k in x_keys],
+        "chipsSide": chips_side,
     }
 
     html = (
         EXPLORER_TEMPLATE.replace("__PAGE_TITLE__", page_title)
+        .replace("__FAMILY_CSS_VARS__", _family_css_vars())
         .replace("__CONFIG_JSON__", json.dumps(config))
         .replace("__POINTS_JSON__", data.to_json(orient="records"))
     )

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
@@ -1,0 +1,287 @@
+"""Focus-style Pareto-front scatter used by the website figures.
+
+Design: color encodes the *model family* (few hues) instead of one hue per
+method; only Pareto-front members plus an explicit ``focus_methods`` list are
+emphasized (family color, direct label, full opacity) while every other method
+recedes into a grey field. Thin connectors tie a method's variants (default /
+tuned / tuned + ensembled) together, and the legend collapses to a single strip
+above the axes.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tabarena.plot.plot_pareto_frontier import get_pareto_frontier, plot_optimal_arrow
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+#: Family display name (see ``tabarena.website.website_format.Constants``) -> color.
+#: Palette validated for color-vision deficiency; family identity is always backed
+#: by a direct text label on emphasized methods, never color alone.
+FAMILY_COLORS: dict[str, str] = {
+    "Foundation Model": "#2a78d6",  # blue
+    "Tree-based": "#eb6834",  # orange
+    "Neural Network": "#1baf7a",  # aqua
+    "Other": "#4a3aa7",  # violet
+    "Reference Pipeline": "#e87ba4",  # magenta
+    "Baseline": "#898781",  # grey
+}
+
+#: Grey used for non-emphasized ("field") methods.
+MUTED_COLOR = "#b9b8b1"
+
+#: Variant ("Type") -> matplotlib marker; mirrors ``LeaderboardReporter.style_markers``.
+DEFAULT_VARIANT_MARKERS: dict[str, str] = {
+    "Default": "o",
+    "Tuned": "s",
+    "Tuned + Ens.": "X",
+    "Baseline": "D",
+    "Best": "*",
+    "Default, Holdout": "^",
+    "Tuned, Holdout": "<",
+    "Tuned + Ens., Holdout": ">",
+}
+
+
+def compute_front_methods(
+    data: pd.DataFrame,
+    *,
+    x_col: str,
+    y_col: str,
+    method_col: str,
+    max_X: bool = False,
+    max_Y: bool = False,
+) -> tuple[list[tuple[float, float]], set[str]]:
+    """Pareto-front vertices over all points + the set of methods that define the front."""
+    front, names = get_pareto_frontier(
+        Xs=list(data[x_col]),
+        Ys=list(data[y_col]),
+        names=list(data[method_col]),
+        max_X=max_X,
+        max_Y=max_Y,
+        include_boundary_edges=False,
+    )
+    return front, {n for n in names if n is not None}
+
+
+def plot_pareto_focus(
+    data: pd.DataFrame,
+    *,
+    x_col: str,
+    y_col: str,
+    method_col: str = "Method",
+    variant_col: str = "Type",
+    family_col: str = "Family",
+    max_X: bool = False,
+    max_Y: bool = False,
+    xlog: bool = True,
+    focus_methods: list[str] | None = None,
+    x_label: str | None = None,
+    y_label: str | None = None,
+    title: str | None = None,
+    save_path: str | Path | None = None,
+    show: bool = False,
+    add_optimal_arrow: bool = True,
+    variant_markers: dict[str, str] | None = None,
+    ylim: tuple[float | None, float | None] | None = None,
+    figsize: tuple[float, float] = (10.5, 6.2),
+):
+    """Render the focus-style Pareto scatter.
+
+    Parameters
+    ----------
+    data
+        One row per (method, variant) point. Must contain ``x_col``, ``y_col``,
+        ``method_col`` (method display name, e.g. "CatBoost"), ``variant_col``
+        (e.g. "Default"/"Tuned"/"Tuned + Ens.") and ``family_col`` (a key of
+        :data:`FAMILY_COLORS`).
+    focus_methods
+        Methods to emphasize *in addition to* the Pareto-front members. Focused
+        methods get a boxed label; front members a plain colored label.
+    max_X, max_Y
+        Direction of "better" per axis (both False = lower-left is optimal).
+    """
+    import matplotlib.patheffects as PathEffects
+    import matplotlib.pyplot as plt
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
+
+    try:
+        from adjustText import adjust_text
+
+        has_adjust_text = True
+    except ImportError:
+        has_adjust_text = False
+
+    if variant_markers is None:
+        variant_markers = DEFAULT_VARIANT_MARKERS
+    if focus_methods is None:
+        focus_methods = []
+
+    data = data.dropna(subset=[x_col, y_col]).copy()
+    variant_rank = {v: i for i, v in enumerate(variant_markers)}
+    data["_variant_rank"] = data[variant_col].map(variant_rank).fillna(len(variant_rank))
+
+    front, front_methods = compute_front_methods(
+        data, x_col=x_col, y_col=y_col, method_col=method_col, max_X=max_X, max_Y=max_Y
+    )
+    emphasized = front_methods | {m for m in focus_methods if m in set(data[method_col])}
+
+    fig, ax = plt.subplots(figsize=figsize)
+    if xlog:
+        ax.set_xscale("log")
+
+    method_family = data.groupby(method_col)[family_col].first().to_dict()
+
+    def _color(method: str) -> str:
+        if method in emphasized:
+            return FAMILY_COLORS.get(method_family.get(method), FAMILY_COLORS["Other"])
+        return MUTED_COLOR
+
+    # Connectors linking a method's variants (default -> tuned -> tuned + ensembled).
+    for method, g in data.groupby(method_col):
+        g = g.sort_values("_variant_rank")
+        if len(g) < 2:
+            continue
+        emph = method in emphasized
+        ax.plot(
+            g[x_col],
+            g[y_col],
+            "-",
+            color=_color(method),
+            lw=1.4 if emph else 0.9,
+            alpha=0.65 if emph else 0.45,
+            zorder=2 if emph else 1,
+        )
+
+    # Points.
+    for _, p in data.iterrows():
+        method = p[method_col]
+        emph = method in emphasized
+        ax.scatter(
+            p[x_col],
+            p[y_col],
+            marker=variant_markers.get(p[variant_col], "o"),
+            s=130 if emph else 70,
+            c=_color(method),
+            alpha=0.95 if emph else 0.55,
+            edgecolor="#0b0b0b" if emph else "white",
+            linewidth=0.8 if emph else 0.4,
+            zorder=4 if emph else 3,
+        )
+
+    if ylim is not None:
+        ax.set_ylim(ylim)
+
+    # Pareto-front staircase, extended to the axis edges. ``get_pareto_frontier``
+    # orders vertices starting at the better-X end, so the vertical extension
+    # (toward the worst Y) attaches to the first vertex and the horizontal
+    # extension (toward the worst X) to the last one.
+    ax.autoscale_view()
+    x_min, x_max = ax.get_xlim()
+    y_min, y_max = ax.get_ylim()
+    y_worst_edge = y_min if max_Y else y_max
+    x_worst_edge = x_min if max_X else x_max
+    fx = [front[0][0], *[v[0] for v in front], x_worst_edge]
+    fy = [y_worst_edge, *[v[1] for v in front], front[-1][1]]
+    ax.plot(fx, fy, "--", color="#0b0b0b", lw=1.5, zorder=2)
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+
+    if add_optimal_arrow:
+        plot_optimal_arrow(ax=ax, max_X=max_X, max_Y=max_Y, size=0.45, scale=1.2)
+
+    # Direct labels: one per emphasized method, anchored at its best-Y point.
+    texts = []
+    for method in sorted(emphasized):
+        g = data[data[method_col] == method]
+        if g.empty:
+            continue
+        p = g.loc[g[y_col].idxmax() if max_Y else g[y_col].idxmin()]
+        is_focus = method in focus_methods
+        txt = ax.text(
+            p[x_col],
+            p[y_col],
+            method,
+            fontsize=10.5 if is_focus else 9.5,
+            color=FAMILY_COLORS.get(method_family.get(method), FAMILY_COLORS["Other"]),
+            fontweight="bold",
+            ha="left",
+            va="bottom",
+            bbox=dict(boxstyle="round,pad=0.25", facecolor="white", edgecolor="#0b0b0b", linewidth=1.2, alpha=0.9)
+            if is_focus
+            else None,
+            zorder=6,
+        )
+        txt.set_path_effects([PathEffects.withStroke(linewidth=3, foreground="white")])
+        texts.append(txt)
+    if has_adjust_text and texts:
+        adjust_text(
+            texts,
+            x=data[x_col].tolist(),
+            y=data[y_col].tolist(),
+            ax=ax,
+            force_text=(0.35, 0.5),
+            force_static=(0.6, 0.8),
+            expand=(1.15, 1.3),
+            arrowprops=dict(arrowstyle="-", color="#898781", lw=0.6, alpha=0.7),
+            iter_lim=120,
+        )
+
+    # Single legend strip above the axes: family swatches, variant markers,
+    # front line, grey "other methods" swatch.
+    families_present = [f for f in FAMILY_COLORS if f in {method_family[m] for m in emphasized}]
+    variants_present = [v for v in variant_markers if v in set(data[variant_col])]
+    handles = [Patch(facecolor=FAMILY_COLORS[f], edgecolor="none", label=f) for f in families_present]
+    handles += [
+        Line2D(
+            [0],
+            [0],
+            marker=variant_markers[v],
+            ls="None",
+            markerfacecolor="white",
+            markeredgecolor="#0b0b0b",
+            markersize=8,
+            label=v,
+        )
+        for v in variants_present
+    ]
+    handles.append(Line2D([0], [0], ls="--", color="#0b0b0b", lw=1.5, label="Pareto front"))
+    if len(emphasized) < data[method_col].nunique():
+        handles.append(Patch(facecolor=MUTED_COLOR, edgecolor="none", label="Other methods"))
+    legend = ax.legend(
+        handles=handles,
+        loc="lower left",
+        bbox_to_anchor=(0.0, 1.02),
+        ncol=4,
+        frameon=False,
+        fontsize=10,
+        handletextpad=0.5,
+        columnspacing=1.2,
+        borderaxespad=0.0,
+    )
+
+    ax.set_xlabel(x_label if x_label is not None else x_col, fontsize=13)
+    ax.set_ylabel(y_label if y_label is not None else y_col, fontsize=13)
+    ax.grid(True, color="#e1e0d9", lw=0.7)
+    ax.tick_params(labelsize=10, color="#c3c2b7")
+    for spine in ax.spines.values():
+        spine.set_color("#c3c2b7")
+    if title is not None:
+        # The legend strip sits just above the axes; pad the title past it
+        # (one legend row ≈ 22pt at this font size).
+        legend_rows = math.ceil(len(handles) / 4)
+        ax.set_title(title, fontsize=15, pad=14 + 22 * legend_rows)
+
+    fig.tight_layout()
+    if save_path is not None:
+        os.makedirs(os.path.dirname(str(save_path)), exist_ok=True)
+        fig.savefig(str(save_path), dpi=300, bbox_inches="tight", bbox_extra_artists=[legend])
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
+++ b/packages/tabarena/src/tabarena/plot/plot_pareto_focus.py
@@ -21,15 +21,17 @@ if TYPE_CHECKING:
     import pandas as pd
 
 #: Family display name (see ``tabarena.website.website_format.Constants``) -> color.
-#: Palette validated for color-vision deficiency; family identity is always backed
-#: by a direct text label on emphasized methods, never color alone.
+#: Mirrors the leaderboard website's ``model_type_color`` (the Space repo's
+#: ``constants.py``), which colors model names in the tables — every surface
+#: speaks the same family color language. Family identity is always backed by
+#: a direct text label on emphasized methods, never color alone.
 FAMILY_COLORS: dict[str, str] = {
-    "Foundation Model": "#2a78d6",  # blue
-    "Tree-based": "#eb6834",  # orange
-    "Neural Network": "#1baf7a",  # aqua
-    "Other": "#4a3aa7",  # violet
-    "Reference Pipeline": "#e87ba4",  # magenta
-    "Baseline": "#898781",  # grey
+    "Foundation Model": "#b07cf0",  # purple
+    "Neural Network": "#5aa9e6",  # blue
+    "Tree-based": "#5cb85c",  # green
+    "Reference Pipeline": "#f0a35a",  # orange
+    "Baseline": "#9e9e9e",  # gray
+    "Other": "#9e9e9e",  # gray
 }
 
 #: Grey used for non-emphasized ("field") methods.

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -743,6 +743,9 @@ def compute_tuning_trajectories_leaderboard(
             "time_infer_s_per_1K",
             "time_total_s",
             "time_total_s_per_1K",
+            # Aggregates to the per-method fraction of imputed tasks, used to
+            # mark partially imputed methods in the interactive explorer.
+            "imputed",
         ],
         groupby_columns=["problem_type", "metric"],
         seed_column="fold",
@@ -1600,6 +1603,13 @@ def plot_tuning_trajectories_from_leaderboard(
     )
     if "n_configs" in leaderboard.columns:
         explorer_points["n_configs"] = leaderboard["n_configs"]
+    # `imputed` aggregates to the per-method-point fraction of imputed tasks
+    # (0 everywhere on the no-imputation subsets, where imputed methods are
+    # dropped up front).
+    if "imputed" in leaderboard.columns:
+        imputed_frac = leaderboard["imputed"].fillna(0.0).astype(float)
+        explorer_points["imputed"] = imputed_frac > 0
+        explorer_points["imputed_pct"] = imputed_frac * 100
     explorer_points = explorer_points.dropna(subset=["x", "imp", "elo"])
     if not explorer_points.empty:
         build_pareto_explorer_html(

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -1590,13 +1590,15 @@ def plot_tuning_trajectories_from_leaderboard(
         )
 
     # Interactive explorer + underlying data export, mirroring the
-    # ``pareto_n_configs_imp`` figure (improvability vs train time, with an
-    # Elo y-axis toggle). Self-contained HTML embedded by the website.
+    # ``pareto_n_configs_imp`` figure (improvability vs train time, with
+    # Elo y-axis and inference-time x-axis toggles). Self-contained HTML
+    # embedded by the website.
     explorer_points = pd.DataFrame(
         {
             "method": leaderboard[method_col],
             "family": leaderboard[method_col].map(get_model_family),
-            "x": leaderboard["Train time per 1K samples (s) (median)"],
+            "x_train": leaderboard["Train time per 1K samples (s) (median)"],
+            "x_infer": leaderboard["Inference time per 1K samples (s) (median)"],
             "imp": leaderboard["Improvability (%)"],
             "elo": leaderboard["Elo"],
         }
@@ -1610,12 +1612,14 @@ def plot_tuning_trajectories_from_leaderboard(
         imputed_frac = leaderboard["imputed"].fillna(0.0).astype(float)
         explorer_points["imputed"] = imputed_frac > 0
         explorer_points["imputed_pct"] = imputed_frac * 100
-    explorer_points = explorer_points.dropna(subset=["x", "imp", "elo"])
+    explorer_points = explorer_points.dropna(subset=["x_train", "x_infer", "imp", "elo"])
     if not explorer_points.empty:
         build_pareto_explorer_html(
             points=explorer_points,
             mode="trajectory",
-            x_label="Train time per 1K samples (s), median — log scale",
+            # Train time is the default view (tuning budget); inference time
+            # is the toggle.
+            x_keys=["x_train", "x_infer"],
             save_path=fig_save_dir / "tuning_trajectories_explorer.html",
             page_title="TabArena tuning trajectories",
         )

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -886,6 +886,7 @@ def plot_tuning_trajectories_all(
     progress_bar: bool = True,
     use_elo_method_order: bool = True,
     focus_mode: bool = False,
+    website_only: bool = False,
 ):
     if isinstance(fig_save_dir, str):
         fig_save_dir = Path(fig_save_dir)
@@ -948,6 +949,7 @@ def plot_tuning_trajectories_all(
             "include_baselines": include_baselines,
             "use_elo_method_order": use_elo_method_order,
             "focus_mode": focus_mode,
+            "website_only": website_only,
         },
         engine=engine,
         progress_bar=progress_bar,
@@ -1349,6 +1351,7 @@ def _plot_tuning_trajectories_from_prepared(
     subset_display_names: dict[str, str] | None = None,
     use_elo_method_order: bool = True,
     focus_mode: bool = False,
+    website_only: bool = False,
 ):
     """Run the per-(dataset-subset, subset_map) leaderboard + plotting steps from already-prepared data."""
     fig_save_dir = Path(fig_save_dir)
@@ -1375,7 +1378,10 @@ def _plot_tuning_trajectories_from_prepared(
         leaderboard["name"] = leaderboard["name"].map(method_rename_map).fillna(leaderboard["name"])
 
         if ban_bad_methods:
-            bad_methods = ["KNN", "Linear", "PerpetualBooster", "TabSTAR", "TabFlex"]
+            # Baselines only: they sit far above every real method and would
+            # stretch the improvability axis. Weak non-baseline methods stay
+            # (greyed out by the focus styling).
+            bad_methods = ["KNN", "Linear"]
             leaderboard = leaderboard[~leaderboard["config_type"].isin(bad_methods)]
 
         if hidden_methods:
@@ -1454,6 +1460,7 @@ def _plot_tuning_trajectories_from_prepared(
             use_elo_method_order=use_elo_method_order,
             benchmark_name=getattr(tabarena_context, "benchmark_name", "Arena"),
             focus_mode=focus_mode,
+            website_only=website_only,
         )
 
 
@@ -1480,6 +1487,7 @@ def plot_tuning_trajectories(
     subset_display_names: dict[str, str] | None = None,
     use_elo_method_order: bool = True,
     focus_mode: bool = False,
+    website_only: bool = False,
 ):
     name_col = "config_type"
     if subset_map is None:
@@ -1530,6 +1538,7 @@ def plot_tuning_trajectories(
         subset_display_names=subset_display_names,
         use_elo_method_order=use_elo_method_order,
         focus_mode=focus_mode,
+        website_only=website_only,
     )
 
 
@@ -1568,6 +1577,7 @@ def plot_tuning_trajectories_from_leaderboard(
     use_elo_method_order: bool = True,
     benchmark_name: str = "Arena",
     focus_mode: bool = False,
+    website_only: bool = False,
 ):
     fig_save_dir = Path(fig_save_dir)
     if plot_kwargs is None:
@@ -1617,9 +1627,9 @@ def plot_tuning_trajectories_from_leaderboard(
         build_pareto_explorer_html(
             points=explorer_points,
             mode="trajectory",
-            # Train time is the default view (tuning budget); inference time
-            # is the toggle.
-            x_keys=["x_train", "x_infer"],
+            # Single time axis (train time = tuning budget); inference time
+            # stays available in the CSV export.
+            x_keys=["x_train"],
             save_path=fig_save_dir / "tuning_trajectories_explorer.html",
             page_title="TabArena tuning trajectories",
         )
@@ -1654,6 +1664,21 @@ def plot_tuning_trajectories_from_leaderboard(
 
     ylim_imp = plot_kwargs.pop("ylim_imp")
     err_ylabel = _test_error_ylabel(error_ylabel_metric)
+
+    # The one trajectory figure the website ships (improvability vs train
+    # time); in website_only mode every other figure variant below is skipped.
+    plot_hpo(
+        df=leaderboard,
+        xlabel="Train time per 1K samples (s) (median)",
+        ylabel="Improvability (%)",
+        save_path=fig_save_dir / f"pareto_n_configs_imp{file_ext}",
+        max_Y=False,
+        ylim=ylim_imp,
+        clamp_negative_ymin=True,
+        **plot_kwargs,
+    )
+    if website_only:
+        return
 
     plot_hpo(
         df=leaderboard,
@@ -1712,16 +1737,6 @@ def plot_tuning_trajectories_from_leaderboard(
         save_path=fig_save_dir / f"pareto_n_configs_elo_val{file_ext}",
         max_Y=True,
         optimal_arrow=False,
-        **plot_kwargs,
-    )
-    plot_hpo(
-        df=leaderboard,
-        xlabel="Train time per 1K samples (s) (median)",
-        ylabel="Improvability (%)",
-        save_path=fig_save_dir / f"pareto_n_configs_imp{file_ext}",
-        max_Y=False,
-        ylim=ylim_imp,
-        clamp_negative_ymin=True,
         **plot_kwargs,
     )
     plot_hpo(

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import math
 import os
 from pathlib import Path
 
@@ -19,8 +20,11 @@ from tabarena.nips2025_utils.eval_all import (
     get_all_subset_combinations,
     get_website_folder_name,
 )
-from tabarena.plot.plot_pareto_frontier import plot_optimal_arrow
+from tabarena.plot.interactive.pareto_explorer import build_pareto_explorer_html
+from tabarena.plot.plot_pareto_focus import FAMILY_COLORS, MUTED_COLOR
+from tabarena.plot.plot_pareto_frontier import get_pareto_frontier, plot_optimal_arrow
 from tabarena.utils.parallel_for import parallel_for
+from tabarena.website.website_format import get_model_family
 
 
 def _clip_title(title: str, max_chars: int) -> str:
@@ -74,6 +78,9 @@ def plot_hpo(
     left_label_methods: list[str] | None = None,
     below_label_methods: list[str] | None = None,
     clamp_negative_ymin: bool = False,
+    focus_mode: bool = False,
+    family_map: dict[str, str] | None = None,
+    focus_methods: list[str] | None = None,
 ):
     """Plot HPO trajectories for multiple methods.
 
@@ -100,6 +107,19 @@ def plot_hpo(
     sort_col : str | None, default=None
         If provided, sorts each method’s points by this numeric column (ascending),
         and highlights the point with the highest value of this column using a different marker.
+    focus_mode : bool, default=False
+        Focus styling: methods on the Pareto front (plus ``focus_methods``) are
+        drawn in their model-family color with a direct label; every other
+        trajectory recedes to grey. Implies ``show_pareto_frontier`` and
+        replaces the per-method legend with a family legend strip above the
+        axes (the ``dataset_metadata`` legend is not rendered in this mode).
+    family_map : dict[str, str] | None, default=None
+        Method display name -> model family (a key of
+        :data:`tabarena.plot.plot_pareto_focus.FAMILY_COLORS`); used by
+        ``focus_mode`` to pick colors. Unmapped methods fall back to "Other".
+    focus_methods : list[str] | None, default=None
+        Methods to emphasize in ``focus_mode`` in addition to the
+        Pareto-front members.
     clip_title : bool, default=False
         When True, truncate a long ``title`` to ``max_title_chars`` (with an
         ellipsis) so it doesn't widen the ``bbox_inches="tight"`` output canvas
@@ -169,6 +189,42 @@ def plot_hpo(
         # related variants like TabPFN-3 and TabPFN-3-Thinking).
         color_map.update(method_color_overrides)
 
+    # Focus mode: front-defining methods (plus ``focus_methods``) keep their
+    # family color, everything else is muted grey. Overrides the 60-color
+    # per-method palette above.
+    focus_methods = list(focus_methods or [])
+    if display_names is not None:
+        focus_methods = [display_names.get(m, m) for m in focus_methods]
+    emphasized_methods: set[str] | None = None
+    if focus_mode:
+        show_pareto_frontier = True
+        _, front_names = get_pareto_frontier(
+            Xs=df[xlabel].to_numpy(),
+            Ys=df[ylabel].to_numpy(),
+            names=df[method_col].tolist(),
+            max_X=max_X,
+            max_Y=max_Y,
+            include_boundary_edges=False,
+        )
+        front_method_set = {n for n in front_names if n is not None}
+        emphasized_methods = front_method_set | {m for m in focus_methods if m in method_names}
+        family_map = family_map or {}
+        color_map = {
+            m: (
+                FAMILY_COLORS.get(family_map.get(m, "Other"), FAMILY_COLORS["Other"])
+                if m in emphasized_methods
+                else MUTED_COLOR
+            )
+            for m in method_names
+        }
+        if method_color_overrides:
+            color_map.update(method_color_overrides)
+        # Focused-but-not-front methods still get a printed name (front members
+        # are annotated at their frontier vertices further down).
+        force_label_methods = list(force_label_methods or []) + [
+            m for m in focus_methods if m in method_names and m not in (force_label_methods or [])
+        ]
+
     fig, ax = plt.subplots(figsize=figsize)
     if xlog:
         ax.set_xscale("log")
@@ -202,6 +258,9 @@ def plot_hpo(
         times = df_method[xlabel].to_numpy()
         scores = df_method[ylabel].to_numpy()
         color = color_map[method_name]
+        emphasized = emphasized_methods is None or method_name in emphasized_methods
+        line_alpha = 0.9 if emphasized else 0.4
+        marker_size = 64 if emphasized else 25
 
         # 1) Draw the connecting line (no markers)
         (_h,) = ax.plot(
@@ -210,12 +269,13 @@ def plot_hpo(
             "-",  # no point markers
             label=method_name,
             color=color,
-            alpha=0.9,
-            linewidth=1.5,
+            alpha=line_alpha,
+            linewidth=1.5 if emphasized else 1.0,
+            zorder=3 if emphasized else 2,
         )
 
         # 2) Draw circle markers for all-but-the-max (if sort_col used)
-        if max_sort_pos is not None:
+        if max_sort_pos is not None and emphasized:
             mask = np.ones(len(df_method), dtype=bool)
             mask[max_sort_pos] = False
             if mask.any():
@@ -223,7 +283,7 @@ def plot_hpo(
                     times[mask],
                     scores[mask],
                     marker="o",
-                    s=64,  # ~markersize=16 equivalent
+                    s=marker_size,
                     color=color,
                     alpha=0.9,
                     zorder=4,
@@ -241,15 +301,16 @@ def plot_hpo(
                 zorder=5,
             )
         else:
-            # Back-compat: no sort_col → keep circles for all points
+            # Muted methods (and the no-sort_col back-compat path): plain
+            # circles for every point, no bolded max marker.
             ax.scatter(
                 times,
                 scores,
                 marker="o",
-                s=64,
+                s=marker_size,
                 color=color,
-                alpha=0.9,
-                zorder=4,
+                alpha=line_alpha,
+                zorder=4 if emphasized else 3,
             )
         points_legend = ax.scatter([], [], marker="o", s=64, color=color, alpha=0.9)
 
@@ -335,8 +396,6 @@ def plot_hpo(
         # of its trajectory points, not just the peak), then overlay it as
         # a step-style line at zorder=1 so per-method trajectories still
         # render on top.
-        from tabarena.plot.plot_pareto_frontier import get_pareto_frontier
-
         frontier_df = df[df[method_col].isin(sorted_methods)]
         Xs = frontier_df[xlabel].to_numpy()
         Ys = frontier_df[ylabel].to_numpy()
@@ -483,7 +542,35 @@ def plot_hpo(
     if legend_display_names:
         labels_legend = [legend_display_names.get(lbl, lbl) for lbl in labels_legend]
 
-    if legend_in_plot:
+    if focus_mode:
+        # Family legend strip above the axes replaces the per-method legend:
+        # with the grey-out styling, per-method entries would mostly repeat
+        # "grey" and the emphasized methods are already labeled directly.
+        from matplotlib.patches import Patch
+
+        family_map_local = family_map or {}
+        emphasized_families = {
+            family_map_local.get(m, "Other")
+            for m in sorted_methods
+            if emphasized_methods is None or m in emphasized_methods
+        }
+        families_present = [f for f in FAMILY_COLORS if f in emphasized_families]
+        focus_handles = [Patch(facecolor=FAMILY_COLORS[f], edgecolor="none", label=f) for f in families_present]
+        if emphasized_methods is not None and len(emphasized_methods) < len(method_names):
+            focus_handles.append(Patch(facecolor=MUTED_COLOR, edgecolor="none", label="Other methods"))
+        legend1 = ax.legend(
+            handles=focus_handles,
+            loc="lower left",
+            bbox_to_anchor=(0.0, 1.02),
+            ncol=4,
+            frameon=False,
+            fontsize=10,
+            handletextpad=0.5,
+            columnspacing=1.2,
+            borderaxespad=0.0,
+        )
+        bbox1_axes = None
+    elif legend_in_plot:
         legend1 = ax.legend(
             handles_legend,
             labels_legend,
@@ -524,7 +611,7 @@ def plot_hpo(
     # provided and we're rendering the legend outside the axes — the in-plot
     # path is too cramped for an extra legend without overlapping the data).
     legend2 = None
-    if dataset_metadata and not legend_in_plot:
+    if dataset_metadata and not legend_in_plot and bbox1_axes is not None:
         from matplotlib.lines import Line2D
 
         # Render keys in column 1, values in column 2, row-aligned.
@@ -586,7 +673,13 @@ def plot_hpo(
     if title is not None:
         if clip_title:
             title = _clip_title(title, max_title_chars)
-        ax.set_title(title, fontsize=title_fontsize)
+        # In focus mode the family legend strip sits just above the axes, so
+        # push the title up past it (one legend row ≈ 22pt; pad=None keeps
+        # the matplotlib default otherwise).
+        title_pad = None
+        if focus_mode:
+            title_pad = 14 + 22 * math.ceil(len(legend1.get_patches()) / 4)
+        ax.set_title(title, fontsize=title_fontsize, pad=title_pad)
 
     # ``xlabel`` / ``ylabel`` double as DataFrame column names (used for the
     # peak-per-method bookkeeping above); ``*_display`` decouples the axis
@@ -789,6 +882,7 @@ def plot_tuning_trajectories_all(
     engine: str = "auto",
     progress_bar: bool = True,
     use_elo_method_order: bool = True,
+    focus_mode: bool = False,
 ):
     if isinstance(fig_save_dir, str):
         fig_save_dir = Path(fig_save_dir)
@@ -850,6 +944,7 @@ def plot_tuning_trajectories_all(
             "plot_kwargs": plot_kwargs,
             "include_baselines": include_baselines,
             "use_elo_method_order": use_elo_method_order,
+            "focus_mode": focus_mode,
         },
         engine=engine,
         progress_bar=progress_bar,
@@ -1250,6 +1345,7 @@ def _plot_tuning_trajectories_from_prepared(
     show_coverage_legend: bool = False,
     subset_display_names: dict[str, str] | None = None,
     use_elo_method_order: bool = True,
+    focus_mode: bool = False,
 ):
     """Run the per-(dataset-subset, subset_map) leaderboard + plotting steps from already-prepared data."""
     fig_save_dir = Path(fig_save_dir)
@@ -1354,6 +1450,7 @@ def _plot_tuning_trajectories_from_prepared(
             title_prefix=subset_title_prefix,
             use_elo_method_order=use_elo_method_order,
             benchmark_name=getattr(tabarena_context, "benchmark_name", "Arena"),
+            focus_mode=focus_mode,
         )
 
 
@@ -1379,6 +1476,7 @@ def plot_tuning_trajectories(
     show_coverage_legend: bool = False,
     subset_display_names: dict[str, str] | None = None,
     use_elo_method_order: bool = True,
+    focus_mode: bool = False,
 ):
     name_col = "config_type"
     if subset_map is None:
@@ -1428,6 +1526,7 @@ def plot_tuning_trajectories(
         show_coverage_legend=show_coverage_legend,
         subset_display_names=subset_display_names,
         use_elo_method_order=use_elo_method_order,
+        focus_mode=focus_mode,
     )
 
 
@@ -1465,7 +1564,9 @@ def plot_tuning_trajectories_from_leaderboard(
     title_prefix: str | None = None,
     use_elo_method_order: bool = True,
     benchmark_name: str = "Arena",
+    focus_mode: bool = False,
 ):
+    fig_save_dir = Path(fig_save_dir)
     if plot_kwargs is None:
         plot_kwargs = {}
     plot_kwargs = plot_kwargs.copy()
@@ -1473,6 +1574,42 @@ def plot_tuning_trajectories_from_leaderboard(
     plot_kwargs.setdefault("ylim_imp", (0, None))
     # Threaded into every ``plot_hpo`` call below; harmless when ``None``.
     plot_kwargs["dataset_metadata"] = dataset_metadata
+
+    method_col = plot_kwargs.get("method_col", "name")
+
+    # Focus styling (family colors for Pareto-front + focus methods, grey
+    # field otherwise) for every static figure in this set.
+    if focus_mode:
+        plot_kwargs["focus_mode"] = True
+        plot_kwargs.setdefault(
+            "family_map",
+            {m: get_model_family(m) for m in leaderboard[method_col].unique()},
+        )
+
+    # Interactive explorer + underlying data export, mirroring the
+    # ``pareto_n_configs_imp`` figure (improvability vs train time, with an
+    # Elo y-axis toggle). Self-contained HTML embedded by the website.
+    explorer_points = pd.DataFrame(
+        {
+            "method": leaderboard[method_col],
+            "family": leaderboard[method_col].map(get_model_family),
+            "x": leaderboard["Train time per 1K samples (s) (median)"],
+            "imp": leaderboard["Improvability (%)"],
+            "elo": leaderboard["Elo"],
+        }
+    )
+    if "n_configs" in leaderboard.columns:
+        explorer_points["n_configs"] = leaderboard["n_configs"]
+    explorer_points = explorer_points.dropna(subset=["x", "imp", "elo"])
+    if not explorer_points.empty:
+        build_pareto_explorer_html(
+            points=explorer_points,
+            mode="trajectory",
+            x_label="Train time per 1K samples (s), median — log scale",
+            save_path=fig_save_dir / "tuning_trajectories_explorer.html",
+            page_title="TabArena tuning trajectories",
+        )
+        explorer_points.to_csv(fig_save_dir / "tuning_trajectories.csv", index=False)
 
     # Single shared title across every ``plot_hpo`` call in this set.
     # ``<benchmark_name>-<subset>`` prefix matches the format used by the winrate

--- a/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
+++ b/packages/tabarena/src/tabarena/plot/tuning_trajectories/plot_pareto_over_tuning_time.py
@@ -1630,6 +1630,8 @@ def plot_tuning_trajectories_from_leaderboard(
             # Single time axis (train time = tuning budget); inference time
             # stays available in the CSV export.
             x_keys=["x_train"],
+            # Mirrored against the Pareto scatter explorer (chips left there).
+            chips_side="right",
             save_path=fig_save_dir / "tuning_trajectories_explorer.html",
             page_title="TabArena tuning trajectories",
         )

--- a/packages/tabarena/src/tabarena/website/process_artifacts_to_website.py
+++ b/packages/tabarena/src/tabarena/website/process_artifacts_to_website.py
@@ -67,3 +67,16 @@ def process_one_folder(
                 base_input_path / fig_path,
                 base_output_path / fig_path,
             )
+
+    # Interactive explorers (self-contained HTML embedded by the leaderboard
+    # app) and their underlying data exports. Copy-if-present so raw artifact
+    # folders generated before these existed still process cleanly.
+    for extra_path in [
+        "pareto_front_explorer.html",
+        "pareto_front_points.csv",
+        Path("tuning_trajectories") / "placeholder_name" / "tuning_trajectories_explorer.html",
+        Path("tuning_trajectories") / "placeholder_name" / "tuning_trajectories.csv",
+    ]:
+        src = base_input_path / extra_path
+        if src.is_file():
+            shutil.copy(src, base_output_path / src.name)

--- a/packages/tabarena/src/tabarena/website/website_format.py
+++ b/packages/tabarena/src/tabarena/website/website_format.py
@@ -72,21 +72,41 @@ def strict_merge(
 
 
 def get_model_family(model_name: str) -> str:
+    """Classify a model into its family. Accepts both raw config-type keys
+    (e.g. "GBM", "MNCA") and display names (e.g. "LightGBM", "ModernNCA"),
+    since callers pass whichever identifier they have at hand.
+    """
     prefixes_mapping = {
-        Constants.reference: ["AutoGluon"],
+        Constants.reference: ["AutoGluon", "PORTFOLIO"],
         Constants.neural_network: [
             "REALMLP",
             "TABM",
             "FASTAI",
             "MNCA",
+            "MODERNNCA",
             "NN_TORCH",
+            "TORCHMLP",
         ],
-        Constants.tree: ["GBM", "CAT", "EBM", "XGB", "XT", "RF", "PB", "CHIMERA"],
+        Constants.tree: [
+            "GBM",
+            "LIGHTGBM",
+            "CAT",
+            "EBM",
+            "XGB",
+            "XT",
+            "EXTRATREES",
+            "RF",
+            "RANDOMFOREST",
+            "PB",
+            "PERPETUALBOOSTER",
+            "CHIMERA",
+        ],
         Constants.foundational: [
             "TABDPT",
             "TABDPT_TURBO",
             "TABICL",
             "TABPFN",
+            "REALTABPFN",
             "MITRA",
             "LIMIX",
             "TA-LIMIX",
@@ -103,7 +123,7 @@ def get_model_family(model_name: str) -> str:
             "TA-NORI",
             "TABSWIFT",
         ],
-        Constants.baseline: ["KNN", "LR"],
+        Constants.baseline: ["KNN", "LR", "LINEAR"],
         Constants.other: ["XRFM"],
     }
 
@@ -226,7 +246,7 @@ def legacy_formatting(df_leaderboard: pd.DataFrame) -> pd.DataFrame:
         lambda s: model_type_emoji[get_model_family(s)],
     )
     df_leaderboard["TypeName"] = df_leaderboard.loc[:, "method"].apply(
-        lambda s: get_model_family(s),
+        get_model_family,
     )
 
     _rename_map = get_rename_map()

--- a/packages/tabarena/src/tabarena/website/website_format.py
+++ b/packages/tabarena/src/tabarena/website/website_format.py
@@ -119,6 +119,7 @@ def get_model_family(model_name: str) -> str:
             "TABSTAR",
             "TA-TABPFN-3",
             "TA-ORION-MSP",
+            "ORIONMSP",
             "TA-ILTM",
             "TA-NORI",
             "TABSWIFT",

--- a/scripts/run_generate_website_artifacts.py
+++ b/scripts/run_generate_website_artifacts.py
@@ -89,6 +89,7 @@ class WebsiteArtifactGenerator:
         run_trajectories: bool = True,
         elo_bootstrap_rounds: int = 200,
         zip_raw: bool = False,
+        website_only: bool = True,
     ):
         """Regenerate the raw figures/tables.
 
@@ -99,7 +100,10 @@ class WebsiteArtifactGenerator:
         (Elo CIs are meaningless then); 200 is the official setting. ``zip_raw``
         additionally zips the raw artifacts folder (~hundreds of MB, several
         minutes) — the publishing flow only needs the *clean* zip, so this is
-        off by default.
+        off by default. ``website_only`` (default) renders only the outputs the
+        website ships per subset instead of the full paper figure suite
+        (~35 figures per subset, incl. GIF animations); disable it when the raw
+        artifacts should double as paper material.
         """
         save_path = self.raw_artifacts_dir  # folder to save all figures and tables
 
@@ -143,15 +147,16 @@ class WebsiteArtifactGenerator:
                 use_website_folder_names=True,
                 evaluator_kwargs=evaluator_kwargs,
                 engine=engine,
+                website_only=website_only,
             )
 
         if run_trajectories:
             plot_tuning_trajectories_all(
                 tabarena_context=tabarena_context,
                 fig_save_dir=save_path,
-                # Weak methods (KNN, Linear, ...) are greyed out by the focus
-                # styling instead of being dropped from the plots.
-                ban_bad_methods=False,
+                # Drops the baselines (KNN/Linear) only; weak non-baseline
+                # methods stay, greyed out by the focus styling.
+                ban_bad_methods=True,
                 file_ext=file_ext,
                 engine=engine,
                 # Order methods per-plot by each plot's own y-axis instead of pinning a
@@ -162,6 +167,7 @@ class WebsiteArtifactGenerator:
                 # labels, all other trajectories greyed out. Also writes the
                 # interactive tuning_trajectories_explorer.html per subset.
                 focus_mode=True,
+                website_only=website_only,
             )
 
         if zip_raw:
@@ -230,6 +236,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Also zip the raw artifacts folder (large + slow; the publish flow only needs the clean zip).",
     )
+    parser.add_argument(
+        "--full-figures",
+        action="store_true",
+        help="Render the full paper figure suite per subset instead of only the website-shipped outputs.",
+    )
     args = parser.parse_args()
 
     # Everything (both subfolders and the zips) is written under base_dir.
@@ -241,6 +252,7 @@ if __name__ == "__main__":
         run_trajectories=not args.skip_trajectories,
         elo_bootstrap_rounds=args.elo_bootstrap_rounds,
         zip_raw=args.zip_raw,
+        website_only=not args.full_figures,
     )
 
     # Generate the 'clean_website_artifacts' folder (fast)

--- a/scripts/run_generate_website_artifacts.py
+++ b/scripts/run_generate_website_artifacts.py
@@ -131,7 +131,9 @@ class WebsiteArtifactGenerator:
         plot_tuning_trajectories_all(
             tabarena_context=tabarena_context,
             fig_save_dir=save_path,
-            ban_bad_methods=True,
+            # Weak methods (KNN, Linear, ...) are greyed out by the focus
+            # styling instead of being dropped from the plots.
+            ban_bad_methods=False,
             file_ext=file_ext,
             engine=engine,
             # Order methods per-plot by each plot's own y-axis instead of pinning a

--- a/scripts/run_generate_website_artifacts.py
+++ b/scripts/run_generate_website_artifacts.py
@@ -138,6 +138,10 @@ class WebsiteArtifactGenerator:
             # single Elo-derived order across the whole set (e.g. so the improvability
             # legend ends with the lowest/best method).
             use_elo_method_order=False,
+            # Website styling: Pareto-front methods in family colors with direct
+            # labels, all other trajectories greyed out. Also writes the
+            # interactive tuning_trajectories_explorer.html per subset.
+            focus_mode=True,
         )
 
         zip_results = True

--- a/scripts/run_generate_website_artifacts.py
+++ b/scripts/run_generate_website_artifacts.py
@@ -82,10 +82,26 @@ class WebsiteArtifactGenerator:
         self.raw_artifacts_dir = self.base_dir / raw_artifacts_dirname
         self.clean_artifacts_dir = self.base_dir / clean_artifacts_dirname
 
-    def generate_website_artifacts(self):
-        save_path = self.raw_artifacts_dir  # folder to save all figures and tables
+    def generate_website_artifacts(
+        self,
+        *,
+        run_evaluate: bool = True,
+        run_trajectories: bool = True,
+        elo_bootstrap_rounds: int = 200,
+        zip_raw: bool = False,
+    ):
+        """Regenerate the raw figures/tables.
 
-        elo_bootstrap_rounds = 200  # 1 for toy, 200 for official
+        ``run_evaluate`` / ``run_trajectories`` allow partial refreshes when only
+        one pipeline's outputs changed (e.g. a trajectory-styling fix): the other
+        phase's existing raw artifacts are left in place and the convert step
+        picks them up unchanged. ``elo_bootstrap_rounds=1`` gives a fast toy run
+        (Elo CIs are meaningless then); 200 is the official setting. ``zip_raw``
+        additionally zips the raw artifacts folder (~hundreds of MB, several
+        minutes) — the publishing flow only needs the *clean* zip, so this is
+        off by default.
+        """
+        save_path = self.raw_artifacts_dir  # folder to save all figures and tables
 
         # Set to True if you have the appropriate latex packages installed for nicer figure style
         # TODO: use_latex=True makes some of the plots look worse, but makes the tuning-impact-elo figures look better.
@@ -119,35 +135,36 @@ class WebsiteArtifactGenerator:
                 save_path=Path(save_path) / "per_dataset",
             )
 
-        tabarena_context.evaluate_all(
-            save_path=save_path,
-            elo_bootstrap_rounds=elo_bootstrap_rounds,
-            use_latex=use_latex,
-            use_website_folder_names=True,
-            evaluator_kwargs=evaluator_kwargs,
-            engine=engine,
-        )
+        if run_evaluate:
+            tabarena_context.evaluate_all(
+                save_path=save_path,
+                elo_bootstrap_rounds=elo_bootstrap_rounds,
+                use_latex=use_latex,
+                use_website_folder_names=True,
+                evaluator_kwargs=evaluator_kwargs,
+                engine=engine,
+            )
 
-        plot_tuning_trajectories_all(
-            tabarena_context=tabarena_context,
-            fig_save_dir=save_path,
-            # Weak methods (KNN, Linear, ...) are greyed out by the focus
-            # styling instead of being dropped from the plots.
-            ban_bad_methods=False,
-            file_ext=file_ext,
-            engine=engine,
-            # Order methods per-plot by each plot's own y-axis instead of pinning a
-            # single Elo-derived order across the whole set (e.g. so the improvability
-            # legend ends with the lowest/best method).
-            use_elo_method_order=False,
-            # Website styling: Pareto-front methods in family colors with direct
-            # labels, all other trajectories greyed out. Also writes the
-            # interactive tuning_trajectories_explorer.html per subset.
-            focus_mode=True,
-        )
+        if run_trajectories:
+            plot_tuning_trajectories_all(
+                tabarena_context=tabarena_context,
+                fig_save_dir=save_path,
+                # Weak methods (KNN, Linear, ...) are greyed out by the focus
+                # styling instead of being dropped from the plots.
+                ban_bad_methods=False,
+                file_ext=file_ext,
+                engine=engine,
+                # Order methods per-plot by each plot's own y-axis instead of pinning a
+                # single Elo-derived order across the whole set (e.g. so the improvability
+                # legend ends with the lowest/best method).
+                use_elo_method_order=False,
+                # Website styling: Pareto-front methods in family colors with direct
+                # labels, all other trajectories greyed out. Also writes the
+                # interactive tuning_trajectories_explorer.html per subset.
+                focus_mode=True,
+            )
 
-        zip_results = True
-        if zip_results:
+        if zip_raw:
             # Place the zip next to (and named after) the raw artifacts folder.
             shutil.make_archive(
                 str(save_path),
@@ -181,12 +198,51 @@ class WebsiteArtifactGenerator:
 
 
 if __name__ == "__main__":
+    import argparse
+
     # See the module docstring for the full publishing procedure.
-    # Everything (both subfolders and both zips) is written under base_dir.
+    parser = argparse.ArgumentParser(
+        description="Regenerate the tabarena.ai website artifacts.",
+    )
+    parser.add_argument(
+        "--skip-evaluate",
+        action="store_true",
+        help="Skip the per-subset evaluation figures/tables (reuse existing raw artifacts).",
+    )
+    parser.add_argument(
+        "--skip-trajectories",
+        action="store_true",
+        help="Skip the tuning-trajectory figures (reuse existing raw artifacts).",
+    )
+    parser.add_argument(
+        "--skip-convert",
+        action="store_true",
+        help="Skip the raw -> website-format conversion step.",
+    )
+    parser.add_argument(
+        "--elo-bootstrap-rounds",
+        type=int,
+        default=200,
+        help="Elo bootstrap rounds (200 = official; 1 = fast toy run without meaningful CIs).",
+    )
+    parser.add_argument(
+        "--zip-raw",
+        action="store_true",
+        help="Also zip the raw artifacts folder (large + slow; the publish flow only needs the clean zip).",
+    )
+    args = parser.parse_args()
+
+    # Everything (both subfolders and the zips) is written under base_dir.
     generator = WebsiteArtifactGenerator(base_dir=Path("generated_website_artifacts"))
 
-    # Generate the 'raw_website_artifacts' folder (time-consuming, with 192 cores it takes a few minutes)
-    generator.generate_website_artifacts()
+    # Generate the 'raw_website_artifacts' folder (time-consuming; scales with core count).
+    generator.generate_website_artifacts(
+        run_evaluate=not args.skip_evaluate,
+        run_trajectories=not args.skip_trajectories,
+        elo_bootstrap_rounds=args.elo_bootstrap_rounds,
+        zip_raw=args.zip_raw,
+    )
 
     # Generate the 'clean_website_artifacts' folder (fast)
-    generator.convert_to_website_format()
+    if not args.skip_convert:
+        generator.convert_to_website_format()

--- a/tests/tabarena/plot/interactive/__init__.py
+++ b/tests/tabarena/plot/interactive/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/tabarena/plot/interactive/test_pareto_explorer.py
+++ b/tests/tabarena/plot/interactive/test_pareto_explorer.py
@@ -32,12 +32,12 @@ def test_build_scatter_explorer(tmp_path):
     assert "__CONFIG_JSON__" not in html
     assert "__POINTS_JSON__" not in html
     assert "__PAGE_TITLE__" not in html
+    assert "__FAMILY_CSS_VARS__" not in html
     assert '"mode": "scatter"' in html
     assert '"method":"A"' in html
     assert "Pareto front" in html
-    # Both time axes offered on the x-axis selector.
-    assert '"key": "x_infer"' in html
-    assert '"key": "x_train"' in html
+    # Family colors injected from the shared leaderboard scheme.
+    assert "--fam-foundation: #b07cf0;" in html
 
 
 def test_x_keys_selects_and_orders_axes(tmp_path):

--- a/tests/tabarena/plot/interactive/test_pareto_explorer.py
+++ b/tests/tabarena/plot/interactive/test_pareto_explorer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tabarena.plot.interactive.pareto_explorer import build_pareto_explorer_html
+
+
+def _scatter_points() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "method": ["A", "A", "B"],
+            "variant": ["Default", "Tuned", "Default"],
+            "family": ["Tree-based", "Tree-based", "Foundation Model"],
+            "x": [0.1, 0.5, 1.0],
+            "imp": [10.0, 8.0, 5.0],
+            "elo": [1200.0, 1300.0, 1500.0],
+            "imputed": [False, False, True],
+            "imputed_pct": [0.0, 0.0, 25.0],
+        }
+    )
+
+
+def test_build_scatter_explorer(tmp_path):
+    out = build_pareto_explorer_html(
+        points=_scatter_points(),
+        save_path=tmp_path / "explorer.html",
+        x_label="Inference time per 1K samples (s), median — log scale",
+    )
+    html = out.read_text(encoding="utf-8")
+    # All placeholders substituted, data + interaction hooks present.
+    assert "__CONFIG_JSON__" not in html
+    assert "__POINTS_JSON__" not in html
+    assert "__PAGE_TITLE__" not in html
+    assert '"mode": "scatter"' in html
+    assert '"method":"A"' in html
+    assert "Pareto front" in html
+
+
+def test_build_trajectory_explorer(tmp_path):
+    points = pd.DataFrame(
+        {
+            "method": ["A", "A", "B", "B"],
+            "family": ["Tree-based", "Tree-based", "Foundation Model", "Foundation Model"],
+            "x": [1.0, 10.0, 2.0, 20.0],
+            "imp": [10.0, 8.0, 9.0, 6.0],
+            "elo": [1200.0, 1300.0, 1250.0, 1500.0],
+            "n_configs": [1, 8, 1, 8],
+        }
+    )
+    out = build_pareto_explorer_html(
+        points=points,
+        save_path=tmp_path / "trajectories.html",
+        mode="trajectory",
+        x_label="Train time per 1K samples (s), median — log scale",
+    )
+    html = out.read_text(encoding="utf-8")
+    assert '"mode": "trajectory"' in html
+    assert '"n_configs":' in html
+
+
+def test_nonpositive_x_rows_are_dropped(tmp_path):
+    points = _scatter_points()
+    points.loc[0, "x"] = 0.0  # cannot be placed on a log axis
+    out = build_pareto_explorer_html(points=points, save_path=tmp_path / "e.html", x_label="x")
+    html = out.read_text(encoding="utf-8")
+    assert '"x":0.0' not in html
+
+
+def test_missing_metric_columns_raise(tmp_path):
+    points = _scatter_points().drop(columns=["imp", "elo"])
+    with pytest.raises(ValueError, match="metric column"):
+        build_pareto_explorer_html(points=points, save_path=tmp_path / "e.html", x_label="x")
+
+
+def test_unknown_mode_raises(tmp_path):
+    with pytest.raises(ValueError, match="mode"):
+        build_pareto_explorer_html(points=_scatter_points(), save_path=tmp_path / "e.html", mode="bars", x_label="x")

--- a/tests/tabarena/plot/interactive/test_pareto_explorer.py
+++ b/tests/tabarena/plot/interactive/test_pareto_explorer.py
@@ -12,7 +12,8 @@ def _scatter_points() -> pd.DataFrame:
             "method": ["A", "A", "B"],
             "variant": ["Default", "Tuned", "Default"],
             "family": ["Tree-based", "Tree-based", "Foundation Model"],
-            "x": [0.1, 0.5, 1.0],
+            "x_infer": [0.1, 0.5, 1.0],
+            "x_train": [1.0, 20.0, 5.0],
             "imp": [10.0, 8.0, 5.0],
             "elo": [1200.0, 1300.0, 1500.0],
             "imputed": [False, False, True],
@@ -25,7 +26,6 @@ def test_build_scatter_explorer(tmp_path):
     out = build_pareto_explorer_html(
         points=_scatter_points(),
         save_path=tmp_path / "explorer.html",
-        x_label="Inference time per 1K samples (s), median — log scale",
     )
     html = out.read_text(encoding="utf-8")
     # All placeholders substituted, data + interaction hooks present.
@@ -35,6 +35,20 @@ def test_build_scatter_explorer(tmp_path):
     assert '"mode": "scatter"' in html
     assert '"method":"A"' in html
     assert "Pareto front" in html
+    # Both time axes offered on the x-axis selector.
+    assert '"key": "x_infer"' in html
+    assert '"key": "x_train"' in html
+
+
+def test_x_keys_selects_and_orders_axes(tmp_path):
+    out = build_pareto_explorer_html(
+        points=_scatter_points(),
+        save_path=tmp_path / "explorer.html",
+        x_keys=["x_train"],
+    )
+    html = out.read_text(encoding="utf-8")
+    assert '"key": "x_train"' in html
+    assert '"key": "x_infer"' not in html
 
 
 def test_build_trajectory_explorer(tmp_path):
@@ -42,7 +56,8 @@ def test_build_trajectory_explorer(tmp_path):
         {
             "method": ["A", "A", "B", "B"],
             "family": ["Tree-based", "Tree-based", "Foundation Model", "Foundation Model"],
-            "x": [1.0, 10.0, 2.0, 20.0],
+            "x_train": [1.0, 10.0, 2.0, 20.0],
+            "x_infer": [0.1, 0.2, 0.3, 0.4],
             "imp": [10.0, 8.0, 9.0, 6.0],
             "elo": [1200.0, 1300.0, 1250.0, 1500.0],
             "n_configs": [1, 8, 1, 8],
@@ -52,7 +67,7 @@ def test_build_trajectory_explorer(tmp_path):
         points=points,
         save_path=tmp_path / "trajectories.html",
         mode="trajectory",
-        x_label="Train time per 1K samples (s), median — log scale",
+        x_keys=["x_train", "x_infer"],
     )
     html = out.read_text(encoding="utf-8")
     assert '"mode": "trajectory"' in html
@@ -61,18 +76,24 @@ def test_build_trajectory_explorer(tmp_path):
 
 def test_nonpositive_x_rows_are_dropped(tmp_path):
     points = _scatter_points()
-    points.loc[0, "x"] = 0.0  # cannot be placed on a log axis
-    out = build_pareto_explorer_html(points=points, save_path=tmp_path / "e.html", x_label="x")
+    points.loc[0, "x_infer"] = 0.0  # cannot be placed on a log axis
+    out = build_pareto_explorer_html(points=points, save_path=tmp_path / "e.html")
     html = out.read_text(encoding="utf-8")
-    assert '"x":0.0' not in html
+    assert '"x_infer":0.0' not in html
 
 
 def test_missing_metric_columns_raise(tmp_path):
     points = _scatter_points().drop(columns=["imp", "elo"])
     with pytest.raises(ValueError, match="metric column"):
-        build_pareto_explorer_html(points=points, save_path=tmp_path / "e.html", x_label="x")
+        build_pareto_explorer_html(points=points, save_path=tmp_path / "e.html")
+
+
+def test_missing_x_columns_raise(tmp_path):
+    points = _scatter_points().drop(columns=["x_infer", "x_train"])
+    with pytest.raises(ValueError, match="x column"):
+        build_pareto_explorer_html(points=points, save_path=tmp_path / "e.html")
 
 
 def test_unknown_mode_raises(tmp_path):
     with pytest.raises(ValueError, match="mode"):
-        build_pareto_explorer_html(points=_scatter_points(), save_path=tmp_path / "e.html", mode="bars", x_label="x")
+        build_pareto_explorer_html(points=_scatter_points(), save_path=tmp_path / "e.html", mode="bars")

--- a/tests/tabarena/plot/test_plot_pareto_focus.py
+++ b/tests/tabarena/plot/test_plot_pareto_focus.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import matplotlib
+import pandas as pd
+
+matplotlib.use("Agg", force=True)
+
+from tabarena.plot.plot_pareto_focus import compute_front_methods, plot_pareto_focus
+
+
+def _toy_points() -> pd.DataFrame:
+    """Four points, three methods; method C is dominated by A's default."""
+    return pd.DataFrame(
+        {
+            "Method": ["A", "A", "B", "C"],
+            "Type": ["Default", "Tuned", "Default", "Default"],
+            "Family": ["Tree-based", "Tree-based", "Foundation Model", "Neural Network"],
+            "x": [0.1, 0.5, 1.0, 0.2],
+            "y": [10.0, 8.0, 5.0, 30.0],
+        }
+    )
+
+
+def test_compute_front_methods_min_min():
+    front, methods = compute_front_methods(
+        _toy_points(), x_col="x", y_col="y", method_col="Method", max_X=False, max_Y=False
+    )
+    assert methods == {"A", "B"}
+    # Staircase runs from the best-x end toward the best-y end.
+    assert front[0] == (0.1, 10.0)
+    assert front[-1] == (1.0, 5.0)
+
+
+def test_compute_front_methods_max_y():
+    _, methods = compute_front_methods(
+        _toy_points(), x_col="x", y_col="y", method_col="Method", max_X=False, max_Y=True
+    )
+    # Higher-is-better on y: A's default (leftmost) and C's higher value define the front.
+    assert methods == {"A", "C"}
+
+
+def test_plot_pareto_focus_writes_figure(tmp_path):
+    save_path = tmp_path / "pareto_focus.png"
+    plot_pareto_focus(
+        data=_toy_points(),
+        x_col="x",
+        y_col="y",
+        focus_methods=["C"],
+        x_label="Time (s)",
+        y_label="Improvability (%)",
+        title="Toy",
+        save_path=save_path,
+    )
+    assert save_path.is_file()
+    assert save_path.stat().st_size > 0

--- a/tests/tabarena/plot/tuning_trajectories/__init__.py
+++ b/tests/tabarena/plot/tuning_trajectories/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/tabarena/plot/tuning_trajectories/test_plot_hpo_focus_mode.py
+++ b/tests/tabarena/plot/tuning_trajectories/test_plot_hpo_focus_mode.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import matplotlib
+import pandas as pd
+
+matplotlib.use("Agg", force=True)
+
+from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_hpo
+
+
+def _toy_trajectories() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "name": ["A"] * 3 + ["B"] * 3 + ["C"] * 3,
+            "time": [1.0, 10.0, 100.0, 2.0, 20.0, 200.0, 3.0, 30.0, 300.0],
+            "imp": [10.0, 8.0, 7.0, 9.0, 6.0, 5.0, 20.0, 18.0, 17.0],
+            "n_configs": [1, 4, 16] * 3,
+        }
+    )
+
+
+def test_plot_hpo_focus_mode_writes_figure(tmp_path):
+    save_path = tmp_path / "trajectories_focus.png"
+    plot_hpo(
+        df=_toy_trajectories(),
+        xlabel="time",
+        ylabel="imp",
+        save_path=save_path,
+        max_Y=False,
+        method_col="name",
+        sort_col="n_configs",
+        focus_mode=True,
+        family_map={"A": "Tree-based", "B": "Foundation Model", "C": "Neural Network"},
+        focus_methods=["C"],
+    )
+    assert save_path.is_file()
+    assert save_path.stat().st_size > 0
+
+
+def test_plot_hpo_classic_mode_still_works(tmp_path):
+    save_path = tmp_path / "trajectories_classic.png"
+    plot_hpo(
+        df=_toy_trajectories(),
+        xlabel="time",
+        ylabel="imp",
+        save_path=save_path,
+        max_Y=False,
+        method_col="name",
+        sort_col="n_configs",
+    )
+    assert save_path.is_file()
+    assert save_path.stat().st_size > 0

--- a/tests/tabarena/plot/tuning_trajectories/test_website_only_mode.py
+++ b/tests/tabarena/plot/tuning_trajectories/test_website_only_mode.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import matplotlib
+import pandas as pd
+
+matplotlib.use("Agg", force=True)
+
+from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import (
+    plot_tuning_trajectories_from_leaderboard,
+)
+
+
+def _toy_leaderboard() -> pd.DataFrame:
+    rows = []
+    for method, base_imp, base_elo in [("A", 12.0, 1300.0), ("B", 9.0, 1450.0)]:
+        for i, n_configs in enumerate([1, 4, 16]):
+            train_1k = 2.0 * (4**i)
+            infer_1k = 0.1 * (2**i)
+            imp = base_imp - i
+            elo = base_elo + 20 * i
+            rows.append(
+                {
+                    "name": method,
+                    "n_configs": n_configs,
+                    "Train time per 1K samples (s) (median)": train_1k,
+                    "Inference time per 1K samples (s) (median)": infer_1k,
+                    "Total time per 1K samples (s) (median)": train_1k + infer_1k,
+                    "Train time (s)": train_1k * 10,
+                    "Infer time (s)": infer_1k * 10,
+                    "Total time (s)": (train_1k + infer_1k) * 10,
+                    "Metric Error": imp / 100,
+                    "Improvability (%)": imp,
+                    "Improvability (%) (Test)": imp,
+                    "Improvability (%) (Val)": imp - 1,
+                    "Improvability (%) (Test) - Improvability (%) (Val)": 1.0,
+                    "Elo": elo,
+                    "Elo (Test)": elo,
+                    "Elo (Val)": elo + 15,
+                    "Elo (Val) - Elo (Test)": 15.0,
+                    "Elo (Test) - Elo (Val)": -15.0,
+                    "Baseline Advantage (%)": 5.0 + i,
+                    "Baseline Advantage (%) (Test)": 5.0 + i,
+                    "Baseline Advantage (%) (Val)": 6.0 + i,
+                    "Baseline Advantage (%) (Test - Val)": -1.0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_website_only_renders_shipped_outputs_only(tmp_path):
+    plot_tuning_trajectories_from_leaderboard(
+        leaderboard=_toy_leaderboard(),
+        fig_save_dir=tmp_path,
+        file_ext=".png",
+        website_only=True,
+    )
+    # The shipped figure + interactive artifacts exist ...
+    assert (tmp_path / "pareto_n_configs_imp.png").is_file()
+    assert (tmp_path / "tuning_trajectories_explorer.html").is_file()
+    assert (tmp_path / "tuning_trajectories.csv").is_file()
+    # ... and the rest of the figure suite was skipped.
+    assert not (tmp_path / "pareto_n_configs_elo.png").exists()
+    assert not (tmp_path / "pareto_n_configs_imp_tot_train.png").exists()
+
+
+def test_full_mode_renders_more_figures(tmp_path):
+    plot_tuning_trajectories_from_leaderboard(
+        leaderboard=_toy_leaderboard(),
+        fig_save_dir=tmp_path,
+        file_ext=".png",
+    )
+    assert (tmp_path / "pareto_n_configs_imp.png").is_file()
+    assert (tmp_path / "pareto_n_configs_elo.png").is_file()
+    assert (tmp_path / "pareto_n_configs_imp_tot_train.png").is_file()

--- a/tests/tabarena/website/__init__.py
+++ b/tests/tabarena/website/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/tabarena/website/test_website_format.py
+++ b/tests/tabarena/website/test_website_format.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from tabarena.website.website_format import Constants, get_model_family
+
+
+@pytest.mark.parametrize(
+    ("model_name", "family"),
+    [
+        # Raw config-type keys.
+        ("GBM", Constants.tree),
+        ("TA-TABSWIFT", Constants.foundational),
+        ("TA-ORION-MSP", Constants.foundational),
+        ("MNCA", Constants.neural_network),
+        # Display names (used by the Pareto/trajectory plotting paths).
+        ("LightGBM", Constants.tree),
+        ("RandomForest", Constants.tree),
+        ("ExtraTrees", Constants.tree),
+        ("PerpetualBooster", Constants.tree),
+        ("ModernNCA", Constants.neural_network),
+        ("TorchMLP", Constants.neural_network),
+        ("OrionMSP", Constants.foundational),
+        ("RealTabPFN-2.5", Constants.foundational),
+        ("TabDPT-Turbo", Constants.foundational),
+        ("iLTM", Constants.foundational),
+        ("Nori-30M", Constants.foundational),
+        ("Linear", Constants.baseline),
+        ("AutoGluon 1.5 (extreme, 4h)", Constants.reference),
+        ("xRFM", Constants.other),
+    ],
+)
+def test_get_model_family(model_name: str, family: str):
+    assert get_model_family(model_name) == family


### PR DESCRIPTION
## Summary

The website's Pareto-front scatter and tuning-trajectory figures drew 26+ methods in per-method `tab20` colors with a 26-row legend, making them unreadable. This PR redesigns both, and adds pre-generated interactive versions for the leaderboard Space.

### Static figures (papers + website PNGs)
- **New `plot_pareto_focus`** renders the four `pareto_front_*` figures: color encodes the *model family* (4–6 hues), Pareto-front members plus an explicit `focus_methods` list get direct labels and full opacity, all other methods recede to grey. Thin connectors link a method's default → tuned → tuned+ensembled variants; the legend collapses to a strip above the axes; the green "Optimal" arrow is kept.
- **`plot_hpo` gains `focus_mode`** — the same treatment for the tuning-trajectory figures (front-defining trajectories in family colors, labeled at their frontier vertices; grey field; family legend strip). Opt-in; enabled by `run_generate_website_artifacts.py`. All other callers (paper scripts, per-dataset pages) are unchanged.
- `get_model_family` now also classifies display names (`LightGBM`, `ModernNCA`, ...) so both pipelines can classify from what they have.

### Interactive explorers (leaderboard Space)
- **New `tabarena.plot.interactive.pareto_explorer`** generates a self-contained HTML file (inline SVG + vanilla JS, zero external deps) per subset: per-method highlight chips grouped by family and sorted by rank, family-level toggle buttons, an Improvability↔Elo y-axis selector that re-anchors the Pareto front, hover tooltips with exact values, dashed-ring + ‡ marking of partially imputed methods, and a data-table fallback. Light/dark via `prefers-color-scheme`.
- The reporter writes `pareto_front_explorer.html` + `pareto_front_points.csv`; the trajectory pipeline writes `tuning_trajectories_explorer.html` + `tuning_trajectories.csv` (this data was previously computed and discarded). `process_one_folder` ships them into the website artifacts.
- The Space embeds these via sandboxed `srcdoc` iframes with static-PNG fallback (leaderboard repo change, landing separately).

### Example (rendered from the live leaderboard data)

Static: front + `focus_methods=["TabPFN-3", "LimiX"]` emphasized, field greyed out; interactive: click chips/families to highlight, switch metric, hover for values.

## Testing
- New unit tests: front computation (`compute_front_methods`), both renderers write figures, explorer HTML builder (placeholder substitution, trajectory mode, non-positive-x filtering, error cases): `tests/tabarena/plot/`.
- `ruff check` + `ruff format --check` clean on all touched files.
- Visually verified both static figures and the explorer against the current leaderboard CSV data.

Known follow-ups (intentionally out of scope): BeyondArena's packaging script does not yet copy the explorer HTML (the Space falls back to the PNG there), and the per-dataset trajectory pages keep the classic styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)