### PR TITLE
Add CV-based StackingEnsembler with pluggable meta-model

### DIFF
--- a/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/__init__.py
@@ -11,6 +11,7 @@ from tabarena.simulation.ensemble.basic_ensemblers import (
     TopKAverageEnsembler,
 )
 from tabarena.simulation.ensemble.greedy_ensembler import GreedyEnsembler
+from tabarena.simulation.ensemble.stacking_ensembler import StackingEnsembler
 
 __all__ = [
     "AbstractEnsembler",
@@ -18,6 +19,7 @@ __all__ = [
     "GreedyEnsembler",
     "LegacyEnsemblerAdapter",
     "SingleBestEnsembler",
+    "StackingEnsembler",
     "TopKAverageEnsembler",
     "WeightedEnsembler",
 ]

--- a/packages/tabarena/src/tabarena/simulation/ensemble/stacking_ensembler.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/stacking_ensembler.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tabarena.simulation.ensemble.abstract_ensembler import AbstractEnsembler
+
+if TYPE_CHECKING:
+    from autogluon.core.metrics import Scorer
+
+
+class StackingEnsembler(AbstractEnsembler):
+    """Cross-validated meta-learner stacking over base-model predictions.
+
+    A meta-model is trained to predict the label from the concatenated per-model
+    predictions (for multiclass: ``n_models * n_classes`` probability features). The
+    meta-model is any sklearn-style estimator (``fit`` / ``predict_proba`` or
+    ``predict``); by default multinomial :class:`~sklearn.linear_model.LogisticRegression`
+    for classification and :class:`~sklearn.linear_model.Ridge` for regression. Pass
+    e.g. ``classifier_cls=TabPFNClassifier`` to stack with a foundation model.
+
+    Honest validation error via inner CV
+    ------------------------------------
+    Fitting runs a K-fold cross-validation over the optimization split: the final
+    meta-model is refit on all rows (used for unseen data, e.g. the test split), while
+    out-of-fold meta-predictions are cached and returned when predicting on the fit
+    input itself. The simulation evaluates ``metric_error_val`` on the same rows the
+    ensembler was fitted on, so without this the stacker would score its own training
+    predictions; with it, the reported validation error is an out-of-sample estimate
+    (the same val-OOF / test-full-fit split :class:`EnsembleScorerCalibratedCV` uses
+    for calibrators). The fit input is recognized by object identity; any other input
+    uses the full refit model.
+
+    Note this ensembler is non-linear (``linear = False``): it cannot consume
+    metric-preprocessed prediction spaces, so run it with ``use_fast_metrics=False``.
+
+    Parameters
+    ----------
+    classifier_cls, regressor_cls : type, optional
+        sklearn-style meta-model class per problem kind. Defaults to
+        ``LogisticRegression`` / ``Ridge``.
+    classifier_kwargs, regressor_kwargs : dict, optional
+        Constructor kwargs for the meta-model.
+    n_splits : int, default 5
+        Inner CV folds for the out-of-fold validation predictions. Reduced when the
+        data cannot support it (few rows, or classes rarer than ``n_splits``); with
+        fewer than 2 usable splits the CV step is skipped and validation predictions
+        fall back to in-sample.
+    random_state : int, default 0
+        Seed for the CV split shuffling.
+    """
+
+    linear = False
+
+    def __init__(
+        self,
+        *,
+        problem_type: str,
+        metric: Scorer,
+        classifier_cls: type | None = None,
+        classifier_kwargs: dict | None = None,
+        regressor_cls: type | None = None,
+        regressor_kwargs: dict | None = None,
+        n_splits: int = 5,
+        random_state: int = 0,
+    ):
+        super().__init__(problem_type=problem_type, metric=metric)
+        assert n_splits >= 2
+        self.classifier_cls = classifier_cls
+        self.classifier_kwargs = classifier_kwargs
+        self.regressor_cls = regressor_cls
+        self.regressor_kwargs = regressor_kwargs
+        self.n_splits = n_splits
+        self.random_state = random_state
+        self._n_classes: int | None = None
+
+    @property
+    def _is_classification(self) -> bool:
+        return self.problem_type in ("binary", "multiclass")
+
+    def _make_model(self):
+        if self._is_classification:
+            if self.classifier_cls is not None:
+                return self.classifier_cls(**(self.classifier_kwargs or {}))
+            from sklearn.linear_model import LogisticRegression
+
+            kwargs = dict(self.classifier_kwargs or {})
+            kwargs.setdefault("max_iter", 1000)
+            return LogisticRegression(**kwargs)
+        if self.regressor_cls is not None:
+            return self.regressor_cls(**(self.regressor_kwargs or {}))
+        from sklearn.linear_model import Ridge
+
+        return Ridge(**(self.regressor_kwargs or {}))
+
+    @staticmethod
+    def _to_features(predictions) -> np.ndarray:
+        arr = np.asarray(predictions)
+        if arr.ndim == 2:  # (n_models, n_samples): binary pos-class proba or regression preds
+            return arr.T
+        # (n_models, n_samples, n_classes) -> (n_samples, n_models * n_classes)
+        return arr.transpose(1, 0, 2).reshape(arr.shape[1], -1)
+
+    def _predict_with(self, model, X: np.ndarray) -> np.ndarray:
+        """Meta-model prediction in the same space as the per-model inputs."""
+        if not self._is_classification:
+            return model.predict(X)
+        proba = model.predict_proba(X)
+        classes = np.asarray(model.classes_).astype(int)
+        if len(classes) != self._n_classes:
+            # the training rows missed some classes: place columns by fitted class labels
+            full = np.zeros((proba.shape[0], self._n_classes))
+            full[:, classes] = proba
+            proba = full
+        if self.problem_type == "binary":
+            return proba[:, 1]
+        return proba
+
+    def _compute_oof(self, X: np.ndarray, y: np.ndarray) -> np.ndarray | None:
+        """Out-of-fold meta-predictions over the fit rows, or None when the data cannot
+        support at least 2 CV splits.
+        """
+        from sklearn.model_selection import KFold, StratifiedKFold
+
+        if self._is_classification:
+            _, counts = np.unique(y, return_counts=True)
+            n_splits = min(self.n_splits, int(counts.min()))
+        else:
+            n_splits = min(self.n_splits, len(y))
+        self._n_splits_used = n_splits
+        if n_splits < 2:
+            return None
+
+        splitter_cls = StratifiedKFold if self._is_classification else KFold
+        splitter = splitter_cls(n_splits=n_splits, shuffle=True, random_state=self.random_state)
+
+        if self.problem_type == "multiclass":
+            oof = np.zeros((len(y), self._n_classes))
+        else:
+            oof = np.zeros(len(y))
+        for train_idx, holdout_idx in splitter.split(X, y):
+            model = self._make_model()
+            model.fit(X[train_idx], y[train_idx])
+            oof[holdout_idx] = self._predict_with(model, X[holdout_idx])
+        return oof
+
+    def _fit(self, *, predictions, labels, time_limit=None) -> None:
+        X = self._to_features(predictions)
+        y = np.asarray(labels)
+        if self._is_classification:
+            arr = np.asarray(predictions)
+            self._n_classes = arr.shape[2] if arr.ndim == 3 else 2
+
+        self._oof_prediction = self._compute_oof(X, y)
+        self._fit_predictions_ref = predictions
+
+        self._model = self._make_model()
+        self._model.fit(X, y)
+
+    def predict_proba(self, predictions) -> np.ndarray:
+        if self._oof_prediction is not None and predictions is self._fit_predictions_ref:
+            return self._oof_prediction
+        return self._predict_with(self._model, self._to_features(predictions))
+
+    def info(self) -> dict:
+        return {"n_splits_used": self._n_splits_used}

--- a/tests/tabarena/simulation/test_ensembler.py
+++ b/tests/tabarena/simulation/test_ensembler.py
@@ -358,3 +358,117 @@ def test_nonlinear_ensembler_rejected_on_preprocessed_metric_space():
     assert np.isfinite(results["metric_error"])
     assert "ensemble_weights" not in results  # not weight-based
     assert results["ensemble_models_used"].all()  # conservative default: all models used
+
+
+# -------------------------
+# StackingEnsembler
+# -------------------------
+def _make_multiclass_task(n_models=6, n_samples=400, n_classes=3, seed=0):
+    rng = np.random.default_rng(seed)
+    y = rng.integers(0, n_classes, n_samples)
+    preds = rng.random((n_models, n_samples, n_classes))
+    # make predictions informative
+    for m in range(n_models):
+        preds[m, np.arange(n_samples), y] += rng.uniform(0.5, 2.0)
+    preds /= preds.sum(axis=2, keepdims=True)
+    return y, preds.astype(np.float32)
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass", "regression"])
+def test_stacking_ensembler_basic(problem_type):
+    from tabarena.simulation.ensemble import StackingEnsembler
+
+    if problem_type == "binary":
+        y, preds = _make_binary_task(seed=7)
+        metric = get_metric(metric="roc_auc", problem_type=problem_type)
+    elif problem_type == "multiclass":
+        y, preds = _make_multiclass_task(seed=7)
+        metric = get_metric(metric="log_loss", problem_type=problem_type)
+    else:
+        y, preds = _make_regression_task(seed=7)
+        metric = get_metric(metric="rmse", problem_type=problem_type)
+
+    ensembler = StackingEnsembler(problem_type=problem_type, metric=metric)
+    ensembler.fit(predictions=preds, labels=y)
+    assert ensembler.info() == {"n_splits_used": 5}
+
+    # new data (a copy) uses the full refit model
+    out = ensembler.predict_proba(preds.copy())
+    assert out.shape[0] == len(y)
+    if problem_type == "multiclass":
+        assert out.shape == (len(y), preds.shape[2])
+        np.testing.assert_allclose(out.sum(axis=1), 1.0, rtol=1e-6)
+    else:
+        assert out.ndim == 1
+    assert ensembler.model_weights() is None
+    assert ensembler.models_used().all()
+
+
+def test_stacking_ensembler_oof_val_predictions():
+    """Predicting on the fit input returns out-of-fold predictions (honest val error);
+    predicting on any other input uses the full refit model.
+    """
+    from tabarena.simulation.ensemble import StackingEnsembler
+
+    y, preds = _make_binary_task(seed=8)
+    metric = get_metric(metric="roc_auc", problem_type="binary")
+    ensembler = StackingEnsembler(problem_type="binary", metric=metric)
+    ensembler.fit(predictions=preds, labels=y)
+
+    oof = ensembler.predict_proba(preds)  # same object as fit input -> OOF
+    in_sample = ensembler.predict_proba(preds.copy())  # different object -> refit model
+    assert not np.array_equal(oof, in_sample)
+    # in-sample predictions of the refit model must score better than (or equal to) OOF
+    assert metric.error(y, in_sample) <= metric.error(y, oof)
+
+
+def test_stacking_ensembler_small_data_falls_back():
+    """With classes rarer than 2 per fold, CV is skipped and the fit input predicts
+    in-sample instead of failing.
+    """
+    from tabarena.simulation.ensemble import StackingEnsembler
+
+    metric = get_metric(metric="roc_auc", problem_type="binary")
+    y = np.array([True] + [False] * 9)  # minority class count 1 -> no stratified CV possible
+    rng = np.random.default_rng(9)
+    preds = rng.random((3, 10)).astype(np.float32)
+
+    ensembler = StackingEnsembler(problem_type="binary", metric=metric)
+    ensembler.fit(predictions=preds, labels=y)
+    assert ensembler.info() == {"n_splits_used": 1}
+    np.testing.assert_array_equal(ensembler.predict_proba(preds), ensembler.predict_proba(preds.copy()))
+
+
+def test_stacking_ensembler_custom_meta_model():
+    """The meta-model is pluggable per problem kind (e.g. a foundation model)."""
+    from sklearn.tree import DecisionTreeRegressor
+
+    from tabarena.simulation.ensemble import StackingEnsembler
+
+    y, preds = _make_regression_task(seed=10)
+    metric = get_metric(metric="rmse", problem_type="regression")
+    ensembler = StackingEnsembler(
+        problem_type="regression",
+        metric=metric,
+        regressor_cls=DecisionTreeRegressor,
+        regressor_kwargs={"max_depth": 3, "random_state": 0},
+    )
+    ensembler.fit(predictions=preds, labels=y)
+    assert np.isfinite(metric.error(y, ensembler.predict_proba(preds.copy())))
+
+
+def test_stacking_ensembler_rejected_on_fast_log_loss():
+    """linear=False: the guardrail rejects stacking on metric-preprocessed spaces."""
+    from tabarena.metrics._fast_log_loss import fast_log_loss
+    from tabarena.simulation.ensemble import StackingEnsembler
+    from tabarena.simulation.ensemble_selection_config_scorer import TaskEvaluator
+
+    evaluator = TaskEvaluator(
+        ensembler_cls=StackingEnsembler,
+        ensembler_kwargs={},
+        eval_metric=fast_log_loss,
+        fit_eval_metric=fast_log_loss,
+        problem_type="multiclass",
+    )
+    with pytest.raises(ValueError, match="non-linear"):
+        evaluator.init_ens()


### PR DESCRIPTION
Non-linear reference implementation of AbstractEnsembler: a meta-model (sklearn-style estimator) is trained on the concatenated per-model predictions. Defaults to LogisticRegression / Ridge; classifier_cls / regressor_cls swap in any estimator per problem kind.

Fitting runs an inner K-fold CV over the optimization split: the final meta-model is refit on all rows for unseen data, while out-of-fold predictions are cached and returned when predicting on the fit input itself (recognized by object identity), so the simulation's metric_error_val is an honest out-of-sample estimate instead of the stacker scoring its own training predictions — the same val-OOF / test-full-fit split EnsembleScorerCalibratedCV uses for calibrators. CV degrades gracefully (fewer splits when classes are rare; in-sample fallback below 2 usable splits).

As a linear=False ensembler it requires use_fast_metrics=False; the existing guardrail rejects it on metric-preprocessed spaces.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
