### PR TITLE
[New Model] EXAONE-Tabular (classification only)

### DIFF
--- a/packages/tabarena/pyproject.toml
+++ b/packages/tabarena/pyproject.toml
@@ -116,6 +116,10 @@ tabpfnwide = ["tabpfnwide>=0.3.0"]
 iltm = ["iltm>=0.1.1"]
 chimeraboost = ["chimeraboost>=0.14.1"]
 nori = ["synthefy-nori>=0.10.0"]
+# EXAONE Tabular is not published on PyPI; pinned to a commit so the benchmarked code is fixed.
+exaone_tabular = [
+  "exaonetabular @ git+https://github.com/LGAI-Research/EXAONE-Tabular.git@f8e9cc5a8befa432b2d783bdaffc413384fa2263",
+]
 # TabSwift is vendored under models/tabswift/_vendor/ (not pip-installable). All of its
 # runtime deps (torch, numpy, scikit-learn, scipy, psutil, tqdm, huggingface_hub, packaging)
 # are already in the base tree, so this extra is intentionally empty.
@@ -155,6 +159,7 @@ extended = [
   "tabarena[chimeraboost]",
   "tabarena[nori]",
   "tabarena[tabswift]",
+  "tabarena[exaone_tabular]",
 ]
 
 # Convenience: everything (core + extended + probmetrics).

--- a/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
+++ b/packages/tabarena/src/tabarena/contexts/tabarena/methods.py
@@ -44,6 +44,7 @@ from tabarena.models.ebm.info import (
     ebm_method_metadata as ebm_metadata,
     ebm_new_method_metadata,
 )
+from tabarena.models.exaone_tabular.info import exaone_tabular_method_metadata
 from tabarena.models.extra_trees.info import extra_trees_new_method_metadata
 from tabarena.models.fastai.info import fastai_method_metadata
 from tabarena.models.iltm.info import iltm_method_metadata
@@ -181,6 +182,7 @@ tabarena_method_metadata_collection = MethodMetadataCollection(
         nori30m_method_metadata,
         tabfm_new_method_metadata,
         tabswift_new_method_metadata,
+        exaone_tabular_method_metadata,
     ],
 )
 

--- a/packages/tabarena/src/tabarena/models/__init__.py
+++ b/packages/tabarena/src/tabarena/models/__init__.py
@@ -12,6 +12,7 @@ from tabarena.models._registry import (
 if TYPE_CHECKING:
     from tabarena.models._method_metadata import MethodMetadata
     from tabarena.models.chimeraboost.model import ChimeraBoostModel
+    from tabarena.models.exaone_tabular.model import EXAONETabularModel
     from tabarena.models.iltm.model import ILTMModel
     from tabarena.models.knn.model import KNNNewModel
     from tabarena.models.limix.model import LimiXModel
@@ -41,6 +42,7 @@ if TYPE_CHECKING:
 _LAZY_CLASSES: dict[str, str] = {
     "MethodMetadata": "tabarena.models._method_metadata",
     "ChimeraBoostModel": "tabarena.models.chimeraboost.model",
+    "EXAONETabularModel": "tabarena.models.exaone_tabular.model",
     "ILTMModel": "tabarena.models.iltm.model",
     "KNNNewModel": "tabarena.models.knn.model",
     "LimiXModel": "tabarena.models.limix.model",

--- a/packages/tabarena/src/tabarena/models/exaone_tabular/__init__.py
+++ b/packages/tabarena/src/tabarena/models/exaone_tabular/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from tabarena.models.exaone_tabular.hpo import gen_exaone_tabular
+from tabarena.models.exaone_tabular.info import exaone_tabular_info, exaone_tabular_method_metadata
+
+__all__ = ["exaone_tabular_info", "exaone_tabular_method_metadata", "gen_exaone_tabular"]

--- a/packages/tabarena/src/tabarena/models/exaone_tabular/hpo.py
+++ b/packages/tabarena/src/tabarena/models/exaone_tabular/hpo.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from tabarena.models.exaone_tabular.model import EXAONETabularModel
+from tabarena.utils.config_utils import ConfigGenerator
+
+gen_exaone_tabular = ConfigGenerator(
+    model_cls=EXAONETabularModel,
+    search_space={},
+    manual_configs=[{}],
+)
+
+
+if __name__ == "__main__":
+    from tabarena.benchmark.experiment import YamlExperimentSerializer
+
+    print(
+        YamlExperimentSerializer.to_yaml_str(
+            experiments=gen_exaone_tabular.generate_all_bag_experiments(num_random_configs=0),
+        ),
+    )

--- a/packages/tabarena/src/tabarena/models/exaone_tabular/info.py
+++ b/packages/tabarena/src/tabarena/models/exaone_tabular/info.py
@@ -7,6 +7,7 @@ from tabarena.models.exaone_tabular.model import EXAONETabularModel
 
 exaone_tabular_method_metadata = MethodMetadata.config(
     method="EXAONE-Tabular",
+    suite="tabarena-2026-07-31",
     ag_key="TA-EXAONE-TABULAR",
     config_default="EXAONE-Tabular_c1_default_BAG_L1",
     can_hpo=False,
@@ -16,9 +17,9 @@ exaone_tabular_method_metadata = MethodMetadata.config(
     date_introduced="2026-07-31",
     reference_url="https://github.com/LGAI-Research/EXAONE-Tabular",
     display_name="EXAONE-Tabular",
-    verified=False,
-    # No `suite` / `cache_kwargs` yet: not benchmarked, so the artifacts are local-only. Both are
-    # filled in by the upload flow once a run exists.
+    verified=True,
+    cache_type="r2",
+    cache_kwargs={"bucket": "tabarena", "prefix": "cache"},
 )
 
 

--- a/packages/tabarena/src/tabarena/models/exaone_tabular/info.py
+++ b/packages/tabarena/src/tabarena/models/exaone_tabular/info.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models._model_info import ModelInfo
+from tabarena.models.exaone_tabular.hpo import gen_exaone_tabular
+from tabarena.models.exaone_tabular.model import EXAONETabularModel
+
+exaone_tabular_method_metadata = MethodMetadata.config(
+    method="EXAONE-Tabular",
+    ag_key="TA-EXAONE-TABULAR",
+    config_default="EXAONE-Tabular_c1_default_BAG_L1",
+    can_hpo=False,
+    compute="gpu",
+    is_bag=False,
+    date="2026-07-31",
+    date_introduced="2026-07-31",
+    reference_url="https://github.com/LGAI-Research/EXAONE-Tabular",
+    display_name="EXAONE-Tabular",
+    verified=False,
+    # No `suite` / `cache_kwargs` yet: not benchmarked, so the artifacts are local-only. Both are
+    # filled in by the upload flow once a run exists.
+)
+
+
+exaone_tabular_info = ModelInfo(
+    model_cls=EXAONETabularModel,
+    search_space=gen_exaone_tabular,
+    method_metadata=exaone_tabular_method_metadata,
+    # Pinned to a commit: the package is not on PyPI and the repository was published on
+    # 2026-07-31, so an unpinned `git+...` would silently change what gets benchmarked.
+    pip_extra=(
+        "exaonetabular @ git+https://github.com/LGAI-Research/EXAONE-Tabular.git@f8e9cc5a8befa432b2d783bdaffc413384fa2263",
+    ),
+    prefetch_weights=EXAONETabularModel.prefetch_weights,
+)

--- a/packages/tabarena/src/tabarena/models/exaone_tabular/model.py
+++ b/packages/tabarena/src/tabarena/models/exaone_tabular/model.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+from autogluon.common.utils.resource_utils import ResourceManager
+from autogluon.features.generators import LabelEncoderFeatureGenerator
+from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+class EXAONETabularModel(AbstractTorchModel):
+    """EXAONE Tabular: an in-context-learning tabular foundation model from LG AI Research.
+
+    A ~20.8M-parameter Cross-axis Summary Transformer (CAST) that conditions on the training rows
+    at inference time, with no per-dataset gradient training. Only the classification checkpoint is
+    released, so this wrapper is classification-only.
+
+    Paper: technical report not yet released (the repository's citation block is a placeholder).
+    Authors: LG AI Research
+    Codebase: https://github.com/LGAI-Research/EXAONE-Tabular
+    License: code under the BSD-3-Clause-LG AI Research License; the released weights under the
+        EXAONE AI Model License 1.1-NC, which permits non-commercial use only.
+    """
+
+    ag_key = "TA-EXAONE-TABULAR"
+    ag_name = "TA-EXAONE-Tabular"
+    ag_priority = 65
+    seed_name = "seed"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._feature_generator: LabelEncoderFeatureGenerator | None = None
+
+    def _preprocess(self, X: pd.DataFrame, *, is_train: bool = False, **kwargs) -> np.ndarray:
+        """Produce the dense real-valued matrix EXAONE Tabular's estimators require.
+
+        The estimators accept only a 2-D NumPy array of a real numeric dtype, so categoricals are
+        ordinal-encoded (the encoding the upstream README asks callers to apply). Missing cells stay
+        as NaN: the library's own preprocessor mean-imputes them and keeps a missing mask, which is
+        strictly more informative than imputing here. Infinities are folded into NaN because the
+        library rejects them outright.
+        """
+        X = super()._preprocess(X, **kwargs)
+
+        if is_train:
+            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
+            self._feature_generator.fit(X=X)
+
+        if self._feature_generator.features_in:
+            X = X.copy()
+            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+
+        X = np.asarray(X.to_numpy(), dtype=np.float32)
+        X[~np.isfinite(X)] = np.nan
+        return X
+
+    def _fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        num_cpus: int = 1,
+        num_gpus: int = 0,
+        **kwargs,
+    ):
+        """Fit EXAONE Tabular.
+
+        As an in-context-learning foundation model there is no training loop and no early stopping,
+        so (like the other TFM wrappers) ``X_val`` / ``y_val`` and ``time_limit`` are intentionally
+        ignored — fitting loads the pre-trained checkpoint and stores the support set. ``num_cpus``
+        is likewise unused: the library exposes no thread-count knob.
+        """
+        import torch
+
+        available_num_gpus = ResourceManager.get_gpu_count_torch(cuda_only=True)
+        if num_gpus > available_num_gpus:
+            raise AssertionError(
+                f"Fit specified to use {num_gpus} GPU, but only {available_num_gpus} "
+                "CUDA GPUs are available. Please activate CUDA or switch to CPU usage.",
+            )
+        device = "cuda" if num_gpus != 0 else "cpu"
+        if (device == "cuda") and (not torch.cuda.is_available()):
+            raise AssertionError(
+                "Fit specified to use GPU, but CUDA is not available on this machine. "
+                "Please switch to CPU usage instead.",
+            )
+
+        from exaonetabular import EXAONETabularClassifier
+
+        hps = self._get_model_params()
+        if device == "cpu" and hps.get("compute_dtype") == "float16":
+            # Half precision is a GPU choice; several torch CPU kernels have no half
+            # implementation, so the CPU fallback path runs in float32 instead.
+            logger.log(15, "Running on CPU: overriding compute_dtype 'float16' with 'float32'.")
+            hps["compute_dtype"] = "float32"
+
+        X_np = self.preprocess(X, y=y, is_train=True)
+        y_np = np.asarray(y.to_numpy())
+
+        self.model = EXAONETabularClassifier.from_pretrained(device=device, **hps)
+        self.model.fit(X_np, y_np)
+
+    def _predict_proba(self, X: pd.DataFrame, **kwargs) -> np.ndarray:
+        X = self.preprocess(X, **kwargs)
+        return self._convert_proba_to_unified_form(self.model.predict_proba(X))
+
+    def _set_default_params(self):
+        # The released classifier checkpoint's runtime defaults (exaonetabular.presets).
+        default_params = {
+            "ensemble_count": 8,
+            "compute_dtype": "float16",
+        }
+        for param, val in default_params.items():
+            self._set_default_param_value(param, val)
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        """Classification only: the regression checkpoint is not published on the Hub yet."""
+        return ["binary", "multiclass"]
+
+    def get_device(self) -> str:
+        return self.model.device.type
+
+    def _set_device(self, device: str):
+        device = self.to_torch_device(device)
+        self.model.device = device
+        self.model.model = self.model.model.to(device)
+
+    def _get_default_resources(self) -> tuple[int, int]:
+        # Use only physical cores for better performance based on benchmarks
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
+        return num_cpus, num_gpus
+
+    def get_minimum_resources(self, is_gpu_available: bool = False) -> dict[str, int | float]:
+        return {
+            "num_cpus": 1,
+            "num_gpus": 1 if is_gpu_available else 0,
+        }
+
+    @classmethod
+    def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
+        """Sequential fold fitting avoids contention on the shared Hugging Face checkpoint cache.
+
+        ``refit_folds=True`` matches the other TFM wrappers (TabICL, TabSwift, TabPFN-3, ...): for
+        an in-context-learning model, refitting one model on all data gives faster inference at
+        similar quality to the bagged ensemble.
+        """
+        default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
+        default_ag_args_ensemble.update(
+            {
+                "fold_fitting_strategy": "sequential_local",
+                "refit_folds": True,
+            },
+        )
+        return default_ag_args_ensemble
+
+    @classmethod
+    def _class_tags(cls) -> dict:
+        # TODO: implement memory estimation and set to True
+        return {"can_estimate_memory_usage_static": False}
+
+    def _more_tags(self) -> dict:
+        return {"can_refit_full": True}
+
+    @classmethod
+    def warmup(cls, *, num_gpus: float | None = None, **kwargs) -> None:
+        """Warm torch (+ the CUDA context) and the ``exaonetabular`` import (untimed, data-independent).
+
+        Declaring this overrides the generic ``AbstractTorchModel`` torch warm-up, so the torch part
+        is re-done explicitly here; the extra piece is the library's own import chain (safetensors,
+        scikit-learn, the model modules), which would otherwise land in the timed fit.
+        """
+        from tabarena.models.warmup import warmup_imports, warmup_torch
+
+        warmup_torch(cuda=None if num_gpus is None else num_gpus > 0)
+        warmup_imports("exaonetabular.classifier")
+
+    @classmethod
+    def prefetch_weights(cls) -> str:
+        """Pre-download the released classifier checkpoint and return its local path.
+
+        The Hub coordinates come from ``exaonetabular.presets`` rather than being hardcoded here, so
+        a checkpoint bump in the library is picked up automatically. Tries the local cache first so
+        offline compute nodes skip the etag HEAD-request ``hf_hub_download`` makes by default.
+        """
+        from exaonetabular import released_checkpoint
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        checkpoint = released_checkpoint("classification")
+        try:
+            return hf_hub_download(
+                repo_id=checkpoint.repo_id,
+                filename=checkpoint.filename,
+                revision=checkpoint.revision,
+                local_files_only=True,
+            )
+        except LocalEntryNotFoundError:
+            return hf_hub_download(
+                repo_id=checkpoint.repo_id,
+                filename=checkpoint.filename,
+                revision=checkpoint.revision,
+            )

--- a/packages/tabarena/src/tabarena/plot/interactive/_leaderboard_template.py
+++ b/packages/tabarena/src/tabarena/plot/interactive/_leaderboard_template.py
@@ -407,6 +407,11 @@ __BASE_JS__
     // -- x axis: the method name, colored by model family (the legend below
     //    names the colors).
     const xg = el("g", {}, svg);
+    // Hairlines share one group that is painted before every name, so a name
+    // nudged sideways at the edge (see below) passes over a neighbouring
+    // column's hairline instead of being crossed out by it.
+    const xLines = el("g", {}, xg);
+    const xLabels = el("g", {}, xg);
     entries.forEach((entry, i) => {
       const cx = i * slot + slot / 2;
       const row = labelRows === 1 ? 0 : i % 2;
@@ -416,14 +421,24 @@ __BASE_JS__
         el("line", {
           x1: cx, y1: baseY + 3, x2: cx, y2: y - 10,
           stroke: "var(--line)", "stroke-width": 1,
-        }, xg);
+        }, xLines);
       }
       const t = el("text", {
         x: cx, y, "font-size": LABEL_SIZE, "text-anchor": "middle", "font-weight": 650,
         fill: FAM_INK[entry.family] || "var(--ink)",
-      }, xg);
+        // A halo in the surface color keeps the glyphs legible where a nudged
+        // name crosses a hairline, rather than the line running through them.
+        "paint-order": "stroke", stroke: "var(--paper)", "stroke-width": 3,
+      }, xLabels);
       t.textContent = labels[i];
       fitLabel(t, labels[i], labelWidths[i], slot * labelRows - 8);
+      // The outermost columns sit only half a slot from the edge, so a name
+      // wider than one slot would reach past the SVG viewport and be cut off
+      // there (a name may occupy two slots when the rows are staggered). Nudge
+      // it inwards by just enough to stay whole; every other label keeps its
+      // column centre, and the bar below still marks the column.
+      const half = t.getComputedTextLength() / 2;
+      t.setAttribute("x", Math.max(half + 1, Math.min(cx, plotW - half - 1)));
     });
 
     // -- reference pipelines as threshold lines. Their names live in the legend

--- a/packages/tabarena/src/tabarena/website/website_format.py
+++ b/packages/tabarena/src/tabarena/website/website_format.py
@@ -123,6 +123,7 @@ def get_model_family(model_name: str) -> str:
             "TA-ILTM",
             "TA-NORI",
             "TABSWIFT",
+            "EXAONE",
         ],
         Constants.baseline: ["KNN", "LR", "LINEAR"],
         Constants.other: ["XRFM"],

--- a/tests/tabarena/models/smoke_configs.py
+++ b/tests/tabarena/models/smoke_configs.py
@@ -52,6 +52,7 @@ SMOKE_OVERRIDES: dict[str, ModelSmokeTest] = {
     "Nori-30M": ModelSmokeTest(problem_types=("regression",)),
     "iLTM": ModelSmokeTest({"finetuning_max_steps": 1, "n_ensemble": 1, "tree_n_estimators": 1}),
     "OrionMSP": ModelSmokeTest({"n_estimators": 1}),
+    "EXAONE-Tabular": ModelSmokeTest({"ensemble_count": 1}),
 }
 
 


### PR DESCRIPTION
Adds **EXAONE-Tabular** from LG AI Research: a ~20.8M-parameter in-context-learning tabular foundation model (Cross-axis Summary Transformer) that conditions on the training rows at inference time, with no per-dataset gradient training.

- Wrapper: [`models/exaone_tabular/model.py`](https://github.com/autogluon/tabarena/blob/add_exaone/packages/tabarena/src/tabarena/models/exaone_tabular/model.py)
- Codebase: https://github.com/LGAI-Research/EXAONE-Tabular
- Technical report: not released yet (the repository's citation block is still a placeholder).

### ⚠️ Classification only

Only the classification checkpoint is published, so `supported_problem_types()` is `["binary", "multiclass"]` and the model is **excluded from all regression tasks**. Any leaderboard entry covers the classification subsets only, and results are not comparable to methods evaluated on the full suite. If LG AI Research publishes the regression checkpoint later, lifting the restriction is a one-line change.

### Changes

- `models/exaone_tabular/{model,hpo,info,__init__}.py` — the wrapper + `ModelInfo` (auto-discovered by the registry; `method="EXAONE-Tabular"`, `ag_key="TA-EXAONE-TABULAR"`, `can_hpo=False`, `verified=False`).
- `models/__init__.py` — `EXAONETabularModel` added to `_LAZY_CLASSES`.
- `website/website_format.py` — classified as a foundation model.
- `tests/tabarena/models/smoke_configs.py` — `ensemble_count=1` for the toy fit.
- `pyproject.toml` — `exaone_tabular` extra + added to `extended`.

### Notes

- **Weights are non-commercial.** Code is BSD-3-Clause-LG AI Research; the released checkpoint is under the EXAONE AI Model License 1.1-NC. Reproducing a run needs no token or gating, but the license restricts downstream use.
- The package is **not on PyPI**, and the repository was published on 2026-07-31, so the extra pins a git commit (`f8e9cc5`) instead of tracking the default branch — otherwise the benchmarked code could change silently.
- No search space (`can_hpo=False`): the single default config uses the checkpoint's own runtime defaults (`ensemble_count=8`, `compute_dtype="float16"`, downgraded to float32 on CPU).
- `warmup()` covers torch/CUDA and the `exaonetabular` import chain, and `prefetch_weights()` resolves the checkpoint from `exaonetabular.presets` (cache first) so compute nodes don't pay for either inside the timed fit.
- `verified=False` and no `suite` / `cache_kwargs` yet: filled in by the upload flow once a benchmark run exists.

Results plots to follow in a comment.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
