### PR TITLE
Make the AutoGluon stacker test independent of lightgbm

### DIFF
--- a/packages/tabarena/src/tabarena/simulation/ensemble/autogluon_stacker.py
+++ b/packages/tabarena/src/tabarena/simulation/ensemble/autogluon_stacker.py
@@ -19,6 +19,8 @@ classification problem type is inferred from the fit labels.
 
 from __future__ import annotations
 
+import os
+import tempfile
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -51,11 +53,16 @@ class _AutoGluonStackerBase:
         return pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
 
     def _fit_model(self, X, y, problem_type: str) -> None:
+        model_kwargs = dict(self.model_kwargs or {})
+        # An AbstractModel constructed without a path creates an `AutogluonModels/ag-<timestamp>`
+        # directory in the cwd. The meta-model is only kept in memory (never saved), so default to
+        # a temp location; pass `model_kwargs={"path": ...}` to persist it somewhere specific.
+        model_kwargs.setdefault("path", os.path.join(tempfile.gettempdir(), "tabarena_stacker"))
         model = self.model_cls(
             problem_type=problem_type,
             eval_metric=self.eval_metric,
             hyperparameters=dict(self.hyperparameters) if self.hyperparameters else None,
-            **(self.model_kwargs or {}),
+            **model_kwargs,
         )
         model.fit(X=self._to_frame(X), y=pd.Series(np.asarray(y)))
         self._model = model

--- a/tests/tabarena/simulation/test_ensembler.py
+++ b/tests/tabarena/simulation/test_ensembler.py
@@ -476,8 +476,12 @@ def test_stacking_ensembler_rejected_on_fast_log_loss():
 
 @pytest.mark.parametrize("problem_type", ["binary", "multiclass", "regression"])
 def test_stacking_with_autogluon_abstract_model(problem_type):
-    """StackingEnsembler stacks with any AutoGluon AbstractModel via the adapters."""
-    from autogluon.tabular.models import LGBModel
+    """StackingEnsembler stacks with any AutoGluon AbstractModel via the adapters.
+
+    Uses ``RFModel`` because it ships with the base ``autogluon.tabular`` install, so this
+    runs without the optional model libraries (LightGBM, CatBoost, ...).
+    """
+    from autogluon.tabular.models import RFModel
 
     from tabarena.simulation.ensemble import (
         AutoGluonStackerClassifier,
@@ -505,9 +509,9 @@ def test_stacking_with_autogluon_abstract_model(problem_type):
         problem_type=problem_type,
         metric=metric,
         classifier_cls=AutoGluonStackerClassifier,
-        classifier_kwargs={"model_cls": LGBModel, "hyperparameters": hyperparameters},
+        classifier_kwargs={"model_cls": RFModel, "hyperparameters": hyperparameters},
         regressor_cls=AutoGluonStackerRegressor,
-        regressor_kwargs={"model_cls": LGBModel, "hyperparameters": hyperparameters},
+        regressor_kwargs={"model_cls": RFModel, "hyperparameters": hyperparameters},
         n_splits=2,
     )
     if problem_type == "multiclass":
@@ -524,3 +528,20 @@ def test_stacking_with_autogluon_abstract_model(problem_type):
     # label-space predictions work through the ensembler
     labels_pred = ensembler.predict(preds.copy(), problem_type=problem_type)
     assert len(labels_pred) == len(y)
+
+
+def test_autogluon_stacker_leaves_no_cwd_artifacts(monkeypatch, tmp_path):
+    """The adapter must not drop an ``AutogluonModels/`` dir into the cwd, which is what
+    AbstractModel does when constructed without a path.
+    """
+    from autogluon.tabular.models import RFModel
+
+    from tabarena.simulation.ensemble import AutoGluonStackerRegressor
+
+    monkeypatch.chdir(tmp_path)
+    y, preds = _make_regression_task(n_models=3, n_samples=50, seed=12)
+    regressor = AutoGluonStackerRegressor(model_cls=RFModel, hyperparameters={"n_estimators": 5})
+    regressor.fit(preds.T, y)
+
+    assert np.isfinite(regressor.predict(preds.T)).all()
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
The stacking adapter test fit an LGBModel, but lightgbm is an optional autogluon.tabular extra that the base dependency does not provide -- so the test failed in the default install and in the pytest CI job, which installs only [plot,preprocessing,data-foundry]. Fit RFModel instead: it ships with the base install and exercises the same adapters.

Also stop the adapter from creating an `AutogluonModels/ag-<timestamp>` dir in the cwd for every fitted meta-model (n_splits + refit per stacking fit). The meta-model is only held in memory, so default its path to a temp location; `model_kwargs={"path": ...}` still overrides.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
