### PR TITLE
Add HEAD-aware LFS purge to the update-leaderboard skill

### DIFF
--- a/.claude/skills/update-leaderboard/SKILL.md
+++ b/.claude/skills/update-leaderboard/SKILL.md
@@ -200,20 +200,37 @@ automatically, or `ssh -L 7860:localhost:7860 …`).
 
 ## Step 6: Hand off (maintainer commits + pushes)
 
-Claude does **not** commit/push the Space — it's a HuggingFace Space using **Git LFS + Git Xet** for
-the `.png.zip` files, and there is no HF token on this box. Tell the maintainer to, from
-`<lb_code_dir>`:
+By default the **maintainer** commits/pushes the Space (Git LFS + Git Xet for the `.png.zip` files;
+`hf auth login --add-to-git-credential` is set up on this box, so Claude *can* push when explicitly
+asked). From `<lb_code_dir>`:
 
 ```bash
 git add data website_texts.py && git commit -m "Update leaderboard data + version history" && git push
 ```
 
+`git add data` matters: a refresh both **modifies** the tracked `.png.zip`/CSV files and **adds new
+untracked files** (the `*_explorer.html` + data-export CSVs) — an IDE commit of "changed files only"
+silently drops the interactive plots and the site falls back to static PNGs.
+
 Surface these caveats:
 - The `data/` swap only reflects methods whose results were actually **uploaded** (`upload-method`,
   the real `--no-dry-run`). A method registered in `methods.py` but not uploaded won't have artifacts.
 - `leaderboard-testing` is the **private preview**; pushing to `leaderboard` publishes **live**.
-- If the push is rejected for storage, see the generator's module docstring (Space "Git Storage
-  Usage" cleanup — destructive).
+
+### Storage-limit rejections (`Repository storage limit reached (Max: 1 GB)`)
+
+Space repos cap git-LFS storage at 1 GB and each refresh adds ~85 MB of new figure zips, so this
+rejection recurs every ~10 refreshes. Fix it with the **HEAD-aware purge** script next to this skill
+— it deletes only the stored LFS objects the local HEAD (the state about to be pushed) no longer
+references, so the live revision (incl. `data_beyondarena/`) keeps working, and it leaves history
+un-rewritten so the pending push stays a fast-forward. Old Space revisions permanently lose their
+binaries (fine — artifacts are regenerable):
+
+```bash
+cd <lb_code_dir>   # HEAD must be the commit you are about to push
+<generation_venv>/bin/python <tabarena>/.claude/skills/update-leaderboard/purge_stale_lfs.py            # dry run
+<generation_venv>/bin/python <tabarena>/.claude/skills/update-leaderboard/purge_stale_lfs.py --delete   # purge, then push
+```
 
 ## Note: BeyondArena is a sibling flow
 

--- a/.claude/skills/update-leaderboard/purge_stale_lfs.py
+++ b/.claude/skills/update-leaderboard/purge_stale_lfs.py
@@ -1,0 +1,95 @@
+"""HEAD-aware purge of stale git-LFS objects on a HuggingFace Space repo.
+
+Space repos cap git-LFS storage at 1 GB, and every leaderboard data refresh
+re-uploads ~85 MB of figure zips, so production pushes start failing with
+``Repository storage limit reached (Max: 1 GB)`` after roughly ten refreshes.
+This purges the stored LFS objects that the *current local HEAD* does not
+reference — freeing the space held by superseded refreshes while keeping every
+object the revision about to be pushed still needs (e.g. the
+``data_beyondarena/`` zips a TabArena-only refresh doesn't touch).
+
+Properties:
+
+- **Permanent**: deleted objects cannot be recovered; past Space revisions
+  lose their binary files. Acceptable here because all artifacts are
+  regenerable from the pipeline.
+- **History-preserving**: ``rewriteHistory=false`` leaves the commit graph
+  untouched, so a pending ``git push`` stays a plain fast-forward.
+- **HEAD-aware**: never deletes objects referenced by the local HEAD — unlike
+  the Settings-UI "select all + remove" flow, which breaks the live revision.
+
+Run from *within the Space repo checkout*, with the local HEAD at the state
+you are about to push (it defines the keep-set via ``git lfs ls-files``):
+
+    python purge_stale_lfs.py                                        # dry run
+    python purge_stale_lfs.py --delete                               # purge
+    python purge_stale_lfs.py --repo-id TabArena/leaderboard-testing --delete
+
+Requires ``huggingface_hub`` auth (``hf auth login``) with write access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+
+from huggingface_hub import HfApi
+from huggingface_hub.utils import get_session, paginate
+
+
+def _oid(item: dict) -> str | None:
+    return item.get("fileOid") or item.get("oid") or item.get("sha")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-id", default="TabArena/leaderboard", help="Hub repo to purge.")
+    parser.add_argument("--repo-type", default="space", choices=["space", "model", "dataset"])
+    parser.add_argument("--delete", action="store_true", help="Actually delete (default: dry run).")
+    args = parser.parse_args()
+
+    # LFS oids referenced by the local HEAD = the keep-set.
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("git not found on PATH — run from within the Space repo checkout")
+    lfs_ls = subprocess.run([git, "lfs", "ls-files", "-l"], capture_output=True, text=True, check=True).stdout  # noqa: S603
+    keep = {line.split()[0] for line in lfs_ls.splitlines() if line.strip()}
+    print(f"oids referenced by local HEAD: {len(keep)}")
+
+    # Raw pagination over the lfs-files endpoint: HfApi.list_lfs_files crashes
+    # on entries without a "filename" (orphaned objects), which are exactly
+    # the kind of entry a purge needs to see.
+    api = HfApi()
+    url = f"{api.endpoint}/api/{args.repo_type}s/{args.repo_id}/lfs-files"
+    headers = api._build_hf_headers()
+    items = list(paginate(url, params={}, headers=headers))
+
+    stale = [item for item in items if _oid(item) and _oid(item) not in keep]
+    total_mb = sum(item.get("size", 0) for item in items) / 1e6
+    stale_mb = sum(item.get("size", 0) for item in stale) / 1e6
+    print(
+        f"stored on server: {len(items)} objects ({total_mb:.0f} MB) | "
+        f"stale: {len(stale)} ({stale_mb:.0f} MB) | keep: {len(items) - len(stale)}"
+    )
+
+    if not args.delete:
+        print("dry run — pass --delete to purge the stale objects")
+        return
+
+    session = get_session()
+    shas = [_oid(item) for item in stale]
+    for start in range(0, len(shas), 1000):
+        batch = shas[start : start + 1000]
+        response = session.post(
+            f"{url}/batch",
+            json={"deletions": {"sha": batch, "rewriteHistory": False}},
+            headers=headers,
+        )
+        response.raise_for_status()
+        print(f"deleted batch of {len(batch)}: HTTP {response.status_code}")
+    print(f"purged {stale_mb:.0f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_generate_website_artifacts.py
+++ b/scripts/run_generate_website_artifacts.py
@@ -42,13 +42,15 @@ Steps:
 
 4. Commit all Space file changes and push.
 
-5. If the push is still rejected, check the "Git Storage Usage" here:
-   https://huggingface.co/spaces/TabArena/leaderboard/settings
-   If it is >700 MB, you may have to delete the stored files to free up space.
-   NOTE: This is a destructive operation, the old leaderboard will cease to
-   function once this is done. To delete the stored files, go here and click the
-   top-left button to check all files, then click "Remove selected":
-   https://huggingface.co/spaces/TabArena/leaderboard/settings?lfs-files=true
+5. If the push is rejected with "Repository storage limit reached (Max: 1 GB)":
+   run the HEAD-aware LFS purge from within the Space checkout, then push again:
+       python <tabarena>/.claude/skills/update-leaderboard/purge_stale_lfs.py --delete
+   It permanently deletes only the stored LFS objects the local HEAD no longer
+   references (old refreshes' figures), so the revision being pushed — and the
+   untouched data_beyondarena/ files — keep working. Old Space revisions lose
+   their binaries (they are regenerable). Do NOT use the settings-UI
+   "select all + Remove" flow — that also deletes objects the live revision
+   still needs.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Follow-up to #450. Production pushes to the leaderboard Space fail with `Repository storage limit reached (Max: 1 GB)` every ~10 data refreshes: each refresh re-uploads ~85 MB of figure zips as new git-LFS objects, and superseded refreshes' objects accumulate forever (the Space sat at 984 MB of 1 GB today).

- **`purge_stale_lfs.py`** (in the `update-leaderboard` skill dir): deletes only the stored LFS objects that the *local HEAD* (the state about to be pushed) no longer references — keeping everything the pushed revision needs (including `data_beyondarena/` zips a TabArena-only refresh doesn't touch) and leaving history un-rewritten (`rewriteHistory: false`) so the pending push stays a fast-forward. Dry-run by default; `--delete` to purge. Used successfully today (freed 962 MB / 2,368 stale objects; live revision fully intact).
- Replaces the settings-UI "select all + Remove selected" procedure in the generator docstring — that flow also deletes objects the live revision still needs.
- Skill doc: documents the storage-limit fix, and warns that `git add data` must include the *new* untracked explorer artifacts (an IDE "changed files only" commit silently drops the interactive plots and the site falls back to static PNGs — happened today).

## Testing
- `ruff check` + `ruff format --check` clean.
- Dry-run verified against the production Space after today's purge + push: 280 objects stored, all referenced by HEAD, 0 stale — matching expectations exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)