### PR TITLE
add: interactive leaderboard-overview explorer

### DIFF
--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
@@ -61,18 +61,16 @@ _LIGHT_TOKENS = """
     --fam-reference-ink: #a4600f;
     --fam-baseline-ink: #5f5f5f;
     --fam-other-ink: #5f5f5f;
-    /* Tuning-variant series (default / tuned / tuned + ensembled). Same three
-       hues as the static bar figures, stepped per mode and then muted toward
-       grey — blue/green by 15%, the orange by 24% since it read loudest. That
-       costs some colorblind separation (green vs. orange, 9.2 deutan ΔE at full
-       strength) which the fixed concentric bar widths, the legend and the data
-       table supply. Light mode goes softer still — a further 25% toward white,
-       for the paper view's white surface — landing at 6.0 ΔE; the seaborn
-       pastels the static figures use would be 4.0, which is why we stop here
-       rather than matching them exactly. */
-    --var-default: #6799d4;
-    --var-tuned: #dc9274;
-    --var-tunedens: #61bf9e;
+    /* Tuning-variant series (default / tuned / tuned + ensembled). Light mode
+       is the paper view's surface, so it uses the *static figures' own* seaborn
+       pastels — figures exported from here drop straight into a paper beside
+       them. The cost is colorblind separation: green vs. orange is 4.0 deutan
+       ΔE, well inside the band that needs secondary encoding, which here is the
+       fixed concentric bar widths plus the legend and the data table. Dark mode
+       (the website) keeps the stepped, better-separated version below. */
+    --var-default: #a1c9f4;
+    --var-tuned: #ffb482;
+    --var-tunedens: #8de5a1;
     --optimal: #228b22;
     --tooltip-bg: #14161a;
     --tooltip-ink: #fbfbf9;
@@ -233,15 +231,14 @@ EXPLORER_BASE_CSS = "".join(
   /* One toggle, in the same place in both states and never hidden — an exit
      tucked into a corner of the figure was easy to miss. */
   .viewbar { display: flex; align-items: center; gap: 10px; margin: 0 0 9px; }
-  .papercap { display: none; }
   body.paper .controls,
   body.paper .chips,
   body.paper .sidebox,
   body.paper details.datatable { display: none !important; }
-  /* Only shown when the view departs from the default, so a screenshot cannot
-     quietly hide a filter; the axis labels carry the metric either way. */
-  body.paper .papercap:not(:empty) { display: block; margin: 0 0 9px; font-size: 12.5px; color: var(--muted); }
   body.paper { padding: 14px 18px 18px; }
+  /* Export controls, revealed with the paper view. */
+  .exportbar { display: flex; align-items: center; gap: 8px; margin: 0 0 10px; }
+  .exportbar .hint { font-size: 12.5px; font-weight: 600; color: var(--muted); }
 """,
     ]
 )
@@ -342,15 +339,15 @@ EXPLORER_BASE_JS = r"""
     };
   }
 
-  // Paper view: white surface, caption + legend + chart only. `caption()` is
-  // supplied by each template — the figure has to stay self-describing once the
-  // controls are gone, so it states the subset and anything non-default about
-  // the current view. `afterToggle` re-renders charts whose size is measured.
-  function setUpPaperView(caption, afterToggle) {
+  // Paper view — white surface, legend + chart only — is the *default*: what a
+  // reader wants first is the figure, and it is the state worth exporting. The
+  // controls, chip list and data table are one click away behind "Edit view".
+  // `afterToggle` re-renders charts whose size is measured from the layout.
+  function setUpPaperView(afterToggle) {
     const root = document.documentElement;
     let hostTheme = null;   // the embedding page's choice, captured on entry
     const btn = document.getElementById("btn-paper");
-    const capEl = document.getElementById("papercap");
+    const embedded = window.parent !== window;
 
     function setPaper(on) {
       document.body.classList.toggle("paper", on);
@@ -362,26 +359,262 @@ EXPLORER_BASE_JS = r"""
       } else {
         root.removeAttribute("data-theme");
       }
-      btn.textContent = on ? "Interactive view" : "Paper view";
-      capEl.innerHTML = on ? caption() : "";
+      btn.textContent = on ? "Edit view" : "Paper view";
+      document.getElementById("exportbar").hidden = !on || embedded;
       if (afterToggle) requestAnimationFrame(afterToggle);
       postHeight();
     }
     btn.addEventListener("click", () => setPaper(!document.body.classList.contains("paper")));
-    // Embedded, the host page owns the control (it sits beside the panel's
-    // static-figure toggle) and drives it from the outside; standalone — the
-    // shareable single file — this page needs its own button.
-    if (window.parent !== window) document.querySelector(".viewbar").hidden = true;
+    // Embedded, the host page owns these controls — they sit beside the panel's
+    // static-figure toggle and are driven from the outside. Standalone (the
+    // shareable single file) this page needs its own.
+    if (embedded) document.querySelector(".viewbar").hidden = true;
     window.addEventListener("message", ev => {
       const d = ev.data;
       if (d && d.type === "tabarena-explorer-paper" && typeof d.on === "boolean") setPaper(d.on);
     });
-    document.addEventListener("keydown", ev => {
-      if (ev.key === "Escape" && document.body.classList.contains("paper")) setPaper(false);
+    // Only standalone: embedded, the host owns the button and would not see the
+    // key press, so its label would fall out of step with the frame.
+    if (!embedded) {
+      document.addEventListener("keydown", ev => {
+        if (ev.key === "Escape" && !document.body.classList.contains("paper")) setPaper(true);
+      });
+    }
+    setPaper(true);   // the figure is what opens
+  }
+
+  // --- Figure export ---------------------------------------------------------
+  // The chart is live SVG, so a file can be built from it directly. Three things
+  // a copy has to fix up: the colors are CSS custom properties (var(--x) means
+  // nothing outside this document), it has no background or font of its own, and
+  // the legend is HTML rather than part of the SVG.
+
+  // Rebuild the HTML legend as SVG, reusing its live layout: each item's glyph is
+  // cloned and its label re-emitted at the measured position. foreignObject would
+  // be far simpler, but Chrome refuses to rasterize it onto a canvas, which would
+  // break the PNG path.
+  // Rewrite every var(--x) in a clone's paint attributes; they resolve to nothing
+  // once the node leaves this document.
+  function resolveVars(root, resolve) {
+    for (const node of [root, ...root.querySelectorAll("*")]) {
+      for (const attr of ["fill", "stroke"]) {
+        const value = node.getAttribute(attr);
+        if (value && value.includes("var(")) node.setAttribute(attr, resolve(value));
+      }
+    }
+  }
+
+  function legendToSvg(container, resolve) {
+    const base = container.getBoundingClientRect();
+    const group = document.createElementNS(NS, "g");
+    let height = 0;
+    for (const item of container.querySelectorAll(".item")) {
+      const box = item.getBoundingClientRect();
+      if (!box.width) continue;
+      height = Math.max(height, box.bottom - base.top);
+      let textLeft = box.left - base.left;
+      const glyph = item.querySelector("svg");
+      if (glyph) {
+        const gbox = glyph.getBoundingClientRect();
+        const wrap = el("g", {
+          transform: `translate(${gbox.left - base.left} ${gbox.top - base.top})`,
+        }, group);
+        const glyphClone = glyph.cloneNode(true);
+        resolveVars(glyphClone, resolve);
+        wrap.appendChild(glyphClone);
+        textLeft = gbox.right - base.left + 5;
+      }
+      const label = item.textContent.trim();
+      if (!label) continue;
+      const colored = item.querySelector("[style*='color']");
+      const text = el("text", {
+        x: textLeft, y: box.top - base.top + box.height / 2 + 4, "font-size": 12.5,
+        fill: resolve(getComputedStyle(colored || item).color),
+      }, group);
+      text.textContent = label;
+    }
+    return { group, height: Math.ceil(height) };
+  }
+
+  // `parts` is a list of {svg, dx}, so a chart split across panes (the sticky
+  // y-axis beside the scrolling plot) still exports as one figure.
+  function buildExportSvg(parts, legendEl, pad = 10) {
+    const rootStyle = getComputedStyle(document.documentElement);
+    const resolve = value => String(value).replace(
+      /var\((--[\w-]+)\)/g, (_, name) => rootStyle.getPropertyValue(name).trim() || "none");
+    const paper = rootStyle.getPropertyValue("--paper").trim() || "#ffffff";
+
+    let chartW = 0, chartH = 0;
+    for (const part of parts) {
+      chartW = Math.max(chartW, part.dx + Number(part.svg.getAttribute("width")));
+      chartH = Math.max(chartH, Number(part.svg.getAttribute("height")));
+    }
+
+    const out = document.createElementNS(NS, "svg");
+    out.setAttribute("xmlns", NS);
+    out.setAttribute("font-family", 'system-ui, -apple-system, "Segoe UI", sans-serif');
+    let top = pad;
+    const later = [];   // built after the width is known
+    const legend = legendEl ? legendToSvg(legendEl, resolve) : null;
+    if (legend && legend.height) {
+      legend.group.setAttribute("transform", `translate(${pad} ${top})`);
+      later.push(() => out.appendChild(legend.group));
+      top += legend.height + 8;
+    }
+
+    const width = Math.max(chartW, legendEl ? legendEl.getBoundingClientRect().width : 0) + pad * 2;
+    const height = top + chartH + pad;
+    out.setAttribute("width", Math.ceil(width));
+    out.setAttribute("height", Math.ceil(height));
+    el("rect", { x: 0, y: 0, width: Math.ceil(width), height: Math.ceil(height), fill: paper }, out);
+    for (const build of later) build();
+
+    for (const part of parts) {
+      const group = el("g", { transform: `translate(${part.dx + pad} ${top})` }, out);
+      const clone = part.svg.cloneNode(true);
+      resolveVars(clone, resolve);
+      while (clone.firstChild) group.appendChild(clone.firstChild);
+    }
+    return out;
+  }
+
+  // Page title -> a safe file stem, e.g. "tabarena-leaderboard-explorer-all-tasks".
+  function slugify(text) {
+    return (text || "chart").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80);
+  }
+
+  function downloadUrl(url, filename) {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+
+  // Rasterize the export SVG into a canvas at `scale`, then hand it to `done`.
+  function rasterize(svg, scale, done, fail) {
+    const width = Number(svg.getAttribute("width")), height = Number(svg.getAttribute("height"));
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.round(width * scale);
+      canvas.height = Math.round(height * scale);
+      const ctx = canvas.getContext("2d");
+      ctx.setTransform(scale, 0, 0, scale, 0, 0);
+      ctx.drawImage(img, 0, 0);
+      done(canvas, width, height);
+    };
+    img.onerror = fail;
+    img.src = "data:image/svg+xml;charset=utf-8,"
+      + encodeURIComponent(new XMLSerializer().serializeToString(svg));
+  }
+
+  // A one-page PDF wrapping the rendered figure, written by hand: a library would
+  // cost this page its zero-dependency, single-file property. The image is stored
+  // losslessly (raw RGB + /FlateDecode via CompressionStream) and the page is sized
+  // in points to the figure's CSS size, so it prints at the size it appears here
+  // and the pixels land at 96*scale dpi.
+  async function buildPdf(canvas, cssWidth, cssHeight) {
+    const pixels = canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height).data;
+    const rgb = new Uint8Array((pixels.length / 4) * 3);
+    for (let i = 0, j = 0; i < pixels.length; i += 4, j += 3) {
+      rgb[j] = pixels[i];
+      rgb[j + 1] = pixels[i + 1];
+      rgb[j + 2] = pixels[i + 2];
+    }
+    const deflated = new Uint8Array(await new Response(
+      new Blob([rgb]).stream().pipeThrough(new CompressionStream("deflate"))).arrayBuffer());
+
+    const encoder = new TextEncoder();
+    const chunks = [];
+    const offsets = [];
+    let cursor = 0;
+    const put = data => {
+      const bytes = typeof data === "string" ? encoder.encode(data) : data;
+      chunks.push(bytes);
+      cursor += bytes.length;
+    };
+    const object = (id, body, stream) => {
+      offsets[id] = cursor;
+      put(`${id} 0 obj\n${body}\n`);
+      if (stream) {
+        put("stream\n");
+        put(stream);
+        put("\nendstream\n");
+      }
+      put("endobj\n");
+    };
+
+    const ptW = (cssWidth * 0.75).toFixed(2), ptH = (cssHeight * 0.75).toFixed(2);
+    const content = `q ${ptW} 0 0 ${ptH} 0 0 cm /Im0 Do Q`;
+    put("%PDF-1.4\n");
+    put(new Uint8Array([0x25, 0xe2, 0xe3, 0xcf, 0xd3, 0x0a]));   // binary marker
+    object(1, "<< /Type /Catalog /Pages 2 0 R >>");
+    object(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    object(3, `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${ptW} ${ptH}] `
+      + "/Resources << /XObject << /Im0 4 0 R >> >> /Contents 5 0 R >>");
+    object(4, "<< /Type /XObject /Subtype /Image "
+      + `/Width ${canvas.width} /Height ${canvas.height} /ColorSpace /DeviceRGB `
+      + `/BitsPerComponent 8 /Filter /FlateDecode /Length ${deflated.length} >>`, deflated);
+    object(5, `<< /Length ${content.length} >>`, content);
+
+    const xref = cursor;
+    let table = "xref\n0 6\n0000000000 65535 f \n";
+    for (let id = 1; id <= 5; id++) table += String(offsets[id]).padStart(10, "0") + " 00000 n \n";
+    put(table);
+    put(`trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`);
+    return new Blob(chunks, { type: "application/pdf" });
+  }
+
+  // Wire up the export buttons; `getParts` is called per click so the file always
+  // matches what is on screen. Returns a `run(format)` the host page can drive.
+  function setUpExport(getParts, basename) {
+    const buttons = {
+      svg: document.getElementById("btn-svg"),
+      png: document.getElementById("btn-png"),
+      pdf: document.getElementById("btn-pdf"),
+    };
+    const figure = () => buildExportSvg(getParts(), document.getElementById("legendstrip"));
+
+    // A sandboxed frame has no modals, so a failure is reported on the button.
+    function complain(format) {
+      const button = buttons[format];
+      if (!button) return;
+      const label = button.textContent;
+      button.textContent = "failed";
+      setTimeout(() => { button.textContent = label; }, 2500);
+    }
+
+    function run(format) {
+      const svg = figure();
+      const name = basename();
+      if (format === "svg") {
+        downloadUrl("data:image/svg+xml;charset=utf-8,"
+          + encodeURIComponent(new XMLSerializer().serializeToString(svg)), name + ".svg");
+        return;
+      }
+      // 3x for a screen-resolution PNG; 2x for the PDF, whose page is sized in
+      // points so the pixels already land near 200 dpi at print size.
+      rasterize(svg, format === "pdf" ? 2 : 3, (canvas, cssWidth, cssHeight) => {
+        if (format === "png") {
+          canvas.toBlob(blob => downloadUrl(URL.createObjectURL(blob), name + ".png"), "image/png");
+        } else {
+          buildPdf(canvas, cssWidth, cssHeight)
+            .then(blob => downloadUrl(URL.createObjectURL(blob), name + ".pdf"))
+            .catch(() => complain("pdf"));
+        }
+      }, () => complain(format));
+    }
+
+    for (const format of Object.keys(buttons)) {
+      if (buttons[format]) buttons[format].addEventListener("click", () => run(format));
+    }
+    // Embedded, the buttons live in the host's panel header (see main.taExport).
+    window.addEventListener("message", ev => {
+      const d = ev.data;
+      if (d && d.type === "tabarena-explorer-export" && buttons[d.format] !== undefined) run(d.format);
     });
-    // Keep the caption current while in paper view (a control can still be
-    // driven by keyboard before entering, and re-renders happen on resize).
-    return () => { if (document.body.classList.contains("paper")) capEl.innerHTML = caption(); };
   }
 
   // When embedded, report the content height so the host page can size the

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_shared.py
@@ -1,0 +1,419 @@
+"""Pieces shared by every self-contained interactive explorer page.
+
+The explorers (:mod:`tabarena.plot.interactive.pareto_explorer`,
+:mod:`tabarena.plot.interactive.leaderboard_explorer`) are single dependency-free
+HTML files built by substituting placeholders into a template string. Everything
+that must look and behave the same across them — the color tokens, the control /
+chip / tooltip / table chrome, and the small JS helper set — lives here so the
+pages cannot drift apart.
+
+Each template carries the placeholders ``__BASE_CSS__``, ``__BASE_JS__``,
+``__PAGE_TITLE__``, ``__CONFIG_JSON__`` and ``__POINTS_JSON__``;
+:func:`render_explorer_html` fills them in.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import TYPE_CHECKING
+
+from tabarena.plot.plot_pareto_focus import FAMILY_COLORS
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+#: Family display name -> the CSS custom property carrying its color.
+_FAMILY_CSS_TOKENS: dict[str, str] = {
+    "Foundation Model": "--fam-foundation",
+    "Neural Network": "--fam-nn",
+    "Tree-based": "--fam-tree",
+    "Reference Pipeline": "--fam-reference",
+    "Baseline": "--fam-baseline",
+    "Other": "--fam-other",
+}
+
+
+def _family_css_vars() -> str:
+    """CSS custom-property lines carrying the shared family colors."""
+    return "\n".join(f"    {token}: {FAMILY_COLORS[family]};" for family, token in _FAMILY_CSS_TOKENS.items())
+
+
+#: Theme tokens + the chrome (controls, chips, tooltip, data table) every
+#: explorer shares. Chart-specific layout stays in the individual templates.
+#: Theme tokens, declared once per mode and emitted into four scopes below.
+#: Family colors are mode-independent, so they live only in the base scope.
+_LIGHT_TOKENS = """
+    --paper: #ffffff;
+    --card: #ffffff;
+    --ink: #14161a;
+    --muted: #6d6c65;
+    --line: #e4e3db;
+    --accent: #2a78d6;
+    --chip-bg: #f2f1ec;
+    --pt-muted: #b9b8b1;
+    /* The same family hues as *text*. The mark colors are tuned for fills and
+       drop below readable contrast as small labels on the light surface, so
+       light mode darkens them; dark mode reuses the mark colors as-is. */
+    --fam-foundation-ink: #7d3fc2;
+    --fam-nn-ink: #1c6fa8;
+    --fam-tree-ink: #2f7d32;
+    --fam-reference-ink: #a4600f;
+    --fam-baseline-ink: #5f5f5f;
+    --fam-other-ink: #5f5f5f;
+    /* Tuning-variant series (default / tuned / tuned + ensembled). Same three
+       hues as the static bar figures, stepped per mode and then muted toward
+       grey — blue/green by 15%, the orange by 24% since it read loudest. That
+       costs some colorblind separation (green vs. orange, 9.2 deutan ΔE at full
+       strength) which the fixed concentric bar widths, the legend and the data
+       table supply. Light mode goes softer still — a further 25% toward white,
+       for the paper view's white surface — landing at 6.0 ΔE; the seaborn
+       pastels the static figures use would be 4.0, which is why we stop here
+       rather than matching them exactly. */
+    --var-default: #6799d4;
+    --var-tuned: #dc9274;
+    --var-tunedens: #61bf9e;
+    --optimal: #228b22;
+    --tooltip-bg: #14161a;
+    --tooltip-ink: #fbfbf9;
+    color-scheme: light;
+"""
+
+_DARK_TOKENS = """
+    --paper: #131316;
+    --card: #1b1b1f;
+    --ink: #f0efea;
+    --muted: #9b9a92;
+    --line: #2e2e33;
+    --accent: #3987e5;
+    --chip-bg: #232327;
+    --pt-muted: #55555c;
+    --fam-foundation-ink: var(--fam-foundation);
+    --fam-nn-ink: var(--fam-nn);
+    --fam-tree-ink: var(--fam-tree);
+    --fam-reference-ink: var(--fam-reference);
+    --fam-baseline-ink: var(--fam-baseline);
+    --fam-other-ink: var(--fam-other);
+    --var-default: #4386d5;
+    --var-tuned: #c05f38;
+    --var-tunedens: #289972;
+    --optimal: #2ea043;
+    --tooltip-bg: #f0efea;
+    --tooltip-ink: #14161a;
+    color-scheme: dark;
+"""
+
+
+def _scope(selector: str, *bodies: str, indent: str = "  ") -> str:
+    """One CSS rule, with every body line re-indented under ``selector``."""
+    lines = [f"{indent}{selector} {{"]
+    for body in bodies:
+        lines += [f"{indent}  {line.strip()}" if line.strip() else "" for line in body.strip("\n").split("\n")]
+    lines.append(f"{indent}}}")
+    return "\n".join(lines)
+
+
+#: Theme tokens + the chrome (controls, chips, tooltip, data table) every
+#: explorer shares. Chart-specific layout stays in the individual templates.
+#:
+#: Four scopes, in this order: the base (light) scope carries the family colors;
+#: the media query follows the OS preference; ``[data-theme="dark"]`` lets an
+#: embedding page force dark (the always-dark leaderboard Space does); and
+#: ``[data-theme="light"]`` forces light for the paper view, beating both the
+#: media query (lower specificity) and the dark stamp (same specificity, later).
+EXPLORER_BASE_CSS = "".join(
+    [
+        _scope(":root", "__FAMILY_CSS_VARS__", _LIGHT_TOKENS),
+        "\n  @media (prefers-color-scheme: dark) {\n",
+        _scope(":root", _DARK_TOKENS, indent="    "),
+        "\n  }\n",
+        _scope(':root[data-theme="dark"]', _DARK_TOKENS),
+        "\n",
+        _scope(':root[data-theme="light"]', _LIGHT_TOKENS),
+        r"""
+  html, body { margin: 0; background: var(--paper); }
+  body {
+    color: var(--ink);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.5;
+    padding: 10px 12px 14px;
+  }
+  /* The [hidden] attribute must beat author display rules (e.g. the
+     inline-flex on .metricpick), else hidden controls render empty. */
+  [hidden] { display: none !important; }
+
+  .explorer-title { font-size: 15px; font-weight: 650; margin: 0 0 8px; }
+  .controls { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; margin-bottom: 10px; }
+  .controls .hint { font-size: 12.5px; color: var(--muted); }
+  .btnrow { display: flex; gap: 6px; flex-wrap: wrap; }
+  .btn {
+    font: 600 12.5px/1 system-ui, sans-serif; color: var(--ink);
+    background: var(--chip-bg); border: 1px solid var(--line); border-radius: 7px;
+    padding: 6px 11px; cursor: pointer;
+  }
+  .btn:hover { border-color: var(--muted); }
+  .btn:focus-visible, .chip:focus-visible, .famchip:focus-visible, select:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 2px;
+  }
+  .metricpick { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: 600; color: var(--muted); }
+  .metricpick select {
+    font: 600 12.5px/1.2 system-ui, sans-serif; color: var(--ink);
+    background: var(--chip-bg); border: 1px solid var(--line); border-radius: 7px;
+    padding: 5px 7px; cursor: pointer;
+  }
+
+  .chips { display: flex; flex-direction: column; gap: 9px; }
+  /* One block per family: the family toggle on top, its chips wrapping below. */
+  .chiprow { display: flex; flex-direction: column; align-items: flex-start; gap: 5px; }
+  .famchip {
+    display: inline-flex; align-items: center; gap: 6px;
+    font: 650 10.5px/1.3 system-ui, sans-serif; letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--muted); background: var(--chip-bg); border: 1px dashed var(--line);
+    border-radius: 999px; padding: 5px 10px; cursor: pointer;
+  }
+  .famchip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam); flex: none; }
+  .famchip .count { font-weight: 500; letter-spacing: 0; opacity: 0.75; }
+  .famchip:hover { border-color: var(--fam); color: var(--ink); }
+  .famchip[aria-pressed="true"] {
+    border: 1px solid var(--fam);
+    background: color-mix(in srgb, var(--fam) 13%, transparent);
+    color: var(--ink);
+  }
+  .chipset { display: flex; flex-wrap: wrap; gap: 4px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 5px;
+    font: 500 12.5px/1 system-ui, sans-serif; color: var(--ink);
+    background: none; border: 1px solid var(--line); border-radius: 999px;
+    padding: 5px 10px 5px 8px; cursor: pointer;
+  }
+  .chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--pt-muted); flex: none; }
+  .chip .imp-mark { color: var(--muted); font-weight: 700; margin-left: -2px; }
+  .chip[aria-pressed="true"] { border-color: var(--fam); background: color-mix(in srgb, var(--fam) 13%, transparent); font-weight: 650; }
+  .chip[aria-pressed="true"] .dot { background: var(--fam); }
+  .chip:hover { border-color: var(--muted); }
+
+  .legendstrip {
+    display: flex; flex-wrap: wrap; gap: 5px 16px; align-items: center;
+    font-size: 12.5px; color: var(--muted); padding: 2px 2px 8px;
+  }
+  .legendstrip .item { display: inline-flex; align-items: center; gap: 6px; }
+
+  .tooltip {
+    position: absolute; pointer-events: none; display: none;
+    background: var(--tooltip-bg); color: var(--tooltip-ink);
+    border-radius: 8px; padding: 8px 11px; font-size: 12px; line-height: 1.45;
+    max-width: 260px; z-index: 5; font-variant-numeric: tabular-nums;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.25);
+  }
+  .tooltip .t-name { font-weight: 700; font-size: 12.5px; }
+  .tooltip .t-var { opacity: 0.75; }
+  .tooltip .t-imp { opacity: 0.85; font-style: italic; }
+
+  details.datatable { margin-top: 8px; font-size: 12.5px; }
+  details.datatable summary { cursor: pointer; color: var(--muted); font-weight: 600; }
+  details.datatable .tblwrap { overflow-x: auto; margin-top: 8px; }
+  details.datatable table { border-collapse: collapse; font-variant-numeric: tabular-nums; min-width: 560px; }
+  details.datatable th, details.datatable td {
+    text-align: left; padding: 3px 12px 3px 0; border-bottom: 1px solid var(--line);
+  }
+  details.datatable th { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); }
+
+  svg text { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .chip, .btn, .famchip { transition: border-color 120ms ease, background-color 120ms ease; }
+  }
+
+  /* --- Paper view -----------------------------------------------------------
+     A figure-ready state for slides and papers: white surface, and only the
+     things needed to read the plot — the caption, the legend and the chart.
+     The controls, the chip list and the data table are interactive scaffolding,
+     not part of the figure. Entered via the "Paper view" button (which stamps
+     data-theme="light" on the root, see the scopes above). */
+  /* One toggle, in the same place in both states and never hidden — an exit
+     tucked into a corner of the figure was easy to miss. */
+  .viewbar { display: flex; align-items: center; gap: 10px; margin: 0 0 9px; }
+  .papercap { display: none; }
+  body.paper .controls,
+  body.paper .chips,
+  body.paper .sidebox,
+  body.paper details.datatable { display: none !important; }
+  /* Only shown when the view departs from the default, so a screenshot cannot
+     quietly hide a filter; the axis labels carry the metric either way. */
+  body.paper .papercap:not(:empty) { display: block; margin: 0 0 9px; font-size: 12.5px; color: var(--muted); }
+  body.paper { padding: 14px 18px 18px; }
+""",
+    ]
+)
+
+#: JS every explorer needs, spliced inside each page's IIFE. Declarations plus
+#: one normalization pass over ``POINTS`` (which every template defines just
+#: above the splice point), so a template can use both before its own setup runs.
+EXPLORER_BASE_JS = r"""
+  const NS = "http://www.w3.org/2000/svg";
+  // Baseline and Other are one bucket, as in the site's own type legend: they
+  // already share a color, and each holds only a handful of methods.
+  const FAM_MERGED = "Baseline / Other";
+  const famOf = (family) => (family === "Baseline" || family === "Other" ? FAM_MERGED : family);
+  // Normalized up front so every later lookup — colors, chips, sorting — sees
+  // the merged family. Both templates declare POINTS above this block.
+  for (const p of POINTS) p.family = famOf(p.family);
+
+  const FAM_ORDER = ["Foundation Model", "Tree-based", "Neural Network", "Reference Pipeline", FAM_MERGED];
+  const FAM_VAR = {
+    "Foundation Model": "var(--fam-foundation)",
+    "Tree-based": "var(--fam-tree)",
+    "Neural Network": "var(--fam-nn)",
+    "Reference Pipeline": "var(--fam-reference)",
+    [FAM_MERGED]: "var(--fam-baseline)",
+  };
+  // The same hues stepped for use as text (see the --fam-*-ink tokens).
+  const FAM_INK = {
+    "Foundation Model": "var(--fam-foundation-ink)",
+    "Tree-based": "var(--fam-tree-ink)",
+    "Neural Network": "var(--fam-nn-ink)",
+    "Reference Pipeline": "var(--fam-reference-ink)",
+    [FAM_MERGED]: "var(--fam-baseline-ink)",
+  };
+
+  // Create an SVG element with attributes, optionally appended to `parent`.
+  function el(name, attrs, parent) {
+    const node = document.createElementNS(NS, name);
+    for (const k in attrs) node.setAttribute(k, attrs[k]);
+    if (parent) parent.appendChild(node);
+    return node;
+  }
+
+  // Plain, ungrouped numbers with a "." decimal separator. `toFixed` is
+  // locale-independent by definition, which is the point: `toLocaleString`
+  // would follow the *viewer's* browser locale and print 1234,5 for a German
+  // visitor, disagreeing with the figures and CSVs beside it.
+  function fmtNum(v, decimals) {
+    if (v == null || !isFinite(v)) return "—";
+    return v.toFixed(decimals);
+  }
+
+  function fmtMetric(metric, v) {
+    if (v == null || !isFinite(v)) return "—";
+    return fmtNum(v, metric.decimals) + (metric.suffix || "");
+  }
+
+  function fmtTime(v) {
+    if (v >= 100) return fmtNum(v, 0) + " s";
+    if (v >= 1) return fmtNum(v, 1) + " s";
+    if (v >= 0.1) return fmtNum(v, 2) + " s";
+    return fmtNum(v, 3) + " s";
+  }
+
+  // Smallest "nice" (1/2/2.5/5 x a power of ten) step that is at least `raw`.
+  function niceStep(raw) {
+    if (!(raw > 0)) return 1;
+    const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+    for (const m of [1, 2, 2.5, 5, 10]) {
+      if (mag * m >= raw) return mag * m;
+    }
+    return mag * 10;
+  }
+
+  // ~`target` evenly spaced "nice" tick values covering [min, max]. Stepped by
+  // index rather than by accumulation so fractional steps do not drift.
+  function ticks(min, max, target) {
+    const step = niceStep((max - min) / target);
+    const first = Math.ceil(min / step);
+    const out = [];
+    for (let i = 0; first * step + i * step <= max + 1e-9; i++) out.push((first + i) * step);
+    return out.length ? out : [min];
+  }
+
+  // A hover tooltip anchored inside `box` (which must be position:relative).
+  function makeTooltip(box) {
+    const node = box.querySelector(".tooltip");
+    return {
+      show(html, ev) { node.innerHTML = html; node.style.display = "block"; this.move(ev); },
+      move(ev) {
+        const r = box.getBoundingClientRect();
+        let tx = ev.clientX - r.left + 14;
+        const ty = ev.clientY - r.top + 12;
+        if (tx > r.width - 270) tx = ev.clientX - r.left - 274;
+        node.style.left = tx + "px";
+        node.style.top = ty + "px";
+      },
+      hide() { node.style.display = "none"; },
+    };
+  }
+
+  // Paper view: white surface, caption + legend + chart only. `caption()` is
+  // supplied by each template — the figure has to stay self-describing once the
+  // controls are gone, so it states the subset and anything non-default about
+  // the current view. `afterToggle` re-renders charts whose size is measured.
+  function setUpPaperView(caption, afterToggle) {
+    const root = document.documentElement;
+    let hostTheme = null;   // the embedding page's choice, captured on entry
+    const btn = document.getElementById("btn-paper");
+    const capEl = document.getElementById("papercap");
+
+    function setPaper(on) {
+      document.body.classList.toggle("paper", on);
+      if (on) {
+        hostTheme = root.getAttribute("data-theme");
+        root.setAttribute("data-theme", "light");
+      } else if (hostTheme) {
+        root.setAttribute("data-theme", hostTheme);
+      } else {
+        root.removeAttribute("data-theme");
+      }
+      btn.textContent = on ? "Interactive view" : "Paper view";
+      capEl.innerHTML = on ? caption() : "";
+      if (afterToggle) requestAnimationFrame(afterToggle);
+      postHeight();
+    }
+    btn.addEventListener("click", () => setPaper(!document.body.classList.contains("paper")));
+    // Embedded, the host page owns the control (it sits beside the panel's
+    // static-figure toggle) and drives it from the outside; standalone — the
+    // shareable single file — this page needs its own button.
+    if (window.parent !== window) document.querySelector(".viewbar").hidden = true;
+    window.addEventListener("message", ev => {
+      const d = ev.data;
+      if (d && d.type === "tabarena-explorer-paper" && typeof d.on === "boolean") setPaper(d.on);
+    });
+    document.addEventListener("keydown", ev => {
+      if (ev.key === "Escape" && document.body.classList.contains("paper")) setPaper(false);
+    });
+    // Keep the caption current while in paper view (a control can still be
+    // driven by keyboard before entering, and re-renders happen on resize).
+    return () => { if (document.body.classList.contains("paper")) capEl.innerHTML = caption(); };
+  }
+
+  // When embedded, report the content height so the host page can size the
+  // iframe to fit (avoids an inner scrollbar). Works from a sandboxed frame.
+  // Measure the body (viewport-independent) — documentElement.scrollHeight is
+  // clamped to at least the iframe's current viewport, which turns the
+  // resize round-trip into a grow-forever feedback loop. The change guard
+  // stops re-posting once the height settles.
+  let lastPostedHeight = 0;
+  function postHeight() {
+    if (window.parent === window) return;
+    const height = Math.ceil(document.body.offsetHeight);
+    if (Math.abs(height - lastPostedHeight) < 3) return;
+    lastPostedHeight = height;
+    window.parent.postMessage({ type: "tabarena-explorer-height", height: height }, "*");
+  }
+"""
+
+
+def render_explorer_html(
+    template: str,
+    *,
+    page_title: str,
+    config: dict,
+    points: pd.DataFrame,
+) -> str:
+    """Fill an explorer template's placeholders and return the finished page."""
+    return (
+        template.replace("__BASE_CSS__", EXPLORER_BASE_CSS)
+        .replace("__BASE_JS__", EXPLORER_BASE_JS)
+        .replace("__FAMILY_CSS_VARS__", _family_css_vars())
+        .replace("__PAGE_TITLE__", html.escape(page_title))
+        .replace("__CONFIG_JSON__", json.dumps(config))
+        .replace("__POINTS_JSON__", points.to_json(orient="records"))
+    )

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -73,7 +73,12 @@ __BASE_CSS__
       <div class="chips" id="chips"></div>
     </div>
     <div class="mainbox">
-      <p class="papercap" id="papercap"></p>
+      <div class="exportbar" id="exportbar" hidden>
+        <span class="hint">Export figure</span>
+        <button class="btn" id="btn-svg" title="Download as SVG — vector, keeps text selectable">SVG</button>
+        <button class="btn" id="btn-pdf" title="Download as a one-page PDF">PDF</button>
+        <button class="btn" id="btn-png" title="Download as PNG at 3x scale">PNG</button>
+      </div>
       <!-- Legend above the chart so readers decode the marks before the data. -->
       <div class="legendstrip" id="legendstrip"></div>
       <div class="chartbox" id="chartbox">
@@ -266,10 +271,14 @@ __BASE_JS__
         .textContent = fmtNum(yv, Number.isInteger(yv) ? 0 : metric.decimals);
     }
     el("rect", { x: M.l, y: M.t, width: W - M.l - M.r, height: H - M.t - M.b, fill: "none", stroke: "var(--line)" }, grid);
-    el("text", { x: (M.l + W - M.r) / 2, y: H - 10, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)" }, grid)
-      .textContent = X_AXIS.axisLabel;
-    el("text", { x: 0, y: 0, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)",
-      transform: `translate(16 ${(M.t + H - M.b) / 2}) rotate(-90)` }, grid).textContent = metric.axisLabel;
+    el("text", {
+      x: (M.l + W - M.r) / 2, y: H - 10, "text-anchor": "middle", "font-size": 14,
+      "font-weight": 650, fill: "var(--ink)",
+    }, grid).textContent = X_AXIS.axisLabel;
+    el("text", {
+      x: 0, y: 0, "text-anchor": "middle", "font-size": 14, "font-weight": 650, fill: "var(--ink)",
+      transform: `translate(16 ${(M.t + H - M.b) / 2}) rotate(-90)`,
+    }, grid).textContent = metric.axisLabel;
 
     drawOptimalArrow(grid, metric.lowerBetter, M, W, H);
 
@@ -455,7 +464,6 @@ __BASE_JS__
     if (state.active.has(m)) state.active.delete(m); else state.active.add(m);
     syncChips();
     render();
-    if (refreshCaption) refreshCaption();
   }
   function toggleFamily(fam) {
     const methods = familyMethods(fam);
@@ -470,7 +478,6 @@ __BASE_JS__
     state.active = new Set(methods);
     syncChips();
     render();
-    if (refreshCaption) refreshCaption();
   }
   document.getElementById("btn-front").addEventListener("click",
     () => setActive(computeFront(metricByKey[metricKey]).methods));
@@ -525,22 +532,8 @@ __BASE_JS__
   }
 
   // ---------- paper view ----------
-  // Highlighting is this chart's editorial choice, so the caption records it:
-  // the front is always drawn, and anything highlighted beyond it is the reader's
-  // own selection, which a screenshot would otherwise leave unexplained.
-  // Silent for the default view (front highlighted, full axes) — the axis labels
-  // already say what is plotted. It only reports a reader's own choices, which a
-  // screenshot would otherwise leave unexplained.
-  function paperCaption() {
-    const m = metricByKey[metricKey];
-    const front = computeFront(m).methods;
-    const isFront = state.active.size === front.size && [...state.active].every(x => front.has(x));
-    const notes = [];
-    if (!state.active.size) notes.push("nothing highlighted");
-    else if (!isFront) notes.push(`highlighted: ${[...state.active].join(", ")}`);
-    return notes.join(" &middot; ");
-  }
-  let refreshCaption = setUpPaperView(paperCaption, render);
+  setUpPaperView(render);
+  setUpExport(() => [{ svg: svg, dx: 0 }], () => slugify(document.title));
 
   // ---------- data table ----------
   function buildTable() {

--- a/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_explorer_template.py
@@ -2,8 +2,11 @@
 
 Kept as a Python string constant (rather than a package-data file) so it ships
 with the package without any build-system data-file configuration. The
-placeholders ``__PAGE_TITLE__``, ``__CONFIG_JSON__`` and ``__POINTS_JSON__``
-are substituted by :func:`tabarena.plot.interactive.pareto_explorer.build_pareto_explorer_html`.
+placeholders (``__BASE_CSS__``, ``__BASE_JS__``, ``__PAGE_TITLE__``,
+``__CONFIG_JSON__``, ``__POINTS_JSON__``) are substituted by
+:func:`tabarena.plot.interactive._explorer_shared.render_explorer_html`; the
+chrome and helpers spliced in via the first two are shared with the other
+explorers (see :mod:`tabarena.plot.interactive._explorer_shared`).
 
 The rendered page has zero external dependencies (no plotting library, fonts,
 or CDN assets), renders in light and dark mode via ``prefers-color-scheme``,
@@ -22,67 +25,7 @@ EXPLORER_TEMPLATE = r"""<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>__PAGE_TITLE__</title>
 <style>
-  :root {
-    --paper: #ffffff;
-    --card: #ffffff;
-    --ink: #14161a;
-    --muted: #6d6c65;
-    --line: #e4e3db;
-    --accent: #2a78d6;
-    --chip-bg: #f2f1ec;
-    --pt-muted: #b9b8b1;
-    /* Family colors: injected from FAMILY_COLORS (same scheme as the
-       leaderboard tables), identical in light and dark mode. */
-__FAMILY_CSS_VARS__
-    --optimal: #228b22;
-    --tooltip-bg: #14161a;
-    --tooltip-ink: #fbfbf9;
-    color-scheme: light;
-  }
-  /* Dark tokens twice: the media query follows the OS preference, and the
-     [data-theme="dark"] scope lets an embedding page (e.g. the always-dark
-     leaderboard Space) force dark regardless of the OS setting. */
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --paper: #131316;
-      --card: #1b1b1f;
-      --ink: #f0efea;
-      --muted: #9b9a92;
-      --line: #2e2e33;
-      --accent: #3987e5;
-      --chip-bg: #232327;
-      --pt-muted: #55555c;
-      --optimal: #2ea043;
-      --tooltip-bg: #f0efea;
-      --tooltip-ink: #14161a;
-      color-scheme: dark;
-    }
-  }
-  :root[data-theme="dark"] {
-    --paper: #131316;
-    --card: #1b1b1f;
-    --ink: #f0efea;
-    --muted: #9b9a92;
-    --line: #2e2e33;
-    --accent: #3987e5;
-    --chip-bg: #232327;
-    --pt-muted: #55555c;
-    --optimal: #2ea043;
-    --tooltip-bg: #f0efea;
-    --tooltip-ink: #14161a;
-    color-scheme: dark;
-  }
-
-  html, body { margin: 0; background: var(--paper); }
-  body {
-    color: var(--ink);
-    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
-    line-height: 1.5;
-    padding: 10px 12px 14px;
-  }
-  /* The [hidden] attribute must beat author display rules (e.g. the
-     inline-flex on .metricpick), else hidden controls render empty. */
-  [hidden] { display: none !important; }
+__BASE_CSS__
 
   /* Two-column layout: controls + chips in a side panel, chart beside it.
      ``chips-right`` mirrors the columns. Wraps to stacked when narrow. */
@@ -95,92 +38,24 @@ __FAMILY_CSS_VARS__
     .sidebox { flex: 1 1 100%; }
   }
 
-  .explorer-title { font-size: 15px; font-weight: 650; margin: 0 0 8px; }
-  .controls { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; margin-bottom: 10px; }
-  .controls .hint { font-size: 12.5px; color: var(--muted); }
-  .btnrow { display: flex; gap: 6px; flex-wrap: wrap; }
-  .btn {
-    font: 600 12.5px/1 system-ui, sans-serif; color: var(--ink);
-    background: var(--chip-bg); border: 1px solid var(--line); border-radius: 7px;
-    padding: 6px 11px; cursor: pointer;
-  }
-  .btn:hover { border-color: var(--muted); }
-  .btn:focus-visible, .chip:focus-visible, .famchip:focus-visible, select:focus-visible {
-    outline: 2px solid var(--accent); outline-offset: 2px;
-  }
-  .metricpick { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: 600; color: var(--muted); }
-  .metricpick select {
-    font: 600 12.5px/1.2 system-ui, sans-serif; color: var(--ink);
-    background: var(--chip-bg); border: 1px solid var(--line); border-radius: 7px;
-    padding: 5px 7px; cursor: pointer;
-  }
-
-  .chips { display: flex; flex-direction: column; gap: 9px; }
-  /* One block per family: the family toggle on top, its chips wrapping below. */
-  .chiprow { display: flex; flex-direction: column; align-items: flex-start; gap: 5px; }
-  .famchip {
-    display: inline-flex; align-items: center; gap: 6px;
-    font: 650 10.5px/1.3 system-ui, sans-serif; letter-spacing: 0.06em; text-transform: uppercase;
-    color: var(--muted); background: var(--chip-bg); border: 1px dashed var(--line);
-    border-radius: 999px; padding: 5px 10px; cursor: pointer;
-  }
-  .famchip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam); flex: none; }
-  .famchip .count { font-weight: 500; letter-spacing: 0; opacity: 0.75; }
-  .famchip:hover { border-color: var(--fam); color: var(--ink); }
-  .famchip[aria-pressed="true"] {
-    border: 1px solid var(--fam);
-    background: color-mix(in srgb, var(--fam) 13%, transparent);
-    color: var(--ink);
-  }
-  .chipset { display: flex; flex-wrap: wrap; gap: 4px; }
-  .chip {
-    display: inline-flex; align-items: center; gap: 5px;
-    font: 500 12.5px/1 system-ui, sans-serif; color: var(--ink);
-    background: none; border: 1px solid var(--line); border-radius: 999px;
-    padding: 5px 10px 5px 8px; cursor: pointer;
-  }
-  .chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--pt-muted); flex: none; }
-  .chip .imp-mark { color: var(--muted); font-weight: 700; margin-left: -2px; }
-  .chip[aria-pressed="true"] { border-color: var(--fam); background: color-mix(in srgb, var(--fam) 13%, transparent); font-weight: 650; }
-  .chip[aria-pressed="true"] .dot { background: var(--fam); }
-  .chip:hover { border-color: var(--muted); }
-
+  .legendstrip .legendbreak { flex-basis: 100%; height: 0; }
   .chartbox { position: relative; }
-  .chartbox svg { width: 100%; height: auto; display: block; }
-  .legendstrip {
-    display: flex; flex-wrap: wrap; gap: 5px 16px; align-items: center;
-    font-size: 12.5px; color: var(--muted); padding: 2px 2px 8px;
-  }
-  .legendstrip .item { display: inline-flex; align-items: center; gap: 6px; }
-
-  .tooltip {
-    position: absolute; pointer-events: none; display: none;
-    background: var(--tooltip-bg); color: var(--tooltip-ink);
-    border-radius: 8px; padding: 8px 11px; font-size: 12px; line-height: 1.45;
-    max-width: 260px; z-index: 5; font-variant-numeric: tabular-nums;
-    box-shadow: 0 4px 14px rgba(0,0,0,0.25);
-  }
-  .tooltip .t-name { font-weight: 700; font-size: 12.5px; }
-  .tooltip .t-var { opacity: 0.75; }
-  .tooltip .t-imp { opacity: 0.85; font-style: italic; }
-
-  details.datatable { margin-top: 8px; font-size: 12.5px; }
-  details.datatable summary { cursor: pointer; color: var(--muted); font-weight: 600; }
-  details.datatable .tblwrap { overflow-x: auto; margin-top: 8px; }
-  details.datatable table { border-collapse: collapse; font-variant-numeric: tabular-nums; min-width: 560px; }
-  details.datatable th, details.datatable td {
-    text-align: left; padding: 3px 12px 3px 0; border-bottom: 1px solid var(--line);
-  }
-  details.datatable th { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); }
-
-  svg text { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .chip, .btn, .famchip { transition: border-color 120ms ease, background-color 120ms ease; }
+  /* The chart is sized in device pixels by render() rather than scaled from a
+     viewBox: scaling stretched the type along with the plot, and a viewBox tall
+     enough to read made the whole panel own the screen. */
+  .chartbox svg { display: block; }
+  /* Chips scroll within the column so the panel height follows the chart. */
+  .sidebox .chips { overflow-y: auto; scrollbar-width: thin; scrollbar-color: var(--pt-muted) transparent; }
+  .sidebox .chips::-webkit-scrollbar { width: 9px; }
+  .sidebox .chips::-webkit-scrollbar-thumb {
+    background: var(--pt-muted); border-radius: 8px; border: 3px solid transparent; background-clip: content-box;
   }
 </style>
 </head>
 <body>
+  <div class="viewbar">
+    <button class="btn" id="btn-paper" title="White background, chart and legend only — for slides and papers">Paper view</button>
+  </div>
   <p class="explorer-title" id="title"></p>
   <div class="explorer-grid" id="grid">
     <div class="sidebox">
@@ -198,10 +73,11 @@ __FAMILY_CSS_VARS__
       <div class="chips" id="chips"></div>
     </div>
     <div class="mainbox">
+      <p class="papercap" id="papercap"></p>
       <!-- Legend above the chart so readers decode the marks before the data. -->
       <div class="legendstrip" id="legendstrip"></div>
       <div class="chartbox" id="chartbox">
-        <svg id="chart" viewBox="0 0 960 540" role="img" aria-label="Pareto front explorer"></svg>
+        <svg id="chart" role="img" aria-label="Pareto front explorer"></svg>
         <div class="tooltip"></div>
       </div>
     </div>
@@ -217,16 +93,8 @@ __FAMILY_CSS_VARS__
   const CONFIG = __CONFIG_JSON__;
   const POINTS = __POINTS_JSON__;
 
-  const FAM_ORDER = ["Foundation Model", "Tree-based", "Neural Network", "Other", "Reference Pipeline", "Baseline"];
-  const FAM_VAR = {
-    "Foundation Model": "var(--fam-foundation)",
-    "Tree-based": "var(--fam-tree)",
-    "Neural Network": "var(--fam-nn)",
-    "Other": "var(--fam-other)",
-    "Reference Pipeline": "var(--fam-reference)",
-    "Baseline": "var(--fam-baseline)",
-  };
-  const NS = "http://www.w3.org/2000/svg";
+__BASE_JS__
+
   const TRAJECTORY = CONFIG.mode === "trajectory";
 
   const titleEl = document.getElementById("title");
@@ -237,26 +105,9 @@ __FAMILY_CSS_VARS__
 
   const svg = document.getElementById("chart");
   const box = document.getElementById("chartbox");
-  const tipEl = box.querySelector(".tooltip");
-  const tip = {
-    show(html, ev) { tipEl.innerHTML = html; tipEl.style.display = "block"; this.move(ev); },
-    move(ev) {
-      const r = box.getBoundingClientRect();
-      let tx = ev.clientX - r.left + 14, ty = ev.clientY - r.top + 12;
-      if (tx > r.width - 270) tx = ev.clientX - r.left - 274;
-      tipEl.style.left = tx + "px";
-      tipEl.style.top = ty + "px";
-    },
-    hide() { tipEl.style.display = "none"; },
-  };
-
-  // ---------- helpers ----------
-  function el(name, attrs, parent) {
-    const node = document.createElementNS(NS, name);
-    for (const k in attrs) node.setAttribute(k, attrs[k]);
-    if (parent) parent.appendChild(node);
-    return node;
-  }
+  const chipsBox = document.getElementById("chips");
+  const controlsBox = document.querySelector(".controls");
+  const tip = makeTooltip(box);
 
   // Marker glyph per variant at (cx, cy); trajectories use circles everywhere.
   function drawMark(parent, cx, cy, variant, color, size, opacity, dataM, whiteStroke) {
@@ -328,29 +179,6 @@ __FAMILY_CSS_VARS__
     t.textContent = "Optimal";
   }
 
-  function ticks(min, max, target) {
-    const raw = (max - min) / target;
-    const mag = Math.pow(10, Math.floor(Math.log10(raw)));
-    let step = mag;
-    for (const m of [1, 2, 5, 10]) {
-      if (mag * m >= raw) { step = mag * m; break; }
-    }
-    const out = [];
-    for (let v = Math.ceil(min / step) * step; v <= max + 1e-9; v += step) out.push(v);
-    return out;
-  }
-
-  function fmtTime(v) {
-    if (v >= 100) return v.toFixed(0) + " s";
-    if (v >= 1) return v.toFixed(1) + " s";
-    if (v >= 0.1) return v.toFixed(2) + " s";
-    return v.toFixed(3) + " s";
-  }
-
-  function fmtMetric(metric, v) {
-    return v.toFixed(metric.decimals) + (metric.suffix || "");
-  }
-
   // ---------- data ----------
   const byMethod = new Map();
   for (const p of POINTS) {
@@ -392,11 +220,19 @@ __FAMILY_CSS_VARS__
   const state = { active: new Set(computeFront(metricByKey[metricKey]).methods) };
 
   // ---------- chart ----------
-  const W = 960, H = 540, M = { l: 62, r: 18, t: 14, b: 52 };
+  // A flat, fixed-height plot: two of these panels then fit on one screen.
+  const CHART_H = 400;
+  const M = { l: 62, r: 18, t: 14, b: 52 };
 
   function render() {
     const metric = metricByKey[metricKey];
     svg.textContent = "";
+    const W = Math.max(360, Math.round(box.clientWidth));
+    const H = CHART_H;
+    svg.setAttribute("width", W);
+    svg.setAttribute("height", H);
+    // Keep the chip list from outgrowing the chart beside it.
+    chipsBox.style.maxHeight = Math.max(170, H - controlsBox.offsetHeight + 20) + "px";
 
     // x scale (log)
     const xsAll = POINTS.map(p => p[xKey]);
@@ -419,15 +255,15 @@ __FAMILY_CSS_VARS__
     for (let e = Math.ceil(lx0); Math.pow(10, e) < xmax; e++) {
       const gx = X(Math.pow(10, e));
       el("line", { x1: gx, y1: M.t, x2: gx, y2: H - M.b, stroke: "var(--line)", "stroke-width": 1 }, grid);
-      const lbl = e >= 0 ? String(Math.pow(10, e)) : Math.pow(10, e).toFixed(-e);
-      el("text", { x: gx, y: H - M.b + 20, "text-anchor": "middle", "font-size": 12, fill: "var(--muted)" }, grid)
+      const lbl = fmtNum(Math.pow(10, e), e >= 0 ? 0 : -e);
+      el("text", { x: gx, y: H - M.b + 20, "text-anchor": "middle", "font-size": 12.5, fill: "var(--muted)" }, grid)
         .textContent = lbl;
     }
     for (const yv of ticks(y0, y1, 6)) {
       const gy = Y(yv);
       el("line", { x1: M.l, y1: gy, x2: W - M.r, y2: gy, stroke: "var(--line)", "stroke-width": 1 }, grid);
-      el("text", { x: M.l - 8, y: gy + 4, "text-anchor": "end", "font-size": 12, fill: "var(--muted)" }, grid)
-        .textContent = yv;
+      el("text", { x: M.l - 8, y: gy + 4, "text-anchor": "end", "font-size": 12.5, fill: "var(--muted)" }, grid)
+        .textContent = fmtNum(yv, Number.isInteger(yv) ? 0 : metric.decimals);
     }
     el("rect", { x: M.l, y: M.t, width: W - M.l - M.r, height: H - M.t - M.b, fill: "none", stroke: "var(--line)" }, grid);
     el("text", { x: (M.l + W - M.r) / 2, y: H - 10, "text-anchor": "middle", "font-size": 14, fill: "var(--ink)" }, grid)
@@ -544,7 +380,7 @@ __FAMILY_CSS_VARS__
       html += `<div>${m.label}: <b>${fmtMetric(m, mval(p, m))}</b></div>`;
     }
     html += `<div>${X_AXIS.short}: <b>${fmtTime(p[xKey])}</b></div>`;
-    if (p.imputed) html += `<div class="t-imp">Imputed on ${p.imputed_pct.toFixed(0)}% of datasets</div>`;
+    if (p.imputed) html += `<div class="t-imp">Imputed on ${fmtNum(p.imputed_pct, 0)}% of datasets</div>`;
     tip.show(html, ev);
   }
   function hideTip(method) {
@@ -553,7 +389,6 @@ __FAMILY_CSS_VARS__
   }
 
   // ---------- chips ----------
-  const chipsBox = document.getElementById("chips");
   const chipByMethod = new Map();
   const famChips = new Map();
   function familyMethods(fam) {
@@ -620,6 +455,7 @@ __FAMILY_CSS_VARS__
     if (state.active.has(m)) state.active.delete(m); else state.active.add(m);
     syncChips();
     render();
+    if (refreshCaption) refreshCaption();
   }
   function toggleFamily(fam) {
     const methods = familyMethods(fam);
@@ -634,6 +470,7 @@ __FAMILY_CSS_VARS__
     state.active = new Set(methods);
     syncChips();
     render();
+    if (refreshCaption) refreshCaption();
   }
   document.getElementById("btn-front").addEventListener("click",
     () => setActive(computeFront(metricByKey[metricKey]).methods));
@@ -673,8 +510,37 @@ __FAMILY_CSS_VARS__
     if (POINTS.some(p => p.imputed)) {
       html += '<span class="item"><svg width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="4" fill="var(--muted)"/><circle cx="9" cy="9" r="7.5" fill="none" stroke="var(--muted)" stroke-width="1.3" stroke-dasharray="3 2.5"/></svg> &Dagger; partially imputed</span>';
     }
+    // Model family, named: highlighted points are colored by family, and in paper
+    // view the chip list that would otherwise decode them is hidden.
+    const families = FAM_ORDER.filter(f => POINTS.some(p => p.family === f));
+    if (families.length > 1) {
+      html += '<span class="legendbreak"></span><span class="item">Family:</span>';
+      for (const fam of families) {
+        html += `<span class="item"><svg width="12" height="12" viewBox="0 0 12 12">` +
+          `<circle cx="6" cy="6" r="5" fill="${FAM_VAR[fam]}"/></svg> ` +
+          `<span style="color:${FAM_INK[fam]}">${fam}</span></span>`;
+      }
+    }
     box2.innerHTML = html;
   }
+
+  // ---------- paper view ----------
+  // Highlighting is this chart's editorial choice, so the caption records it:
+  // the front is always drawn, and anything highlighted beyond it is the reader's
+  // own selection, which a screenshot would otherwise leave unexplained.
+  // Silent for the default view (front highlighted, full axes) — the axis labels
+  // already say what is plotted. It only reports a reader's own choices, which a
+  // screenshot would otherwise leave unexplained.
+  function paperCaption() {
+    const m = metricByKey[metricKey];
+    const front = computeFront(m).methods;
+    const isFront = state.active.size === front.size && [...state.active].every(x => front.has(x));
+    const notes = [];
+    if (!state.active.size) notes.push("nothing highlighted");
+    else if (!isFront) notes.push(`highlighted: ${[...state.active].join(", ")}`);
+    return notes.join(" &middot; ");
+  }
+  let refreshCaption = setUpPaperView(paperCaption, render);
 
   // ---------- data table ----------
   function buildTable() {
@@ -689,34 +555,24 @@ __FAMILY_CSS_VARS__
     for (const p of rows) {
       html += `<tr><td>${p.method}</td><td>${TRAJECTORY ? (p.n_configs != null ? p.n_configs : "—") : p.variant}</td><td>${p.family}</td>`;
       for (const m of METRICS) html += `<td>${fmtMetric(m, mval(p, m))}</td>`;
-      html += `<td>${p[xKey].toFixed(3)}</td>`;
-      html += `<td>${p.imputed ? p.imputed_pct.toFixed(0) + "%" : "—"}</td></tr>`;
+      html += `<td>${fmtNum(p[xKey], 3)}</td>`;
+      html += `<td>${p.imputed ? fmtNum(p.imputed_pct, 0) + "%" : "—"}</td></tr>`;
     }
     html += "</tbody></table>";
     document.getElementById("tblwrap").innerHTML = html;
   }
 
-  // When embedded, report the content height so the host page can size the
-  // iframe to fit (avoids an inner scrollbar). Works from a sandboxed frame.
-  // Measure the body (viewport-independent) — documentElement.scrollHeight is
-  // clamped to at least the iframe's current viewport, which turns the
-  // resize round-trip into a grow-forever feedback loop. The change guard
-  // stops re-posting once the height settles.
-  let lastPostedHeight = 0;
-  function postHeight() {
-    if (window.parent === window) return;
-    const height = Math.ceil(document.body.offsetHeight);
-    if (Math.abs(height - lastPostedHeight) < 3) return;
-    lastPostedHeight = height;
-    window.parent.postMessage({ type: "tabarena-explorer-height", height: height }, "*");
-  }
   const _renderInner = render;
   render = function () {
     _renderInner();
     postHeight();
   };
   document.querySelector("details.datatable").addEventListener("toggle", postHeight);
-  window.addEventListener("resize", postHeight);
+  let resizeTimer = null;
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(render, 120);
+  });
   window.addEventListener("load", postHeight);
 
   buildChips();

--- a/packages/tabarena/src/tabarena/plot/interactive/_leaderboard_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_leaderboard_template.py
@@ -76,7 +76,12 @@ __BASE_CSS__
     </div>
     <span class="hint">Click a column or chip to remove a method &middot; hover for exact values</span>
   </div>
-  <p class="papercap" id="papercap"></p>
+  <div class="exportbar" id="exportbar" hidden>
+    <span class="hint">Export figure</span>
+    <button class="btn" id="btn-svg" title="Download as SVG — vector, keeps text selectable">SVG</button>
+    <button class="btn" id="btn-pdf" title="Download as a one-page PDF">PDF</button>
+    <button class="btn" id="btn-png" title="Download as PNG at 3x scale">PNG</button>
+  </div>
   <div class="legendstrip" id="legendstrip"></div>
   <div class="lb-chartwrap" id="chartwrap">
     <svg id="axis" class="lb-axis" role="presentation"></svg>
@@ -173,8 +178,6 @@ __BASE_JS__
     refs: new Set(refs.map(r => r.method)),
     variants: new Set(VARIANT_ORDER),
   };
-
-  let refreshCaption = null;   // assigned once setUpPaperView has the DOM
 
   function metric() { return metricByKey[state.metric]; }
 
@@ -335,8 +338,8 @@ __BASE_JS__
     el("line", { x1: 0, y1: baseY, x2: plotW, y2: baseY, stroke: "var(--muted)", "stroke-width": 1 }, grid);
     el("line", { x1: AXIS_W - 1, y1: TOP, x2: AXIS_W - 1, y2: baseY, stroke: "var(--muted)", "stroke-width": 1 }, axisSvg);
     el("text", {
-      x: 0, y: 0, "text-anchor": "middle", "font-size": LABEL_SIZE, fill: "var(--ink)",
-      transform: `translate(15 ${TOP + PLOT_H / 2}) rotate(-90)`,
+      x: 0, y: 0, "text-anchor": "middle", "font-size": LABEL_SIZE, "font-weight": 650,
+      fill: "var(--ink)", transform: `translate(15 ${TOP + PLOT_H / 2}) rotate(-90)`,
     }, axisSvg).textContent = m.axisLabel;
 
     // -- hover band behind the marks (highlights the whole column group)
@@ -345,12 +348,16 @@ __BASE_JS__
     }, svg);
 
     const defs = el("defs", {}, svg);
-    // -- imputed hatch, reused by every partially imputed bar
+    // -- imputed hatch, reused by every partially imputed bar. Crossed diagonals,
+    //    matching the "x" hatch matplotlib draws in the static figure; the
+    //    diagonals meet the tile corners exactly, so the grid tiles seamlessly.
     const pat = el("pattern", {
-      id: "imp-hatch", width: 6, height: 6, patternUnits: "userSpaceOnUse", patternTransform: "rotate(45)",
+      id: "imp-hatch", width: 8, height: 8, patternUnits: "userSpaceOnUse",
     }, defs);
-    el("rect", { width: 6, height: 6, fill: "none" }, pat);
-    el("line", { x1: 0, y1: 0, x2: 0, y2: 6, stroke: "var(--paper)", "stroke-width": 2.2, opacity: 0.75 }, pat);
+    el("path", {
+      d: "M0,0 L8,8 M8,0 L0,8", stroke: "var(--paper)", "stroke-width": 1.5,
+      opacity: 0.85, fill: "none",
+    }, pat);
 
     // -- Everything data-bearing is clipped to the plot area. The axis floor is
     //    set from the bar values (a couple of very wide intervals would
@@ -412,7 +419,7 @@ __BASE_JS__
         }, xg);
       }
       const t = el("text", {
-        x: cx, y, "font-size": LABEL_SIZE, "text-anchor": "middle",
+        x: cx, y, "font-size": LABEL_SIZE, "text-anchor": "middle", "font-weight": 650,
         fill: FAM_INK[entry.family] || "var(--ink)",
       }, xg);
       t.textContent = labels[i];
@@ -447,7 +454,6 @@ __BASE_JS__
       }, axisSvg).textContent = fmtMetric(m, r[state.metric]);
     });
     buildLegend(m, shownRefs);
-    if (refreshCaption) refreshCaption();
 
     // -- hit targets: one full-height column per method (>= 34px wide)
     const hits = el("g", {}, svg);
@@ -679,7 +685,8 @@ __BASE_JS__
     if (POINTS.some(p => p.imputed)) {
       parts.push('<span class="item"><svg width="14" height="14" viewBox="0 0 14 14">' +
         '<rect x="1" y="1" width="12" height="12" rx="2" fill="var(--pt-muted)"/>' +
-        '<path d="M-2,4 L6,-4 M-2,10 L10,-2 M2,14 L14,2 M8,14 L14,8" stroke="var(--paper)" stroke-width="2.2"/>' +
+        '<path d="M1,1 L7,7 M7,1 L1,7 M7,7 L13,13 M13,7 L7,13 M1,7 L7,13 M7,7 L13,1" ' +
+        'stroke="var(--paper)" stroke-width="1.5" fill="none"/>' +
         "</svg> &Dagger; partially imputed</span>");
     }
     // Model family, named rather than merely pointed at: without the colors
@@ -713,20 +720,9 @@ __BASE_JS__
   }
 
   // ---------- paper view ----------
-  // Nothing when the view is the default one — the axis labels already name the
-  // metric and its direction. It only speaks up about what a screenshot would
-  // otherwise hide: a filtered set, a hidden variant, a raised axis floor.
-  function paperCaption() {
-    const m = metric();
-    const entries = visibleEntries();
-    const notes = [];
-    if (entries.length !== byMethod.size) notes.push(`${entries.length} of ${byMethod.size} methods shown`);
-    const hidden = VARIANT_ORDER.filter(v => !state.variants.has(v) && POINTS.some(p => p.variant === v));
-    if (hidden.length) notes.push(`${hidden.join(" and ")} hidden`);
-    if (state.yMin != null) notes.push(`axis from ${fmtNum(state.yMin, m.decimals)}`);
-    return notes.join(" &middot; ");
-  }
-  refreshCaption = setUpPaperView(paperCaption, render);
+  setUpPaperView(render);
+  // The y-axis lives in its own pane, so it is offset back into place.
+  setUpExport(() => [{ svg: axisSvg, dx: 0 }, { svg: svg, dx: AXIS_W }], () => slugify(document.title));
 
   // ---------- boot ----------
   document.querySelector("details.datatable").addEventListener("toggle", postHeight);

--- a/packages/tabarena/src/tabarena/plot/interactive/_leaderboard_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_leaderboard_template.py
@@ -1,0 +1,748 @@
+"""HTML/CSS/JS template for the interactive leaderboard-overview explorer.
+
+The interactive twin of the static ``tuning-impact-elo`` bar figure: one column
+group per method, nested bars for the tuning variants (default / tuned /
+tuned + ensembled), bootstrap CI whiskers, and reference pipelines as horizontal
+threshold lines. On top of the static figure it offers a metric selector, sorting,
+per-method and per-family removal, hover values and a data table — and it scrolls
+horizontally instead of shrinking 40+ methods into one page-wide strip.
+
+Kept as a Python string constant (rather than a package-data file) so it ships
+with the package without any build-system data-file configuration.
+:func:`tabarena.plot.interactive.leaderboard_explorer.build_leaderboard_explorer_html`
+substitutes the placeholders (see
+:func:`tabarena.plot.interactive._explorer_shared.render_explorer_html`).
+"""
+
+from __future__ import annotations
+
+LEADERBOARD_TEMPLATE = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__PAGE_TITLE__</title>
+<style>
+__BASE_CSS__
+
+  /* Chart: a fixed y-axis pane beside a horizontally scrolling plot pane, so
+     the axis stays readable however far right the reader scrolls. */
+  .lb-chartwrap { position: relative; display: flex; align-items: flex-start; }
+  .lb-axis { flex: none; }
+  .lb-scroll {
+    flex: 1 1 auto; min-width: 0; overflow-x: auto; overflow-y: hidden;
+    scrollbar-width: thin; scrollbar-color: var(--pt-muted) transparent;
+  }
+  .lb-scroll::-webkit-scrollbar { height: 10px; }
+  .lb-scroll::-webkit-scrollbar-thumb {
+    background: var(--pt-muted); border-radius: 8px;
+    border: 3px solid transparent; background-clip: content-box;
+  }
+  .rangepick input[type=range] { width: 96px; accent-color: var(--accent); cursor: pointer; }
+  .rangeval { font-variant-numeric: tabular-nums; font-weight: 500; min-width: 3.4em; }
+  .lb-empty { padding: 40px 0; text-align: center; color: var(--muted); font-size: 13px; }
+  /* Puts the family key on its own line of the legend strip. */
+  .legendstrip .legendbreak { flex-basis: 100%; height: 0; }
+  /* Family blocks pack side by side rather than stacking: below a full-width
+     chart, one row per family leaves the small ones (Other, Baseline) each
+     wasting a line. The wide families still claim a row of their own. */
+  .chips { margin-top: 10px; flex-direction: row; flex-wrap: wrap; gap: 12px 28px; align-items: flex-start; }
+  .chips-head { flex: 1 1 100%; font-size: 12.5px; color: var(--muted); font-weight: 600; }
+  .chiprow { flex: 0 1 auto; min-width: 0; }
+</style>
+</head>
+<body>
+  <div class="viewbar">
+    <button class="btn" id="btn-paper" title="White background, chart and legend only — for slides and papers">Paper view</button>
+  </div>
+  <p class="explorer-title" id="title"></p>
+  <!-- One control row above everything it scopes (axis, sorting, variants, selection). -->
+  <div class="controls">
+    <label class="metricpick">Y-axis
+      <select id="metric-select"></select>
+    </label>
+    <label class="metricpick">Sort
+      <select id="sort-select"></select>
+    </label>
+    <label class="metricpick rangepick" title="Raise the axis floor to spread out the top of the field">Zoom
+      <input type="range" id="ymin-range" aria-label="Y-axis minimum">
+      <span class="rangeval" id="ymin-val"></span>
+    </label>
+    <div class="btnrow" id="variant-btns"></div>
+    <div class="btnrow">
+      <button class="btn" id="btn-all">All methods</button>
+      <button class="btn" id="btn-top">Top 15</button>
+      <button class="btn" id="btn-none">Clear</button>
+    </div>
+    <span class="hint">Click a column or chip to remove a method &middot; hover for exact values</span>
+  </div>
+  <p class="papercap" id="papercap"></p>
+  <div class="legendstrip" id="legendstrip"></div>
+  <div class="lb-chartwrap" id="chartwrap">
+    <svg id="axis" class="lb-axis" role="presentation"></svg>
+    <div class="lb-scroll" id="scroller">
+      <svg id="chart" role="img" aria-label="Leaderboard overview"></svg>
+    </div>
+    <div class="tooltip"></div>
+  </div>
+  <div class="chips" id="chips"></div>
+  <details class="datatable">
+    <summary>Data table</summary>
+    <div class="tblwrap" id="tblwrap"></div>
+  </details>
+
+<script>
+(function () {
+  "use strict";
+  const CONFIG = __CONFIG_JSON__;
+  const POINTS = __POINTS_JSON__;
+
+__BASE_JS__
+
+  // ---------- geometry ----------
+  const AXIS_W = 72;      // width of the sticky y-axis pane
+  const PLOT_H = 320;     // height of the plot area itself
+  const TOP = 14;         // headroom above the tallest bar
+  const LABEL_TOP = 18;   // axis line -> first label row
+  const LABEL_ROW = 19;   // vertical offset of the staggered second row
+  const LABEL_SIZE = 14;  // method names; the slot below scales with it
+  const TICK_SIZE = 12.5;
+  // Method names are set horizontally (rotated ones are markedly harder to
+  // read), staggered over two rows exactly like the static figure — so a slot
+  // has to be wide enough for half a name. Past ~24 methods the chart scrolls
+  // rather than squeezing every column into the viewport.
+  // No upper bound on the slot: with few methods selected a capped slot left
+  // the columns huddled on the left with dead space beside them, so the slots
+  // simply share out whatever width there is.
+  const MIN_SLOT = 66;
+  const BAR_FRAC = 0.88;  // share of the slot the widest bar takes
+  const MAX_BAR = 70;     // ...but never wider than this, however few columns
+
+  // Variant -> (color token, width relative to the widest bar). The bars are
+  // concentric, so the nesting itself encodes the tuning progression.
+  const VARIANT_STYLE = {
+    "Tuned + Ens.": { color: "var(--var-tunedens)", rel: 1 },
+    "Tuned": { color: "var(--var-tuned)", rel: 0.8 },
+    "Default": { color: "var(--var-default)", rel: 0.6 },
+  };
+  const VARIANT_ORDER = ["Default", "Tuned", "Tuned + Ens."];
+  // Dash patterns cycle so several reference lines stay distinguishable.
+  const REF_DASHES = ["8 5", "2 4", "12 4 3 4"];
+
+  const titleEl = document.getElementById("title");
+  if (CONFIG.title) titleEl.textContent = CONFIG.title; else titleEl.hidden = true;
+
+  const axisSvg = document.getElementById("axis");
+  const svg = document.getElementById("chart");
+  const scroller = document.getElementById("scroller");
+  const wrap = document.getElementById("chartwrap");
+  const yminRange = document.getElementById("ymin-range");
+  const yminVal = document.getElementById("ymin-val");
+  const tip = makeTooltip(wrap);
+
+  // ---------- data ----------
+  const METRICS = CONFIG.metrics;
+  const metricByKey = {};
+  for (const m of METRICS) metricByKey[m.key] = m;
+
+  // One entry per method (its variants grouped); reference pipelines are kept
+  // apart — they are drawn as threshold lines, not as columns.
+  const byMethod = new Map();
+  const refs = [];
+  for (const p of POINTS) {
+    if (p.reference) { refs.push(p); continue; }
+    let entry = byMethod.get(p.method);
+    if (!entry) {
+      entry = { method: p.method, family: p.family, url: p.url, points: [] };
+      byMethod.set(p.method, entry);
+    }
+    entry.points.push(p);
+  }
+  for (const e of byMethod.values()) {
+    e.points.sort((a, b) => VARIANT_ORDER.indexOf(a.variant) - VARIANT_ORDER.indexOf(b.variant));
+    e.imputed = e.points.some(p => p.imputed);
+    e.imputed_pct = Math.max(...e.points.map(p => p.imputed_pct || 0));
+  }
+
+  const state = {
+    metric: METRICS[0].key,
+    sort: "best",
+    yMin: null,   // null = the automatic axis floor; a number = zoomed in
+
+    methods: new Set(byMethod.keys()),
+    refs: new Set(refs.map(r => r.method)),
+    variants: new Set(VARIANT_ORDER),
+  };
+
+  let refreshCaption = null;   // assigned once setUpPaperView has the DOM
+
+  function metric() { return metricByKey[state.metric]; }
+
+  // A method's best value under `m`, ignoring variants the reader switched off.
+  function bestOf(entry, m) {
+    const vals = entry.points
+      .filter(p => state.variants.has(p.variant) && p[m.key] != null)
+      .map(p => p[m.key]);
+    if (!vals.length) return null;
+    return m.lowerBetter ? Math.min(...vals) : Math.max(...vals);
+  }
+
+  function sortedMethods(entries, m) {
+    const arr = [...entries];
+    const cmp = {
+      best: (a, b) => rankVal(a, m) - rankVal(b, m),
+      worst: (a, b) => rankVal(b, m) - rankVal(a, m),
+      name: (a, b) => a.method.localeCompare(b.method),
+      family: (a, b) =>
+        FAM_ORDER.indexOf(a.family) - FAM_ORDER.indexOf(b.family) || rankVal(a, m) - rankVal(b, m),
+    }[state.sort];
+    return arr.sort(cmp);
+  }
+  // Sort key that puts "better" first for either metric direction, with
+  // value-less methods last.
+  function rankVal(entry, m) {
+    const v = bestOf(entry, m);
+    if (v == null) return Infinity;
+    return m.lowerBetter ? v : -v;
+  }
+
+  function visibleEntries() {
+    const m = metric();
+    return sortedMethods([...byMethod.values()].filter(e => state.methods.has(e.method) && bestOf(e, m) != null), m);
+  }
+  function visibleRefs() {
+    return refs.filter(r => state.refs.has(r.method) && r[state.metric] != null);
+  }
+
+  // Rendered width of each label, measured in the live document (font metrics
+  // are not knowable up front): it decides whether the names fit on one row or
+  // need the two-row stagger, and which ones have to be shortened.
+  function measureLabels(names) {
+    const probe = el("g", { visibility: "hidden" }, svg);
+    const widths = names.map(name => {
+      const t = el("text", { "font-size": LABEL_SIZE }, probe);
+      t.textContent = name;
+      return t.getComputedTextLength();
+    });
+    probe.remove();
+    return widths;
+  }
+
+  // Trim a name to `budget` px, ending in an ellipsis. The full name stays one
+  // hover (and one data-table row) away.
+  function fitLabel(node, name, width, budget) {
+    if (width <= budget) return;
+    let text = name;
+    while (text.length > 1 && node.getComputedTextLength() > budget) {
+      text = text.slice(0, -1);
+      node.textContent = text + "…";
+    }
+  }
+
+  // ---------- chart ----------
+  function render() {
+    const m = metric();
+    const entries = visibleEntries();
+    const shownRefs = visibleRefs();
+    svg.textContent = "";
+    axisSvg.textContent = "";
+    axisSvg.setAttribute("width", AXIS_W);
+
+    const avail = Math.max(240, scroller.clientWidth - 2);
+    if (!entries.length) {
+      axisSvg.setAttribute("height", 120);
+      svg.setAttribute("width", avail);
+      svg.setAttribute("height", 120);
+      const t = el("text", { x: avail / 2, y: 60, "text-anchor": "middle", "font-size": 13, fill: "var(--muted)" }, svg);
+      t.textContent = "No methods selected — use “All methods” to bring them back.";
+      buildLegend(m, shownRefs);
+      postHeight();
+      return;
+    }
+
+    const slot = Math.max(MIN_SLOT, avail / entries.length);
+    const barUnit = Math.min(MAX_BAR, slot * BAR_FRAC);
+    const plotW = Math.max(avail, slot * entries.length);
+    // Names go on one row when they fit side by side, otherwise on two
+    // staggered rows (each label then has two slots of room).
+    const labels = entries.map(e => e.method + (e.imputed ? " ‡" : ""));
+    const labelWidths = measureLabels(labels);
+    const widest = Math.max(...labelWidths);
+    const labelRows = widest <= slot - 6 ? 1 : 2;
+    const H = TOP + PLOT_H + LABEL_TOP + (labelRows - 1) * LABEL_ROW + 10;
+    svg.setAttribute("width", plotW);
+    svg.setAttribute("height", H);
+    axisSvg.setAttribute("height", H);
+
+    // -- y domain: from zero where the metric has one, else a floor below the
+    //    shortest bar (Elo has no meaningful zero, and starting at zero would
+    //    squash every difference into the top fifth of the chart). The floor
+    //    ignores the CI whiskers so one wide interval cannot deflate the scale.
+    const barVals = [];
+    const allVals = [];
+    for (const e of entries) {
+      for (const p of e.points) {
+        if (!state.variants.has(p.variant) || p[m.key] == null) continue;
+        barVals.push(p[m.key]);
+        allVals.push(p[m.key]);
+        if (m.ci && p[m.ci.hi] != null) allVals.push(p[m.ci.hi]);
+      }
+    }
+    for (const r of shownRefs) { barVals.push(r[state.metric]); allVals.push(r[state.metric]); }
+    const barMin = Math.min(...barVals), barMax = Math.max(...allVals);
+    const span = barMax - barMin || Math.abs(barMax) || 1;
+    let autoY0, y1;
+    if (m.fromZero) {
+      autoY0 = 0;
+      y1 = barMax * 1.06 || 1;
+    } else {
+      // Snap the floor down to a tick multiple so the axis reads in round
+      // numbers, and keep it just below the shortest bar: every bar stays
+      // visible (the static figure clips the ones below its fixed floor).
+      const step = niceStep(span / 6);
+      autoY0 = Math.floor((barMin - span * 0.05) / step) * step;
+      y1 = barMax + span * 0.04;
+    }
+    // The zoom slider raises the floor from there toward the top of the field,
+    // magnifying the differences between the leaders. Its bounds follow the
+    // metric's own scale, so they are refreshed on every render; the bars and
+    // whiskers that drop below the new floor are clipped away (see plot-clip).
+    const zoomMax = autoY0 + (y1 - autoY0) * 0.9;
+    yminRange.min = autoY0;
+    yminRange.max = zoomMax;
+    yminRange.step = (zoomMax - autoY0) / 200 || 1;
+    if (state.yMin != null) state.yMin = Math.min(state.yMin, zoomMax);
+    if (state.yMin != null && state.yMin <= autoY0) state.yMin = null;
+    const y0 = state.yMin == null ? autoY0 : state.yMin;
+    yminRange.value = y0;
+    yminVal.textContent = state.yMin == null ? "auto" : fmtNum(y0, m.decimals);
+    const Y = v => TOP + (1 - (v - y0) / (y1 - y0)) * PLOT_H;
+    const baseY = Y(y0);
+
+    // -- grid (solid hairlines) in the plot pane, tick labels in the axis pane
+    const tickVals = ticks(y0, y1, 6);
+    const grid = el("g", {}, svg);
+    const tickLabels = [];
+    for (const tv of tickVals) {
+      const gy = Y(tv);
+      el("line", { x1: 0, y1: gy, x2: plotW, y2: gy, stroke: "var(--line)", "stroke-width": 1 }, grid);
+      const t = el("text", {
+        x: AXIS_W - 10, y: gy + 4, "text-anchor": "end", "font-size": TICK_SIZE, fill: "var(--muted)",
+      }, axisSvg);
+      t.textContent = fmtNum(tv, m.decimals);
+      tickLabels.push({ y: gy, node: t });
+    }
+    el("line", { x1: 0, y1: baseY, x2: plotW, y2: baseY, stroke: "var(--muted)", "stroke-width": 1 }, grid);
+    el("line", { x1: AXIS_W - 1, y1: TOP, x2: AXIS_W - 1, y2: baseY, stroke: "var(--muted)", "stroke-width": 1 }, axisSvg);
+    el("text", {
+      x: 0, y: 0, "text-anchor": "middle", "font-size": LABEL_SIZE, fill: "var(--ink)",
+      transform: `translate(15 ${TOP + PLOT_H / 2}) rotate(-90)`,
+    }, axisSvg).textContent = m.axisLabel;
+
+    // -- hover band behind the marks (highlights the whole column group)
+    const band = el("rect", {
+      x: 0, y: TOP, width: slot, height: PLOT_H + 6, fill: "var(--ink)", opacity: 0, "pointer-events": "none",
+    }, svg);
+
+    const defs = el("defs", {}, svg);
+    // -- imputed hatch, reused by every partially imputed bar
+    const pat = el("pattern", {
+      id: "imp-hatch", width: 6, height: 6, patternUnits: "userSpaceOnUse", patternTransform: "rotate(45)",
+    }, defs);
+    el("rect", { width: 6, height: 6, fill: "none" }, pat);
+    el("line", { x1: 0, y1: 0, x2: 0, y2: 6, stroke: "var(--paper)", "stroke-width": 2.2, opacity: 0.75 }, pat);
+
+    // -- Everything data-bearing is clipped to the plot area. The axis floor is
+    //    set from the bar values (a couple of very wide intervals would
+    //    otherwise deflate the whole scale), so a long lower CI whisker can
+    //    reach past it and run into the method names below. Clip it there; the
+    //    exact interval stays in the tooltip and the data table.
+    const clip = el("clipPath", { id: "plot-clip" }, defs);
+    el("rect", { x: 0, y: 0, width: plotW, height: baseY }, clip);
+
+    // -- bars: one concentric group per method
+    const barsG = el("g", { "clip-path": "url(#plot-clip)" }, svg);
+    entries.forEach((entry, i) => {
+      const cx = i * slot + slot / 2;
+      // Widest bar first, narrowest last: the bars are concentric, so painting
+      // them by width guarantees each one stays visible. Ordering by height
+      // instead loses a variant outright whenever a narrower bar is the taller
+      // of the two (TabSTAR's tuned bar sat 1 Elo above tuned + ensembled, and
+      // the wider bar covered it completely).
+      const relOf = p => (VARIANT_STYLE[p.variant] || VARIANT_STYLE["Default"]).rel;
+      const drawn = entry.points
+        .filter(p => state.variants.has(p.variant) && p[m.key] != null)
+        .slice()
+        .sort((a, b) => relOf(b) - relOf(a));
+      for (const p of drawn) {
+        const style = VARIANT_STYLE[p.variant] || VARIANT_STYLE["Default"];
+        const w = barUnit * style.rel;
+        const top = Y(p[m.key]);
+        const rect = {
+          x: cx - w / 2, y: Math.min(top, baseY), width: w, height: Math.max(1, Math.abs(baseY - top)),
+        };
+        // 2px surface ring, not a border: it is what keeps a nested bar legible
+        // against the wider bar it sits inside.
+        el("rect", { ...rect, fill: style.color, stroke: "var(--paper)", "stroke-width": 1.5, rx: 2 }, barsG);
+        if (p.imputed) el("rect", { ...rect, fill: "url(#imp-hatch)", rx: 2 }, barsG);
+        if (m.ci && p[m.ci.lo] != null) {
+          const cap = Math.max(2.5, w * 0.34);
+          const whisk = el("g", {
+            stroke: `color-mix(in srgb, ${style.color} 55%, var(--ink))`, "stroke-width": 1.4, opacity: 0.9,
+          }, barsG);
+          el("line", { x1: cx, y1: Y(p[m.ci.lo]), x2: cx, y2: Y(p[m.ci.hi]) }, whisk);
+          el("line", { x1: cx - cap, y1: Y(p[m.ci.hi]), x2: cx + cap, y2: Y(p[m.ci.hi]) }, whisk);
+          el("line", { x1: cx - cap, y1: Y(p[m.ci.lo]), x2: cx + cap, y2: Y(p[m.ci.lo]) }, whisk);
+        }
+      }
+    });
+
+    // -- x axis: the method name, colored by model family (the legend below
+    //    names the colors).
+    const xg = el("g", {}, svg);
+    entries.forEach((entry, i) => {
+      const cx = i * slot + slot / 2;
+      const row = labelRows === 1 ? 0 : i % 2;
+      const y = baseY + LABEL_TOP + row * LABEL_ROW;
+      // A hairline drops the staggered row back to its own column.
+      if (row) {
+        el("line", {
+          x1: cx, y1: baseY + 3, x2: cx, y2: y - 10,
+          stroke: "var(--line)", "stroke-width": 1,
+        }, xg);
+      }
+      const t = el("text", {
+        x: cx, y, "font-size": LABEL_SIZE, "text-anchor": "middle",
+        fill: FAM_INK[entry.family] || "var(--ink)",
+      }, xg);
+      t.textContent = labels[i];
+      fitLabel(t, labels[i], labelWidths[i], slot * labelRows - 8);
+    });
+
+    // -- reference pipelines as threshold lines. Their names live in the legend
+    //    (matched by dash pattern) rather than on the line, where they would
+    //    cover the tallest bars at every scroll position.
+    const refG = el("g", {}, svg);
+    const tagYs = [];
+    shownRefs.forEach((r, i) => {
+      const ry = Y(r[state.metric]);
+      if (ry < TOP || ry > baseY) return;
+      el("line", {
+        x1: 0, y1: ry, x2: plotW, y2: ry, stroke: "var(--fam-reference)", "stroke-width": 1.8,
+        "stroke-dasharray": REF_DASHES[i % REF_DASHES.length], opacity: 0.95,
+      }, refG);
+      // Sticky value tag in the axis pane, so the threshold stays readable at
+      // any scroll position. Two nearby thresholds would print on top of each
+      // other, so nudge each tag clear of the ones already placed; a tag wins
+      // over a tick label it would sit on.
+      let ty = ry;
+      while (tagYs.some(y => Math.abs(y - ty) < 12)) ty += 12;
+      tagYs.push(ty);
+      for (const t of tickLabels) {
+        if (Math.abs(t.y - ty) < 10) t.node.remove();
+      }
+      el("text", {
+        x: AXIS_W - 10, y: ty + 4, "text-anchor": "end", "font-size": 11, "font-weight": 650,
+        fill: "var(--fam-reference)",
+      }, axisSvg).textContent = fmtMetric(m, r[state.metric]);
+    });
+    buildLegend(m, shownRefs);
+    if (refreshCaption) refreshCaption();
+
+    // -- hit targets: one full-height column per method (>= 34px wide)
+    const hits = el("g", {}, svg);
+    entries.forEach((entry, i) => {
+      const h = el("rect", {
+        x: i * slot, y: TOP, width: slot, height: PLOT_H + 6, fill: "transparent", cursor: "pointer",
+      }, hits);
+      h.addEventListener("mouseenter", ev => {
+        band.setAttribute("x", i * slot);
+        band.setAttribute("opacity", 0.06);
+        showTip(entry, ev);
+      });
+      h.addEventListener("mousemove", ev => tip.move(ev));
+      h.addEventListener("mouseleave", () => { band.setAttribute("opacity", 0); tip.hide(); });
+      h.addEventListener("click", () => toggleMethod(entry.method));
+    });
+
+    postHeight();
+  }
+
+  function showTip(entry, ev) {
+    const m = metric();
+    let html = `<div class="t-name">${entry.method}</div><div>${entry.family}</div>`;
+    for (const p of entry.points) {
+      if (!state.variants.has(p.variant) || p[m.key] == null) continue;
+      const ci = m.ci && p[m.ci.lo] != null
+        ? ` <span class="t-var">(${fmtNum(p[m.ci.lo], m.decimals)}–${fmtNum(p[m.ci.hi], m.decimals)})</span>`
+        : "";
+      html += `<div><span class="t-var">${p.variant}:</span> <b>${fmtMetric(m, p[m.key])}</b>${ci}</div>`;
+    }
+    if (entry.imputed) html += `<div class="t-imp">Imputed on ${fmtNum(entry.imputed_pct, 0)}% of datasets</div>`;
+    tip.show(html, ev);
+  }
+
+  // ---------- chips ----------
+  const chipsBox = document.getElementById("chips");
+  const chipByMethod = new Map();
+  const famChips = new Map();
+
+  function familyMembers(fam) {
+    const out = [...byMethod.values()].filter(e => e.family === fam).map(e => e.method);
+    for (const r of refs) if (r.family === fam) out.push(r.method);
+    return out;
+  }
+  function isOn(name) { return state.methods.has(name) || state.refs.has(name); }
+
+  function buildChips() {
+    const rankMetric = metricByKey[CONFIG.rankMetric] || METRICS[0];
+    const head = document.createElement("div");
+    head.className = "chips-head";
+    head.textContent = "Methods shown — click to remove, click a family to toggle the whole group";
+    chipsBox.appendChild(head);
+    for (const fam of FAM_ORDER) {
+      const members = familyMembers(fam);
+      if (!members.length) continue;
+      members.sort((a, b) => chipRank(a, rankMetric) - chipRank(b, rankMetric));
+      const row = document.createElement("div");
+      row.className = "chiprow";
+      const famBtn = document.createElement("button");
+      famBtn.className = "famchip";
+      famBtn.style.setProperty("--fam", FAM_VAR[fam]);
+      famBtn.innerHTML = `<span class="dot"></span>${fam} <span class="count">&times;${members.length}</span>`;
+      famBtn.title = `Toggle all ${members.length} ${fam} methods`;
+      famBtn.addEventListener("click", () => toggleFamily(fam));
+      row.appendChild(famBtn);
+      famChips.set(fam, famBtn);
+      const set = document.createElement("div");
+      set.className = "chipset";
+      for (const name of members) {
+        const entry = byMethod.get(name);
+        const b = document.createElement("button");
+        b.className = "chip";
+        b.style.setProperty("--fam", FAM_VAR[fam]);
+        b.appendChild(Object.assign(document.createElement("span"), { className: "dot" }));
+        b.appendChild(Object.assign(document.createElement("span"), { textContent: name }));
+        if (entry && entry.imputed) {
+          const mark = document.createElement("span");
+          mark.className = "imp-mark";
+          mark.textContent = "‡";
+          b.appendChild(mark);
+        }
+        b.title = name + (entry && entry.imputed ? " — partially imputed" : "");
+        b.addEventListener("click", () => toggleMethod(name));
+        set.appendChild(b);
+        chipByMethod.set(name, b);
+      }
+      row.appendChild(set);
+      chipsBox.appendChild(row);
+    }
+  }
+  function chipRank(name, m) {
+    const entry = byMethod.get(name);
+    if (entry) return rankVal(entry, m);
+    const r = refs.find(x => x.method === name);
+    const v = r ? r[m.key] : null;
+    return v == null ? Infinity : (m.lowerBetter ? v : -v);
+  }
+  function syncChips() {
+    for (const [name, b] of chipByMethod) b.setAttribute("aria-pressed", String(isOn(name)));
+    for (const [fam, b] of famChips) b.setAttribute("aria-pressed", String(familyMembers(fam).every(isOn)));
+  }
+
+  function toggleMethod(name) {
+    const set = byMethod.has(name) ? state.methods : state.refs;
+    if (set.has(name)) set.delete(name); else set.add(name);
+    syncChips();
+    render();
+  }
+  function toggleFamily(fam) {
+    const members = familyMembers(fam);
+    const allOn = members.every(isOn);
+    for (const name of members) {
+      const set = byMethod.has(name) ? state.methods : state.refs;
+      if (allOn) set.delete(name); else set.add(name);
+    }
+    syncChips();
+    render();
+  }
+  function setMethods(names) {
+    state.methods = new Set(names);
+    syncChips();
+    render();
+  }
+
+  document.getElementById("btn-all").addEventListener("click", () => {
+    state.refs = new Set(refs.map(r => r.method));
+    setMethods(byMethod.keys());
+  });
+  document.getElementById("btn-none").addEventListener("click", () => {
+    state.refs = new Set();
+    setMethods([]);
+  });
+  document.getElementById("btn-top").addEventListener("click", () => {
+    const m = metric();
+    // Rank explicitly rather than reusing the display sort: which 15 methods are
+    // kept must not depend on which end of the axis the best ones are drawn at
+    // (sorting "best on the right" would otherwise select the 15 worst).
+    const top = [...byMethod.values()]
+      .sort((a, b) => rankVal(a, m) - rankVal(b, m))
+      .slice(0, 15)
+      .map(e => e.method);
+    state.refs = new Set(refs.map(r => r.method));
+    setMethods(top);
+  });
+
+  // ---------- selectors ----------
+  yminRange.addEventListener("input", ev => {
+    state.yMin = Number(ev.target.value);
+    render();
+  });
+
+  const metricSelect = document.getElementById("metric-select");
+  for (const m of METRICS) {
+    metricSelect.appendChild(Object.assign(document.createElement("option"), { value: m.key, textContent: m.label }));
+  }
+  metricSelect.addEventListener("change", ev => {
+    state.metric = ev.target.value;
+    state.yMin = null;  // the previous floor means nothing on a new scale
+    buildTable();
+    render();
+  });
+
+  const sortSelect = document.getElementById("sort-select");
+  for (const [value, label] of [
+    ["best", "Best on the left"], ["worst", "Best on the right"],
+    ["family", "Model family"], ["name", "A–Z"],
+  ]) {
+    sortSelect.appendChild(Object.assign(document.createElement("option"), { value, textContent: label }));
+  }
+  sortSelect.value = state.sort;
+  sortSelect.addEventListener("change", ev => { state.sort = ev.target.value; render(); });
+
+  // Variant toggles: buttons rather than chips, since they filter the series
+  // rather than the rows. "Default" gets no button at all — every method has a
+  // default result, so it is the baseline of the chart rather than an option
+  // (switching it off would leave the default-only methods with no bar). Only
+  // the extras layered on top, tuning and ensembling, are toggleable; the legend
+  // still carries Default's color.
+  const ALWAYS_SHOWN = "Default";
+  const variantBtns = document.getElementById("variant-btns");
+  const variantBtnByKey = new Map();
+  for (const v of VARIANT_ORDER) {
+    if (v === ALWAYS_SHOWN || !POINTS.some(p => p.variant === v)) continue;
+    const b = document.createElement("button");
+    b.className = "btn";
+    b.textContent = v === "Tuned + Ens." ? "Tuned + Ensembled" : v;
+    b.style.setProperty("--fam", VARIANT_STYLE[v].color);
+    b.title = `Show or hide the ${b.textContent.toLowerCase()} bars`;
+    b.addEventListener("click", () => {
+      if (state.variants.has(v)) state.variants.delete(v);
+      else state.variants.add(v);
+      syncVariantBtns();
+      render();
+    });
+    variantBtns.appendChild(b);
+    variantBtnByKey.set(v, b);
+  }
+  function syncVariantBtns() {
+    for (const [v, b] of variantBtnByKey) {
+      const on = state.variants.has(v);
+      b.setAttribute("aria-pressed", String(on));
+      b.style.opacity = on ? "1" : "0.45";
+      b.style.borderColor = on ? VARIANT_STYLE[v].color : "var(--line)";
+    }
+  }
+
+  // ---------- legend ----------
+  // Rebuilt on every render: it names the reference lines (each by its dash
+  // pattern and current value), which change with the metric and the selection.
+  function buildLegend(m, shownRefs) {
+    const parts = [];
+    for (const v of VARIANT_ORDER) {
+      if (!POINTS.some(p => p.variant === v)) continue;
+      const label = v === "Tuned + Ens." ? "Tuned + Ensembled" : v;
+      const off = state.variants.has(v) ? "" : ' style="opacity:0.4"';
+      parts.push(
+        `<span class="item"${off}><svg width="12" height="12" viewBox="0 0 12 12">` +
+        `<rect x="1" y="1" width="10" height="10" rx="2" fill="${VARIANT_STYLE[v].color}"/></svg> ${label}</span>`);
+    }
+    if (m.ci) {
+      parts.push('<span class="item"><svg width="12" height="14" viewBox="0 0 12 14">' +
+        '<path d="M6,2 V12 M2,2 H10 M2,12 H10" stroke="var(--muted)" stroke-width="1.4" fill="none"/></svg> 95% CI</span>');
+    }
+    shownRefs.forEach((r, i) => {
+      parts.push(`<span class="item"><svg width="26" height="8" viewBox="0 0 26 8">` +
+        `<line x1="0" y1="4" x2="26" y2="4" stroke="var(--fam-reference)" stroke-width="1.8" ` +
+        `stroke-dasharray="${REF_DASHES[i % REF_DASHES.length]}"/></svg> ${r.method} · ${fmtMetric(m, r[state.metric])}</span>`);
+    });
+    if (POINTS.some(p => p.imputed)) {
+      parts.push('<span class="item"><svg width="14" height="14" viewBox="0 0 14 14">' +
+        '<rect x="1" y="1" width="12" height="12" rx="2" fill="var(--pt-muted)"/>' +
+        '<path d="M-2,4 L6,-4 M-2,10 L10,-2 M2,14 L14,2 M8,14 L14,8" stroke="var(--paper)" stroke-width="2.2"/>' +
+        "</svg> &Dagger; partially imputed</span>");
+    }
+    // Model family, named rather than merely pointed at: without the colors
+    // spelled out, the swatch under each column decodes to nothing.
+    const families = FAM_ORDER.filter(f => POINTS.some(p => !p.reference && p.family === f));
+    if (families.length > 1) {
+      parts.push('<span class="legendbreak"></span><span class="item">Family:</span>');
+      for (const fam of families) {
+        parts.push(`<span class="item"><svg width="16" height="9" viewBox="0 0 16 9">` +
+          `<rect x="0" y="1" width="16" height="7" rx="2" fill="${FAM_VAR[fam]}"/></svg> ` +
+          `<span style="color:${FAM_INK[fam]}">${fam}</span></span>`);
+      }
+    }
+    document.getElementById("legendstrip").innerHTML = parts.join("");
+  }
+
+  // ---------- data table (the WCAG-clean twin of the chart) ----------
+  function buildTable() {
+    const m = metric();
+    const rows = [...POINTS].filter(p => p[m.key] != null).sort((a, b) =>
+      m.lowerBetter ? a[m.key] - b[m.key] : b[m.key] - a[m.key]);
+    let html = "<table><thead><tr><th>Method</th><th>Variant</th><th>Family</th>";
+    for (const x of METRICS) html += `<th>${x.label}</th>`;
+    html += "<th>Imputed</th></tr></thead><tbody>";
+    for (const p of rows) {
+      html += `<tr><td>${p.method}</td><td>${p.variant || "—"}</td><td>${p.family}</td>`;
+      for (const x of METRICS) html += `<td>${fmtMetric(x, p[x.key])}</td>`;
+      html += `<td>${p.imputed ? fmtNum(p.imputed_pct, 0) + "%" : "—"}</td></tr>`;
+    }
+    document.getElementById("tblwrap").innerHTML = html + "</tbody></table>";
+  }
+
+  // ---------- paper view ----------
+  // Nothing when the view is the default one — the axis labels already name the
+  // metric and its direction. It only speaks up about what a screenshot would
+  // otherwise hide: a filtered set, a hidden variant, a raised axis floor.
+  function paperCaption() {
+    const m = metric();
+    const entries = visibleEntries();
+    const notes = [];
+    if (entries.length !== byMethod.size) notes.push(`${entries.length} of ${byMethod.size} methods shown`);
+    const hidden = VARIANT_ORDER.filter(v => !state.variants.has(v) && POINTS.some(p => p.variant === v));
+    if (hidden.length) notes.push(`${hidden.join(" and ")} hidden`);
+    if (state.yMin != null) notes.push(`axis from ${fmtNum(state.yMin, m.decimals)}`);
+    return notes.join(" &middot; ");
+  }
+  refreshCaption = setUpPaperView(paperCaption, render);
+
+  // ---------- boot ----------
+  document.querySelector("details.datatable").addEventListener("toggle", postHeight);
+  let resizeTimer = null;
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(render, 120);
+  });
+
+  buildChips();
+  buildTable();
+  syncChips();
+  syncVariantBtns();
+  render();  // also builds the legend (it depends on the metric + selection)
+})();
+</script>
+</body>
+</html>
+"""

--- a/packages/tabarena/src/tabarena/plot/interactive/leaderboard_explorer.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/leaderboard_explorer.py
@@ -1,0 +1,191 @@
+"""Build the self-contained interactive leaderboard-overview explorer HTML.
+
+The interactive twin of the static ``tuning-impact-elo`` bar figure. It is built
+from the *website* leaderboard table (``website_leaderboard.csv``) rather than
+from the raw evaluation frame, so the chart and the table below it on
+tabarena.ai can never disagree — and so refreshing it is part of the fast
+artifact-conversion step instead of a full re-evaluation.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pandas as pd
+
+from tabarena.plot.interactive._explorer_shared import render_explorer_html
+from tabarena.plot.interactive._leaderboard_template import LEADERBOARD_TEMPLATE
+from tabarena.website.website_format import Constants
+
+#: ``Model`` cell -> variant. The website spells the variants out in the model
+#: name; the explorer wants them as a separate series.
+_VARIANT_RE = re.compile(r"\((default|tuned \+ ensembled|tuned)\)")
+_VARIANT_LABELS = {"default": "Default", "tuned": "Tuned", "tuned + ensembled": "Tuned + Ens."}
+
+#: ``+106/-103`` -> (106.0, 103.0).
+_CI_RE = re.compile(r"\+\s*([0-9.]+)\s*/\s*-\s*([0-9.]+)")
+
+#: Metric key -> (website column, spec). Order = order in the y-axis selector;
+#: the first entry is the default axis and the ranking used for the chips.
+_METRIC_SPECS: dict[str, tuple[str, dict]] = {
+    "elo": (
+        "Elo [⬆️]",
+        {
+            "label": "Elo",
+            "axisLabel": "Elo — higher is better",
+            "lowerBetter": False,
+            "fromZero": False,
+            "decimals": 0,
+            "suffix": "",
+            "ci": {"lo": "elo_lo", "hi": "elo_hi"},
+        },
+    ),
+    "imp": (
+        "Improvability (%) [⬇️]",
+        {
+            "label": "Improvability (%)",
+            "axisLabel": "Improvability (%) — lower is better",
+            "lowerBetter": True,
+            "fromZero": True,
+            "decimals": 1,
+            "suffix": "%",
+        },
+    ),
+    "score": (
+        "Score [⬆️]",
+        {
+            "label": "Score",
+            "axisLabel": "Score — higher is better",
+            "lowerBetter": False,
+            "fromZero": True,
+            "decimals": 3,
+            "suffix": "",
+        },
+    ),
+    "rank": (
+        "Rank [⬇️]",
+        {
+            "label": "Average rank",
+            "axisLabel": "Average rank — lower is better",
+            "lowerBetter": True,
+            "fromZero": True,
+            "decimals": 2,
+            "suffix": "",
+        },
+    ),
+    "hrank": (
+        "Harmonic Rank [⬇️]",
+        {
+            "label": "Harmonic rank",
+            "axisLabel": "Harmonic rank — lower is better",
+            "lowerBetter": True,
+            "fromZero": True,
+            "decimals": 2,
+            "suffix": "",
+        },
+    ),
+}
+
+
+def _parse_model(model: str) -> tuple[str, str, str | None]:
+    """Split a website ``Model`` cell into (method name, variant, url).
+
+    The cell is ``[Name (variant) [X% IMPUTED]](url)`` with every part optional;
+    a name whose parenthetical is not a tuning variant (e.g. the reference
+    pipeline "AutoGluon 1.5 (extreme, 4h)") keeps it as part of the name.
+    """
+    link = re.match(r"\[(.*?)\]\((.*?)\)", model)
+    text, url = (link.group(1), link.group(2)) if link else (model, None)
+    text = text.split("[")[0].strip()  # drop any "[X% IMPUTED]" tag
+    match = _VARIANT_RE.search(text)
+    variant = _VARIANT_LABELS[match.group(1)] if match else ""
+    return _VARIANT_RE.sub("", text).strip(), variant, url
+
+
+def _parse_ci(value: object) -> tuple[float, float]:
+    """``+106/-103`` -> the (upper, lower) offsets; (nan, nan) when absent."""
+    match = _CI_RE.search(str(value)) if pd.notna(value) else None
+    if not match:
+        return float("nan"), float("nan")
+    return float(match.group(1)), float(match.group(2))
+
+
+def leaderboard_explorer_points(df_website_leaderboard: pd.DataFrame) -> pd.DataFrame:
+    """The explorer's point frame: one row per method-variant of a website leaderboard."""
+    df = df_website_leaderboard
+    parsed = [_parse_model(m) for m in df["Model"]]
+    points = pd.DataFrame(
+        {
+            "method": [p[0] for p in parsed],
+            "variant": [p[1] for p in parsed],
+            "family": df["TypeName"].to_numpy(),
+            "url": [p[2] for p in parsed],
+            "reference": (df["TypeName"] == Constants.reference).to_numpy(),
+        },
+    )
+    for key, (column, _spec) in _METRIC_SPECS.items():
+        points[key] = pd.to_numeric(df[column], errors="coerce").to_numpy() if column in df.columns else pd.NA
+
+    if "Elo 95% CI" in df.columns:
+        offsets = [_parse_ci(v) for v in df["Elo 95% CI"]]
+        points["elo_hi"] = points["elo"] + [o[0] for o in offsets]
+        points["elo_lo"] = points["elo"] - [o[1] for o in offsets]
+
+    imputed_column = df["Imputed (%) [⬇️]"] if "Imputed (%) [⬇️]" in df.columns else pd.Series(0.0, index=df.index)
+    imputed_pct = pd.to_numeric(imputed_column, errors="coerce").fillna(0.0)
+    points["imputed_pct"] = imputed_pct.to_numpy()
+    points["imputed"] = (imputed_pct > 0).to_numpy()
+    return points.dropna(subset=["elo"]).reset_index(drop=True)
+
+
+def build_leaderboard_explorer_html(
+    df_website_leaderboard: pd.DataFrame,
+    *,
+    save_path: str | Path,
+    title: str | None = None,
+    page_title: str = "TabArena leaderboard explorer",
+) -> Path | None:
+    """Render the interactive leaderboard overview for one subset's website table.
+
+    Parameters
+    ----------
+    df_website_leaderboard
+        A ``website_leaderboard.csv`` frame (see
+        :func:`tabarena.website.website_format.format_leaderboard`). Required
+        columns: ``Model``, ``TypeName`` and ``Elo [⬆️]``; every other metric of
+        :data:`_METRIC_SPECS` is offered on the y-axis selector when present.
+    save_path
+        Where to write the page.
+    title
+        Headline shown above the chart; omitted when ``None``.
+
+    Returns:
+    -------
+    The written path, or ``None`` when the table has no usable Elo values.
+    """
+    for column in ("Model", "TypeName", "Elo [⬆️]"):
+        if column not in df_website_leaderboard.columns:
+            raise ValueError(f"website leaderboard is missing required column {column!r}")
+
+    points = leaderboard_explorer_points(df_website_leaderboard)
+    if points.empty:
+        return None
+
+    metrics = [
+        {"key": key, **spec}
+        for key, (column, spec) in _METRIC_SPECS.items()
+        if column in df_website_leaderboard.columns and points[key].notna().any()
+    ]
+    # The CI only exists for Elo, and only when the table carries the column.
+    for spec in metrics:
+        if spec.get("ci") and "elo_hi" not in points.columns:
+            spec.pop("ci")
+
+    config = {"title": title, "metrics": metrics, "rankMetric": metrics[0]["key"]}
+    html = render_explorer_html(LEADERBOARD_TEMPLATE, page_title=page_title, config=config, points=points)
+
+    save_path = Path(save_path)
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    save_path.write_text(html, encoding="utf-8")
+    return save_path

--- a/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/pareto_explorer.py
@@ -8,31 +8,14 @@ self-contained it also works as a local artifact anyone can open in a browser.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from tabarena.plot.interactive._explorer_shared import render_explorer_html
 from tabarena.plot.interactive._explorer_template import EXPLORER_TEMPLATE
-from tabarena.plot.plot_pareto_focus import FAMILY_COLORS
 
 if TYPE_CHECKING:
     import pandas as pd
-
-#: Family display name -> the template's CSS custom property carrying its color.
-_FAMILY_CSS_TOKENS: dict[str, str] = {
-    "Foundation Model": "--fam-foundation",
-    "Neural Network": "--fam-nn",
-    "Tree-based": "--fam-tree",
-    "Reference Pipeline": "--fam-reference",
-    "Baseline": "--fam-baseline",
-    "Other": "--fam-other",
-}
-
-
-def _family_css_vars() -> str:
-    """CSS custom-property lines carrying the shared family colors."""
-    return "\n".join(f"    {token}: {FAMILY_COLORS[family]};" for family, token in _FAMILY_CSS_TOKENS.items())
-
 
 #: Variant display order used to sort each method's points so the connector
 #: line runs default -> tuned -> tuned + ensembled.
@@ -175,12 +158,7 @@ def build_pareto_explorer_html(
         "chipsSide": chips_side,
     }
 
-    html = (
-        EXPLORER_TEMPLATE.replace("__PAGE_TITLE__", page_title)
-        .replace("__FAMILY_CSS_VARS__", _family_css_vars())
-        .replace("__CONFIG_JSON__", json.dumps(config))
-        .replace("__POINTS_JSON__", data.to_json(orient="records"))
-    )
+    html = render_explorer_html(EXPLORER_TEMPLATE, page_title=page_title, config=config, points=data)
 
     save_path = Path(save_path)
     save_path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/tabarena/src/tabarena/website/process_artifacts_to_website.py
+++ b/packages/tabarena/src/tabarena/website/process_artifacts_to_website.py
@@ -7,12 +7,20 @@ from pathlib import Path
 
 import pandas as pd
 
+from tabarena.plot.interactive.leaderboard_explorer import build_leaderboard_explorer_html
+
 
 def process_one_folder(
     *,
     base_input_path: Path,
     base_output_path: Path,
+    subset_label: str | None = None,
 ):
+    """Copy one subset's artifacts into the website layout.
+
+    ``subset_label`` is the human-readable subset name used in the interactive
+    explorers' headline (e.g. "All Tasks | Small"); omitted when ``None``.
+    """
     base_output_path.mkdir(parents=True, exist_ok=True)
 
     figure_file_type = "png"
@@ -80,3 +88,17 @@ def process_one_folder(
         src = base_input_path / extra_path
         if src.is_file():
             shutil.copy(src, base_output_path / src.name)
+
+    # The interactive twin of `tuning-impact-elo.png`. Built here rather than in
+    # the evaluation step because it needs nothing beyond the website table it
+    # sits next to — so a styling fix is a re-run of the (fast) conversion step,
+    # and the chart can never disagree with the table below it on the site.
+    build_leaderboard_explorer_html(
+        pd.read_csv(base_output_path / "website_leaderboard.csv"),
+        save_path=base_output_path / "leaderboard_overview_explorer.html",
+        # No in-page heading: the website's panel header already names the
+        # figure and the subset. The label identifies the standalone file.
+        page_title=f"TabArena leaderboard explorer — {subset_label}"
+        if subset_label
+        else "TabArena leaderboard explorer",
+    )

--- a/scripts/run_generate_website_artifacts.py
+++ b/scripts/run_generate_website_artifacts.py
@@ -63,6 +63,32 @@ from tabarena.plot.tuning_trajectories.plot_pareto_over_tuning_time import plot_
 from tabarena.website.process_artifacts_to_website import process_one_folder
 from tabarena.website.process_pngs import process_png_bulk
 
+# Subset folder segment -> the human label the website shows. Mirrors
+# ``data_loading.TASK_LABELS`` / ``DATASET_LABELS`` in the leaderboard Space.
+_SUBSET_LABELS: dict[str, str] = {
+    "tasks_all": "All Tasks",
+    "tasks_classification": "Classification",
+    "tasks_regression": "Regression",
+    "tasks_binary": "Binary",
+    "tasks_multiclass": "Multiclass",
+    "datasets_all": "All Datasets",
+    "datasets_small": "Small",
+    "datasets_medium": "Medium",
+    "splits_lite": "Lite",
+    "imputation_no": "no imputation",
+}
+
+
+def _subset_label(rel_path: Path) -> str:
+    """Human-readable label for a subset folder, e.g. "All Tasks | Small".
+
+    Only the parts that carry information are shown: the default imputation and
+    splits settings are dropped, so a path like
+    ``imputation_yes/splits_all/tasks_all/datasets_small`` reads as
+    "<tasks> | <datasets>".
+    """
+    return " | ".join(_SUBSET_LABELS[part] for part in rel_path.parts if part in _SUBSET_LABELS)
+
 
 class WebsiteArtifactGenerator:
     """Regenerate, convert, and zip the tabarena.ai website artifacts.
@@ -188,12 +214,12 @@ class WebsiteArtifactGenerator:
 
         for path in file_paths:
             base_input_path = Path(path).parent
-            base_output_path = output_path / base_input_path.relative_to(
-                input_path,
-            )
+            rel_path = base_input_path.relative_to(input_path)
+            base_output_path = output_path / rel_path
             process_one_folder(
                 base_input_path=Path(path).parent,
                 base_output_path=base_output_path,
+                subset_label=_subset_label(rel_path),
             )
             process_png_bulk(path=base_output_path)
 


### PR DESCRIPTION
The interactive twin of the static tuning-impact-elo bar figure: one column group per method, nested bars for the tuning variants, bootstrap CI whiskers, reference pipelines as threshold lines, plus a metric selector, sorting, per-method and per-family removal, a y-axis zoom, hover values and a data table.

It is built from website_leaderboard.csv in the artifact-*conversion* step rather than during evaluation, because it needs nothing beyond the table it sits beside. A restyle is therefore a re-run of the fast step (--skip-evaluate --skip-trajectories), not a full re-evaluation, and the chart cannot disagree with the table below it on the site.

Shared chrome moves into _explorer_shared: the theme tokens (now declared once per mode and emitted into four scopes, including a data-theme="light" scope that lets the paper view force white over the site's dark stamp), the control/chip/tooltip/table CSS, and the JS helpers. Both explorers use it, which also removes the duplicated dark-token block.

Two behaviours worth calling out:

- Numbers are formatted with an explicit "." decimal separator instead of toLocaleString, which would follow the viewer's browser locale and disagree with the figures and CSV exports.
- Concentric bars are painted widest-first. Ordering by height loses a variant whenever a narrower bar is the taller of the two, which hid TabSTAR's tuned bar (1 Elo above tuned + ensembled) completely.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
